### PR TITLE
feat(mcp): enforce declared timeouts on host-effecting tools + role enum (#3647)

### DIFF
--- a/docs/mcp/input-validation.md
+++ b/docs/mcp/input-validation.md
@@ -102,6 +102,35 @@ constrained field, and that the set of schema file stems equals the set of
 registered tool names in both directions. Tightening enforcement without
 updating what is advertised fails the build.
 
+## Declared execution bounds (timeouts)
+
+The four tools that leave the process — `bernstein_create_subtask`,
+`bernstein_post_artifact`, `bernstein_update` and `load_skill` — carry a
+`timeoutSeconds` key at the top of their schema file. That number is the
+upper execution bound the server enforces per call: the tool manager's
+`call_tool` path wraps the call in `asyncio.wait_for` (via
+`_apply_tool_timeouts` in `src/bernstein/mcp/server.py`) and, when the
+bound is exceeded, returns a structured error naming the tool and the
+limit instead of letting the client block indefinitely or guess its own
+timeout. The bound is advertised to clients with the schema, so a caller
+can plan against it. `_HTTP_TIMEOUT` inside the handlers bounds only the
+httpx hop to the task server; `timeoutSeconds` bounds the whole tool call.
+
+The streamable HTTP transport (`bernstein.mcp.remote_transport`) is a
+separate execution path and does not apply these bounds; see the scope
+note above (issue #3083 tracks unifying both transports).
+
+## `bernstein_create_subtask.role` is a known-role enum
+
+`bernstein_create_subtask` constrains `scope` and `complexity` to enums but
+leaves `role` a free string in the schema file — JSON has no way to import
+a Python constant. At registry load time (`load_registry` in
+`src/bernstein/mcp/input_validation.py`), the `role` property's `enum` is
+bound to `plan_schema.KNOWN_ROLES` itself, so the schema and the constant
+are the same object: adding a role to `KNOWN_ROLES` widens the MCP boundary
+automatically, and an unknown role is refused at the schema boundary with
+the offending value echoed in the validation message (issue #3647).
+
 ## Permissive mode (migration aid)
 
 Set `BERNSTEIN_MCP_VALIDATION=permissive` to log rejected payloads instead of

--- a/src/bernstein/mcp/input_validation.py
+++ b/src/bernstein/mcp/input_validation.py
@@ -34,6 +34,8 @@ from typing import TYPE_CHECKING, Any, Final, cast
 
 import jsonschema
 
+from bernstein.core.planning.plan_schema import KNOWN_ROLES
+
 if TYPE_CHECKING:
     from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
 
@@ -175,6 +177,16 @@ def load_registry(
             # operator bug we want to surface at startup, not on the first
             # incoming call.
             jsonschema.Draft7Validator.check_schema(schemas[tool])
+    # #3647: create_subtask's ``role`` is a closed set that must track
+    # plan_schema.KNOWN_ROLES exactly. The JSON schema file cannot import
+    # the Python constant, so bind the enum here at load time - the schema
+    # and the constant are then the same object, and adding a role to one
+    # cannot leave the other behind.
+    subtask = schemas.get("bernstein_create_subtask")
+    if subtask is not None:
+        role_schema = cast("dict[str, Any] | None", subtask.get("properties", {}).get("role"))
+        if isinstance(role_schema, dict):
+            role_schema["enum"] = KNOWN_ROLES
     return SchemaRegistry(
         schemas=schemas,
         allow_unsafe_args=allow_unsafe_args or frozenset(),

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -1858,8 +1858,8 @@ def _apply_tool_timeouts(mcp: FastMCP[None]) -> None:
 
     # FastMCP exposes no public per-tool timeout hook, so replace the call
     # path on the tool manager directly (same access pattern as
-    # _apply_tool_tier). ``setattr`` keeps the method patch off the class.
-    setattr(manager, "call_tool", bounded_call)
+    # _apply_tool_tier).
+    manager.call_tool = bounded_call  # pyright: ignore[reportAttributeAccessIssue]
 
 
 def _apply_advertised_schemas(mcp: FastMCP[None]) -> None:

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -1800,6 +1800,68 @@ def _apply_cost_meter(mcp: FastMCP[None]) -> None:
         tool.fn = metered
 
 
+def _apply_tool_timeouts(mcp: FastMCP[None]) -> None:
+    """Enforce the declared timeoutSeconds of the host-effecting tools.
+
+    The four tools that leave the process (bernstein_create_subtask,
+    bernstein_post_artifact, bernstein_update, load_skill) declare an upper
+    execution bound in their schema file (``timeoutSeconds``). Without an
+    enforced bound a client can only block indefinitely or invent a
+    timeout - and a client timeout that fires mid-write reports a failure
+    for a call that in fact succeeded. This wrap gives the caller the
+    declared bound to plan against and turns an overrun into a structured
+    error naming the tool and the limit instead of a dropped connection
+    (#3647).
+
+    The wrap sits on the tool manager's call path, which every FastMCP
+    transport (stdio and SSE) and direct ``mcp.call_tool`` calls funnel
+    through. The bound is read from the registry on every call, so
+    tightening a schema file takes effect without a server restart.
+
+    Args:
+        mcp: The FastMCP server whose tools should be timeout-enforced.
+    """
+    import asyncio
+    import functools
+
+    registry = get_registry()
+    manager = mcp._tool_manager  # pyright: ignore[reportPrivateUsage]
+    original_call = manager.call_tool
+
+    @functools.wraps(original_call)
+    async def bounded_call(
+        name: str,
+        arguments: dict[str, Any],
+        context: Any = None,
+        convert_result: bool = False,
+    ) -> Any:
+        schema = registry.get(name)
+        declared = schema.get("timeoutSeconds") if schema is not None else None
+        if declared is None:
+            return await original_call(name, arguments, context=context, convert_result=convert_result)
+        try:
+            return await asyncio.wait_for(
+                original_call(name, arguments, context=context, convert_result=convert_result),
+                timeout=float(declared),
+            )
+        except TimeoutError:
+            # Structured error naming the tool and the limit, matching the
+            # shape clients already parse from validation failures.
+            payload = {
+                "error": f"tool {name} exceeded its declared timeout of {declared}s",
+                "tool": name,
+                "timeoutSeconds": declared,
+                "timeout": True,
+            }
+            text = json.dumps(payload)
+            return CallToolResult(content=[TextContent(type="text", text=text)])
+
+    # FastMCP exposes no public per-tool timeout hook, so replace the call
+    # path on the tool manager directly (same access pattern as
+    # _apply_tool_tier). ``setattr`` keeps the method patch off the class.
+    setattr(manager, "call_tool", bounded_call)
+
+
 def _apply_advertised_schemas(mcp: FastMCP[None]) -> None:
     """Advertise each tool's enforced schema and host-effect description.
 
@@ -2296,6 +2358,7 @@ def create_mcp_server(
     _apply_advertised_schemas(mcp)
     _shape_tools_list(mcp)
     _apply_cost_meter(mcp)
+    _apply_tool_timeouts(mcp)
     return mcp
 
 

--- a/src/bernstein/mcp/tool_schemas/bernstein_create_subtask.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_create_subtask.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_create_subtask",
   "description": "Deprecated alias folded into bernstein_run. Queues a subtask that writes orchestration state and starts agent work; the call returns before that work finishes. Host effects: writes files; spawns agent processes; makes network requests.",
+  "timeoutSeconds": 30.0,
   "type": "object",
   "additionalProperties": false,
   "required": ["parent_task_id", "goal"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_post_artifact.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_post_artifact.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_post_artifact",
   "description": "Post a versioned artifact to a task on the Bernstein server. Host effects: makes network requests.",
+  "timeoutSeconds": 30.0,
   "type": "object",
   "additionalProperties": false,
   "required": ["task_id", "key", "artifact_type", "poster"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_update.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_update.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_update",
   "description": "Deprecated alias of bernstein_post_message. Posts a progress message to a task mailbox on the Bernstein server. Host effects: makes network requests.",
+  "timeoutSeconds": 30.0,
   "type": "object",
   "additionalProperties": false,
   "required": ["task_id", "body", "sender"],

--- a/src/bernstein/mcp/tool_schemas/load_skill.json
+++ b/src/bernstein/mcp/tool_schemas/load_skill.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "load_skill",
   "description": "List available skills when name is omitted, or load a named skill body, reference, or script file contents. Returns file contents as text; executes nothing. Host effects: reads files.",
+  "timeoutSeconds": 30.0,
   "type": "object",
   "additionalProperties": false,
   "dependencies": {

--- a/tests/unit/mcp/test_tool_timeout_enforcement.py
+++ b/tests/unit/mcp/test_tool_timeout_enforcement.py
@@ -1,0 +1,185 @@
+"""Per-tool timeout enforcement and create_subtask role enum binding.
+
+Drives the five acceptance criteria of issue #3647:
+
+1. The four host-effecting tools declare a timeout AND the server enforces it.
+2. Exceeding the declared bound returns a structured MCP error naming the
+   tool and the limit, instead of dropping the connection.
+3. A test drives a tool past its declared timeout and asserts the error
+   shape (fail-before, pass-after).
+4. ``bernstein_create_subtask``'s ``role`` field is an enum sourced from
+   ``KNOWN_ROLES`` - the schema cannot drift from the constant without
+   failing this test.
+5. An unknown ``role`` value is rejected at the schema boundary with the
+   offending value in the message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from bernstein.core.planning.plan_schema import KNOWN_ROLES
+from bernstein.mcp.input_validation import get_registry, validate_tool_call
+from bernstein.mcp.server import create_mcp_server
+
+# Host-effecting tools from the audit list - these are the four whose declared
+# bound has to be enforced (acceptance #1).
+_HOST_EFFECT_TOOLS: tuple[str, ...] = (
+    "bernstein_create_subtask",
+    "bernstein_post_artifact",
+    "bernstein_update",
+    "load_skill",
+)
+
+# Bound to declare (seconds) - short enough to fire inside a test, long
+# enough that the request still reaches the tool handler before the bound.
+_TIMEOUT_FLOOR_SECONDS = 0.01
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #1 + #4: declarations exist and create_subtask's role is an enum
+# ---------------------------------------------------------------------------
+
+
+def test_host_effect_tools_declare_timeout_seconds() -> None:
+    """Every host-effecting tool schema declares a positive timeoutSeconds."""
+    schemas = get_registry().schemas
+    for name in _HOST_EFFECT_TOOLS:
+        schema = schemas[name]
+        assert "timeoutSeconds" in schema, (
+            f"{name} must declare timeoutSeconds so the bound is advertised "
+            "(acceptance #1)."
+        )
+        declared = schema["timeoutSeconds"]
+        assert isinstance(declared, (int, float))
+        assert declared > 0
+
+
+def test_create_subtask_role_enum_matches_known_roles() -> None:
+    """create_subtask.role enum is the same list as plan_schema.KNOWN_ROLES."""
+    schema = get_registry().schemas["bernstein_create_subtask"]
+    props = schema["properties"]
+    assert "role" in props, "create_subtask must keep role as a constrained field"
+    role_schema = props["role"]
+    assert "enum" in role_schema, (
+        "create_subtask.role must be an enum sourced from KNOWN_ROLES "
+        "(acceptance #4); schema validator uses enum to reject unknown roles."
+    )
+    assert sorted(role_schema["enum"]) == sorted(KNOWN_ROLES), (
+        "create_subtask.role enum must equal KNOWN_ROLES bit-for-bit "
+        "(acceptance #4) - if you add or remove a role, change both sides."
+    )
+
+
+def test_create_subtask_rejects_unknown_role_at_schema_boundary() -> None:
+    """Unknown role is refused by validate_tool_call, value appears in error."""
+    payload = {
+        "parent_task_id": "p1",
+        "goal": "g",
+        "role": "not-a-real-role",
+        "scope": "medium",
+        "complexity": "low",
+        "priority": 2,
+        "estimated_minutes": 30,
+    }
+    result = validate_tool_call("bernstein_create_subtask", payload)
+    assert not hasattr(result, "payload") or not isinstance(result, type(result))
+    # validate_tool_call returns ValidatedPayload or ValidationError; the
+    # ValidationError path renders the offending value in the message.
+    assert result.__class__.__name__ == "ValidationError", (
+        f"unknown role must surface as ValidationError (acceptance #5), "
+        f"got {result.__class__.__name__}"
+    )
+    rendered = json.dumps(result.__dict__)
+    assert "not-a-real-role" in rendered, (
+        "error message must name the offending value (acceptance #5) - "
+        "otherwise the caller cannot tell which field is wrong."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #2 + #3: server enforces the declared bound, returns a
+# structured error with the tool name and the limit.
+# ---------------------------------------------------------------------------
+
+
+async def _drive_tool_past_timeout(mcp: Any, tool_name: str, args: dict[str, Any]) -> str:
+    """Call ``tool_name`` with a patched handler that sleeps past the bound."""
+    tool = mcp._tool_manager._tools[tool_name]  # pyright: ignore[reportPrivateUsage]
+    original = tool.fn
+
+    async def _slow(*_a: Any, **_kw: Any) -> str:
+        # Sleep comfortably longer than any sane test timeout. The wrapping
+        # layer must abort and return its structured error first.
+        await asyncio.sleep(5.0)
+        return json.dumps({"would_have_succeeded": True})
+
+    tool.fn = _slow
+    try:
+        result = await mcp.call_tool(tool_name, args)
+        if hasattr(result, "content") and result.content:
+            return result.content[0].text
+        if hasattr(result, "text"):
+            return result.text  # type: ignore[no-any-return]
+        return json.dumps(result.__dict__)
+    finally:
+        tool.fn = original
+
+
+async def test_server_enforces_declared_timeout_for_host_effect_tools() -> None:
+    """Drive bernstein_post_artifact past its bound - returns structured error."""
+    mcp = create_mcp_server(tier="all", lineage_enabled=True)
+
+    # patch the handler's network step to wait, so the call surfaces a timeout.
+    import bernstein.mcp.server as server_mod
+
+    async def _slow_post(*_a: Any, **_kw: Any) -> Any:
+        await asyncio.sleep(5.0)
+        return json.dumps({"ok": True})
+
+    original_post = getattr(server_mod, "_post_artifact_impl", None)
+    server_mod._post_artifact_impl = _slow_post  # type: ignore[assignment]
+
+    try:
+        text = await _drive_tool_past_timeout(
+            mcp,
+            "bernstein_post_artifact",
+            {
+                "task_id": "t1",
+                "key": "k",
+                "artifact_type": "report",
+                "poster": "p",
+                "body": "b",
+            },
+        )
+        parsed = json.loads(text)
+        assert parsed.get("error") or parsed.get("timeout"), (
+            f"expected structured timeout error, got: {parsed}"
+        )
+        # Acceptance #2: the error names the tool and the limit.
+        msg = json.dumps(parsed)
+        assert "bernstein_post_artifact" in msg
+        assert "timeoutSeconds" in msg or "timeout" in msg
+    finally:
+        if original_post is not None:
+            server_mod._post_artifact_impl = original_post  # type: ignore[assignment]
+
+
+def test_pass_within_bound_returns_normal_payload() -> None:
+    """A call that finishes well inside the declared bound returns the
+    normal payload (acceptance #3: pass-after)."""
+    mcp = create_mcp_server(tier="all", lineage_enabled=True)
+    # bernstein_status with status=None is a near-instant local read.
+    result = asyncio.run(
+        mcp.call_tool("bernstein_status", {"status": None, "detail": False})
+    )
+    text = result.content[0].text if hasattr(result, "content") else json.dumps(result)
+    # It either succeeded normally or returned a structured outage/error -
+    # but it must NOT be the timeout error shape.
+    assert "timeout" not in text.lower() or "exceeded" not in text.lower(), (
+        f"fast bernstein_status unexpectedly hit the timeout path: {text}"
+    )

--- a/tests/unit/mcp/test_tool_timeout_enforcement.py
+++ b/tests/unit/mcp/test_tool_timeout_enforcement.py
@@ -76,7 +76,9 @@ def test_create_subtask_role_enum_matches_known_roles() -> None:
 
 
 def test_create_subtask_rejects_unknown_role_at_schema_boundary() -> None:
-    """Unknown role is refused by validate_tool_call, value appears in error."""
+    """Unknown role is refused by validate_tool_call, value appears in message."""
+    from bernstein.mcp.input_validation import ValidationError
+
     payload = {
         "parent_task_id": "p1",
         "goal": "g",
@@ -87,17 +89,17 @@ def test_create_subtask_rejects_unknown_role_at_schema_boundary() -> None:
         "estimated_minutes": 30,
     }
     result = validate_tool_call("bernstein_create_subtask", payload)
-    assert not hasattr(result, "payload") or not isinstance(result, type(result))
-    # validate_tool_call returns ValidatedPayload or ValidationError; the
-    # ValidationError path renders the offending value in the message.
-    assert result.__class__.__name__ == "ValidationError", (
+    assert isinstance(result, ValidationError), (
         f"unknown role must surface as ValidationError (acceptance #5), "
-        f"got {result.__class__.__name__}"
+        f"got {type(result).__name__}"
     )
-    rendered = json.dumps(result.__dict__)
-    assert "not-a-real-role" in rendered, (
-        "error message must name the offending value (acceptance #5) - "
-        "otherwise the caller cannot tell which field is wrong."
+    # Acceptance #5: the offending value must appear in either the top-level
+    # message or one of the per-violation reasons, so the caller knows which
+    # field is wrong.
+    blob = " ".join([result.message, *(e.get("reason", "") for e in result.errors)])
+    assert "not-a-real-role" in blob, (
+        f"error must name the offending value (acceptance #5); got message={result.message!r} "
+        f"errors={result.errors!r}"
     )
 
 
@@ -107,6 +109,7 @@ def test_create_subtask_rejects_unknown_role_at_schema_boundary() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.asyncio
 async def _drive_tool_past_timeout(mcp: Any, tool_name: str, args: dict[str, Any]) -> str:
     """Call ``tool_name`` with a patched handler that sleeps past the bound."""
     tool = mcp._tool_manager._tools[tool_name]  # pyright: ignore[reportPrivateUsage]
@@ -130,6 +133,7 @@ async def _drive_tool_past_timeout(mcp: Any, tool_name: str, args: dict[str, Any
         tool.fn = original
 
 
+@pytest.mark.asyncio
 async def test_server_enforces_declared_timeout_for_host_effect_tools() -> None:
     """Drive bernstein_post_artifact past its bound - returns structured error."""
     mcp = create_mcp_server(tier="all", lineage_enabled=True)
@@ -169,14 +173,13 @@ async def test_server_enforces_declared_timeout_for_host_effect_tools() -> None:
             server_mod._post_artifact_impl = original_post  # type: ignore[assignment]
 
 
-def test_pass_within_bound_returns_normal_payload() -> None:
+@pytest.mark.asyncio
+async def test_pass_within_bound_returns_normal_payload() -> None:
     """A call that finishes well inside the declared bound returns the
     normal payload (acceptance #3: pass-after)."""
     mcp = create_mcp_server(tier="all", lineage_enabled=True)
     # bernstein_status with status=None is a near-instant local read.
-    result = asyncio.run(
-        mcp.call_tool("bernstein_status", {"status": None, "detail": False})
-    )
+    result = await mcp.call_tool("bernstein_status", {"status": None, "detail": False})
     text = result.content[0].text if hasattr(result, "content") else json.dumps(result)
     # It either succeeded normally or returned a structured outage/error -
     # but it must NOT be the timeout error shape.

--- a/tests/unit/mcp/test_tool_timeout_enforcement.py
+++ b/tests/unit/mcp/test_tool_timeout_enforcement.py
@@ -51,8 +51,7 @@ def test_host_effect_tools_declare_timeout_seconds() -> None:
     for name in _HOST_EFFECT_TOOLS:
         schema = schemas[name]
         assert "timeoutSeconds" in schema, (
-            f"{name} must declare timeoutSeconds so the bound is advertised "
-            "(acceptance #1)."
+            f"{name} must declare timeoutSeconds so the bound is advertised (acceptance #1)."
         )
         declared = schema["timeoutSeconds"]
         assert isinstance(declared, (int, float))
@@ -90,16 +89,14 @@ def test_create_subtask_rejects_unknown_role_at_schema_boundary() -> None:
     }
     result = validate_tool_call("bernstein_create_subtask", payload)
     assert isinstance(result, ValidationError), (
-        f"unknown role must surface as ValidationError (acceptance #5), "
-        f"got {type(result).__name__}"
+        f"unknown role must surface as ValidationError (acceptance #5), got {type(result).__name__}"
     )
     # Acceptance #5: the offending value must appear in either the top-level
     # message or one of the per-violation reasons, so the caller knows which
     # field is wrong.
     blob = " ".join([result.message, *(e.get("reason", "") for e in result.errors)])
     assert "not-a-real-role" in blob, (
-        f"error must name the offending value (acceptance #5); got message={result.message!r} "
-        f"errors={result.errors!r}"
+        f"error must name the offending value (acceptance #5); got message={result.message!r} errors={result.errors!r}"
     )
 
 
@@ -138,6 +135,13 @@ async def test_server_enforces_declared_timeout_for_host_effect_tools() -> None:
     """Drive bernstein_post_artifact past its bound - returns structured error."""
     mcp = create_mcp_server(tier="all", lineage_enabled=True)
 
+    # Shorten the declared bound so the test can drive past it quickly; the
+    # schema's real 30s bound would make the test take half a minute.
+    registry = get_registry()
+    schema = registry.schemas["bernstein_post_artifact"]
+    original_bound = schema.get("timeoutSeconds")
+    schema["timeoutSeconds"] = 0.05
+
     # patch the handler's network step to wait, so the call surfaces a timeout.
     import bernstein.mcp.server as server_mod
 
@@ -161,9 +165,7 @@ async def test_server_enforces_declared_timeout_for_host_effect_tools() -> None:
             },
         )
         parsed = json.loads(text)
-        assert parsed.get("error") or parsed.get("timeout"), (
-            f"expected structured timeout error, got: {parsed}"
-        )
+        assert parsed.get("error") or parsed.get("timeout"), f"expected structured timeout error, got: {parsed}"
         # Acceptance #2: the error names the tool and the limit.
         msg = json.dumps(parsed)
         assert "bernstein_post_artifact" in msg
@@ -171,6 +173,10 @@ async def test_server_enforces_declared_timeout_for_host_effect_tools() -> None:
     finally:
         if original_post is not None:
             server_mod._post_artifact_impl = original_post  # type: ignore[assignment]
+        if original_bound is None:
+            schema.pop("timeoutSeconds", None)
+        else:
+            schema["timeoutSeconds"] = original_bound
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #3647

## What

The four tools that leave the process — `bernstein_create_subtask`, `bernstein_post_artifact`, `bernstein_update`, `load_skill` — now declare an upper execution bound (`timeoutSeconds`) in their schema file, and the server actually enforces it. A client can plan against a declared bound instead of blocking indefinitely or inventing its own timeout; an overrun returns a structured error naming the tool and the limit rather than a dropped connection.

The second half of the issue: `bernstein_create_subtask.role` is now bound to `plan_schema.KNOWN_ROLES` at registry load time, so the schema enum and the constant are the same object — adding a role to one cannot leave the other behind. Unknown roles are rejected at the schema boundary with the offending value echoed back.

## Decision: what the bound does to work already in flight

The bound cancels the wait on the in-flight call (`asyncio.wait_for`). For the two write-then-return tools (`bernstein_post_artifact`, `bernstein_update`) the HTTP write itself is a single httpx request bounded internally by `_HTTP_TIMEOUT = 5.0`; the declared `timeoutSeconds = 30.0` is a whole-tool-call ceiling, so an overrun there means the call as a whole exceeded its advertised bound. The structured error the caller receives names the tool and the limit, so the client can decide to retry or to inspect state via `bernstein_status` — it never has to guess.

Chose cancel-over-return because:
- the server can't atomically roll back a write that already reached the task server;
- the alternative (return a "resolvable handle") would leak run handles for calls the client may never poll, and would need a new result type for marginal value;
- the declared bound is what lets the client plan; the error shape is what lets it react.

## Files (8)

- `src/bernstein/mcp/tool_schemas/{bernstein_create_subtask,bernstein_post_artifact,bernstein_update,load_skill}.json` — declare `timeoutSeconds: 30.0`
- `src/bernstein/mcp/input_validation.py` — bind `role.enum` to `KNOWN_ROLES` at load
- `src/bernstein/mcp/server.py` — `_apply_tool_timeouts()` wraps the tool manager call path
- `tests/unit/mcp/test_tool_timeout_enforcement.py` — 5 tests, one per acceptance criterion
- `docs/mcp/input-validation.md` — documents both changes

## Verification

- `pytest tests/unit/mcp/test_tool_timeout_enforcement.py` — 5 passed (was 4 failed / 1 passed before the fix)
- `pytest tests/unit/mcp/` — 209 passed, no regressions
- `ruff check` + `ruff format --check` on changed files — clean
- `pyright` on changed src files — no new errors vs baseline
- `mypy --config-file mypy.gate.ini` on changed src files — no new errors vs baseline