### PR TITLE
fix(docs): resolve CLI reference table spellings through the real CLI

### DIFF
--- a/docs/operations/commit-attribution.md
+++ b/docs/operations/commit-attribution.md
@@ -14,8 +14,8 @@ bernstein report commits --repo-dir ../other-repo
 bernstein report commits --json              # machine-readable output
 ```
 
-`bernstein commit-stats` remains as a deprecated alias with identical
-behaviour until v4.0.0; it prints a migration notice on stderr.
+The top-level `bernstein commit-stats` alias was removed in v4.0.0 (#3472).
+`bernstein report commits` is the only spelling.
 
 | Flag | Default | Meaning |
 |---|---|---|

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -281,12 +281,12 @@ See [`cli/task-lifecycle.md#bernstein-review-bernstein-verify`](cli/task-lifecyc
 | `bernstein retro` | Detailed retrospective. | `cli/commands/advanced_cmd.py:299` |
 | `bernstein wrap-up` | End-of-session summary. | `cli/wrap_up_cmd.py` |
 | `bernstein history` | Show run history. | `cli/maintenance_cmd.py:history_cmd` |
-| `bernstein report commits` | Per-run git diff stats. Deprecated alias until v4.0.0: `bernstein commit-stats`. | `cli/commands/status_cmd.py:914` |
+| `bernstein report commits` | Per-run git diff stats. | `cli/commands/status_cmd.py:1232` |
 | `bernstein report` | Build a custom report (group). | `cli/report_cmd.py` |
 | `bernstein slo` | SLO dashboard. | `cli/slo_cmd.py:191` |
 | `bernstein trace TASK_ID` | Step-by-step trace. | `cli/commands/advanced_cmd.py:666` |
-| `bernstein report incident` | Open an incident report. Deprecated alias until v4.0.0: `bernstein incident`. | `cli/incident_cmd.py:53` |
-| `bernstein report postmortem` | Failed-task postmortem. Deprecated alias until v4.0.0: `bernstein postmortem`. | `cli/postmortem_cmd.py:12` |
+| `bernstein report incident` | Open an incident report. | `cli/commands/incident_cmd.py:53` |
+| `bernstein report postmortem` | Failed-task postmortem. | `cli/commands/postmortem_cmd.py:12` |
 
 #### `bernstein status`
 
@@ -1516,16 +1516,24 @@ First slice of the prompt-to-repo scaffolder. See
 
 ## Hidden commands
 
-Four task-related commands are wired but hidden from `--help`. They are stable and supported; just not surfaced because their UX is uneven or because their visible counterpart (`bernstein add-task`, `bernstein logs`) is what most users want.
+Three task-related commands carry `hidden=True`, so they do not appear in
+`--help`. They are stable and supported, and each is registered at the **top
+level** -- not under `bernstein task`. The spellings below are the ones that
+resolve.
 
-| Command | Source | Replacement |
+| Command | Source | Notes |
 |---|---|---|
-| `bernstein task compose TITLE` | `cli/commands/task_cmd.py:37` | Use `bernstein add-task TITLE` (it's the same command, registered with a different name at `cli/main.py:696`). |
-| `bernstein task sync` | `cli/commands/task_cmd.py:116` | Reconciles on-disk task files with the running server. Use when you've hand-edited backlog files and want them registered without restarting. |
-| `bernstein task notes` | `cli/commands/task_cmd.py:614` | Tail server / spawner logs. Prefer `bernstein logs tail`. |
-| `bernstein task parts` | `cli/commands/task_cmd.py:637` | Same as `bernstein list-tasks`. |
+| `bernstein add-task TITLE` | `cli/commands/task_cmd.py:155` | Declared as `compose`, registered top-level as `add-task`. |
+| `bernstein sync` | `cli/commands/task_cmd.py:337` | Reconciles on-disk task files with the running server. Use when you've hand-edited backlog files and want them registered without restarting. |
+| `bernstein list-tasks` | `cli/commands/task_cmd.py:776` | Declared as `parts`, registered top-level as `list-tasks`. |
 
-To invoke any of them, just type the full path (`bernstein task compose ...`) - they accept the same flags as their visible siblings.
+A command's declared name and its registered name differ here, so the
+declared spelling is not an invocation: `bernstein task compose` and
+`bernstein task parts` resolve to nothing. Type the names in the table.
+
+`task_cmd.py` also declares a `notes` command (`_notes_legacy`,
+`cli/commands/task_cmd.py:753`) that is registered nowhere and therefore
+cannot be invoked at all. To tail server / spawner logs, use `bernstein logs`.
 
 ---
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -115,6 +115,15 @@ landed since the newest one.
 
 ## Fixed
 
+- The CLI reference no longer names command spellings that do not resolve. It
+  claimed `bernstein commit-stats`, `bernstein incident`, and `bernstein
+  postmortem` were live deprecated aliases after v4.0.0 removed them, and
+  listed `bernstein task compose`, `task sync`, `task notes`, and `task parts`
+  as invocable when those commands are registered at the top level (or, for
+  `notes`, nowhere). `bernstein report commits --help` printed the removed
+  spelling in its own examples. Every command spelling named in a reference
+  table cell is now resolved through the real CLI in CI, so a documented
+  invocation that would exit "No such command" fails the build.
 - `bernstein trace verify-projection` now authenticates the complete
   `otel.projection` audit binding instead of accepting any projection whose
   signature and journal-derived span ids verify (#3551). A verified result

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -1225,7 +1225,7 @@ def _detect_runtime_environment() -> str:
 
 
 # ---------------------------------------------------------------------------
-# commit-stats - agent attribution report
+# report commits - agent attribution report
 # ---------------------------------------------------------------------------
 
 
@@ -1238,9 +1238,9 @@ def commit_stats_cmd(since: str | None, until: str | None, repo_dir: str, as_jso
     """Show commit attribution by agent role.
 
     \b
-      bernstein commit-stats                    # all-time stats
-      bernstein commit-stats --since 2025-01-01 # since a date
-      bernstein commit-stats --json             # machine-readable output
+      bernstein report commits                    # all-time stats
+      bernstein report commits --since 2025-01-01 # since a date
+      bernstein report commits --json             # machine-readable output
     """
     from bernstein.cli.commit_stats import collect_commit_stats, render_commit_stats
 

--- a/tests/unit/test_cli_command_registration.py
+++ b/tests/unit/test_cli_command_registration.py
@@ -475,6 +475,107 @@ def test_subcommand_rows_resolve_and_accept_their_flags(path: str, flags: frozen
     assert not ghosts, f"`bernstein {path}`'s subcommand row mentions flags it does not accept: {ghosts}"
 
 
+# ---------------------------------------------------------------------------
+# Command spellings named inside table cells (#3730 follow-up)
+# ---------------------------------------------------------------------------
+#
+# The heading sweep above resolves a command only where the reference gives it
+# its own section.  A spelling asserted inside a *table cell* escaped every
+# check, so the reference kept claiming `bernstein commit-stats` was a live
+# deprecated alias for ~4 months after #3472 deleted it, and told readers to
+# invoke `bernstein task compose` / `task parts`, which were never registered
+# under `task` at all.  Each read to a user exactly like the command being
+# broken, and CI stayed green throughout.
+#
+# This resolves every ``bernstein <verb>`` spelling a table cell names --
+# purpose cells and replacement cells included, not just the first cell --
+# through the real ``cli`` object.
+#
+# Deliberately out of scope: the ``Deprecated | Canonical`` alias-mapping
+# table, whose left column exists precisely to name spellings that no longer
+# resolve.  Rows are skipped from that header to the end of the table.
+
+# Spellings a table cell names that do not resolve, each with the reason it is
+# tolerated.  An entry here records a documented invocation that fails; keep
+# this as close to empty as the surface allows.
+UNREGISTERED_MENTION_EXEMPTIONS: dict[str, str] = {
+    "cost report": (
+        "never existed as a command; `bernstein fleet bulk-cost-report` dispatches it "
+        "to every project, so the doc row mirrors a live runtime bug in "
+        "src/bernstein/core/fleet/bulk.py:238 -- tracked separately, fixing it here "
+        "would change fleet behaviour"
+    ),
+}
+
+
+def _table_command_mentions() -> list[pytest.param]:
+    """Every ``bernstein <verb>`` spelling named in a reference table cell.
+
+    Rows of the alias-mapping table are skipped: its whole purpose is to name
+    deprecated spellings alongside their canonical replacement, so a left-hand
+    cell that no longer resolves is the documented outcome, not a defect.
+    """
+    reference = Path(__file__).resolve().parents[2] / "docs" / "reference" / "cli-reference.md"
+    mentions: dict[str, int] = {}
+    in_fence = False
+    in_alias_table = False
+
+    for lineno, line in enumerate(reference.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if not stripped.startswith("|"):
+            in_alias_table = False
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if cells and cells[0].strip("`").lower() == "deprecated":
+            in_alias_table = True
+            continue
+        if in_alias_table:
+            continue
+        for raw in _CMD_IN_HEADING.findall(stripped):
+            if "--" in raw or not (path := _strip_argument_placeholders(raw)):
+                continue
+            mentions.setdefault(path, lineno)
+
+    return [pytest.param(path, lineno, id=path) for path, lineno in sorted(mentions.items())]
+
+
+@pytest.mark.parametrize(("path", "lineno"), _table_command_mentions())
+def test_table_cell_command_mentions_resolve(path: str, lineno: int) -> None:
+    """Every command spelling a reference table names resolves through ``cli``.
+
+    A cell asserting that ``bernstein X`` is a usable spelling is a contract
+    with the reader in exactly the way a heading is.  Following one that does
+    not resolve produces "No such command".
+    """
+    if path in UNREGISTERED_MENTION_EXEMPTIONS:
+        pytest.skip(f"known-unregistered spelling: {UNREGISTERED_MENTION_EXEMPTIONS[path]}")
+    assert _resolve(path) is not None, (
+        f"docs/reference/cli-reference.md:{lineno} names `bernstein {path}`, "
+        "which does not resolve through the top-level CLI"
+    )
+
+
+def test_unregistered_mention_exemptions_are_still_needed() -> None:
+    """Every exemption names a spelling that is still both documented and broken.
+
+    An entry that starts resolving -- or that no longer appears in the
+    reference -- would silently exempt nothing while reading as if it did,
+    so the set can only shrink deliberately.
+    """
+    documented = {param.values[0] for param in _table_command_mentions()}
+    for path, reason in UNREGISTERED_MENTION_EXEMPTIONS.items():
+        assert reason.strip(), f"exemption for `bernstein {path}` carries no reason"
+        assert path in documented, f"exempted spelling `bernstein {path}` is no longer named in the reference"
+        assert _resolve(path) is None, (
+            f"exempted spelling `bernstein {path}` resolves now -- drop it from UNREGISTERED_MENTION_EXEMPTIONS"
+        )
+
+
 @pytest.mark.parametrize(
     "exemptions",
     [GHOST_FLAG_EXEMPTIONS, PARTIAL_FLAG_TABLES],


### PR DESCRIPTION
# User description
Opened as a **draft** deliberately: this is for review, not to land on green.

## What

`docs/reference/cli-reference.md` named seven `bernstein <verb>` spellings that do not resolve. Following any of them gives `No such command`.

| Documented spelling | Reality |
|---|---|
| `bernstein commit-stats` | removed by #3472 (closes #3380, v4.0.0 deprecation schedule) |
| `bernstein incident` | removed by #3472 |
| `bernstein postmortem` | removed by #3472 |
| `bernstein task compose` | registered top-level as `add-task` |
| `bernstein task sync` | registered top-level as `sync` |
| `bernstein task parts` | registered top-level as `list-tasks` |
| `bernstein task notes` | `_notes_legacy` - registered nowhere at all |

The first three were documented as deprecated aliases "until v4.0.0". Checked the history before deciding which way to fix it: #3472 removed them on purpose, so the doc claim is stale and the correct fix is to drop it, not to re-register the commands.

The last four sat under a "Hidden commands" heading whose closing line told the reader to "just type the full path". They carry `hidden=True` but are never added to `task_group` - the same shape as #3134 and #3139, one level down.

`bernstein report commits --help` also printed `bernstein commit-stats` in its own usage examples, so the dead spelling reached users straight from the CLI.

## Why CI did not catch it

`test_documented_commands_are_registered` resolves commands named in markdown **headings**. All seven claims live in table cells, so every one escaped the gate.

## The gate

`test_table_cell_command_mentions_resolve` walks table cells and resolves each spelling through the real `cli` object.

Verified in both directions:

```
# with the doc fix reverted
FAILED ...::test_table_cell_command_mentions_resolve[commit-stats]
FAILED ...::test_table_cell_command_mentions_resolve[incident]
FAILED ...::test_table_cell_command_mentions_resolve[postmortem]
FAILED ...::test_table_cell_command_mentions_resolve[task compose]
FAILED ...::test_table_cell_command_mentions_resolve[task notes]
FAILED ...::test_table_cell_command_mentions_resolve[task parts]
FAILED ...::test_table_cell_command_mentions_resolve[task sync]
```

```
# as submitted
665 passed, 2 skipped
```

One test per spelling, so a regression names the command rather than only reporting that some command went missing.

**Scoped out by design:** the `Deprecated | Canonical` alias-mapping table. Its left column exists to name spellings that no longer resolve, so rows from that header to the end of the table are skipped.

## One exemption, and a bug it points at

Widening the gate surfaced `bernstein cost report`, which never existed - and `bernstein fleet bulk-cost-report` shells out to it for every project (`src/bernstein/core/fleet/bulk.py:238`). That is a live runtime bug, not a doc defect, and fixing it means choosing a replacement command and changing fleet behaviour. Filed as #3755 and exempted here with that reason.

`test_unregistered_mention_exemptions_are_still_needed` stops the exemption rotting: it fails if the spelling starts resolving or stops being documented, so closing #3755 forces the entry out.

## Also

Corrected three stale `Source` paths in the same rows (`cli/incident_cmd.py` -> `cli/commands/incident_cmd.py`, and a `status_cmd.py:914` that pointed at neither).

## Checklist

- [x] `ruff check` + `ruff format --check` pass on touched files
- [x] `tests/unit/test_cli_command_registration.py` - 665 passed, 2 skipped
- [x] `test_commit_stats.py`, `test_docs_prose_cli_drift.py`, `test_docs_capability_reachability.py`, `test_docs_url_hygiene.py` - 39 passed
- [x] New test has type hints

### Documentation duty

- [x] `docs/reference/cli-reference.md` updated
- [x] `docs/operations/commit-attribution.md` updated
- [x] `docs/release-notes/unreleased.md` updated
- [x] `docs/api/` schema regenerated if a public surface changed (N/A - no API surface change)
- [x] `bernstein agents-md sync` (N/A - no module added or moved)
- [x] Tests cover the documented behaviour

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Correct CLI documentation and commit-report help to use only registered command spellings, while updating source references and operational guidance. Add table-cell command resolution checks and a guarded exemption for the known <code>cost report</code> runtime defect.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3756?tool=ast&topic=CLI+docs+accuracy>CLI docs accuracy</a>
        </td><td>Update CLI reference, commit-attribution guidance, and release notes to remove obsolete aliases, correct top-level task commands, document the unregistered <code>notes</code> command, and fix source paths.<details><summary>Modified files (4)</summary><ul><li>docs/operations/commit-attribution.md</li>
<li>docs/reference/cli-reference.md</li>
<li>docs/release-notes/unreleased.md</li>
<li>src/bernstein/cli/commands/status_cmd.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(docs): resolve CLI...</td><td>August 14, 2026</td></tr>
<tr><td>ngminhkhoayj2706@gmail...</td><td>fix(mcp): disclose too...</td><td>August 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3756?tool=ast&topic=Documentation+CI+gate>Documentation CI gate</a>
        </td><td>Validate every command spelling in CLI reference table cells through the real <code>cli</code>, while preserving and monitoring the intentional <code>cost report</code> exemption.<details><summary>Modified files (1)</summary><ul><li>tests/unit/test_cli_command_registration.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(docs): resolve CLI...</td><td>August 14, 2026</td></tr>
<tr><td>chernistry</td><td>docs(cli): reconcile t...</td><td>August 10, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3756?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>