### PR TITLE
release: v3.15.0

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.14.159",
+  "version": "3.15.0",
   "description": "Deterministic orchestrator for CLI coding agents. Spawn parallel agents in per-task git worktrees, verify their work, and merge results; no model in the coordination loop, so runs replay byte-identically.",
   "author": {
     "name": "chernistry",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,8 +32,8 @@ keywords:
   - gemini-cli
   - aider
   - software-engineering
-version: "3.14.159"
-date-released: "2026-08-10"
+version: "3.15.0"
+date-released: "2026-08-14"
 preferred-citation:
   type: software
   title: "Bernstein: a deterministic Python orchestrator for CLI coding agents"

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -102,8 +102,8 @@ python3 scripts/build_copr_srpm.py --version v3.13.0 --render-only   # no rpmbui
 Run the install smoke locally exactly the way CI runs it (needs Docker):
 
 ```
-scripts/rpm_install_smoke.sh fedora:43 3.14.159
-scripts/rpm_install_smoke.sh quay.io/centos/centos:stream9 3.14.159
+scripts/rpm_install_smoke.sh fedora:43 3.15.0
+scripts/rpm_install_smoke.sh quay.io/centos/centos:stream9 3.15.0
 ```
 
 ### Chroots

--- a/docs/release-notes/v3.15.0.md
+++ b/docs/release-notes/v3.15.0.md
@@ -1,0 +1,173 @@
+# v3.15.0
+
+Four days after π. Nothing clever about the number this time.
+
+v3.14.159 was the release where the surface stopped pretending. This is the
+release where the trust boundary stopped leaking around the edges: the read
+paths that feed verification now go through the authenticated path
+themselves, writes into the lineage store have to carry verified tool-call
+evidence, a run cannot close without an authenticated closure record, what
+reaches trace persistence has its credentials redacted first — and the
+tenant a request acts as is derived from its authenticated state, not from
+a header the caller controls. Around that: receipts extended to stalls,
+checkpoints and findings, a batch of plan-validation strictness this
+project promised last release and delivered, and the reference docs gate
+grew from tables to narrative prose.
+
+## Security: tenant isolation and friends (read this one)
+
+- **Tenant scope binds from authenticated state (#3677).** The API
+  previously trusted `X-Tenant-Id` as the acting tenant. It is now derived
+  from the authenticated principal; the header survives only as a requested
+  override that must be authorized against the principal's scope, and a
+  token whose identity record disagrees with its credential's scope is
+  refused before it authenticates. Reported responsibly by Lawal Qasim
+  (callgh0st), with proof-of-concept reproductions across each credential
+  type; the fix ships with a security advisory. Regression tests cover
+  each credential type.
+- **Tenant ids are validated before they become path segments (#3691)**,
+  and caller-supplied paths are asserted to stay under their base
+  directory (#3692). A tenant id is an identifier, not a relative path.
+- **Project hooks honor workspace trust (#3782).** Committed hooks
+  previously executed under a trust short-circuit when the manager had no
+  workdir or matched the process cwd; being inside a directory is not
+  consent to run its committed code. Trust is now resolved against the
+  tree the hooks load from, re-checked at the exec boundary, and fails
+  closed.
+- **Both Slack webhook receivers require a signing secret (#3690).** With
+  `SLACK_SIGNING_SECRET` unset, `POST /webhooks/slack/commands` and
+  `POST /webhooks/slack/events` now answer 404 and create no task;
+  previously they processed the request without checking a signature. A
+  configured deployment is unaffected. Set the secret before pointing
+  Slack at the endpoint.
+- **CAS blob reads refuse symlinked parent components (#3577).** A
+  sandboxed read of content-addressed state resolves its full path and
+  fails closed when a parent component is a symlink pointing elsewhere.
+- Two honest limits, documented rather than implied: `allowed_files` in an
+  identity credential is recorded and signed but not yet consulted by any
+  write path — the operations guide now says so plainly instead of letting
+  it read as a permission; and events whose `details` field is malformed
+  can still normalize into the default tenant's evidence bundle. Both are
+  tracked as follow-ups, not silently carried.
+
+## Behaviour changes (read before upgrading)
+
+- **Two leniencies the last notes documented are gone.** The journal
+  verifiers now load strictly — a corrupt journal row fails the verdict
+  with exit 1 instead of being skipped (#3549 closed by #3636). And the
+  standalone `bernstein dry-run --plan` propagates plan-load failures with
+  a non-zero exit instead of converting them into an empty success (#3550
+  closed by #3602).
+- **Plan validation got stricter again, deliberately.** `files` entries
+  must be strings (#3633); `depends_on`, `constraints` and `context_files`
+  are validated as string lists (#3640); `attachments` is validated rather
+  than coerced (#3641); an explicit `null` now means absent instead of
+  crashing or half-loading (#3653). A plan that has been silently wrong
+  fails loudly at load.
+- **Lineage writes require verified tool-call evidence (#3652).** A record
+  arriving without evidence that its tool call actually ran is refused.
+  Anything writing lineage records through private APIs will notice.
+- **A dependent of a failed task is named in the log (#3657, outside
+  contribution).** It previously spun in silence forever; the claim path
+  now warns with the failed dependency's id every time it skips the
+  dependent. The derived terminal blocked state is follow-up work, not in
+  this release.
+- **MCP tools declare their blast radius and keep their promises.** Tools
+  must disclose host effects (#3673), declared timeouts are enforced on
+  host-effecting tools, and roles are a closed enum (#3749).
+- **The protobuf floor moved (#3630)** to match the generated gRPC modules.
+
+## Verifiability
+
+The receipt substrate kept growing edges this cycle:
+
+- **Provisional run attestation receipts (#3518)** — a run projects an
+  attestation before it finishes, so an interrupted run leaves evidence
+  instead of a gap.
+- **Universal authenticated run closure (#3660)** and the **plan-graph
+  digest recorded in the run journal (#3655)** — the journal now pins which
+  graph actually ran.
+- **A stall writes `stall.verdict` into the audit chain before any
+  automatic worker kill (#3678, #3721)** — a kill without a recorded
+  verdict is now a bug by construction.
+- **Findings are content-addressed lineage records (#3659 laid the
+  contract, #3695 the store)** and the external reference extractor signs
+  its identity into what it extracts (#3726).
+- **Checkpoint recovery is grant-bound (#3723):** a resume binds to and
+  verifies the original grant before any state is restored.
+- **Skill injection leaves an audit trail (#3658)**, and the injected-set
+  record is no longer opt-out-local-only (#3382 groundwork).
+- **The read side authenticates too:** SPIFFE binding rows (#3569),
+  projection audit evidence (#3672), and the web UI's event streams
+  (#3632) all moved onto authenticated reads, and credentials are redacted
+  before traces persist (#3734).
+- **First-contact runs leave a sealed, attributable record:** the demo
+  waits for the finalization entry marker before teardown (#3713), mock
+  workers carry real task identity instead of colliding on attribution
+  (#3728), and retry exhaustion checks quarantine before recording
+  (#3638).
+- Trajectory receipts finished their acceptance run — AC tests and docs
+  landed as the last third of #2925 (#3598).
+
+## Adapters
+
+- **The wheel ships adapter contracts and golden transcripts (#3554)** —
+  conformance is installable, not repo-only.
+- Community CLIs are driven with flags they actually accept (#3584), goose
+  gets its inline-prompt flag (#3580), and adapter refusal handling is
+  isolated from the host PATH in tests (#3715).
+- Per-adapter canary runs gate on the binary being present (#3666), and
+  admission compares exact canary versions instead of prefixes (#3703).
+- Model selection and workflow routing extended for multi-model setups
+  (#3722, an outside contribution).
+
+## Web and TUI
+
+- **Receipt-backed steering from the task drawer (#3592)** — the steering
+  action and its receipt are one surface.
+- The review board is linked from the dashboard (#3727), theme resolves
+  before first paint (#3624), the SSE parser derives its record terminator
+  from the actual match (#3644), and a TUI placeholder crash is fixed
+  (#3583).
+
+## Docs, first-use, and gates
+
+- **The CLI drift gate extends to narrative prose (#3717).** Reference
+  tables were already gated; now the getting-started pages fail CI when
+  they name a command the CLI renamed. The gate immediately caught real
+  drift (#3623, #3756), and `bernstein task` — complete, suspend, resume,
+  list-suspended — is documented as the group it actually is (#3775).
+- Install and use-case pages match verified behaviour, including Docker
+  first-run permissions (#3574); README and translations got an accuracy
+  pass (#3568, #3708, #3709); the front-page renders are re-captured real
+  runs and their freshness-gate exemption is closed (#3575).
+- **The feature matrix is refreshed and gated against the CLI (#3746)**,
+  and the contributor register is complete and linked (#3744).
+- **The security policy states a 90-day response window and drops the
+  timetables the project was not meeting (#3689).** Solo-maintained means
+  honest windows, not aspirational ones.
+- The RPM ships the released version and its channel gates on an install
+  smoke (#3572).
+
+## Process
+
+- **The external review-bot integration is removed.** Its ack gate is no
+  longer a required check; the merge gate is the CI gate plus human
+  review. A second required gate has to earn its place in the critical
+  path, and this one's signal did not justify its noise.
+- Three release/review gates that reported the wrong outcome are fixed
+  (#3626), fork PRs see the gate summary (#3706), labelled-PR review
+  starts when the label is added (#3600), and four e2e workflows stopped
+  requesting conflicting extras (#3686).
+
+Upgrade in place. Things worth checking first: anything that parses plan
+files (stricter again: #3633, #3640, #3641, #3653), anything that keys on
+journal-verify exit codes (strict now — a corrupt row fails instead of
+skipping, #3636), anything writing lineage records through private APIs
+(evidence required, #3652), MCP tool definitions (host effects and
+timeouts are enforced, #3673, #3749), a Slack deployment that has not set
+`SLACK_SIGNING_SECRET` (the receivers answer 404 until it is set, #3690),
+project hooks that relied on running in an untrusted workspace (they no
+longer do, #3782), and any client that sent `X-Tenant-Id` expecting it to
+be trusted — it is now an authorized override, and the principal's scope
+has to cover it (#3677).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -520,6 +520,7 @@ nav:
       - Release notes:
           - Changelog: CHANGELOG.md
           - Unreleased: release-notes/unreleased.md
+          - v3.15.0: release-notes/v3.15.0.md
           - v3.14.159: release-notes/v3.14.159.md
           - v3.13.0: release-notes/v3.13.0.md
           - v3.12.0: release-notes/v3.12.0.md

--- a/plugin.json
+++ b/plugin.json
@@ -17,5 +17,5 @@
   "license": "Apache-2.0",
   "name": "bernstein",
   "repository": "https://github.com/sipyourdrink-ltd/bernstein",
-  "version": "3.14.159"
+  "version": "3.15.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.14.159"
+version = "3.15.0"
 description = "Deterministic orchestrator for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40+ more). No model in the coordination loop, so parallel runs in per-task git worktrees replay byte-identically. Signed lineage plus an opt-in HMAC audit chain a reviewer checks offline, without rerunning it. Cluster mode, air-gap deploy."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -7,19 +7,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.14.159",
+  "version": "3.15.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.14.159",
+      "version": "3.15.0",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.14.159",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.15.0",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -364,7 +364,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.14.159"
+version = "3.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Release PR for v3.15.0.

- `pyproject.toml` 3.14.159 → 3.15.0
- Distribution manifests regenerated via `scripts/gen_distribution_manifests.py` (server.json, plugin.json, .plugin/plugin.json, CITATION.cff); `uv.lock` re-locked
- Hand-written notes at `docs/release-notes/v3.15.0.md`, added to the mkdocs nav
- Version examples in `docs/operations/release.md` refreshed

On merge, the auto-release workflow tags `v3.15.0` once main CI is green, and the publish chain (PyPI, Docker, Homebrew, SBOM) dispatches from the tag.