### PR TITLE
fix(plugins): honor workspace trust for project-hook execution

### DIFF
--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -925,7 +925,7 @@ async def create_task(body: TaskCreate, request: Request) -> TaskResponse:
 
         # Pre-create hook: may block via HookBlockingError (T719)
         try:
-            pm = get_plugin_manager()
+            pm = get_plugin_manager(_get_workdir(request))
             pm.fire_pre_task_create(
                 task_id="",  # ID not yet assigned - use empty string
                 role=effective_body.role,
@@ -987,7 +987,7 @@ async def create_task(body: TaskCreate, request: Request) -> TaskResponse:
             build_log_record(task.id, task, assessment),
         )
         sse_bus.publish("task_update", json.dumps({"id": task.id, "status": task.status.value}))
-        get_plugin_manager().fire_task_created(task_id=task.id, role=task.role, title=task.title)
+        get_plugin_manager(_get_workdir(request)).fire_task_created(task_id=task.id, role=task.role, title=task.title)
         return task_to_response(task)
 
 
@@ -1033,7 +1033,7 @@ async def create_tasks_batch(body: BatchCreateRequest, request: Request) -> Batc
 
         # Pre-create hook: skip individual task if blocked (don't fail entire batch)
         try:
-            pm = get_plugin_manager()
+            pm = get_plugin_manager(_get_workdir(request))
             pm.fire_pre_task_create(
                 task_id="",
                 role=effective.role,
@@ -1059,7 +1059,7 @@ async def create_tasks_batch(body: BatchCreateRequest, request: Request) -> Batc
                 build_log_record(task.id, task, task_assessment),
             )
         sse_bus.publish("task_update", json.dumps({"id": task.id, "status": task.status.value}))
-        get_plugin_manager().fire_task_created(task_id=task.id, role=task.role, title=task.title)
+        get_plugin_manager(_get_workdir(request)).fire_task_created(task_id=task.id, role=task.role, title=task.title)
 
     return BatchCreateResponse(
         created=[task_to_response(t) for t in created_tasks],
@@ -1129,7 +1129,7 @@ async def self_create_subtask(body: TaskSelfCreate, request: Request) -> TaskRes
                     json.dumps({"id": parent.id, "status": "waiting_for_subtasks"}),
                 )
 
-        get_plugin_manager().fire_task_created(task_id=task.id, role=task.role, title=task.title)
+        get_plugin_manager(_get_workdir(request)).fire_task_created(task_id=task.id, role=task.role, title=task.title)
         return task_to_response(task)
 
 
@@ -1337,7 +1337,7 @@ async def _handle_contract_violation(
         sanitize_log(violation.path),
     )
     sse_bus.publish("task_update", json.dumps({"id": failed_task.id, "status": failed_task.status.value}))
-    get_plugin_manager().fire_task_failed(
+    get_plugin_manager(_get_workdir(request)).fire_task_failed(
         task_id=failed_task.id,
         role=failed_task.role,
         error=f"contract_violation: {violation.path}",
@@ -1487,7 +1487,7 @@ async def complete_task(task_id: str, body: TaskCompleteRequest, request: Reques
                     "task_update",
                     json.dumps({"id": failed_task.id, "status": failed_task.status.value}),
                 )
-                get_plugin_manager().fire_task_failed(
+                get_plugin_manager(_get_workdir(request)).fire_task_failed(
                     task_id=failed_task.id,
                     role=failed_task.role,
                     error="completion missing summary",
@@ -1505,7 +1505,9 @@ async def complete_task(task_id: str, body: TaskCompleteRequest, request: Reques
         if refusal is not None:
             return await _finalize_refusal(request, task, refusal, store, sse_bus)
         sse_bus.publish("task_update", json.dumps({"id": task.id, "status": "done"}))
-        get_plugin_manager().fire_task_completed(task_id=task.id, role=task.role, result_summary=result_summary)
+        get_plugin_manager(_get_workdir(request)).fire_task_completed(
+            task_id=task.id, role=task.role, result_summary=result_summary
+        )
 
         # Sigstore/Ed25519 attestation for the task completion (fire-and-forget)
         _try_attest_task_completion(request, task.id, task.role, result_summary)
@@ -1583,7 +1585,7 @@ async def fail_task(task_id: str, body: TaskFailRequest, request: Request) -> Ta
         )
         raise HTTPException(status_code=409, detail=str(exc)) from None
     sse_bus.publish("task_update", json.dumps({"id": task.id, "status": "failed"}))
-    get_plugin_manager().fire_task_failed(task_id=task.id, role=task.role, error=body.reason)
+    get_plugin_manager(_get_workdir(request)).fire_task_failed(task_id=task.id, role=task.role, error=body.reason)
 
     # Update per-file health scores with failure outcome (fire-and-forget)
     _update_file_health(request, task.id, list(task.owned_files), "failure")

--- a/src/bernstein/plugins/manager.py
+++ b/src/bernstein/plugins/manager.py
@@ -174,6 +174,7 @@ class CommandHook:
         hooks_dir: Path,
         plugin_root: str = "",
         seen: set[tuple[str, str]] | None = None,
+        workspace_root: Path | None = None,
     ) -> None:
         """Create a CommandHook instance.
 
@@ -183,10 +184,21 @@ class CommandHook:
                 source. Used for dedup logging when collisions occur.
             seen: Shared set tracking registered hook+script combos across all
                 CommandHook instances. Mutated in place.
+            workspace_root: Project root whose trust state gates execution of
+                these committed hook scripts. When ``None`` it is derived from
+                *hooks_dir* (``.bernstein/hooks`` lives directly under the
+                project root), so the trust decision always tracks the tree the
+                scripts were discovered in.
         """
         self._hooks_dir = hooks_dir
         self._plugin_root = plugin_root
         self._seen: set[tuple[str, str]] = seen if seen is not None else set()
+        # ``.bernstein/hooks`` sits directly under the project root, so the
+        # root is the grandparent of the hooks directory.  Anchoring the trust
+        # check here means committed hook scripts can only run when the tree
+        # they live in has been explicitly trusted, independent of whatever
+        # workdir the shared PluginManager happens to hold.
+        self._workspace_root = workspace_root if workspace_root is not None else hooks_dir.parent.parent
 
     def _script_key(self, script: Path) -> str:
         """Return a dedup key for a script based on its resolved path."""
@@ -314,6 +326,19 @@ class CommandHook:
         self, hook_name: str, script: Path, current_payload: dict[str, Any]
     ) -> tuple[dict[str, Any], bool]:
         """Execute a single hook script and return (updated_payload, should_abort)."""
+        # Fail-closed trust gate at the execution boundary.  This is the last
+        # check before a committed script is handed to the shell, so a hook
+        # that reached this point through any dispatch path - including one
+        # whose PluginManager never resolved a workdir - cannot run in an
+        # untrusted or indeterminate workspace.
+        if not is_workspace_trusted(self._workspace_root):
+            log.warning(
+                "Hook execution gated: workspace is not trusted (%s). "
+                "Skipping hook script %s. Grant workspace trust to enable hook execution.",
+                self._workspace_root,
+                script.name,
+            )
+            return current_payload, False
         sub_kwargs, env = self._prepare_hook_env(**current_payload)
         proc = subprocess.run(
             [str(script)],
@@ -1079,7 +1104,10 @@ class PluginManager:
         try:
             hooks_dir = root / ".bernstein" / "hooks"
             if hooks_dir.is_dir():
-                self.register(CommandHook(hooks_dir, seen=self._hook_seen), name="command_hooks")
+                self.register(
+                    CommandHook(hooks_dir, seen=self._hook_seen, workspace_root=root),
+                    name="command_hooks",
+                )
         except Exception as exc:
             log.warning("Command hooks subsystem failed to load: %s", exc)
 
@@ -1123,6 +1151,12 @@ class PluginManager:
             workdir: Project root directory.  Defaults to ``Path.cwd()``.
         """
         root = workdir or Path.cwd()
+
+        # Anchor the trust decision to the tree we are about to load from.
+        # Discovering hooks under ``root`` and then gating them on a different
+        # (or absent) ``_workdir`` is exactly the gap that let committed hooks
+        # run untrusted, so the manager's trust root is the root it loads.
+        self._workdir = root
 
         # Load enterprise plugin policy before any plugin registration.
         self._policy = load_plugin_policy(root)
@@ -1172,6 +1206,15 @@ class PluginManager:
     # ------------------------------------------------------------------
     # Introspection
     # ------------------------------------------------------------------
+
+    @property
+    def workdir(self) -> Path | None:
+        """Project root this manager is anchored to for trust decisions.
+
+        ``None`` until a workdir is established (via the constructor or
+        :meth:`load_from_workdir`), in which case hook execution is gated.
+        """
+        return self._workdir
 
     @property
     def registered_names(self) -> list[str]:
@@ -1236,14 +1279,21 @@ class PluginManager:
     def _check_workspace_trust(self) -> bool:
         """Check whether the workspace is trusted for hook execution (T456).
 
-        Returns True if hooks are allowed to run, False if they should be
-        skipped because trust has not been granted.
+        Fails closed: hooks run only when the workspace root is known *and*
+        has been explicitly trusted.  An indeterminate root (``None``) is
+        treated as untrusted rather than auto-trusted, and simply matching the
+        current working directory no longer grants trust on its own - being
+        *inside* a directory is not consent to run code committed into it.
 
         Returns:
             True when hooks are allowed, False when gated.
         """
-        if self._workdir is None or self._workdir == Path.cwd():
-            return True
+        if self._workdir is None:
+            log.warning(
+                "Hook execution gated: workspace root is indeterminate; treating as untrusted. "
+                "Initialise the plugin manager with the project workdir to enable hook execution.",
+            )
+            return False
         if not is_workspace_trusted(self._workdir):
             log.warning(
                 "Hook execution gated: workspace is not trusted (%s). Run the trust command to enable hook execution.",
@@ -1291,6 +1341,15 @@ class PluginManager:
 def get_plugin_manager(workdir: Path | None = None, reload: bool = False) -> PluginManager:
     """Return the global :class:`PluginManager` instance.
 
+    The manager is a process-global singleton, but the *first* caller does not
+    always know the project root: internal callers (guardrails, trackers,
+    metrics) invoke this with no ``workdir`` and could otherwise pin the
+    singleton to an indeterminate root before a request-scoped caller supplies
+    the real one.  To keep the trust decision anchored to the real project
+    root, a concrete ``workdir`` that differs from the current singleton's root
+    rebuilds the manager against it.  ``None`` never forces a rebuild, so
+    workdir-less callers keep sharing whatever manager is already established.
+
     Args:
         workdir: Project root for loading local plugins.
         reload: If True, discard any existing manager and create a new one.
@@ -1299,7 +1358,7 @@ def get_plugin_manager(workdir: Path | None = None, reload: bool = False) -> Plu
         The (possibly freshly constructed) :class:`PluginManager`.
     """
     global _manager
-    if _manager is None or reload:
+    if _manager is None or reload or (workdir is not None and _manager.workdir != workdir):
         _manager = PluginManager(workdir=workdir)
         _manager.load_from_workdir(workdir)
     return _manager

--- a/tests/unit/plugins/test_background_hooks.py
+++ b/tests/unit/plugins/test_background_hooks.py
@@ -1,5 +1,8 @@
 import threading
 import time
+from pathlib import Path
+
+import pytest
 
 from bernstein.plugins import hookimpl, hookspec
 from bernstein.plugins.manager import PluginManager
@@ -7,6 +10,16 @@ from bernstein.plugins.manager import PluginManager
 # Generous upper bound for a thread hand-off. Only ever reached when dispatch
 # is broken, so a loaded runner cannot turn it into a flake.
 DISPATCH_TIMEOUT = 5.0
+
+
+@pytest.fixture(autouse=True)
+def _trusted_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise hook-dispatch mechanics against a trusted workspace.
+
+    Trust gating (untrusted / indeterminate workspaces) is owned by
+    tests/unit/test_plugins.py; these tests assume trust has been granted.
+    """
+    monkeypatch.setattr("bernstein.plugins.manager.is_workspace_trusted", lambda _root: True)
 
 
 class BackgroundSpec:
@@ -38,8 +51,8 @@ class SlowPlugin:
         self.done.set()
 
 
-def test_background_hook_is_non_blocking():
-    pm = PluginManager()
+def test_background_hook_is_non_blocking(tmp_path: Path):
+    pm = PluginManager(workdir=tmp_path)
     # Replace spec for testing
     pm._pm.add_hookspecs(BackgroundSpec)
 
@@ -82,8 +95,8 @@ class BlockingPlugin:
         self.finished = True
 
 
-def test_sync_hook_blocks():
-    pm = PluginManager()
+def test_sync_hook_blocks(tmp_path: Path):
+    pm = PluginManager(workdir=tmp_path)
     pm._pm.add_hookspecs(SyncSpec)
 
     plugin = BlockingPlugin()

--- a/tests/unit/test_command_hook_fixture_harness.py
+++ b/tests/unit/test_command_hook_fixture_harness.py
@@ -29,6 +29,17 @@ import pytest
 
 from bernstein.plugins.manager import CommandHook, HookBlockingError
 
+
+@pytest.fixture(autouse=True)
+def _trusted_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise hook-execution mechanics against a trusted workspace.
+
+    Trust gating (untrusted / indeterminate workspaces) is owned by
+    tests/unit/test_plugins.py; these suites assume trust has been granted.
+    """
+    monkeypatch.setattr("bernstein.plugins.manager.is_workspace_trusted", lambda _root: True)
+
+
 # ---------------------------------------------------------------------------
 # CommandHookHarness - the reusable harness
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_command_hook_harness.py
+++ b/tests/unit/test_command_hook_harness.py
@@ -19,6 +19,16 @@ from tests.fixtures.command_hook_harness import CommandHookHarness
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _trusted_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise hook-execution mechanics against a trusted workspace.
+
+    Trust gating (untrusted / indeterminate workspaces) is owned by
+    tests/unit/test_plugins.py; these suites assume trust has been granted.
+    """
+    monkeypatch.setattr("bernstein.plugins.manager.is_workspace_trusted", lambda _root: True)
+
+
 @pytest.fixture()
 def harness(tmp_path: Path) -> CommandHookHarness:
     """Fresh CommandHookHarness backed by a temp directory."""

--- a/tests/unit/test_hook_dedup.py
+++ b/tests/unit/test_hook_dedup.py
@@ -5,7 +5,20 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from bernstein.plugins.manager import CommandHook
+
+
+@pytest.fixture(autouse=True)
+def _trusted_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise hook-execution mechanics against a trusted workspace.
+
+    Trust gating (untrusted / indeterminate workspaces) is owned by
+    tests/unit/test_plugins.py; these suites assume trust has been granted.
+    """
+    monkeypatch.setattr("bernstein.plugins.manager.is_workspace_trusted", lambda _root: True)
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/test_hook_exit_codes.py
+++ b/tests/unit/test_hook_exit_codes.py
@@ -11,6 +11,16 @@ import pytest
 from bernstein.plugins.manager import HookBlockingError, PluginManager
 
 
+@pytest.fixture(autouse=True)
+def _trusted_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise hook-execution mechanics against a trusted workspace.
+
+    Trust gating (untrusted / indeterminate workspaces) is owned by
+    tests/unit/test_plugins.py; these suites assume trust has been granted.
+    """
+    monkeypatch.setattr("bernstein.plugins.manager.is_workspace_trusted", lambda _root: True)
+
+
 @pytest.fixture
 def hooks_dir(tmp_path: Path) -> Path:
     d = tmp_path / ".bernstein" / "hooks" / "on_task_created"

--- a/tests/unit/test_hook_json_contract.py
+++ b/tests/unit/test_hook_json_contract.py
@@ -11,6 +11,16 @@ import pytest
 from bernstein.plugins.manager import HookBlockingError, PluginManager
 
 
+@pytest.fixture(autouse=True)
+def _trusted_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise hook-execution mechanics against a trusted workspace.
+
+    Trust gating (untrusted / indeterminate workspaces) is owned by
+    tests/unit/test_plugins.py; these suites assume trust has been granted.
+    """
+    monkeypatch.setattr("bernstein.plugins.manager.is_workspace_trusted", lambda _root: True)
+
+
 @pytest.fixture
 def hooks_dir(tmp_path: Path) -> Path:
     d = tmp_path / ".bernstein" / "hooks" / "on_task_created"

--- a/tests/unit/test_hook_lifecycle_events.py
+++ b/tests/unit/test_hook_lifecycle_events.py
@@ -20,6 +20,16 @@ from bernstein.plugins.manager import (
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _trusted_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise hook-execution mechanics against a trusted workspace.
+
+    Trust gating (untrusted / indeterminate workspaces) is owned by
+    tests/unit/test_plugins.py; these suites assume trust has been granted.
+    """
+    monkeypatch.setattr("bernstein.plugins.manager.is_workspace_trusted", lambda _root: True)
+
+
 @pytest.fixture()
 def plugin_mgr(tmp_path: Path) -> PluginManager:
     """PluginManager with no plugins loaded."""

--- a/tests/unit/test_hook_protocol.py
+++ b/tests/unit/test_hook_protocol.py
@@ -11,6 +11,16 @@ from bernstein.plugins.manager import CommandHook
 from tests.fixtures.command_hook_harness import CommandHookHarness
 
 
+@pytest.fixture(autouse=True)
+def _trusted_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise hook-execution mechanics against a trusted workspace.
+
+    Trust gating (untrusted / indeterminate workspaces) is owned by
+    tests/unit/test_plugins.py; these suites assume trust has been granted.
+    """
+    monkeypatch.setattr("bernstein.plugins.manager.is_workspace_trusted", lambda _root: True)
+
+
 def test_command_hook_rejects_invalid_payload(tmp_path: Path) -> None:
     hooks_dir = tmp_path / ".bernstein" / "hooks"
     hooks_dir.mkdir(parents=True)

--- a/tests/unit/test_hook_timing.py
+++ b/tests/unit/test_hook_timing.py
@@ -4,11 +4,22 @@ from __future__ import annotations
 
 import logging
 import time
+from pathlib import Path
 
 import pytest
 
 from bernstein.plugins import hookimpl
 from bernstein.plugins.manager import HookBlockingError, PluginManager
+
+
+@pytest.fixture(autouse=True)
+def _trusted_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise hook-execution mechanics against a trusted workspace.
+
+    Trust gating (untrusted / indeterminate workspaces) is owned by
+    tests/unit/test_plugins.py; these suites assume trust has been granted.
+    """
+    monkeypatch.setattr("bernstein.plugins.manager.is_workspace_trusted", lambda _root: True)
 
 
 class _NoopPlugin:
@@ -22,9 +33,9 @@ class _NoopPlugin:
 class TestHookTiming:
     """Tests for hook execution timing and outcome logging."""
 
-    def test_successful_hook_logs_debug_duration(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_successful_hook_logs_debug_duration(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         """Successful hook execution logs debug-level duration."""
-        pm = PluginManager()
+        pm = PluginManager(workdir=tmp_path)
         pm.register(_NoopPlugin(), name="noop")
 
         caplog.set_level(logging.DEBUG)
@@ -36,7 +47,7 @@ class TestHookTiming:
         assert "outcome=success" in timing_msgs[0]
         assert "foreground" in timing_msgs[0]
 
-    def test_failing_hook_logs_exception_outcome(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_failing_hook_logs_exception_outcome(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         """Failing hook logs warning with exception in message."""
 
         class FailingPlugin:
@@ -44,7 +55,7 @@ class TestHookTiming:
             def on_task_created(self, task_id: str, role: str, title: str) -> None:
                 raise ValueError("plugin bug")
 
-        pm = PluginManager()
+        pm = PluginManager(workdir=tmp_path)
         pm.register(FailingPlugin(), name="failing")
 
         pm.fire_task_created(task_id="t1", role="backend", title="Test")
@@ -54,7 +65,7 @@ class TestHookTiming:
         assert len(raised) >= 1
         assert "plugin bug" in raised[0]
 
-    def test_slow_hook_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_slow_hook_logs_warning(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         """Slow hook (above threshold) logs a warning with timing detail."""
 
         class SlowPlugin:
@@ -62,7 +73,7 @@ class TestHookTiming:
             def on_task_created(self, task_id: str, role: str, title: str) -> None:
                 time.sleep(0.05)  # 50ms - small but measurable
 
-        pm = PluginManager()
+        pm = PluginManager(workdir=tmp_path)
         pm.register(SlowPlugin(), name="slow")
 
         import bernstein.plugins.manager as mgr_mod
@@ -81,7 +92,7 @@ class TestHookTiming:
         assert "on_task_created" in slow_msgs[0]
         assert "foreground" in slow_msgs[0]
 
-    def test_hook_blocking_error_propagates(self) -> None:
+    def test_hook_blocking_error_propagates(self, tmp_path: Path) -> None:
         """Blocking errors are re-raised, not swallowed."""
 
         class BlockingPlugin:
@@ -89,7 +100,7 @@ class TestHookTiming:
             def on_task_created(self, task_id: str, role: str, title: str) -> None:
                 raise HookBlockingError("on_task_created", "blocked by policy")
 
-        pm = PluginManager()
+        pm = PluginManager(workdir=tmp_path)
         pm.register(BlockingPlugin(), name="blocking")
 
         with pytest.raises(HookBlockingError) as exc_info:

--- a/tests/unit/test_permission_denied_hook.py
+++ b/tests/unit/test_permission_denied_hook.py
@@ -5,10 +5,21 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from bernstein.core.guardrails import GuardrailsConfig, run_guardrails
 from bernstein.core.models import Task
 
 from bernstein.plugins import hookimpl
+
+
+@pytest.fixture(autouse=True)
+def _trusted_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise the permission-denied hook against a trusted workspace.
+
+    Trust gating (untrusted / indeterminate workspaces) is owned by
+    tests/unit/test_plugins.py; this suite assumes trust has been granted.
+    """
+    monkeypatch.setattr("bernstein.plugins.manager.is_workspace_trusted", lambda _root: True)
 
 
 class HintPlugin:
@@ -23,7 +34,7 @@ def test_guardrail_triggers_hook_and_appends_hint(tmp_path: Path):
     # Setup plugin manager with our test plugin
     from bernstein.plugins.manager import PluginManager
 
-    pm = PluginManager()
+    pm = PluginManager(workdir=tmp_path)
     pm._pm.register(HintPlugin())
 
     # Mock get_plugin_manager to return our custom pm

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, cast
+from pathlib import Path
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
+from bernstein.core.persistence.workspace import grant_workspace_trust
 from bernstein.plugins import hookimpl
 from bernstein.plugins.manager import PluginManager
 
@@ -70,9 +69,15 @@ class _BrokenPlugin:
 
 
 @pytest.fixture()
-def pm() -> PluginManager:
-    """Fresh PluginManager with no external plugins loaded."""
-    return PluginManager()
+def pm(tmp_path: Path) -> PluginManager:
+    """Fresh PluginManager anchored to a trusted workspace.
+
+    Hook dispatch is fail-closed: it only runs in a workspace whose trust has
+    been granted.  These tests exercise dispatch mechanics, not the trust
+    policy, so they run against an explicitly-trusted temp workspace.
+    """
+    grant_workspace_trust(tmp_path)
+    return PluginManager(workdir=tmp_path)
 
 
 # ---------------------------------------------------------------------------
@@ -380,15 +385,36 @@ class TestWorkspaceTrustGating:
         # Must not have fired any hooks
         assert len(plugin.calls) == 0
 
-    def test_hooks_run_without_workdir(self) -> None:
-        """Hooks execute when no workdir is set (defaults to trusting)."""
+    def test_hooks_gated_without_workdir(self) -> None:
+        """Hooks are gated when the workspace root is indeterminate.
+
+        A ``None`` workdir must fail closed rather than auto-trust: an
+        indeterminate root cannot be shown to be trusted, so hooks do not run.
+        """
         pm = PluginManager()
+        assert pm.workdir is None
         plugin = _CollectorPlugin()
         pm.register(plugin, name="c")
 
         pm.fire_task_completed(task_id="t2", role="qa", result_summary="ok")
 
-        assert len(plugin.calls) == 1
+        assert len(plugin.calls) == 0
+
+    def test_hooks_gated_when_cwd_untrusted(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Being *inside* a workspace does not by itself grant trust.
+
+        The old short-circuit trusted any workspace equal to ``Path.cwd()``.
+        That is the workspace-trust bypass: hooks must consult the recorded
+        trust state even when the workdir is the current directory.
+        """
+        monkeypatch.chdir(tmp_path)
+        pm = PluginManager(workdir=tmp_path)  # == Path.cwd(), but untrusted
+        plugin = _CollectorPlugin()
+        pm.register(plugin, name="c")
+
+        pm.fire_task_completed(task_id="t2", role="qa", result_summary="ok")
+
+        assert len(plugin.calls) == 0
 
     def test_fire_permission_denied_gated(self, tmp_path: Path) -> None:
         """fire_permission_denied returns None when trust is gated."""
@@ -428,6 +454,128 @@ class TestWorkspaceTrustGating:
             args={"cmd": "#file/edit"},
         )
         assert result == "use safe command"
+
+
+class TestCommittedHookExecutionGate:
+    """End-to-end trust gate for committed ``.bernstein/hooks`` scripts.
+
+    A committed hook script is local code-execution: it must run only when the
+    workspace it lives in has been explicitly trusted.  These tests drive the
+    real ``get_plugin_manager`` / ``subprocess`` path an operator would hit.
+    """
+
+    @staticmethod
+    def _install_hook(workdir: Path, sentinel: Path) -> None:
+        """Write a committed on_task_created hook that touches *sentinel*."""
+        import os
+        import stat
+
+        hook_dir = workdir / ".bernstein" / "hooks" / "on_task_created"
+        hook_dir.mkdir(parents=True)
+        script = hook_dir / "touch.sh"
+        script.write_text(f"#!/bin/sh\ntouch {sentinel}\n", encoding="utf-8")
+        script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        assert os.access(script, os.X_OK)
+
+    @staticmethod
+    def _set_trust(workdir: Path, *, trusted: bool) -> None:
+        import json as _json
+
+        trust_dir = workdir / ".sdd" / "runtime"
+        trust_dir.mkdir(parents=True, exist_ok=True)
+        (trust_dir / "workspace_trust.json").write_text(
+            _json.dumps({"trusted": trusted, "granted_by": "test", "granted_at": 0}),
+            encoding="utf-8",
+        )
+
+    def test_committed_hook_not_executed_when_untrusted(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A committed hook must NOT run when workspace_trust.json is false.
+
+        Reproduces the production bug faithfully: the caller invokes
+        ``get_plugin_manager()`` with *no* workdir while sitting inside the
+        untrusted project (exactly what the task route did).  The side effect
+        must never happen and the shell must never be invoked.
+        """
+        from bernstein.plugins.manager import get_plugin_manager
+
+        sentinel = tmp_path / "hook_ran.marker"
+        self._install_hook(tmp_path, sentinel)
+        self._set_trust(tmp_path, trusted=False)
+        monkeypatch.chdir(tmp_path)
+
+        with (
+            patch("bernstein.plugins.manager.subprocess.run") as mock_run,
+            patch("bernstein.plugins.manager.entry_points", return_value=[]),
+        ):
+            pm = get_plugin_manager(reload=True)  # no workdir -> the vulnerable path
+            pm.fire_task_created(task_id="t1", role="backend", title="Build auth")
+
+        assert not sentinel.exists(), "untrusted committed hook must not run"
+        mock_run.assert_not_called()
+
+    def test_committed_hook_not_executed_when_untrusted_explicit_workdir(self, tmp_path: Path) -> None:
+        """The exec-boundary gate also holds when the workdir is passed explicitly."""
+        from bernstein.plugins.manager import get_plugin_manager
+
+        sentinel = tmp_path / "hook_ran.marker"
+        self._install_hook(tmp_path, sentinel)
+        self._set_trust(tmp_path, trusted=False)
+
+        with (
+            patch("bernstein.plugins.manager.subprocess.run") as mock_run,
+            patch("bernstein.plugins.manager.entry_points", return_value=[]),
+        ):
+            pm = get_plugin_manager(tmp_path, reload=True)
+            pm.fire_task_created(task_id="t1", role="backend", title="Build auth")
+
+        assert not sentinel.exists(), "untrusted committed hook must not run"
+        mock_run.assert_not_called()
+
+    def test_committed_hook_executed_when_trusted(self, tmp_path: Path) -> None:
+        """The same committed hook DOES run once trust is granted (no regression)."""
+        from bernstein.plugins.manager import get_plugin_manager
+
+        sentinel = tmp_path / "hook_ran.marker"
+        self._install_hook(tmp_path, sentinel)
+        self._set_trust(tmp_path, trusted=True)
+
+        with patch("bernstein.plugins.manager.entry_points", return_value=[]):
+            pm = get_plugin_manager(tmp_path, reload=True)
+            pm.fire_task_created(task_id="t1", role="backend", title="Build auth")
+
+        assert sentinel.exists(), "trusted committed hook must run"
+
+    def test_get_plugin_manager_receives_real_workdir(self, tmp_path: Path) -> None:
+        """get_plugin_manager on the hook path anchors to a real workdir, not None."""
+        from bernstein.plugins.manager import get_plugin_manager
+
+        with patch("bernstein.plugins.manager.entry_points", return_value=[]):
+            pm = get_plugin_manager(tmp_path, reload=True)
+
+        assert pm.workdir == tmp_path
+
+    def test_concrete_workdir_supersedes_indeterminate_singleton(self, tmp_path: Path) -> None:
+        """A workdir-less first caller must not pin the singleton to an untrusted root.
+
+        Mirrors production ordering: an internal caller (e.g. guardrails) builds
+        the singleton with no workdir, then a request-scoped caller supplies the
+        real project root.  The later concrete workdir must win so trust is
+        evaluated against the real tree.
+        """
+        from bernstein.plugins.manager import get_plugin_manager
+
+        sentinel = tmp_path / "hook_ran.marker"
+        self._install_hook(tmp_path, sentinel)
+        self._set_trust(tmp_path, trusted=True)
+
+        with patch("bernstein.plugins.manager.entry_points", return_value=[]):
+            first = get_plugin_manager(reload=True)  # no workdir (internal caller)
+            second = get_plugin_manager(tmp_path)  # real project root (request path)
+            second.fire_task_created(task_id="t1", role="backend", title="Build auth")
+
+        assert second.workdir == tmp_path
+        assert first is not second
+        assert sentinel.exists(), "hook must run against the adopted, trusted workdir"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_task_hook_rejection.py
+++ b/tests/unit/test_task_hook_rejection.py
@@ -11,6 +11,16 @@ import pytest
 from bernstein.plugins.manager import HookBlockingError, PluginManager
 
 
+@pytest.fixture(autouse=True)
+def _trusted_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise hook-execution mechanics against a trusted workspace.
+
+    Trust gating (untrusted / indeterminate workspaces) is owned by
+    tests/unit/test_plugins.py; these suites assume trust has been granted.
+    """
+    monkeypatch.setattr("bernstein.plugins.manager.is_workspace_trusted", lambda _root: True)
+
+
 class TestPreTaskCreateHook:
     """T719 - pre-task-create hooks can block task creation."""
 
@@ -20,7 +30,7 @@ class TestPreTaskCreateHook:
         pm.fire_pre_task_create(task_id="t1", role="backend", title="Test", description="A task")
 
     def test_fire_pre_task_create_blocked_by_hook(self, tmp_path: Path) -> None:
-        pm = PluginManager()
+        pm = PluginManager(workdir=tmp_path)
 
         class BlockingPlugin:
             from bernstein.plugins import hookimpl


### PR DESCRIPTION
## What

Project hooks under `.bernstein/hooks/<event>/` run through the plugin manager's dispatch path, which is meant to execute committed hook scripts only when the workspace has been explicitly trusted (`.sdd/runtime/workspace_trust.json`). The trust check short-circuited to "trusted" whenever the plugin manager had no resolved workdir, and also whenever the workdir merely equaled the current directory. As a result the trust state was not consulted on those paths.

## Change (fail closed)

- **Thread the resolved project workdir** into every `get_plugin_manager()` call on the task hook path (`core/routes/task_crud.py`), so the trust check runs against the real project root rather than `None`. The manager is a process-global singleton; a concrete workdir now supersedes an indeterminate (workdir-less) singleton, so the trust root is always the real project root.
- **Anchor the trust root to the loaded tree.** `load_from_workdir` records the root it discovers hooks under, and `_check_workspace_trust` treats a `None`/indeterminate workdir as untrusted instead of auto-trusting it. Being inside a directory is not consent to run code committed into it, so the `== cwd` special case is removed.
- **Re-check trust at the execution boundary.** `CommandHook` verifies the workspace is trusted immediately before a script is handed to the shell, so a hook that reaches the boundary through any dispatch path cannot run in an untrusted or indeterminate workspace.

Genuinely-trusted workspaces are unchanged: with `workspace_trust.json = {"trusted": true}` hooks run exactly as before.

## Tests

- New regression tests: a committed hook under an **untrusted** workspace does not execute (the side effect never happens and the subprocess is never invoked); the same hook under a **trusted** workspace does execute; and the hook path resolves a real workdir (not `None`). Also covers the current-directory case and the indeterminate-singleton adoption.
- Existing hook-execution suites now run against an explicitly trusted workspace; trust gating itself is centralized in `tests/unit/test_plugins.py`.
- `ruff check` / `ruff format` clean; `import bernstein` verified.
