### PR TITLE
chore(ci): ratchet coverage baseline up to 83.5%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
   "diff_coverage_floor_percent": 85,
-  "head_sha": "3b915b095d0c169271071da1f34664b8aa04fe71",
-  "line_rate": 0.8333,
-  "run_id": "31793224648",
-  "total_coverage_percent": 83.33,
-  "updated_at": "2026-08-14T11:19:57+00:00"
+  "head_sha": "2a491cc15f483402ed7ea5dd31e70d405f6d8a74",
+  "line_rate": 0.835,
+  "run_id": "31796907484",
+  "total_coverage_percent": 83.5,
+  "updated_at": "2026-08-14T12:19:36+00:00"
 }


### PR DESCRIPTION
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **83.5%**.

Measured on `2a491cc15f483402ed7ea5dd31e70d405f6d8a74` from the
`coverage-report` artifact of CI run
[31796907484](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/31796907484).
Those, and the raw Cobertura `line-rate` the percentage was
rounded from, are recorded in the baseline, so the number in the
diff can be re-derived from the file itself:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.