### PR TITLE
docs(reference): refresh the feature matrix and gate it against the CLI

### DIFF
--- a/.github/workflows/feature-matrix-drift.yml
+++ b/.github/workflows/feature-matrix-drift.yml
@@ -1,0 +1,97 @@
+name: Feature matrix drift
+
+# The feature matrix is the index a reader is sent to for the full picture,
+# and nothing held it to the code.
+#
+# Problem
+# -------
+# ``docs/reference/FEATURE_MATRIX.md`` is what README links to as the
+# exhaustive capability index. Its two sibling reference pages already have
+# gates: ``cli-reference.md`` is held to the registered command tree by
+# ``tests/unit/test_cli_command_registration.py``, and ``capabilities.md``
+# by ``tests/unit/test_docs_capability_reachability.py``. The matrix had
+# neither, so a command could ship, be documented on every other surface,
+# and never reach the index -- with every check green.
+#
+# Fix
+# ---
+# ``tests/unit/test_feature_matrix_drift.py`` walks the registered command
+# tree against the rows of the matrix in both directions: a registered
+# command named by no row fails, and a row naming an unregistered command
+# fails. It runs in the unit suite like any other test; this workflow runs
+# it directly on the diffs that can cause the drift, so a change to the
+# command tree cannot land it past a PR lane that only runs affected tests.
+#
+# No job here is named ``CI gate``: the required-check name canary
+# allow-lists exactly two emitters of that string and rejects a third. See
+# docs/operations/ci.md.
+#
+# It also has no ``merge_group`` trigger, so it must not be made a required
+# context as it stands - a required context that cannot report on a queued
+# ref wedges the merge queue (see docs/operations/merge-queue.md). Add the
+# trigger first if branch protection is ever meant to require it.
+
+on:
+  pull_request:
+    paths:
+      - "docs/reference/FEATURE_MATRIX.md"
+      - "src/bernstein/cli/**"
+      - "tests/unit/test_feature_matrix_drift.py"
+      - ".github/workflows/feature-matrix-drift.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/reference/FEATURE_MATRIX.md"
+      - "src/bernstein/cli/**"
+      - "tests/unit/test_feature_matrix_drift.py"
+      - ".github/workflows/feature-matrix-drift.yml"
+
+concurrency:
+  group: feature-matrix-drift-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  matrix-rows:
+    name: registered CLI commands have a matrix row
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/bootstrap
+        with:
+          python-version: "3.13"
+
+      - name: Check the matrix against the registered command tree
+        run: |
+          uv sync --group dev --frozen
+          uv run pytest tests/unit/test_feature_matrix_drift.py -q --no-cov --timeout=120
+        shell: bash
+
+      - name: How to fix
+        if: failure()
+        run: |
+          echo "The feature matrix no longer matches the CLI surface it indexes."
+          echo
+          echo "A registered command with no row: add one to the CLI commands"
+          echo "section of docs/reference/FEATURE_MATRIX.md with a Docs status"
+          echo "and a Maturity score."
+          echo
+          echo "A row naming a command the CLI does not register: correct or"
+          echo "remove the row - following it produces 'No such command'."
+          echo
+          echo "Reproduce locally:"
+          echo "  uv run pytest tests/unit/test_feature_matrix_drift.py -q --no-cov"
+        shell: bash

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -40,6 +40,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/docs-drift.yml | docs-drift | pull_request, push, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "docs-drift-${{ github.ref }}"} | 2 |
 | .github/workflows/docs-observability-snapshot.yml | Observability snapshot | workflow_dispatch | {"cancel-in-progress": "false", "group": "docs-observability-snapshot"} | 1 |
 | .github/workflows/eval-nightly.yml | eval-nightly | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "eval-nightly-${{ github.ref }}"} | 3 |
+| .github/workflows/feature-matrix-drift.yml | Feature matrix drift | pull_request, push | {"cancel-in-progress": "true", "group": "feature-matrix-drift-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
 | .github/workflows/hotfix-r-tracker.yml | Hotfix R-counter | push | {"cancel-in-progress": "false", "group": "hotfix-r-tracker-${{ github.sha }}"} | 1 |
 | .github/workflows/license-compliance.yml | License Compliance | pull_request, push | {"cancel-in-progress": "true", "group": "license-${{ github.ref }}"} | 1 |
 | .github/workflows/main-sha-marker.yml | Main SHA marker | push | {"cancel-in-progress": "false", "group": "main-sha-marker-${{ github.sha }}"} | 1 |
@@ -108,6 +109,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/docs-drift.yml | drift-check: Run drift check<br>drift-publish: Publish drift surfaces |
 | .github/workflows/docs-observability-snapshot.yml | snapshot: Capture snapshot |
 | .github/workflows/eval-nightly.yml | bench: bench (full)<br>preflight: preflight (gate)<br>smoke: smoke (synthetic) |
+| .github/workflows/feature-matrix-drift.yml | matrix-rows: registered CLI commands have a matrix row |
 | .github/workflows/hotfix-r-tracker.yml | track: Detect hotfix-begets-hotfix |
 | .github/workflows/license-compliance.yml | license-check |
 | .github/workflows/main-sha-marker.yml | marker: Main SHA marker |
@@ -176,6 +178,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/docs-drift.yml | workflow: {"contents": "read"}<br>drift-check: {"contents": "read"}<br>drift-publish: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |
 | .github/workflows/docs-observability-snapshot.yml | workflow: {"contents": "read"}<br>snapshot: {"contents": "write", "pull-requests": "write", "security-events": "read"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |
 | .github/workflows/eval-nightly.yml | workflow: {"contents": "read"} | EVAL_ENABLED |
+| .github/workflows/feature-matrix-drift.yml | workflow: {"contents": "read"}<br>matrix-rows: {"contents": "read"} | - |
 | .github/workflows/hotfix-r-tracker.yml | track: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |
 | .github/workflows/license-compliance.yml | workflow: {"contents": "read"}<br>license-check: {"contents": "read"} | - |
 | .github/workflows/main-sha-marker.yml | - | - |

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -16,6 +16,7 @@ documentation read the inline comments in `.github/workflows/ci.yml`.
 | Concurrency | PR-scoped cancel, push-scoped non-cancel | `.github/workflows/ci.yml` |
 | Integration suite | Whole directory, every event, via `integration-tests` | `.github/workflows/ci.yml` |
 | Collection completeness | Guard test, fails on an uncollected test file | `scripts/check_test_collection.py` |
+| Feature-matrix drift | Advisory; fails on a registered command with no matrix row | `.github/workflows/feature-matrix-drift.yml` |
 | Required-context presence | Operator command + advisory PR step | `scripts/check_required_contexts.py` |
 | Type-check scope | Blocking vs advisory scopes | `docs/operations/type-check-scope.md` |
 
@@ -270,7 +271,8 @@ Everything else that triggers on `pull_request` is advisory:
 `a2a-federation-e2e`, `airgap-e2e`, `bernstein-pr-review`,
 `cluster-e2e`, `codeql`,
 `contract-drift-autofix`, `dependabot-auto-merge`,
-`dependency-review`, `docs-drift`, `license-compliance`, `pr-labels`,
+`dependency-review`, `docs-drift`, `feature-matrix-drift`,
+`license-compliance`, `pr-labels`,
 `pr-observability-summary`, `pr-policy`, `required-check-canary`,
 `spa-bundle-freshness`, `spiffe-extra-e2e`, `trufflehog`, `typecheck-ts`,
 `zizmor`.

--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -13,310 +13,331 @@ module docstrings rather than on its own reference page. Every row names a
 surface an operator can invoke; `tests/unit/test_cli_server_route_parity.py`
 additionally holds the CLI's server calls to the registered route table.
 
+The "Maturity" column says how far a capability has been proven, which is a
+different question from whether a page documents it:
+
+| Maturity | Meaning |
+|---|---|
+| 5 | End-to-end evidence, no open correctness issues, docs current |
+| 4 | Tested and documented, minor gaps |
+| 3 | Works, known gaps |
+| 2 | A first-run path is broken |
+| 1 | Stub |
+
+The score describes the subsystem behind the row, so rows served by the same
+code usually carry the same number. `bernstein audit` and the audit-chain
+capability rows move together; so do a CLI verb and the capability it drives.
+
+`tests/unit/test_feature_matrix_drift.py` holds the CLI-commands section to
+the commands the code registers: a new command with no row here fails that
+test, and a row naming a command the CLI no longer registers fails it too.
+
 ---
 
 ## Core orchestration
 
-| Capability | Docs status | Notes |
-|---|---|---|
-| Goal-based run (`-g`) | Full | Main entry flow |
-| Seed-file run (`bernstein.yaml`) | Full | Auto-discovery supported |
-| Plan-file execution (`stages`/`steps`) | Full | `bernstein run plan.yaml` |
-| Retry + escalation plumbing | Full | In task lifecycle, with configurable retries |
-| Completion verification (janitor + signals) | Full | API + getting started coverage |
-| Process-aware stop/drain | Full | Graceful and force stop, drain mode |
-| [Multi-cell orchestration](../orchestration/multi-cell.md) | Full | Implemented in `multi_cell.py` |
-| [Fast-path execution](../architecture/fast-path-execution.md) | Full | Trivial tasks skip the LLM agent entirely (`fast_path.py`) |
-| Plan mode (human approval) | Full | `--plan-only`, `--from-plan`, approval routes |
-| Headless mode | Full | `--headless` for CI/overnight |
-| Dry-run mode | Full | `--dry-run` previews the plan without spawning |
-| [Typed activity boundary](../operations/activity-boundary.md) | Full | One hash-in/hash-out contract for coding, research, browser, data, and ops activities, verified by `bernstein activity verify <run>` (`core/orchestration/activity.py`). Browser is the one non-coding modality with a CLI dispatch verb (`bernstein activity browser run`), the rest are Python-API only; dispatching a non-coding modality from a seed, plan, or backlog file is not wired yet, see "Reachability today" |
-| Missions (multi-phase goals) | Full | Phases run under isolated budget envelopes; a halted phase seals a halt receipt and leaves runnable siblings active (`core/orchestration/missions.py`) |
-| Durable task suspend/resume | Full | A waiting task parks with an attested receipt that frees its seat, sandbox, and budget; resume reconstructs byte-identically (`core/tasks/suspension.py`) |
-| [Tournament runs](../operations/tournament-runs.md) | Full | Parallel attempts selected by deterministic evaluators; the winner carries a signed selection receipt (`core/tournament/`) |
-| [Fleet steering](../operations/fleet-steering.md) | Full | Pause, resume, guidance, redirect, and abort each land a signed steering receipt before any effect runs (`core/orchestration/steering.py`) |
-| [Detached run service](../operations/run-service.md) | Full | Submit a goal, disconnect, and reattach later against a supervised run service (`core/run_service/`) |
-| [Named resource pools](../operations/named-resource-pools.md) | Full | Lease-backed admission with chain-anchored grant and release receipts (`core/admission/`) |
-| Spec-to-graph compile | Full | `bernstein plan compile` runs the draft/approve/compile pipeline offline into a gated task graph with a chain-anchored receipt (`plan_compile_cmd.py`) |
+| Capability | Docs status | Maturity | Notes |
+|---|---|---|---|
+| Goal-based run (`-g`) | Full | 3 | Main entry flow |
+| Seed-file run (`bernstein.yaml`) | Full | 3 | Auto-discovery supported |
+| Plan-file execution (`stages`/`steps`) | Full | 3 | `bernstein run plan.yaml` |
+| Retry + escalation plumbing | Full | 3 | In task lifecycle, with configurable retries |
+| Completion verification (janitor + signals) | Full | 3 | API + getting started coverage |
+| Process-aware stop/drain | Full | 3 | Graceful and force stop, drain mode |
+| [Multi-cell orchestration](../orchestration/multi-cell.md) | Full | 3 | Implemented in `multi_cell.py` |
+| [Fast-path execution](../architecture/fast-path-execution.md) | Full | 3 | Trivial tasks skip the LLM agent entirely (`fast_path.py`) |
+| Plan mode (human approval) | Full | 3 | `--plan-only`, `--from-plan`, approval routes |
+| Headless mode | Full | 3 | `--headless` for CI/overnight |
+| Dry-run mode | Full | 3 | `--dry-run` previews the plan without spawning |
+| [Typed activity boundary](../operations/activity-boundary.md) | Full | 3 | One hash-in/hash-out contract for coding, research, browser, data, and ops activities, verified by `bernstein activity verify <run>` (`core/orchestration/activity.py`). Browser is the one non-coding modality with a CLI dispatch verb (`bernstein activity browser run`), the rest are Python-API only; dispatching a non-coding modality from a seed, plan, or backlog file is not wired yet, see [Reachability today](../operations/activity-boundary.md#reachability-today) |
+| Missions (multi-phase goals) | Full | 3 | Phases run under isolated budget envelopes; a halted phase seals a halt receipt and leaves runnable siblings active (`core/orchestration/missions.py`) |
+| Durable task suspend/resume | Full | 3 | A waiting task parks with an attested receipt that frees its seat, sandbox, and budget; resume reconstructs byte-identically (`core/tasks/suspension.py`) |
+| [Tournament runs](../operations/tournament-runs.md) | Full | 3 | Parallel attempts selected by deterministic evaluators; the winner carries a signed selection receipt (`core/tournament/`) |
+| [Fleet steering](../operations/fleet-steering.md) | Full | 3 | Pause, resume, guidance, redirect, and abort each land a signed steering receipt before any effect runs (`core/orchestration/steering.py`) |
+| [Detached run service](../operations/run-service.md) | Full | 3 | Submit a goal, disconnect, and reattach later against a supervised run service (`core/run_service/`) |
+| [Named resource pools](../operations/named-resource-pools.md) | Full | 3 | Lease-backed admission with chain-anchored grant and release receipts (`core/admission/`) |
+| Spec-to-graph compile | Full | 3 | `bernstein plan compile` runs the draft/approve/compile pipeline offline into a gated task graph with a chain-anchored receipt (`plan_compile_cmd.py`) |
 
 ## State and persistence
 
-| Capability | Docs status | Notes |
-|---|---|---|
-| File-based state in `.sdd/` | Full | Primary operating model |
-| Metrics/trace persistence | Full | Paths documented, JSONL schema |
-| [Lessons/memory persistence](../concepts/lesson-persistence.md) | Full | Stored and injected at spawn time |
-| Storage backends (`memory/postgres/redis`) | Full | Config + doctor coverage |
-| [Session persistence (fast resume)](../operations/session-fast-resume.md) | Full | `session.py` resumes after stop/restart |
-| [Bulletin board (cross-agent messaging)](../orchestration/bulletin-board.md) | Full | Append-only, used by agents for handoff |
-| [Content-addressed artifact store](../architecture/cas-store.md) | Full | Content-addressed deduplication for artifacts (`core/persistence/cas_store.py`) |
-| Cloud artifact sinks | Full | Local, S3, GCS, Azure Blob, and R2 sinks behind an async `ArtifactSink` protocol |
+| Capability | Docs status | Maturity | Notes |
+|---|---|---|---|
+| File-based state in `.sdd/` | Full | 3 | Primary operating model |
+| Metrics/trace persistence | Full | 3 | Paths documented, JSONL schema |
+| [Lessons/memory persistence](../concepts/lesson-persistence.md) | Full | 4 | Stored and injected at spawn time |
+| Storage backends (`memory/postgres/redis`) | Full | 3 | Config + doctor coverage |
+| [Session persistence (fast resume)](../operations/session-fast-resume.md) | Full | 3 | `session.py` resumes after stop/restart |
+| [Bulletin board (cross-agent messaging)](../orchestration/bulletin-board.md) | Full | 3 | Append-only, used by agents for handoff |
+| [Content-addressed artifact store](../architecture/cas-store.md) | Full | 3 | Content-addressed deduplication for artifacts (`core/persistence/cas_store.py`) |
+| Cloud artifact sinks | Full | 3 | Local, S3, GCS, Azure Blob, and R2 sinks behind an async `ArtifactSink` protocol |
 
 ## Observability
 
-| Capability | Docs status | Notes |
-|---|---|---|
-| `/status` and task API | Full | Core API documented |
-| [Prometheus `/metrics`](../operations/observability-overview.md) | Full | Endpoint is real; Grafana dashboards are user-defined |
-| [OTLP telemetry initialization](../operations/observability-overview.md) | Full | Wiring exists in `core/observability/` |
-| [OTel GenAI span projection](../operations/observability-overview.md) | Full | `trace project` projects a run journal into signed OTel GenAI spans; `trace verify-projection` recomputes span ids |
-| Live OTLP bridge | Full | The signed span projection streams to any OpenTelemetry collector live or via `telemetry export-otel`; `telemetry verify-span` recomputes a span id from its journal entry (`core/telemetry/`) |
-| Retrospective reporting (`retro`) | Full | CLI coverage present |
-| Cost analysis (`cost`, history/anomaly hooks) | Full | `bernstein cost`, cost anomaly detection active |
-| [Per-agent token progress](../observability/token-progress.md) | Full | Tracked in `api_usage.py`, surfaced in `bernstein status` |
-| [Session analytics](../operations/session-analytics.md) | Full | `bernstein recap` shows session-level stats |
-| [Debug bundle](../operations/debug-bundle.md) | Full | `bernstein debug` collects logs/state/config for triage |
+| Capability | Docs status | Maturity | Notes |
+|---|---|---|---|
+| `/status` and task API | Full | 3 | Core API documented |
+| [Prometheus `/metrics`](../operations/observability-overview.md) | Full | 3 | Endpoint is real; Grafana dashboards are user-defined |
+| [OTLP telemetry initialization](../operations/observability-overview.md) | Full | 3 | Wiring exists in `core/observability/` |
+| [OTel GenAI span projection](../operations/observability-overview.md) | Full | 3 | `trace project` projects a run journal into signed OTel GenAI spans; `trace verify-projection` recomputes span ids |
+| Live OTLP bridge | Full | 3 | The signed span projection streams to any OpenTelemetry collector live or via `telemetry export-otel`; `telemetry verify-span` recomputes a span id from its journal entry (`core/telemetry/`) |
+| Retrospective reporting (`retro`) | Full | 3 | CLI coverage present |
+| Cost analysis (`cost`, history/anomaly hooks) | Full | 4 | `bernstein cost`, cost anomaly detection active |
+| [Per-agent token progress](../observability/token-progress.md) | Full | 3 | Tracked in `api_usage.py`, surfaced in `bernstein status` |
+| [Session analytics](../operations/session-analytics.md) | Full | 3 | `bernstein recap` shows session-level stats |
+| [Debug bundle](../operations/debug-bundle.md) | Full | 4 | `bernstein debug` collects logs/state/config for triage |
 
 ## Safety and governance
 
-| Capability | Docs status | Notes |
-|---|---|---|
-| Quality gates (lint, type-check, tests) | Full | In the run flow; extended with coverage, benchmark, arch-conformance, and mutation-testing gates |
-| [PII scan quality gate](../security/pii-scan-gate.md) | Full | Active, auto-installed via `log_redact.py` |
-| Rule enforcement (`.bernstein/rules.yaml`) | Full | Enforcement behavior documented |
-| [Log redaction (PII filter)](../security/log-redaction.md) | Full | Active |
-| Lethal-trifecta capability gate | Full | Taint-aware egress denial: a chain that unions private data, tainted input, and external comms is refused even when static tags would pass (`core/security/capability_matrix.py`) |
-| Circuit breaker | Full | Halts misbehaving agents, writes SHUTDOWN signal |
-| [Token growth monitor](../operations/token-growth-monitor.md) | Full | Auto-intervention on runaway consumption |
-| [Cost anomaly detection](../operations/cost-anomaly-detection.md) | Full | Z-score based, acts via task completion |
-| [Agent loop detection](../operations/agent-loop-detection.md) | Full | Kills agents in edit-loop cycles |
-| [Deadlock detection](../architecture/deadlock-detection.md) | Full | Wait-for graph, automatic victim selection |
-| [Cross-model verification](../architecture/quality-pipeline.md) | Full | A different model reviews completed diffs (opt-in) |
-| [Behaviour anomaly detection](../operations/observability-overview.md) | Full | Flags agents whose runtime metrics deviate statistically from baseline (`core/observability/behavior_anomaly.py`) |
-| [Context degradation detector](../architecture/context-degradation-detector.md) | Full | Monitors quality over time, restarts when degraded |
-| Agent trust tiers | Brief | `bernstein agents trust`; tiers accrue from task outcomes in `.sdd/trust/` and map to an `AgentPermissions` profile (`core/agents/agent_trust.py`) |
+| Capability | Docs status | Maturity | Notes |
+|---|---|---|---|
+| Quality gates (lint, type-check, tests) | Full | 3 | In the run flow; extended with coverage, benchmark, arch-conformance, and mutation-testing gates |
+| [PII scan quality gate](../security/pii-scan-gate.md) | Full | 3 | Active, auto-installed via `log_redact.py` |
+| Rule enforcement (`.bernstein/rules.yaml`) | Full | 3 | Enforcement behavior documented |
+| [Log redaction (PII filter)](../security/log-redaction.md) | Full | 3 | Active |
+| Lethal-trifecta capability gate | Full | 3 | Taint-aware egress denial: a chain that unions private data, tainted input, and external comms is refused even when static tags would pass (`core/security/capability_matrix.py`) |
+| Circuit breaker | Full | 3 | Halts misbehaving agents, writes SHUTDOWN signal |
+| [Token growth monitor](../operations/token-growth-monitor.md) | Full | 3 | Auto-intervention on runaway consumption |
+| [Cost anomaly detection](../operations/cost-anomaly-detection.md) | Full | 3 | Z-score based, acts via task completion |
+| [Agent loop detection](../operations/agent-loop-detection.md) | Full | 3 | Kills agents in edit-loop cycles |
+| [Deadlock detection](../architecture/deadlock-detection.md) | Full | 3 | Wait-for graph, automatic victim selection |
+| [Cross-model verification](../architecture/quality-pipeline.md) | Full | 3 | A different model reviews completed diffs (opt-in) |
+| [Behaviour anomaly detection](../operations/observability-overview.md) | Full | 3 | Flags agents whose runtime metrics deviate statistically from baseline (`core/observability/behavior_anomaly.py`) |
+| [Context degradation detector](../architecture/context-degradation-detector.md) | Full | 3 | Monitors quality over time, restarts when degraded |
+| Agent trust tiers | Brief | 3 | `bernstein agents trust`; tiers accrue from task outcomes in `.sdd/trust/` and map to an `AgentPermissions` profile (`core/agents/agent_trust.py`) |
 
 ## Verifiability and provenance
 
-| Capability | Docs status | Notes |
-|---|---|---|
-| Unified lineage spine | Full | The journal head is sealed into a single lineage root at run finalization; artifact provenance and replay identity share that root (`core/lineage/`) |
-| Always-on event journal | Full | Merkle-chained per-run `EventJournal`; the head hash is the run identity (`core/replay/journal.py`) |
-| HMAC-chained audit log | Full | Tamper-evident, daily rotation, cross-process append lock (`core/security/audit_chain.py`) |
-| [Execution WAL](../architecture/state-persistence.md) | Full | Hash-chained write-ahead log for crash recovery and determinism fingerprinting |
-| Deterministic replay + fork | Full | `replay --verify` recomputes the journal head; `fork --from-step` rebuilds state at a journal step into an isolated run (`core/replay/`) |
-| Audit-chain export | Full | Projects a chain range into COSE_Sign1, in-toto, and DSSE receipts re-verifiable offline with no Bernstein imports (`core/security/audit_export.py`) |
-| Provenance trust classes | Full | Every tool result carries a trust class; effective trust is the minimum over the lineage closure, recomputed offline by `audit taint` (`core/lineage/provenance.py`) |
-| [Gate adjudication records](../operations/gate-adjudication.md) | Full | Gate panel decisions are recomputable; `gate verify` confirms the inputs hash |
-| [In-process verification gates](../operations/hook-gate.md) | Full | Verification-gate hooks rendered into capable adapters so the check runs inside the agent (`adapters/hook_gate_render.py`) |
-| Evidence bundles | Full | Sealed verification-evidence bundle, projectable as a tracker comment (`core/evidence/bundle.py`) |
-| Intent capsules | Full | Approval compiles the goal into a signed capsule; a deterministic drift monitor escalates divergence, verified by `intent verify` (`core/security/intent_capsule.py`) |
-| Query receipts (datasources) | Full | Read-only SQL results become content-addressed signed receipts; `datasource verify --re-execute` reports MATCH or DRIFT (`core/datasources/`) |
-| Compaction receipts | Full | Context and template compaction is recorded as a chain-anchored, reversible receipt (`core/tokens/compaction_receipt.py`) |
-| Tamper-evident memory | Full | Memory entries are hash-chained with provenance; `memory verify/why/forget` proves authorship, traces origin, and tombstones (`core/memory/chain.py`) |
-| [Review / autofix / escalation / consent / webhook-node receipts](../operations/review-receipts.md) | Full | Signed, journal-anchored receipts verified offline (`review-receipt verify`, `escalation verify`, `webhook verify`) |
-| [Stall escalation receipts](../operations/stall-escalation.md) | Full | A stalled worker produces a signed escalation receipt embedding the last audit entries and a deterministic recommended action (`supervisor escalate`) |
-| C2PA content credentials | Full | Artifact lineage projected into signed C2PA credentials (`credential emit/verify`) |
-| Skill install receipts | Full | Install and usage links recomputable via `skill verify` / `skill provenance` |
-| Adapter security-floor receipts | Full | A below-floor adapter spawn is refused with a content-addressed, chain-anchored refusal receipt (`adapters/security_floor.py`) |
-| Endpoint certification | Full | Local-model workers are conformance-tested and issued a signed certification (`core/endpoints/certification.py`) |
-| SLA violation receipts | Full | Per-goal SLA contracts evaluated read-only each tick; a breach becomes a signed, offline-verifiable violation receipt (`core/planning/sla_store.py`) |
-| Signed daily mission digests | Full | Each day's mission progress is a signed digest projecting that day's chain; `mission digest verify` re-derives it (`core/orchestration/mission_digest.py`) |
-| [Agent run manifest](../operations/run-manifest.md) | Full | Hashable workflow spec for SOC 2 evidence |
-| [RBAC / budget / seat projections](../operations/governance.md) | Full | Access and budget verdicts re-derivable via `governance verify` |
-| [Unified event feed](../events/grammar.md) | Full | Chain-projected event feed with a typed grammar and per-event receipts (`core/events/feed.py`) |
+| Capability | Docs status | Maturity | Notes |
+|---|---|---|---|
+| Unified lineage spine | Full | 4 | The journal head is sealed into a single lineage root at run finalization; artifact provenance and replay identity share that root (`core/lineage/`) |
+| Always-on event journal | Full | 3 | Merkle-chained per-run `EventJournal`; the head hash is the run identity (`core/replay/journal.py`) |
+| HMAC-chained audit log | Full | 4 | Tamper-evident, daily rotation, cross-process append lock (`core/security/audit_chain.py`) |
+| [Execution WAL](../architecture/state-persistence.md) | Full | 3 | Hash-chained write-ahead log for crash recovery and determinism fingerprinting |
+| Deterministic replay + fork | Full | 3 | `replay --verify` recomputes the journal head; `fork --from-step` rebuilds state at a journal step into an isolated run (`core/replay/`) |
+| Audit-chain export | Full | 4 | Projects a chain range into COSE_Sign1, in-toto, and DSSE receipts re-verifiable offline with no Bernstein imports (`core/security/audit_export.py`) |
+| Provenance trust classes | Full | 4 | Every tool result carries a trust class; effective trust is the minimum over the lineage closure, recomputed offline by `audit taint` (`core/lineage/provenance.py`) |
+| [Gate adjudication records](../operations/gate-adjudication.md) | Full | 3 | Gate panel decisions are recomputable; `gate verify` confirms the inputs hash |
+| [In-process verification gates](../operations/hook-gate.md) | Full | 3 | Verification-gate hooks rendered into capable adapters so the check runs inside the agent (`adapters/hook_gate_render.py`) |
+| Evidence bundles | Full | 3 | Sealed verification-evidence bundle, projectable as a tracker comment (`core/evidence/bundle.py`) |
+| Intent capsules | Full | 3 | Approval compiles the goal into a signed capsule; a deterministic drift monitor escalates divergence, verified by `intent verify` (`core/security/intent_capsule.py`) |
+| Query receipts (datasources) | Full | 3 | Read-only SQL results become content-addressed signed receipts; `datasource verify --re-execute` reports MATCH or DRIFT (`core/datasources/`) |
+| Compaction receipts | Full | 3 | Context and template compaction is recorded as a chain-anchored, reversible receipt (`core/tokens/compaction_receipt.py`) |
+| Tamper-evident memory | Full | 4 | Memory entries are hash-chained with provenance; `memory verify/why/forget` proves authorship, traces origin, and tombstones (`core/memory/chain.py`) |
+| [Review / autofix / escalation / consent / webhook-node receipts](../operations/review-receipts.md) | Full | 3 | Signed, journal-anchored receipts verified offline (`review-receipt verify`, `escalation verify`, `webhook verify`) |
+| [Stall escalation receipts](../operations/stall-escalation.md) | Full | 3 | A stalled worker produces a signed escalation receipt embedding the last audit entries and a deterministic recommended action (`supervisor escalate`) |
+| C2PA content credentials | Full | 3 | Artifact lineage projected into signed C2PA credentials (`credential emit/verify`) |
+| Skill install receipts | Full | 3 | Install and usage links recomputable via `skill verify` / `skill provenance` |
+| Adapter security-floor receipts | Full | 3 | A below-floor adapter spawn is refused with a content-addressed, chain-anchored refusal receipt (`adapters/security_floor.py`) |
+| Endpoint certification | Full | 3 | Local-model workers are conformance-tested and issued a signed certification (`core/endpoints/certification.py`) |
+| SLA violation receipts | Full | 3 | Per-goal SLA contracts evaluated read-only each tick; a breach becomes a signed, offline-verifiable violation receipt (`core/planning/sla_store.py`) |
+| Signed daily mission digests | Full | 3 | Each day's mission progress is a signed digest projecting that day's chain; `mission digest verify` re-derives it (`core/orchestration/mission_digest.py`) |
+| [Agent run manifest](../operations/run-manifest.md) | Full | 3 | Hashable workflow spec for SOC 2 evidence |
+| [RBAC / budget / seat projections](../operations/governance.md) | Full | 3 | Access and budget verdicts re-derivable via `governance verify` |
+| [Unified event feed](../events/grammar.md) | Full | 3 | Chain-projected event feed with a typed grammar and per-event receipts (`core/events/feed.py`) |
 
 ## Identity and delegation
 
-| Capability | Docs status | Notes |
-|---|---|---|
-| [Native subagent delegation](../architecture/subagent-delegation.md) | Full | The scheduler delegates leaf execution to native subagents; schema-validated results anchor as `subagent.delegation` journal entries, chain verified via `delegation verify` (`core/agents/subagent_delegation.py`) |
-| [Attenuated capability tokens](../operations/security-and-identity.md) | Full | Each delegation hop is a signed, scope-attenuating token, so the principal to orchestrator to sub-agent authority chain verifies offline (`core/security/capability_tokens.py`) |
-| Signed agent cards | Full | `AgentIdentityCard` signed for A2A federation and served at `/.well-known/agent-card.json` (`core/security/agent_card_signer.py`) |
-| A2A node + message receipts | Full | Callable JSON-RPC node; a completed task returns an artifact whose parts carry a lineage receipt verified by `a2a verify` (`core/interop/a2a_card.py`) |
-| HTTP message signatures | Full | RFC 9421 Ed25519 signatures on outbound agent-facing requests; keys served as JWKS via `identity keydir` (`core/identity/http_signing.py`) |
-| SPIFFE workload identity | Full | SPIFFE/SVID workload identity with `spiffe id` and `spiffe verify-binding` (`core/identity/spiffe/`) |
+| Capability | Docs status | Maturity | Notes |
+|---|---|---|---|
+| [Native subagent delegation](../architecture/subagent-delegation.md) | Full | 4 | The scheduler delegates leaf execution to native subagents; schema-validated results anchor as `subagent.delegation` journal entries, chain verified via `delegation verify` (`core/agents/subagent_delegation.py`) |
+| [Attenuated capability tokens](../operations/security-and-identity.md) | Full | 4 | Each delegation hop is a signed, scope-attenuating token, so the principal to orchestrator to sub-agent authority chain verifies offline (`core/security/capability_tokens.py`) |
+| Signed agent cards | Full | 4 | `AgentIdentityCard` signed for A2A federation and served at `/.well-known/agent-card.json` (`core/security/agent_card_signer.py`) |
+| A2A node + message receipts | Full | 4 | Callable JSON-RPC node; a completed task returns an artifact whose parts carry a lineage receipt verified by `a2a verify` (`core/interop/a2a_card.py`) |
+| HTTP message signatures | Full | 4 | RFC 9421 Ed25519 signatures on outbound agent-facing requests; keys served as JWKS via `identity keydir` (`core/identity/http_signing.py`) |
+| SPIFFE workload identity | Full | 4 | SPIFFE/SVID workload identity with `spiffe id` and `spiffe verify-binding` (`core/identity/spiffe/`) |
 
 ## Payments and cost governance
 
-| Capability | Docs status | Notes |
-|---|---|---|
-| Spending mandates | Full | Authorized-spend mandates enforced before a paid action, with signed spend receipts (`core/payments/`) |
-| [Authorized-action mandates](../operations/spending-mandates.md) | Full | `mandate emit/verify/revoke` binds, proves, and revokes an authorized-action mandate |
-| Cost-policy receipts | Full | The live dispatch gate records batch, cache, and model policy verdicts as receipts (`core/cost/scheduling/receipt.py`) |
-| [Budget envelopes](../operations/cost-envelopes.md) | Full | Per-phase and per-task budget envelopes with rollup by envelope (`core/cost/cost_rollup_by_envelope.py`) |
+| Capability | Docs status | Maturity | Notes |
+|---|---|---|---|
+| Spending mandates | Full | 3 | Authorized-spend mandates enforced before a paid action, with signed spend receipts (`core/payments/`) |
+| [Authorized-action mandates](../operations/spending-mandates.md) | Full | 3 | `mandate emit/verify/revoke` binds, proves, and revokes an authorized-action mandate |
+| Cost-policy receipts | Full | 4 | The live dispatch gate records batch, cache, and model policy verdicts as receipts (`core/cost/scheduling/receipt.py`) |
+| [Budget envelopes](../operations/cost-envelopes.md) | Full | 4 | Per-phase and per-task budget envelopes with rollup by envelope (`core/cost/cost_rollup_by_envelope.py`) |
 
 ## Ecosystem and integrations
 
-| Capability | Docs status | Notes |
-|---|---|---|
-| Agent catalog/discovery | Full | `bernstein agents sync/list/discover/match/showcase` (40+ CLI agent adapters) |
-| Browser / computer-use adapter | Full | Adapter family for autonomous browser and computer-use agents; every action is a content-addressed lineage anchor (`adapters/computer_use.py`) |
-| GitHub App and CI fix flows | Full | `bernstein ci fix <url>`, `github setup` |
-| [Trigger sources](../operations/trigger-sources.md) | Full | `github`, `gitlab`, `slack`, `discord`, `file_watch`, `webhook`, `odata`, and `schedule` source adapters (`core/trigger_sources/`) |
-| [OData trigger source](../operations/odata.md) | Full | Polls an OData endpoint into normalized trigger events (`core/trigger_sources/odata_poll.py`) |
-| [Webhook node](../operations/webhook-node.md) | Full | Outbound webhook node with recomputable inbound-event and node hashes (`core/trigger_sources/webhook_node.py`, `webhook verify`) |
-| Automation bridge | Full | Signed trigger receipts and chain-anchored status callbacks for external automations (`core/trigger_sources/automation_platforms.py`) |
-| Plugin hooks (pluggy) | Full | SDK docs in CONTRIBUTING.md |
-| Cluster/worker primitives | Full | `bernstein worker --server URL`, cluster routes documented |
-| Multi-repo workspaces | Full | `workspace:` in bernstein.yaml, workspace CLI |
-| [MCP server mode](../mcp/server.md) | Full | `bernstein mcp`, MCP server in `mcp/server.py` |
-| [MCP tool registry](../integrations/mcp-server-injection.md) | Full | Auto-discovery and per-task config |
-| [MCP catalog client](mcp-catalog.md) | Full | `bernstein mcp catalog browse/search/install` installable server catalog (`core/protocols/mcp_catalog/`) |
-| [MCP input contracts](../mcp/input-validation.md) | Full | Schema-validated, deny-by-default MCP tool-call input firewall (`mcp/input_validation.py`); the enforced schema is also the advertised `inputSchema` |
-| [Stateless MCP anchoring](../mcp/server.md) | Full | A stateless MCP client can poll a run and verify it offline; calls anchor as `mcp.stateless_call` journal entries (`core/protocols/mcp/stateless_core.py`) |
-| [Runtime capability cards (MCP)](../mcp/server.md) | Full | Per-server capability cards for the MCP server (`mcp/capability.py`) |
-| ACP native bridge | Full | `bernstein acp serve --stdio\|--http :PORT` IDE-native bridge (`core/protocols/acp/`); see `reference/acp-bridge.md` |
-| [Protocol negotiation](../architecture/protocol-negotiation.md) | Full | `protocol_negotiation.py` runtime protocol-version handshake |
-| [Schema registry](../architecture/schema-registry.md) | Full | `schema_registry.py` versioned message schemas for protocols |
-| [Credential vault](../operations/secrets.md) | Full | `bernstein connect <provider>`, `bernstein creds list/revoke/test` OS-keychain token storage (`core/security/vault/`) |
-| [Autofix CI daemon](../operations/autofix.md) | Full | `bernstein autofix start/stop/status/attach` watches PRs and dispatches repair runs on CI failure (`core/autofix/`) |
-| [Dev preview](../operations/preview.md) | Full | `bernstein preview start/stop/list/status` exposes an agent dev server via tunnel with configurable auth (`core/preview/`) |
-| [Fleet dashboard](../operations/fleet.md) | Full | `bernstein fleet [--web HOST:PORT]` cross-session multi-instance view (`core/fleet/`) |
-| [Notification sinks](../operations/notifications.md) | Full | `bernstein notify test --sink <id>` pluggable notification backends (`core/notifications/`) |
-| [PR review responder](../operations/review-responder.md) | Full | `bernstein review-responder start/status/tick` auto-responds to PR review comments (`core/review_responder/`) |
-| [Review pipeline DSL](../operations/review-pipeline.md) | Full | `bernstein review --pipeline review.yaml` YAML-driven multi-phase review (`core/quality/review_pipeline/`) |
-| [Plan archival](../operations/plan-archival.md) | Full | `bernstein plan ls/show` list and inspect archived plans (`core/planning/lifecycle.py`) |
-| [Slack integration](../operations/slack-webhooks.md) | Full | Slash commands and events API endpoints |
-| [Webhook ingestion](../integrations/automation-bridge.md) | Full | `POST /webhooks/` for external event routing |
-| [Adaptive parallelism](../architecture/adaptive-parallelism.md) | Full | Auto-tunes concurrency from observed success rates (`core/orchestration/adaptive_parallelism.py`) |
-| [Warm pool](../architecture/warm-pool.md) | Full | Pre-spawned agent pool to cut spawn latency (`core/agents/warm_pool.py`) |
-| Pluggable sandbox backends | Full | Worktree, Docker, E2B, and Modal backends behind a `SandboxSession` protocol |
-| microVM sandbox backend | Brief | Isolation tier with content-addressed snapshots for deterministic fork-and-race (`--sandbox microvm`) |
-| Named sandbox pools | Full | Chain-projected pool manifests with capability and egress ceilings and signed worker enrolment (`core/sandbox/pool.py`) |
-| Cache policy engine | Full | Content-addressed key recipes, drift expiry, and fleet dedup with signed duplicate-of receipts (`core/persistence/cache_policy.py`) |
-| Sovereign deployment profile | Full | Signed residency-posture attestation; posture drift at spawn is a signed refusal (`core/security/deployment_profile.py`) |
-| [Workflow DSL](../operations/workflow-manifests.md) | Full | `bernstein workflow validate/list/show` |
-| [Chaos engineering](../operations/chaos-engineering.md) | Full | `bernstein chaos agent-kill/file-remove/status/slo` |
-| Benchmark suite | Full | `bernstein eval run/compare/swe-bench/programbench` |
-| [Eval harness](../eval/golden-harness.md) | Full | `bernstein eval run/report/failures` |
-| SWE-Bench harness | Full | Verified eval in `benchmarks/swe_bench/run.py` |
-| [Graduation system](../operations/graduation.md) | Full | Agent promotion stages, routes in `routes/graduation.py` |
-| [Semantic caching](../concepts/semantic-caching.md) | Full | `semantic_cache.py` prompt deduplication |
-| [Cascade router (intra-Claude tier escalation)](../architecture/model-routing.md) | Full | Tier escalation within a single provider (`core/routing/cascade_router.py`) |
-| [Cascade fallback manager (cross-adapter failover)](../architecture/model-routing.md) | Full | Cross-adapter provider failover (`core/routing/cascade.py`) |
-| [Batch router](../architecture/batch-routing.md) | Full | Task batching for non-urgent work |
-| [Prompt caching](../operations/performance-tuning.md) | Full | SHA-256 system prefix deduplication |
-| Output style customization | Brief | `.bernstein/output-styles/*.md`, selected by `output_style:` in `bernstein.yaml`, injected into the spawn prompt |
-| [Installation mismatch detection](../operations/doctor.md) | Full | Detects adapter/installation gaps |
-| [Worker badge identity](../operations/worker-process-identity.md) | Full | Process identification in `ps`/Activity Monitor |
-| [Keybinding system (TUI)](../operations/tui-keybindings.md) | Full | Configurable TUI keyboard shortcuts |
-| Diff folding display | Brief | `bernstein diff --fold`; the TUI agent log also folds long diffs in its historical tail |
-| Word-level diff rendering | Brief | `bernstein diff --word-diff` highlights only the tokens that changed |
-| Contextual tips system | Brief | One cooldown-limited hint after an interactive command; `BERNSTEIN_NO_TIPS` opts out |
-| Security review command | Brief | `bernstein security-review` pattern-scans a diff for secrets, injection, and weak crypto |
-| [Commit attribution stats](../operations/commit-attribution.md) | Full | Per-agent commit statistics |
-| Away summary generation | Brief | `bernstein recap --since 6h` builds the report from workspace files, no server needed |
-| Plugin trust warning | Brief | Trust tier and score per plugin in `bernstein plugins` (`--trust-details` for the signal breakdown) |
-| [Cumulative progress tracking](../observability/cumulative-progress.md) | Full | Progress tracking across runs |
+| Capability | Docs status | Maturity | Notes |
+|---|---|---|---|
+| Agent catalog/discovery | Full | 3 | `bernstein agents sync/list/discover/match/showcase` (40+ CLI agent adapters) |
+| Browser / computer-use adapter | Full | 3 | Adapter family for autonomous browser and computer-use agents; every action is a content-addressed lineage anchor (`adapters/computer_use.py`) |
+| GitHub App and CI fix flows | Full | 3 | `bernstein ci fix <url>`, `github setup` |
+| [Trigger sources](../operations/trigger-sources.md) | Full | 3 | `github`, `gitlab`, `slack`, `discord`, `file_watch`, `webhook`, `odata`, and `schedule` source adapters (`core/trigger_sources/`) |
+| [OData trigger source](../operations/odata.md) | Full | 3 | Polls an OData endpoint into normalized trigger events (`core/trigger_sources/odata_poll.py`) |
+| [Webhook node](../operations/webhook-node.md) | Full | 3 | Outbound webhook node with recomputable inbound-event and node hashes (`core/trigger_sources/webhook_node.py`, `webhook verify`) |
+| Automation bridge | Full | 3 | Signed trigger receipts and chain-anchored status callbacks for external automations (`core/trigger_sources/automation_platforms.py`) |
+| Plugin hooks (pluggy) | Full | 3 | SDK docs in CONTRIBUTING.md |
+| Cluster/worker primitives | Full | 2 | `bernstein worker --server URL`, cluster routes documented |
+| Multi-repo workspaces | Full | 3 | `workspace:` in bernstein.yaml, workspace CLI |
+| [MCP server mode](../mcp/server.md) | Full | 3 | `bernstein mcp`, MCP server in `mcp/server.py` |
+| [MCP tool registry](../integrations/mcp-server-injection.md) | Full | 3 | Auto-discovery and per-task config |
+| [MCP catalog client](mcp-catalog.md) | Full | 3 | `bernstein mcp catalog browse/search/install` installable server catalog (`core/protocols/mcp_catalog/`) |
+| [MCP input contracts](../mcp/input-validation.md) | Full | 3 | Schema-validated, deny-by-default MCP tool-call input firewall (`mcp/input_validation.py`); the enforced schema is also the advertised `inputSchema` |
+| [Stateless MCP anchoring](../mcp/server.md) | Full | 3 | A stateless MCP client can poll a run and verify it offline; calls anchor as `mcp.stateless_call` journal entries (`core/protocols/mcp/stateless_core.py`) |
+| [Runtime capability cards (MCP)](../mcp/server.md) | Full | 3 | Per-server capability cards for the MCP server (`mcp/capability.py`) |
+| ACP native bridge | Full | 3 | `bernstein acp serve --stdio\|--http :PORT` IDE-native bridge (`core/protocols/acp/`); see `reference/acp-bridge.md` |
+| [Protocol negotiation](../architecture/protocol-negotiation.md) | Full | 3 | `protocol_negotiation.py` runtime protocol-version handshake |
+| [Schema registry](../architecture/schema-registry.md) | Full | 3 | `schema_registry.py` versioned message schemas for protocols |
+| [Credential vault](../operations/secrets.md) | Full | 3 | `bernstein connect <provider>`, `bernstein creds list/revoke/test` OS-keychain token storage (`core/security/vault/`) |
+| [Autofix CI daemon](../operations/autofix.md) | Full | 3 | `bernstein autofix start/stop/status/attach` watches PRs and dispatches repair runs on CI failure (`core/autofix/`) |
+| [Dev preview](../operations/preview.md) | Full | 3 | `bernstein preview start/stop/list/status` exposes an agent dev server via tunnel with configurable auth (`core/preview/`) |
+| [Fleet dashboard](../operations/fleet.md) | Full | 3 | `bernstein fleet [--web HOST:PORT]` cross-session multi-instance view (`core/fleet/`) |
+| [Notification sinks](../operations/notifications.md) | Full | 3 | `bernstein notify test --sink <id>` pluggable notification backends (`core/notifications/`) |
+| [PR review responder](../operations/review-responder.md) | Full | 3 | `bernstein review-responder start/status/tick` auto-responds to PR review comments (`core/review_responder/`) |
+| [Review pipeline DSL](../operations/review-pipeline.md) | Full | 3 | `bernstein review --pipeline review.yaml` YAML-driven multi-phase review (`core/quality/review_pipeline/`) |
+| [Plan archival](../operations/plan-archival.md) | Full | 3 | `bernstein plan ls/show` list and inspect archived plans (`core/planning/lifecycle.py`) |
+| [Slack integration](../operations/slack-webhooks.md) | Full | 3 | Slash commands and events API endpoints |
+| [Webhook ingestion](../integrations/automation-bridge.md) | Full | 3 | `POST /webhooks/` for external event routing |
+| [Adaptive parallelism](../architecture/adaptive-parallelism.md) | Full | 3 | Auto-tunes concurrency from observed success rates (`core/orchestration/adaptive_parallelism.py`) |
+| [Warm pool](../architecture/warm-pool.md) | Full | 3 | Pre-spawned agent pool to cut spawn latency (`core/agents/warm_pool.py`) |
+| Pluggable sandbox backends | Full | 3 | Worktree, Docker, E2B, and Modal backends behind a `SandboxSession` protocol |
+| microVM sandbox backend | Brief | 3 | Isolation tier with content-addressed snapshots for deterministic fork-and-race (`--sandbox microvm`) |
+| Named sandbox pools | Full | 3 | Chain-projected pool manifests with capability and egress ceilings and signed worker enrolment (`core/sandbox/pool.py`) |
+| Cache policy engine | Full | 3 | Content-addressed key recipes, drift expiry, and fleet dedup with signed duplicate-of receipts (`core/persistence/cache_policy.py`) |
+| Sovereign deployment profile | Full | 3 | Signed residency-posture attestation; posture drift at spawn is a signed refusal (`core/security/deployment_profile.py`) |
+| [Workflow DSL](../operations/workflow-manifests.md) | Full | 3 | `bernstein workflow validate/list/show` |
+| [Chaos engineering](../operations/chaos-engineering.md) | Full | 3 | `bernstein chaos agent-kill/file-remove/status/slo` |
+| Benchmark suite | Full | 4 | `bernstein eval run/compare/swe-bench/programbench` |
+| [Eval harness](../eval/golden-harness.md) | Full | 4 | `bernstein eval run/report/failures` |
+| SWE-Bench harness | Full | 4 | Verified eval in `benchmarks/swe_bench/run.py` |
+| [Graduation system](../operations/graduation.md) | Full | 2 | Agent promotion stages, routes in `routes/graduation.py` |
+| [Semantic caching](../concepts/semantic-caching.md) | Full | 3 | `semantic_cache.py` prompt deduplication |
+| [Cascade router (intra-Claude tier escalation)](../architecture/model-routing.md) | Full | 3 | Tier escalation within a single provider (`core/routing/cascade_router.py`) |
+| [Cascade fallback manager (cross-adapter failover)](../architecture/model-routing.md) | Full | 3 | Cross-adapter provider failover (`core/routing/cascade.py`) |
+| [Batch router](../architecture/batch-routing.md) | Full | 3 | Task batching for non-urgent work |
+| [Prompt caching](../operations/performance-tuning.md) | Full | 3 | SHA-256 system prefix deduplication |
+| Output style customization | Brief | 3 | `.bernstein/output-styles/*.md`, selected by `output_style:` in `bernstein.yaml`, injected into the spawn prompt |
+| [Installation mismatch detection](../operations/doctor.md) | Full | 4 | Detects adapter/installation gaps |
+| [Worker badge identity](../operations/worker-process-identity.md) | Full | 3 | Process identification in `ps`/Activity Monitor |
+| [Keybinding system (TUI)](../operations/tui-keybindings.md) | Full | 2 | Configurable TUI keyboard shortcuts |
+| Diff folding display | Brief | 3 | `bernstein diff --fold`; the TUI agent log also folds long diffs in its historical tail |
+| Word-level diff rendering | Brief | 3 | `bernstein diff --word-diff` highlights only the tokens that changed |
+| Contextual tips system | Brief | 3 | One cooldown-limited hint after an interactive command; `BERNSTEIN_NO_TIPS` opts out |
+| Security review command | Brief | 3 | `bernstein security-review` pattern-scans a diff for secrets, injection, and weak crypto |
+| [Commit attribution stats](../operations/commit-attribution.md) | Full | 3 | Per-agent commit statistics, via `bernstein report commits` |
+| Away summary generation | Brief | 3 | `bernstein recap --since 6h` builds the report from workspace files, no server needed |
+| Plugin trust warning | Brief | 3 | Trust tier and score per plugin in `bernstein plugins` (`--trust-details` for the signal breakdown) |
+| [Cumulative progress tracking](../observability/cumulative-progress.md) | Full | 3 | Progress tracking across runs |
 
 ## CLI commands
 
-| Command | Docs status | Notes |
-|---|---|---|
-| `bernstein -g GOAL` | Full | Inline goal |
-| `bernstein run plan.yaml` | Full | Plan file execution |
-| `bernstein init` | Full | Workspace setup |
-| `bernstein stop` | Full | Graceful/force stop |
-| `bernstein live` | Full | TUI dashboard |
-| `bernstein dashboard` | Full | Web dashboard |
-| `bernstein status` | Full | Task summary |
-| `bernstein ps` | Full | Process list |
-| `bernstein cost` | Full | Spend breakdown |
-| `bernstein doctor` | Full | Pre-flight health check |
-| `bernstein recap` | Full | Post-run summary |
-| `bernstein retro` | Full | Retrospective report |
-| `bernstein trace ID` | Full | Decision trace |
-| `bernstein logs` | Full | Agent log tail |
-| `bernstein diff ID` | Full | Per-task git diff |
-| `bernstein plan` | Full | Task backlog |
-| `bernstein plan compile` | Full | Compile a spec into a gated task graph offline |
-| [`bernstein replay ID`](../operations/replay.md) | Full | Deterministic replay |
-| [`bernstein checkpoint`](../operations/checkpoint.md) | Full | Session snapshot |
-| [`bernstein wrap-up`](../operations/wrap-up.md) | Full | End session with summary |
-| `bernstein demo` | Full | Zero-config demo |
-| [`bernstein demo --flask-todo`](../getting-started/quickstart-demo.md) | Full | Flask TODO demo (3 tasks). `bernstein quickstart` is a deprecated alias, removed in 4.0.0. |
-| `bernstein agents ...` | Full | Catalog management |
-| `bernstein evolve ...` | Full | Self-improvement |
-| `bernstein ci fix` | Full | CI autofix |
-| `bernstein github setup` | Full | GitHub App setup |
-| [`bernstein worker`](../operations/cluster-mode.md) | Full | Join cluster as worker |
-| [`bernstein mcp`](../mcp/server.md) | Full | Run as MCP server |
-| [`bernstein chaos`](../operations/chaos-engineering.md) | Full | Fault injection |
-| [`bernstein audit`](../security/audit-log.md) | Full | Cryptographic audit (`seal/verify/export/taint/pack/slice`) |
-| [`bernstein verify`](cli/verify.md) | Full | Merkle/HMAC verification |
-| `bernstein benchmark` | Full | Deprecated alias for `bernstein eval`, removed in v4.0.0 |
-| [`bernstein eval`](../eval/golden-harness.md) | Full | Evaluation harness |
-| `bernstein workspace` | Full | Multi-repo workspace |
-| [`bernstein config`](../operations/global-config.md) | Full | Configuration management |
-| `bernstein quarantine` | Brief | Cross-run task quarantine read from `.sdd/runtime/quarantine.json` (`list`, `clear`) |
-| [`bernstein cache`](../concepts/semantic-caching.md) | Full | Response cache management |
-| [`bernstein test-adapter`](../adapters/test-adapter.md) | Full | Adapter smoke test |
-| [`bernstein add-task`](cli/task-lifecycle.md) | Full | Inject task via CLI |
-| [`bernstein cancel`](cli/task-lifecycle.md) | Full | Cancel task |
-| [`bernstein review/approve/reject/pending`](cli/task-lifecycle.md) | Full | Review workflow |
-| [`bernstein sync`](../operations/backlog-sync.md) | Full | Sync backlog with server |
-| [`bernstein manifest`](../operations/run-manifest.md) | Full | Run manifest inspection |
-| [`bernstein gateway`](../operations/mcp-gateway.md) | Full | MCP gateway proxy |
-| [`bernstein workflow`](../operations/workflow-manifests.md) | Full | Workflow DSL |
-| [`bernstein watch`](../operations/watch.md) | Full | Directory file watcher |
-| [`bernstein listen`](../operations/voice-control.md) | Full | Voice commands (experimental) |
-| [`bernstein completions`](../operations/shell-completions.md) | Full | Shell completion scripts |
-| [`bernstein self`](../operations/updates.md) | Full | Provenance-verified update lifecycle: signed feed, chain-anchored advisory, pre-install wheel verification, pin, receipted rollback |
-| [`bernstein self-update`](../operations/self-update.md) | Full | Compatibility alias for `bernstein self` |
-| [`bernstein plugins`](../integrations/plugin-sdk.md) | Full | List active plugins |
-| [`bernstein install-hooks`](../contributing/git-hooks.md) | Full | Install git hooks |
-| [`bernstein debug`](../operations/debug-bundle.md) | Full | Generate debug bundle for triage |
-| `bernstein acp serve` | Full | ACP bridge (`--stdio` or `--http :PORT`) |
-| [`bernstein autofix ...`](../operations/autofix.md) | Full | CI autofix daemon (start/stop/status/attach) |
-| [`bernstein connect`](../operations/secrets.md) | Full | Credential vault setup for a provider |
-| [`bernstein creds ...`](../operations/secrets.md) | Full | Credential management (list/revoke/test) |
-| [`bernstein preview ...`](../operations/preview.md) | Full | Dev server preview (start/stop/list/status) |
-| [`bernstein fleet`](../operations/fleet.md) | Full | Fleet dashboard (optionally `--web HOST:PORT`) |
-| [`bernstein fleet steer`](../operations/fleet-steering.md) | Full | Mid-run steering: pause/resume/guidance/redirect/abort |
-| [`bernstein mcp catalog ...`](mcp-catalog.md) | Full | MCP catalog browser (browse/search/install) |
-| [`bernstein notify test`](../operations/notifications.md) | Full | Notification sink smoke test |
-| [`bernstein plan ls/show`](../operations/plan-archival.md) | Full | List and inspect archived plans |
-| [`bernstein review-responder ...`](../operations/review-responder.md) | Full | PR review responder (start/status/tick) |
-| [`bernstein review --pipeline`](../operations/review-pipeline.md) | Full | Review with YAML pipeline DSL |
-| [`bernstein fork --run --from-step`](../operations/fork-from-step.md) | Full | Fork a run at a journal step into a new isolated run |
-| [`bernstein gate verify`](../operations/gate-adjudication.md) | Full | Recompute a gate panel's inputs hash and confirm the adjudication |
-| [`bernstein mandate emit/verify/revoke`](../operations/spending-mandates.md) | Full | Bind, prove, and revoke authorized-action mandates |
-| `bernstein payment-mandate issue/show/spend` | Full | Issue and spend against authorized-spend mandates with signed receipts |
-| [`bernstein governance verify`](../operations/governance.md) | Full | Recompute access and budget verdicts for a run |
-| [`bernstein webhook verify`](../operations/webhook-node.md) | Full | Recompute inbound-event and outbound webhook-node hashes |
-| [`bernstein review-receipt emit/verify`](../operations/review-receipts.md) | Full | Bind and offline-verify PR review receipts (issue + plan + tool calls + diff) |
-| [`bernstein escalation show/verify`](../operations/stall-escalation.md) | Full | Project and reconstruct escalation receipts from the journal |
-| [`bernstein supervisor status/escalate`](../api/supervisor.md) | Full | Supervise stalled workers and seal stall escalation receipts |
-| [`bernstein delegation verify`](../operations/delegation-verify.md) | Full | Reconstruct and verify a run's delegation chain |
-| [`bernstein credential emit/verify`](../operations/content-credentials.md) | Full | Project an artifact's lineage into a signed C2PA credential and verify it |
-| [`bernstein skills provenance/verify`](../operations/skill-provenance.md) | Full | Recompute a skill's install receipt and usage-provenance graph |
-| [`bernstein schedule verify/audit`, `schedule show --at`](../operations/schedule.md) | Full | Replay recorded fires, chain-check fire receipts, project a schedule at a time |
-| `bernstein sla add/list/show/verify/report` | Full | Attach per-goal SLA contracts; a breach is an offline-verifiable violation receipt |
-| [`bernstein trace project/verify-projection`](../observability/otel-span-projection.md) | Full | Project a run journal into signed OTel GenAI spans and verify the projection |
-| `bernstein telemetry export-otel/verify-span` | Full | Stream the span projection to an OTLP collector and verify a single span offline |
-| [`bernstein thread verify`](../operations/deterministic-replay.md) | Full | Prove a streamed TUI thread equals its executed journal |
-| `bernstein memory verify/why/forget` | Full | Prove authorship, trace origin, and tombstone a memory entry |
-| [`bernstein replay --verify/--from-step`](../operations/deterministic-replay.md) | Full | Recompute the journal head or rebuild state to a step |
-| `bernstein intent show/verify` | Full | Project and recompute an intent capsule's conformance offline |
-| `bernstein a2a verify/publish` | Full | Verify an A2A message receipt and publish the agent card |
-| `bernstein activity verify` | Full | Verify a typed activity's replay hashes (`activity browser run` for browser checks) |
-| `bernstein datasource register/query/verify` | Full | Register read-only SQL datasources and verify content-addressed query receipts |
-| [`bernstein evidence show/verify`](../operations/evidence-bundles.md) | Full | Project and verify a sealed evidence bundle |
-| [`bernstein events query/verify`](../events/grammar.md) | Full | Query the unified event feed and verify its chain projection |
-| `bernstein endpoints certify/verify` | Full | Conformance-certify a local-model endpoint and verify its certification |
-| `bernstein ledger verify/anchor/fetch` | Full | Verify, anchor, and fetch work-ledger segments |
-| `bernstein mission define/status/verify` | Full | Define multi-phase missions and verify mission status (`mission digest verify` for digests) |
-| [`bernstein tournament show/verify`](../operations/tournament-runs.md) | Full | Inspect a tournament run and verify its selection receipt |
-| `bernstein spiffe id/verify-binding` | Full | Print the SPIFFE id and verify a workload-identity binding |
-| `bernstein spec check/auto-fix` | Full | Evaluate and auto-fix a spec against the quality checklist |
-| [`bernstein run-service submit/attach/status`](../operations/run-service.md) | Full | Submit a detached run, then reattach to it later |
-| `bernstein compaction log` | Full | Inspect chain-anchored compaction receipts |
-| `bernstein identity keydir/decode/verify` | Full | Print the JWKS key directory and decode/verify install identity |
-| [`bernstein pool register/list/show/verify`](../operations/sandbox-pools.md) | Full | Manage lease-backed named resource pools |
+| Command | Docs status | Maturity | Notes |
+|---|---|---|---|
+| `bernstein -g GOAL` | Full | 3 | Inline goal |
+| `bernstein run plan.yaml` | Full | 3 | Plan file execution |
+| `bernstein init` | Full | 2 | Workspace setup |
+| `bernstein stop` | Full | 3 | Graceful/force stop |
+| `bernstein live` | Full | 2 | TUI dashboard |
+| `bernstein dashboard` | Full | 3 | Web dashboard |
+| `bernstein status` | Full | 3 | Task summary |
+| `bernstein ps` | Full | 3 | Process list |
+| `bernstein cost` | Full | 4 | Spend breakdown |
+| `bernstein doctor` | Full | 4 | Pre-flight health check |
+| `bernstein recap` | Full | 3 | Post-run summary |
+| `bernstein retro` | Full | 3 | Retrospective report |
+| `bernstein report commits/incident/postmortem` | Brief | 3 | Per-run markdown summaries: `commits` is per-agent commit attribution ([reference](../operations/commit-attribution.md)), `incident` correlates a timeline from logs, metrics, and traces, `postmortem` writes a structured report for a failed run. The group has no reference page of its own; `cli-reference.md` and `bernstein report --help` carry it |
+| `bernstein trace ID` | Full | 3 | Decision trace |
+| `bernstein logs` | Full | 3 | Agent log tail |
+| `bernstein diff ID` | Full | 3 | Per-task git diff |
+| `bernstein plan` | Full | 3 | Task backlog |
+| `bernstein plan compile` | Full | 3 | Compile a spec into a gated task graph offline |
+| [`bernstein replay ID`](../operations/replay.md) | Full | 3 | Deterministic replay |
+| [`bernstein checkpoint`](../operations/checkpoint.md) | Full | 3 | Session snapshot |
+| [`bernstein wrap-up`](../operations/wrap-up.md) | Full | 3 | End session with summary |
+| `bernstein demo` | Full | 2 | Zero-config demo |
+| [`bernstein demo --flask-todo`](../getting-started/quickstart-demo.md) | Full | 2 | Flask TODO demo (3 tasks). `bernstein quickstart` is a deprecated alias, removed in 4.0.0. |
+| `bernstein agents ...` | Full | 3 | Catalog management |
+| `bernstein evolve ...` | Full | 2 | Self-improvement |
+| `bernstein ci fix` | Full | 3 | CI autofix |
+| `bernstein github setup` | Full | 3 | GitHub App setup |
+| [`bernstein worker`](../operations/cluster-mode.md) | Full | 2 | Join cluster as worker |
+| [`bernstein mcp`](../mcp/server.md) | Full | 3 | Run as MCP server |
+| [`bernstein chaos`](../operations/chaos-engineering.md) | Full | 3 | Fault injection |
+| [`bernstein audit`](../security/audit-log.md) | Full | 4 | Cryptographic audit chain. Seventeen subcommands: `seal`, `verify`, `verify-hmac`, `verify-gates`, `verify-multitenant`, `verify-suspension`, `show`, `query`, `diagnose`, `receipt`, `taint`, `capabilities`, `ack-tear`, `export`, `pack`, `slice`, `archive` |
+| [`bernstein verify`](cli/verify.md) | Full | 4 | Merkle/HMAC verification |
+| `bernstein benchmark` | Full | 4 | Deprecated alias for `bernstein eval`, removed in v4.0.0 |
+| [`bernstein eval`](../eval/golden-harness.md) | Full | 4 | Evaluation harness |
+| `bernstein workspace` | Full | 3 | Multi-repo workspace |
+| [`bernstein config`](../operations/global-config.md) | Full | 3 | Configuration management |
+| `bernstein quarantine` | Brief | 3 | Cross-run task quarantine read from `.sdd/runtime/quarantine.json` (`list`, `clear`) |
+| [`bernstein cache`](../concepts/semantic-caching.md) | Full | 3 | Response cache management |
+| [`bernstein test-adapter`](../adapters/test-adapter.md) | Full | 3 | Adapter smoke test |
+| [`bernstein add-task`](cli/task-lifecycle.md) | Full | 3 | Inject task via CLI |
+| [`bernstein cancel`](cli/task-lifecycle.md) | Full | 3 | Cancel task |
+| [`bernstein review/approve/reject/pending`](cli/task-lifecycle.md) | Full | 3 | Review workflow |
+| [`bernstein sync`](../operations/backlog-sync.md) | Full | 3 | Sync backlog with server |
+| [`bernstein manifest`](../operations/run-manifest.md) | Full | 3 | Run manifest inspection |
+| [`bernstein gateway`](../operations/mcp-gateway.md) | Full | 3 | MCP gateway proxy |
+| [`bernstein workflow`](../operations/workflow-manifests.md) | Full | 3 | Workflow DSL |
+| [`bernstein watch`](../operations/watch.md) | Full | 3 | Directory file watcher |
+| [`bernstein listen`](../operations/voice-control.md) | Full | 2 | Voice commands (experimental). Needs the optional `voice` extra (`pip install 'bernstein[voice]'`); without it the command exits with the install hint rather than starting a session |
+| [`bernstein completions`](../operations/shell-completions.md) | Full | 3 | Shell completion scripts |
+| [`bernstein self`](../operations/updates.md) | Full | 3 | Provenance-verified update lifecycle: signed feed, chain-anchored advisory, pre-install wheel verification, pin, receipted rollback |
+| [`bernstein self-update`](../operations/self-update.md) | Full | 3 | Compatibility alias for `bernstein self` |
+| [`bernstein plugins`](../integrations/plugin-sdk.md) | Full | 3 | List active plugins |
+| [`bernstein install-hooks`](../contributing/git-hooks.md) | Full | 3 | Install git hooks |
+| [`bernstein debug`](../operations/debug-bundle.md) | Full | 4 | Generate debug bundle for triage |
+| `bernstein acp serve` | Full | 3 | ACP bridge (`--stdio` or `--http :PORT`) |
+| [`bernstein autofix ...`](../operations/autofix.md) | Full | 3 | CI autofix daemon (start/stop/status/attach) |
+| [`bernstein connect`](../operations/secrets.md) | Full | 3 | Credential vault setup for a provider |
+| [`bernstein creds ...`](../operations/secrets.md) | Full | 3 | Credential management (list/revoke/test) |
+| [`bernstein preview ...`](../operations/preview.md) | Full | 3 | Dev server preview (start/stop/list/status) |
+| [`bernstein fleet`](../operations/fleet.md) | Full | 3 | Fleet dashboard (optionally `--web HOST:PORT`) |
+| [`bernstein fleet steer`](../operations/fleet-steering.md) | Full | 3 | Mid-run steering: pause/resume/guidance/redirect/abort |
+| [`bernstein mcp catalog ...`](mcp-catalog.md) | Full | 3 | MCP catalog browser (browse/search/install) |
+| [`bernstein notify test`](../operations/notifications.md) | Full | 3 | Notification sink smoke test |
+| [`bernstein plan ls/show`](../operations/plan-archival.md) | Full | 3 | List and inspect archived plans |
+| [`bernstein review-responder ...`](../operations/review-responder.md) | Full | 3 | PR review responder (start/status/tick) |
+| [`bernstein review --pipeline`](../operations/review-pipeline.md) | Full | 3 | Review with YAML pipeline DSL |
+| [`bernstein fork --run --from-step`](../operations/fork-from-step.md) | Full | 3 | Fork a run at a journal step into a new isolated run |
+| [`bernstein gate verify`](../operations/gate-adjudication.md) | Full | 3 | Recompute a gate panel's inputs hash and confirm the adjudication |
+| [`bernstein mandate emit/verify/revoke`](../operations/spending-mandates.md) | Full | 3 | Bind, prove, and revoke authorized-action mandates |
+| `bernstein payment-mandate issue/show/spend` | Full | 3 | Issue and spend against authorized-spend mandates with signed receipts |
+| [`bernstein governance verify`](../operations/governance.md) | Full | 3 | Recompute access and budget verdicts for a run |
+| [`bernstein webhook verify`](../operations/webhook-node.md) | Full | 3 | Recompute inbound-event and outbound webhook-node hashes |
+| [`bernstein review-receipt emit/verify`](../operations/review-receipts.md) | Full | 3 | Bind and offline-verify PR review receipts (issue + plan + tool calls + diff) |
+| [`bernstein escalation show/verify`](../operations/stall-escalation.md) | Full | 3 | Project and reconstruct escalation receipts from the journal |
+| [`bernstein supervisor status/escalate`](../api/supervisor.md) | Full | 3 | Supervise stalled workers and seal stall escalation receipts |
+| [`bernstein delegation verify`](../operations/delegation-verify.md) | Full | 4 | Reconstruct and verify a run's delegation chain |
+| [`bernstein credential emit/verify`](../operations/content-credentials.md) | Full | 3 | Project an artifact's lineage into a signed C2PA credential and verify it |
+| [`bernstein skills provenance/verify`](../operations/skill-provenance.md) | Full | 3 | Recompute a skill's install receipt and usage-provenance graph |
+| [`bernstein schedule verify/audit`, `schedule show --at`](../operations/schedule.md) | Full | 3 | Replay recorded fires, chain-check fire receipts, project a schedule at a time |
+| `bernstein sla add/list/show/verify/report` | Full | 3 | Attach per-goal SLA contracts; a breach is an offline-verifiable violation receipt |
+| [`bernstein trace project/verify-projection`](../observability/otel-span-projection.md) | Full | 3 | Project a run journal into signed OTel GenAI spans and verify the projection |
+| `bernstein telemetry export-otel/verify-span` | Full | 3 | Stream the span projection to an OTLP collector and verify a single span offline |
+| [`bernstein thread verify`](../operations/deterministic-replay.md) | Full | 3 | Prove a streamed TUI thread equals its executed journal |
+| `bernstein memory verify/why/forget` | Full | 4 | Prove authorship, trace origin, and tombstone a memory entry |
+| [`bernstein replay --verify/--from-step`](../operations/deterministic-replay.md) | Full | 3 | Recompute the journal head or rebuild state to a step |
+| [`bernstein lineage verify/walk/chain/replay/export`](../lineage.md) | Full | 4 | Per-artifact lineage spine: recompute a run's Merkle chain and HMAC tags, walk an artifact back to its producer, replay the spine in append order, and export a run's chain as a regulator artefact (`tracker-audit`, `forks`, `conflicts`, `resolve`, `merge`, `reindex`, `gate`, and `v2` complete the group) |
+| `bernstein intent show/verify` | Full | 3 | Project and recompute an intent capsule's conformance offline |
+| `bernstein a2a verify/publish` | Full | 3 | Verify an A2A message receipt and publish the agent card |
+| `bernstein activity verify` | Full | 3 | Verify a typed activity's replay hashes (`activity browser run` for browser checks) |
+| `bernstein datasource register/query/verify` | Full | 3 | Register read-only SQL datasources and verify content-addressed query receipts |
+| [`bernstein evidence show/verify`](../operations/evidence-bundles.md) | Full | 3 | Project and verify a sealed evidence bundle |
+| [`bernstein events query/verify`](../events/grammar.md) | Full | 3 | Query the unified event feed and verify its chain projection |
+| `bernstein endpoints certify/verify` | Full | 3 | Conformance-certify a local-model endpoint and verify its certification |
+| `bernstein ledger verify/anchor/fetch` | Full | 3 | Verify, anchor, and fetch work-ledger segments |
+| `bernstein mission define/status/verify` | Full | 3 | Define multi-phase missions and verify mission status (`mission digest verify` for digests) |
+| [`bernstein tournament show/verify`](../operations/tournament-runs.md) | Full | 3 | Inspect a tournament run and verify its selection receipt |
+| `bernstein spiffe id/verify-binding` | Full | 4 | Print the SPIFFE id and verify a workload-identity binding |
+| `bernstein spec check/auto-fix` | Full | 3 | Evaluate and auto-fix a spec against the quality checklist |
+| [`bernstein run-service submit/attach/status`](../operations/run-service.md) | Full | 3 | Submit a detached run, then reattach to it later |
+| `bernstein compaction log` | Full | 3 | Inspect chain-anchored compaction receipts |
+| `bernstein identity keydir/decode/verify` | Full | 4 | Print the JWKS key directory and decode/verify install identity |
+| [`bernstein pool register/list/show/verify`](../operations/sandbox-pools.md) | Full | 3 | Manage lease-backed named resource pools |
 
 ---
 
 ## Cloud / Cloudflare
 
-| Capability | Docs status | Notes |
-|---|---|---|
-| Workers RuntimeBridge | Full | `bridges/cloudflare.py` agents on Workers + Durable Objects |
-| Workflow Bridge (durable execution) | Full | `bridges/cloudflare_workflow.py` auto-retry, approval gates |
-| Browser Rendering Bridge | Full | `bridges/browser_rendering.py` screenshots, scraping, PDFs |
-| R2 Workspace Sync | Full | `bridges/r2_sync.py` content-addressed delta sync |
-| Workers AI Provider (free LLMs) | Full | `core/routing/cloudflare_ai.py` Llama, Mistral, Gemma, Qwen |
-| D1 Analytics & Billing | Full | `core/cost/d1_analytics.py` usage metering, billing tiers |
-| MCP Remote Transport | Full | `mcp/remote_transport.py` streamable HTTP for remote MCP |
-| Cloud CLI (`bernstein cloud`) | Full | `cli/commands/cloud_cmd.py` login, run, status, cost, deploy |
-| Codex-on-Cloudflare Adapter | Brief | `adapters/codex_cloudflare.py` experimental; targets a REST API that does not yet exist and refuses fast |
+| Capability | Docs status | Maturity | Notes |
+|---|---|---|---|
+| Workers RuntimeBridge | Full | 2 | `bridges/cloudflare.py` agents on Workers + Durable Objects |
+| Workflow Bridge (durable execution) | Full | 2 | `bridges/cloudflare_workflow.py` auto-retry, approval gates |
+| Browser Rendering Bridge | Full | 2 | `bridges/browser_rendering.py` screenshots, scraping, PDFs |
+| R2 Workspace Sync | Full | 2 | `bridges/r2_sync.py` content-addressed delta sync |
+| Workers AI Provider (free LLMs) | Full | 2 | `core/routing/cloudflare_ai.py` Llama, Mistral, Gemma, Qwen |
+| D1 Analytics & Billing | Full | 2 | `core/cost/d1_analytics.py` usage metering, billing tiers |
+| MCP Remote Transport | Full | 2 | `mcp/remote_transport.py` streamable HTTP for remote MCP |
+| Cloud CLI (`bernstein cloud`) | Full | 2 | `cli/commands/cloud_cmd.py` login, run, status, cost, deploy |
+| Codex-on-Cloudflare Adapter | Brief | 1 | `adapters/codex_cloudflare.py` experimental; targets a REST API that does not yet exist and refuses fast |

--- a/tests/unit/test_feature_matrix_drift.py
+++ b/tests/unit/test_feature_matrix_drift.py
@@ -1,0 +1,291 @@
+"""The feature matrix must track the CLI surface it claims to index.
+
+``docs/reference/FEATURE_MATRIX.md`` is the exhaustive capability index the
+README links to, and it was the only major reference page with nothing
+holding it to the code.  ``docs/reference/cli-reference.md`` has
+``test_cli_command_registration.py``; ``docs/reference/capabilities.md`` has
+``test_docs_capability_reachability.py``.  The matrix had neither, so a
+command could ship, be documented everywhere else, and never reach the index
+a reader is pointed at for the full picture -- with every check green.
+
+What this file asserts
+----------------------
+
+* **Forward.** Every command registered on the top-level ``bernstein`` group
+  is named by some matrix row, or is listed in ``UNLISTED_COMMANDS`` below.
+  A newly registered command is in neither, so it fails here.
+* **Reverse.** No matrix row names a command the CLI does not register.  A
+  reader following the matrix must not land on "No such command".  There are
+  no exemptions to this direction and none should be added: a row naming a
+  deleted verb is a factual error, not staleness.
+* **Pin hygiene.** ``UNLISTED_COMMANDS`` may only shrink.  An entry for a
+  command that has since gained a row fails, and so does an entry for a
+  command that no longer exists -- either way the pin cannot rot into a
+  list that exempts nothing while reading as if it did.
+* **Column shape.** Every row carries a ``Maturity`` score in 1-5, and the
+  legend at the top of the page defines every score the table uses.
+
+Scope, stated precisely: this is a check of *names*, at the top level of the
+command tree.  A verb named anywhere in a table row counts as indexed,
+including in a Notes cell; prose outside the tables does not count.  Whether
+a row's prose is accurate is not decidable here and is not claimed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from bernstein.cli.main import cli
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MATRIX = _REPO_ROOT / "docs" / "reference" / "FEATURE_MATRIX.md"
+
+#: ``bernstein <verb>``, plus any slash alternatives written directly after
+#: the verb.  ``bernstein review/approve/reject/pending`` names four
+#: top-level commands; ``bernstein mandate emit/verify/revoke`` names one,
+#: because there the slash run follows a subcommand.
+_VERB = re.compile(r"bernstein ([a-z][a-z0-9-]*(?:/[a-z][a-z0-9-]*)*)")
+
+#: Markdown table cell separator: a pipe that is not backslash-escaped.
+_CELL_SPLIT = re.compile(r"(?<!\\)\|")
+
+#: Registered commands with no row in the matrix yet.
+#:
+#: The matrix indexes the operator-facing surface, and the command tree has
+#: outgrown it: these are reachable today and unlisted.  The list is a pin,
+#: not a permission -- it exists so a *newly* registered command fails the
+#: forward check instead of joining a backlog nobody can see.  Adding a row
+#: means deleting the entry here; the tests below enforce both halves.
+UNLISTED_COMMANDS: frozenset[str] = frozenset(
+    {
+        "ab-test",
+        "abandonments",
+        "adapters",
+        "agents-md",
+        "aliases",
+        "analyze",
+        "api-check",
+        "approve-tool",
+        "artifact",
+        "artifacts",
+        "auth",
+        "backlog",
+        "bench",
+        "best-of-n",
+        "blast-radius",
+        "bom",
+        "bundle",
+        "changelog",
+        "chat",
+        "cleanup",
+        "cluster",
+        "compare",
+        "compliance",
+        "config-path",
+        "conn",
+        "context",
+        "cook",
+        "cost-envelopes",
+        "criterion-profile",
+        "ctx",
+        "daemon",
+        "debug-bundle",
+        "decisions",
+        "dep-impact",
+        "desktop-register",
+        "dr",
+        "dry-run",
+        "estimate",
+        "explain",
+        "export",
+        "fingerprint",
+        "from-ticket",
+        "git",
+        "graph",
+        "gui",
+        "handoff",
+        "help-all",
+        "history",
+        "hook-gate",
+        "hooks",
+        "impact",
+        "init-wizard",
+        "integrations",
+        "interop",
+        "issue-to-pr",
+        "knowledge",
+        "limits",
+        "list-tasks",
+        "login",
+        "man-pages",
+        "merge",
+        "migrate",
+        "pipeline",
+        "policy",
+        "pr",
+        "profile",
+        "prompts",
+        "quality",
+        "readme-l10n",
+        "recipes",
+        "reject-tool",
+        "remote",
+        "resume",
+        "routine",
+        "run-changelog",
+        "run-lookup",
+        "sandbox",
+        "scaffold",
+        "secrets",
+        "security",
+        "serve",
+        "session",
+        "simulate",
+        "skill",
+        "slo",
+        "start",
+        "task",
+        "tasks",
+        "team",
+        "templates",
+        "test",
+        "ticket",
+        "trackers",
+        "trend-scan",
+        "triggers",
+        "tunnel",
+        "undo",
+        "validate",
+        "var",
+        "wheelhouse",
+        "wiki",
+        "worktrees",
+    }
+)
+
+_FIX_HINT = (
+    "Add a row to docs/reference/FEATURE_MATRIX.md (the CLI commands section) "
+    "with a Docs status and a Maturity score, or -- if the command is not part "
+    "of the operator-facing surface -- add it to UNLISTED_COMMANDS in "
+    f"{Path(__file__).name} with the reason in the commit message."
+)
+
+
+def _table_rows() -> list[list[str]]:
+    """Cells of every content row of every table in the matrix.
+
+    Header rows (``Capability`` / ``Command`` / ``Maturity``) and separator
+    rows are dropped; what is left is one list of cells per capability.
+
+    Cells are split on unescaped pipes only: ``bernstein acp serve
+    --stdio\\|--http :PORT`` writes a literal pipe inside one cell, and
+    splitting on it would report that row as malformed while silently
+    truncating its Notes.
+    """
+    rows: list[list[str]] = []
+    for line in _MATRIX.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        if set(stripped) <= {"|", "-", ":", " "}:
+            continue
+        cells = [cell.strip() for cell in _CELL_SPLIT.split(stripped.strip("|"))]
+        if cells[0] in {"Capability", "Command", "Maturity"}:
+            continue
+        rows.append(cells)
+    return rows
+
+
+def _capability_rows() -> list[list[str]]:
+    """Capability rows only -- the four-column tables, not the legend."""
+    return [cells for cells in _table_rows() if len(cells) == 4]
+
+
+def documented_commands() -> set[str]:
+    """Top-level ``bernstein`` verbs named by some row of the matrix."""
+    found: set[str] = set()
+    for cells in _table_rows():
+        for match in _VERB.findall(" | ".join(cells)):
+            found.update(match.split("/"))
+    return found
+
+
+def registered_commands() -> set[str]:
+    return set(cli.commands)
+
+
+def test_registered_commands_have_a_matrix_row() -> None:
+    """A command the CLI registers is indexed by the matrix, or pinned."""
+    unindexed = sorted(registered_commands() - documented_commands() - UNLISTED_COMMANDS)
+    assert not unindexed, (
+        f"registered on the CLI but named nowhere in docs/reference/FEATURE_MATRIX.md: {unindexed}. {_FIX_HINT}"
+    )
+
+
+def test_matrix_rows_name_live_commands() -> None:
+    """No row points a reader at a command that does not resolve.
+
+    Deliberately without an exemption list: a documented verb the CLI does
+    not register fails with "No such command" in the reader's terminal, which
+    is a defect rather than a lag.
+    """
+    ghosts = sorted(documented_commands() - registered_commands())
+    assert not ghosts, (
+        f"named in docs/reference/FEATURE_MATRIX.md but not registered on the CLI: {ghosts}. "
+        "Remove or correct the row -- following it produces 'No such command'."
+    )
+
+
+def test_pinned_commands_are_still_registered() -> None:
+    """Every pinned command still exists, so the pin cannot rot."""
+    stale = sorted(UNLISTED_COMMANDS - registered_commands())
+    assert not stale, (
+        f"UNLISTED_COMMANDS names commands the CLI no longer registers: {stale}. "
+        f"Delete them from the set in {Path(__file__).name}."
+    )
+
+
+def test_pinned_commands_have_no_row() -> None:
+    """A pinned command that has since gained a row leaves the pin.
+
+    Without this the set would keep exempting commands the matrix already
+    covers, and the forward check would quietly stop applying to them.
+    """
+    covered = sorted(UNLISTED_COMMANDS & documented_commands())
+    assert not covered, (
+        f"UNLISTED_COMMANDS names commands the matrix now indexes: {covered}. "
+        f"Delete them from the set in {Path(__file__).name} so the forward check covers them again."
+    )
+
+
+def test_every_row_carries_a_maturity_score() -> None:
+    """Every capability row scores 1-5 in the Maturity column."""
+    bad = [(cells[0], cells[2]) for cells in _capability_rows() if cells[2] not in {"1", "2", "3", "4", "5"}]
+    assert not bad, f"rows whose Maturity cell is not a score in 1-5: {bad}"
+
+
+def test_every_table_has_four_columns() -> None:
+    """A row that lost a cell would silently shift the Maturity column."""
+    malformed = [cells for cells in _table_rows() if len(cells) not in {2, 4}]
+    assert not malformed, f"rows with neither 2 (legend) nor 4 (capability) cells: {malformed}"
+
+
+def test_legend_defines_every_score_in_use() -> None:
+    """The legend explains each score the table actually uses."""
+    text = _MATRIX.read_text(encoding="utf-8")
+    used = {cells[2] for cells in _capability_rows()}
+    undefined = sorted(score for score in used if not re.search(rf"^\| {score} \| \S", text, re.MULTILINE))
+    assert not undefined, f"Maturity scores used by rows but absent from the legend: {undefined}"
+
+
+@pytest.mark.parametrize("command", ["audit", "lineage", "report", "listen"])
+def test_named_verification_surfaces_stay_indexed(command: str) -> None:
+    """Spot-check the verbs the index is read for.
+
+    Kept separate from the sweep so a regression names the command instead of
+    only reporting that some command fell out of the matrix.
+    """
+    assert command in documented_commands(), f"`bernstein {command}` is not named by any matrix row"


### PR DESCRIPTION
# User description
## Why

`docs/reference/FEATURE_MATRIX.md` is what the README links to as the exhaustive capability index. It is the only major reference page with nothing holding it to the code:

| Page | Gate |
|---|---|
| `docs/reference/cli-reference.md` | `tests/unit/test_cli_command_registration.py` |
| `docs/reference/capabilities.md` | `tests/unit/test_docs_capability_reachability.py` |
| `docs/reference/FEATURE_MATRIX.md` | none |

Its last content pass predates the current release, and it had drifted accordingly. This PR fixes the drift and adds the missing gate so it cannot recur silently.

## Content fixes

- **`bernstein audit`** listed 6 of its 17 subcommands. All 17 are named now, including `diagnose`.
- **`bernstein listen`** did not say it needs the optional `voice` extra (`pyproject.toml`), so a reader following the row gets an install error instead of a session.
- **Typed activity boundary** pointed at a `"Reachability today"` heading that does not exist on this page. It now links to the heading on `docs/operations/activity-boundary.md`.
- **`bernstein lineage`** and **`bernstein report`** had no row anywhere in the index. Added. The commit-attribution row now names the verb that produces it (`bernstein report commits`).

## Maturity column

Every row carries a 1-5 score for how far the capability behind it has been proven. `Docs status: Full` only means a page exists, and it says so on 96% of rows, so it was being read as a readiness signal it cannot give. Legend at the top of the page:

| Maturity | Meaning |
|---|---|
| 5 | End-to-end evidence, no open correctness issues, docs current |
| 4 | Tested and documented, minor gaps |
| 3 | Works, known gaps |
| 2 | A first-run path is broken |
| 1 | Stub |

Rows served by the same subsystem carry the same number. Current spread over 256 rows: 32 at 4, 205 at 3, 18 at 2, 1 at 1.

## Gate

`tests/unit/test_feature_matrix_drift.py` walks the registered command tree against the matrix rows in both directions:

- **Forward** — a registered command named by no row fails. The 102 commands already absent are pinned in `UNLISTED_COMMANDS`, so a *new* command fails instead of joining a backlog nobody can see.
- **Reverse** — a row naming an unregistered command fails, with no exemption list: following such a row produces `No such command`, which is a defect rather than a lag.
- **Pin hygiene** — the pin can only shrink. An entry that gains a row fails; so does an entry whose command no longer exists.
- **Shape** — every row scores 1-5, and the legend defines every score in use.

`.github/workflows/feature-matrix-drift.yml` runs that test on the diffs that cause the drift (`src/bernstein/cli/**`, the matrix, the test, the workflow), so a change to the command tree cannot land it past a PR lane that only runs affected tests. Advisory, modelled on `spa-bundle-freshness.yml`: no `merge_group` trigger and no job named after a required context.

## Verification

```
pytest tests/unit/test_feature_matrix_drift.py                    11 passed
```

Negative controls, run against a mutated copy of the matrix:

| Mutation | Result |
|---|---|
| delete the `bernstein lineage` row | `test_registered_commands_have_a_matrix_row` fails: `['lineage']` |
| add a row for `bernstein teleport` | `test_matrix_rows_name_live_commands` fails: `['teleport']` |

Also green: `test_cli_command_registration`, `test_docs_capability_reachability`, `test_docs_prose_cli_drift`, `test_test_impact*`, and the workflow-shape suites (`pull_request_workflow_concurrency`, `required_check_canary`, `merge_queue_gate_coverage`, `workflow_topology_report`, `workflow_extra_conflicts`, `workflow_uv_installers`, `bot_pull_request_tokens`, `zizmor`) — 594 + 133 passed. `scripts/check_docs_drift.py` reports no drift; `scripts/check_test_collection.py` reports 0 uncollected files.

## Docs duty

`docs/operations/ci.md` catalogues the new workflow (TL;DR table + advisory list); `docs/operations/ci-topology.md` regenerated via `scripts/gen_workflow_topology.py --update`.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refresh the feature matrix with current CLI coverage, maturity scores, corrected references, optional dependency guidance, and newly documented reporting and lineage commands. Add <code>test_feature_matrix_drift.py</code> and the advisory <code>feature-matrix-drift</code> workflow to validate matrix/CLI parity, pin hygiene, score coverage, and workflow documentation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3746?tool=ast&topic=Feature+matrix+refresh>Feature matrix refresh</a>
        </td><td>Update the feature matrix to reflect current capabilities, add maturity scoring, document missing <code>bernstein</code> commands, clarify <code>listen</code> installation requirements, and correct activity-boundary links.<details><summary>Modified files (1)</summary><ul><li>docs/reference/FEATURE_MATRIX.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>docs(reference): refre...</td><td>August 14, 2026</td></tr>
<tr><td>chernistry</td><td>cli(commands): fold be...</td><td>August 09, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3746?tool=ast&topic=CLI+drift+gate>CLI drift gate</a>
        </td><td>Enforce bidirectional CLI-to-matrix coverage with <code>test_feature_matrix_drift.py</code>, run it through the new advisory workflow, and document the workflow in CI references and topology.<details><summary>Modified files (4)</summary><ul><li>.github/workflows/feature-matrix-drift.yml</li>
<li>docs/operations/ci-topology.md</li>
<li>docs/operations/ci.md</li>
<li>tests/unit/test_feature_matrix_drift.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>docs(reference): refre...</td><td>August 14, 2026</td></tr>
<tr><td>chernistry</td><td>fix(ci): hand the gate...</td><td>August 12, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3746?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>