### PR TITLE
fix(rpm): keep rawhide churn from holding the release, and give it a C++ toolchain

### DIFF
--- a/packaging/rpm/bernstein.spec
+++ b/packaging/rpm/bernstein.spec
@@ -47,6 +47,12 @@ URL:            https://github.com/sipyourdrink-ltd/bernstein
 # (cryptography, pillow, lxml, pydantic-core, grpcio), so the built package is
 # specific to both the architecture and the interpreter ABI of its chroot.
 BuildRequires:  %{python_pkg}
+# A C++ toolchain, because not every chroot has a prebuilt wheel for every
+# dependency. On the released Fedora and EPEL chroots the closure resolves to
+# manylinux wheels and nothing compiles; on a chroot whose interpreter is ahead
+# of the wheel publishers - rawhide is permanently in that state - pip falls
+# back to building a sdist and the build dies on a missing `g++`.
+BuildRequires:  gcc-c++
 Requires:       %{python_pkg}
 
 # The venv is a self-contained tree. The manylinux wheels inside it carry their

--- a/scripts/copr_build_watch.py
+++ b/scripts/copr_build_watch.py
@@ -78,11 +78,7 @@ def is_gating_chroot(name: str) -> bool:
 
 def failed_gating_chroots(chroots: dict[str, str]) -> list[str]:
     """Return the gating chroots that did not succeed."""
-    return sorted(
-        name
-        for name, state in chroots.items()
-        if is_gating_chroot(name) and classify(state) == "failure"
-    )
+    return sorted(name for name, state in chroots.items() if is_gating_chroot(name) and classify(state) == "failure")
 
 
 def fetch_state(build_id: int) -> str:
@@ -131,21 +127,14 @@ def _verdict_from_chroots(
 
     blocking = failed_gating_chroots(chroots)
     if blocking:
-        print(
-            f"::error::Copr build {build_id} failed on gating chroot(s) "
-            f"{', '.join(blocking)}: {build_url}"
-        )
+        print(f"::error::Copr build {build_id} failed on gating chroot(s) {', '.join(blocking)}: {build_url}")
         return 1
 
     published = sorted(
-        name
-        for name, state in chroots.items()
-        if is_gating_chroot(name) and classify(state) == "success"
+        name for name, state in chroots.items() if is_gating_chroot(name) and classify(state) == "success"
     )
     if not published:
-        print(
-            f"::error::Copr build {build_id} published no gating chroot: {build_url}"
-        )
+        print(f"::error::Copr build {build_id} published no gating chroot: {build_url}")
         return 1
 
     tolerated = sorted(name for name in chroots if not is_gating_chroot(name))
@@ -190,9 +179,7 @@ def watch(
                 return 0
             if verdict == "failure":
                 if state.strip().lower() == "failed":
-                    return _verdict_from_chroots(
-                        build_id, build_url, fetch_chroot_states=fetch_chroot_states
-                    )
+                    return _verdict_from_chroots(build_id, build_url, fetch_chroot_states=fetch_chroot_states)
                 print(f"::error::Copr build {build_id} ended in state '{state}': {build_url}")
                 return 1
 

--- a/scripts/copr_build_watch.py
+++ b/scripts/copr_build_watch.py
@@ -36,8 +36,17 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 API_URL = "https://copr.fedorainfracloud.org/api_3/build/{build_id}"
+CHROOT_API_URL = "https://copr.fedorainfracloud.org/api_3/build-chroot/list?build_id={build_id}"
 BUILD_URL = "https://copr.fedorainfracloud.org/coprs/build/{build_id}"
 USER_AGENT = "bernstein-copr-build-watch"
+
+# Copr reports one state for the whole build, and that state is `failed` when
+# any single chroot failed. `publish.yml` deliberately submits to rawhide
+# without gating the release on it: rawhide is a moving target whose churn
+# costs more than it catches. Reading the aggregate state alone contradicts
+# that, so a `failed` aggregate is re-read per chroot and only the gating ones
+# decide the verdict.
+NON_GATING_CHROOT_MARKERS = ("rawhide",)
 
 SUCCESS_STATES = frozenset({"succeeded"})
 # `skipped` means Copr already had this exact build and did not rebuild it. It
@@ -61,6 +70,21 @@ def classify(state: str) -> str:
     return "pending"
 
 
+def is_gating_chroot(name: str) -> bool:
+    """Return whether a chroot's outcome decides the release verdict."""
+    lowered = name.strip().lower()
+    return not any(marker in lowered for marker in NON_GATING_CHROOT_MARKERS)
+
+
+def failed_gating_chroots(chroots: dict[str, str]) -> list[str]:
+    """Return the gating chroots that did not succeed."""
+    return sorted(
+        name
+        for name, state in chroots.items()
+        if is_gating_chroot(name) and classify(state) == "failure"
+    )
+
+
 def fetch_state(build_id: int) -> str:
     """Return the current Copr state for ``build_id``."""
     # Fixed https API host, no user-controlled scheme.
@@ -73,10 +97,71 @@ def fetch_state(build_id: int) -> str:
     return str(payload["state"])
 
 
+def fetch_chroots(build_id: int) -> dict[str, str]:
+    """Return ``{chroot name: state}`` for ``build_id``."""
+    # Fixed https API host, no user-controlled scheme.
+    request = urllib.request.Request(
+        CHROOT_API_URL.format(build_id=build_id),
+        headers={"User-Agent": USER_AGENT},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.load(response)
+    items = payload if isinstance(payload, list) else payload["items"]
+    return {str(item["name"]): str(item["state"]) for item in items}
+
+
+def _verdict_from_chroots(
+    build_id: int,
+    build_url: str,
+    *,
+    fetch_chroot_states: Callable[[int], dict[str, str]],
+) -> int:
+    """Decide a `failed` aggregate by the gating chroots alone.
+
+    Returns 0 when every failure sits in a non-gating chroot and at least one
+    gating chroot published, 1 otherwise. An unreadable chroot list is a
+    failure: an aggregate that says `failed` with no evidence about where is
+    not something to wave through.
+    """
+    try:
+        chroots = fetch_chroot_states(build_id)
+    except READ_ERRORS as exc:
+        print(f"::error::Copr build {build_id} failed and its chroots were unreadable ({exc}): {build_url}")
+        return 1
+
+    blocking = failed_gating_chroots(chroots)
+    if blocking:
+        print(
+            f"::error::Copr build {build_id} failed on gating chroot(s) "
+            f"{', '.join(blocking)}: {build_url}"
+        )
+        return 1
+
+    published = sorted(
+        name
+        for name, state in chroots.items()
+        if is_gating_chroot(name) and classify(state) == "success"
+    )
+    if not published:
+        print(
+            f"::error::Copr build {build_id} published no gating chroot: {build_url}"
+        )
+        return 1
+
+    tolerated = sorted(name for name in chroots if not is_gating_chroot(name))
+    print(
+        f"::notice::Copr build {build_id} published {len(published)} gating chroot(s) "
+        f"({', '.join(published)}); non-gating {', '.join(tolerated)} did not build and "
+        f"does not hold the release: {build_url}"
+    )
+    return 0
+
+
 def watch(
     build_id: int,
     *,
     fetch: Callable[[int], str] = fetch_state,
+    fetch_chroot_states: Callable[[int], dict[str, str]] = fetch_chroots,
     deadline_seconds: float = 900,
     poll_seconds: float = 30,
     time_fn: Callable[[], float] = time.monotonic,
@@ -104,6 +189,10 @@ def watch(
                 print(f"Copr published build {build_id}: {build_url}")
                 return 0
             if verdict == "failure":
+                if state.strip().lower() == "failed":
+                    return _verdict_from_chroots(
+                        build_id, build_url, fetch_chroot_states=fetch_chroot_states
+                    )
                 print(f"::error::Copr build {build_id} ended in state '{state}': {build_url}")
                 return 1
 

--- a/tests/unit/scripts/test_copr_build_watch.py
+++ b/tests/unit/scripts/test_copr_build_watch.py
@@ -86,7 +86,7 @@ def test_succeeded_build_passes(mod: ModuleType) -> None:
     assert code == 0
 
 
-@pytest.mark.parametrize("state", ["failed", "canceled", "cancelled", "skipped"])
+@pytest.mark.parametrize("state", ["canceled", "cancelled", "skipped"])
 def test_terminal_failure_fails_the_job(mod: ModuleType, state: str, capsys: pytest.CaptureFixture[str]) -> None:
     """A build that ends badly must fail the job, not warn inside a green run."""
     clock = FakeClock()
@@ -104,6 +104,113 @@ def test_terminal_failure_fails_the_job(mod: ModuleType, state: str, capsys: pyt
     assert "::error::" in out
     assert state in out
     assert str(BUILD_ID) in out
+
+
+# A `failed` aggregate says only that some chroot failed, never which. Copr
+# reports it whether a released Fedora target broke or rawhide churned, and
+# publish.yml submits rawhide precisely because it does not gate the release.
+# These pin which of those a failed aggregate is allowed to mean.
+
+GATING_PUBLISHED = {
+    "fedora-43-x86_64": "succeeded",
+    "fedora-44-x86_64": "succeeded",
+    "epel-9-x86_64": "succeeded",
+    "epel-10-x86_64": "succeeded",
+}
+RAWHIDE_FAILED = {
+    "fedora-rawhide-x86_64": "failed",
+    "fedora-rawhide-aarch64": "failed",
+}
+
+
+def _chroots(states: dict[str, str]):
+    def fetch(build_id: int) -> dict[str, str]:
+        assert build_id == BUILD_ID
+        return dict(states)
+
+    return fetch
+
+
+def test_failure_confined_to_rawhide_does_not_hold_the_release(
+    mod: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Every released chroot published; only rawhide broke. That ships."""
+    clock = FakeClock()
+    code = mod.watch(
+        BUILD_ID,
+        fetch=_fetcher(["pending", "failed"]),
+        fetch_chroot_states=_chroots({**GATING_PUBLISHED, **RAWHIDE_FAILED}),
+        deadline_seconds=600,
+        poll_seconds=30,
+        time_fn=clock.time,
+        sleep_fn=clock.sleep,
+    )
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert "::error::" not in out
+    assert "::notice::" in out
+    assert "fedora-rawhide-x86_64" in out
+
+
+def test_failure_on_a_released_chroot_still_fails_the_job(
+    mod: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A broken Fedora 44 is a broken release, whatever rawhide did."""
+    clock = FakeClock()
+    code = mod.watch(
+        BUILD_ID,
+        fetch=_fetcher(["failed"]),
+        fetch_chroot_states=_chroots(
+            {**GATING_PUBLISHED, "fedora-44-x86_64": "failed", **RAWHIDE_FAILED}
+        ),
+        deadline_seconds=600,
+        poll_seconds=30,
+        time_fn=clock.time,
+        sleep_fn=clock.sleep,
+    )
+    assert code == 1
+
+    out = capsys.readouterr().out
+    assert "::error::" in out
+    assert "fedora-44-x86_64" in out
+
+
+def test_failure_with_no_gating_chroot_published_fails_the_job(mod: ModuleType) -> None:
+    """Tolerating rawhide must not tolerate a build that published nothing."""
+    clock = FakeClock()
+    code = mod.watch(
+        BUILD_ID,
+        fetch=_fetcher(["failed"]),
+        fetch_chroot_states=_chroots(RAWHIDE_FAILED),
+        deadline_seconds=600,
+        poll_seconds=30,
+        time_fn=clock.time,
+        sleep_fn=clock.sleep,
+    )
+    assert code == 1
+
+
+def test_failure_with_unreadable_chroots_fails_the_job(
+    mod: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A failure with no evidence about where is not something to wave through."""
+
+    def unreadable(build_id: int) -> dict[str, str]:
+        raise OSError("connection reset")
+
+    clock = FakeClock()
+    code = mod.watch(
+        BUILD_ID,
+        fetch=_fetcher(["failed"]),
+        fetch_chroot_states=unreadable,
+        deadline_seconds=600,
+        poll_seconds=30,
+        time_fn=clock.time,
+        sleep_fn=clock.sleep,
+    )
+    assert code == 1
+    assert "::error::" in capsys.readouterr().out
 
 
 def test_build_still_queued_at_the_deadline_hands_off_to_the_reconciler(

--- a/tests/unit/scripts/test_copr_build_watch.py
+++ b/tests/unit/scripts/test_copr_build_watch.py
@@ -153,17 +153,13 @@ def test_failure_confined_to_rawhide_does_not_hold_the_release(
     assert "fedora-rawhide-x86_64" in out
 
 
-def test_failure_on_a_released_chroot_still_fails_the_job(
-    mod: ModuleType, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_failure_on_a_released_chroot_still_fails_the_job(mod: ModuleType, capsys: pytest.CaptureFixture[str]) -> None:
     """A broken Fedora 44 is a broken release, whatever rawhide did."""
     clock = FakeClock()
     code = mod.watch(
         BUILD_ID,
         fetch=_fetcher(["failed"]),
-        fetch_chroot_states=_chroots(
-            {**GATING_PUBLISHED, "fedora-44-x86_64": "failed", **RAWHIDE_FAILED}
-        ),
+        fetch_chroot_states=_chroots({**GATING_PUBLISHED, "fedora-44-x86_64": "failed", **RAWHIDE_FAILED}),
         deadline_seconds=600,
         poll_seconds=30,
         time_fn=clock.time,
@@ -191,9 +187,7 @@ def test_failure_with_no_gating_chroot_published_fails_the_job(mod: ModuleType) 
     assert code == 1
 
 
-def test_failure_with_unreadable_chroots_fails_the_job(
-    mod: ModuleType, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_failure_with_unreadable_chroots_fails_the_job(mod: ModuleType, capsys: pytest.CaptureFixture[str]) -> None:
     """A failure with no evidence about where is not something to wave through."""
 
     def unreadable(build_id: int) -> dict[str, str]:


### PR DESCRIPTION
## Root cause

The v3.15.0 publish run went red on `Publish RPM to Copr` while the RPM itself was fine: fedora-43, fedora-44, epel-9 and epel-10 all published ([build 10865143](https://copr.fedorainfracloud.org/coprs/build/10865143)); only `fedora-rawhide` failed, on a dependency with no wheel for rawhide's interpreter falling back to an sdist build that died on a missing `g++`.

Two defects behind one red check:

1. **The watcher read the wrong signal.** Copr reports one state per *build*, and that state is `failed` when any single chroot failed. `publish.yml` says in its own comments that rawhide is submitted deliberately and must not gate the release — the watcher contradicted that by treating the aggregate as the verdict.
2. **rawhide had no C++ toolchain.** On released chroots the closure resolves to manylinux wheels and nothing compiles, so the gap only shows on a chroot whose interpreter is ahead of the wheel publishers.

## Change

`scripts/copr_build_watch.py` re-reads a `failed` aggregate per chroot and decides on the gating ones alone. `canceled`/`cancelled`/`skipped` are untouched — those are build-level, not chroot-level. `packaging/rpm/bernstein.spec` gains `BuildRequires: gcc-c++`.

Tolerating rawhide deliberately does not widen into tolerating a bad build: a failed aggregate still fails when a released chroot broke, when nothing gating published, or when the chroot list cannot be read.

## Tests

Written before the implementation, each named for the property it protects:

1. `test_failure_confined_to_rawhide_does_not_hold_the_release` — released chroots published, rawhide broke → exit 0, notice names the tolerated chroot
2. `test_failure_on_a_released_chroot_still_fails_the_job` — fedora-44 broke → exit 1, error names it
3. `test_failure_with_no_gating_chroot_published_fails_the_job` — rawhide-only chroot list → exit 1
4. `test_failure_with_unreadable_chroots_fails_the_job` — chroot API unreadable → exit 1, no wave-through
5. `test_terminal_failure_fails_the_job` — narrowed to the build-level terminal states, which take no chroot re-read

All four new tests fail without the source change (verified by stashing it).

## Out of scope

The failed v3.15.0 Copr build is not retried here; the RPM channel for 3.15.0 is republished separately with `copr_only`.