### PR TITLE
fix(mcp): reject undocumented auth_type values at RemoteMCPConfig construction

### DIFF
--- a/docs/cloudflare/cloudflare-mcp.md
+++ b/docs/cloudflare/cloudflare-mcp.md
@@ -18,11 +18,13 @@ The MCP remote transport exposes Bernstein's MCP server over HTTP using the stre
 | `host` | `str` | `"127.0.0.1"` | Bind host (loopback by default) |
 | `port` | `int` | `8053` | Bind port |
 | `path` | `str` | `"/mcp"` | URL path for MCP endpoint |
-| `auth_type` | `str` | `"bearer"` | Authentication: `"none"`, `"bearer"`, or `"oauth"` |
+| `auth_type` | `str` | `"bearer"` | Authentication: `"none"` or `"bearer"` |
 | `auth_token` | `str` | `""` | Bearer token; when empty it is read from `BERNSTEIN_MCP_TOKEN` (or `BERNSTEIN_MCP_AUTH_TOKEN`) |
 | `cors_origins` | `list[str]` | `["http://localhost:*"]` | CORS allowed origins; clear-text `http://` origins must be loopback-pinned |
 
-The config is safe by default: it binds to loopback and expects a bearer token. Construction raises `RemoteMCPConfigError` for any combination that would expose the JSON-RPC surface without authentication -- `auth_type="none"` on a non-loopback host, or `auth_type="bearer"` with no token on a non-loopback host. There is no session store, so there are no session capacity or timeout fields; see [Stateless serving](../mcp/server.md#stateless-serving).
+The config is safe by default: it binds to loopback and expects a bearer token. Construction raises `RemoteMCPConfigError` for any combination that would expose the JSON-RPC surface without authentication -- an `auth_type` other than `"none"`/`"bearer"`, `auth_type="none"` on a non-loopback host, or `auth_type="bearer"` with no token on a non-loopback host. There is no session store, so there are no session capacity or timeout fields; see [Stateless serving](../mcp/server.md#stateless-serving).
+
+`auth_type` does not have an `"oauth"` value: the streamable HTTP transport authenticates only anonymous or static-bearer callers. The OAuth-2 discovery surface described below (protected-resource metadata and the `WWW-Authenticate` challenge) exists so a client can locate an external IdP; it is independent of how this transport checks the token that comes back, and does not add a third `auth_type`. See [Auth](../mcp/server.md#auth) in the MCP server doc.
 
 The same rule covers browser origins. Bearer tokens ride on whatever origin CORS admits, so a clear-text origin is only accepted when it is pinned to a loopback host (`127.0.0.1`, `localhost` or `[::1]`); that is why the default is safe despite being clear-text. Any other clear-text origin is refused with a `RemoteMCPConfigError` naming the offending entries, so a non-loopback origin has to use TLS. The clear-text schemes held to this rule are `http`, `ws` and `ftp`.
 

--- a/docs/mcp/server.md
+++ b/docs/mcp/server.md
@@ -60,6 +60,15 @@ removal date.
 | Anonymous | default on loopback | Allowed only on `127.0.0.1` / `localhost` / `::1`. |
 | Static bearer | `BERNSTEIN_MCP_TOKEN` (or `BERNSTEIN_MCP_AUTH_TOKEN`) | Constant-time check; required on non-loopback binds. |
 
+These two are the only modes `RemoteMCPConfig.auth_type` accepts (`"none"`
+or `"bearer"`); construction refuses any other value with
+`RemoteMCPConfigError` rather than starting a server that would deny every
+request. There is no `"oauth"` mode: the discovery surface described below
+proves only that the resource is *pointed at* an authorization server, not
+that this transport can *validate* a token that server issues. An IdP-issued
+token is not a `BERNSTEIN_MCP_TOKEN` value, so presenting one under static
+bearer is refused like any other wrong token.
+
 OAuth-2 PKCE token issuance is delegated to an external IdP. Bernstein is
 the **resource server**: it does not host an authorization server and so
 does not publish RFC 8414 authorization-server metadata. When the operator
@@ -97,8 +106,13 @@ The discovery handshake is:
    example `https://idp.example.com/.well-known/oauth-authorization-server`
    or whatever path the IdP uses (Keycloak, Auth0, Okta all differ).
 4. Client completes the PKCE S256 authorization-code flow against the
-   IdP and presents the resulting bearer token to the streamable HTTP
-   transport.
+   IdP, obtaining a token minted by that IdP.
+
+The discovery handshake ends there: the streamable HTTP transport does not
+accept the IdP-minted token as a credential (see the `auth_type` note
+above). An operator who wants this discovery flow to end in a working
+request still configures `auth_type="bearer"` and hands the client a
+`BERNSTEIN_MCP_TOKEN` value out of band; the IdP token is not that value.
 
 The protected-resource path is served without authentication, since a
 client probing discovery has no token yet. When the env var is unset,

--- a/src/bernstein/mcp/remote_transport.py
+++ b/src/bernstein/mcp/remote_transport.py
@@ -155,6 +155,15 @@ _CLEAR_TEXT_SCHEMES = frozenset({_PLAINTEXT_SCHEME, "ws", "ftp"})
 # non-loopback origin is required to be TLS.
 _DEFAULT_CORS_ORIGINS: tuple[str, ...] = (f"{_PLAINTEXT_SCHEME}://localhost:*",)
 
+#: The only ``RemoteMCPConfig.auth_type`` values ``_authenticate`` implements.
+#: An ``"oauth"`` value used to be documented here but ``_authenticate`` never
+#: implemented it and fell through to deny (issue #3463): a server configured
+#: with it refused every request, including correctly authenticated ones. The
+#: OAuth-2 discovery surface (``bernstein.mcp.oauth``) is unaffected -- it
+#: serves protected-resource metadata so a client can locate an external IdP,
+#: which is orthogonal to how this transport authenticates a bearer token.
+_VALID_AUTH_TYPES: tuple[str, ...] = ("none", "bearer")
+
 
 class RemoteMCPConfigError(RuntimeError):
     """Raised when an MCP remote transport config is unsafe to start with.
@@ -256,6 +265,9 @@ class RemoteMCPConfig:
     Validation (in ``__post_init__``) refuses any combination that would
     expose MCP JSON-RPC without authentication:
 
+    * an ``auth_type`` outside :data:`_VALID_AUTH_TYPES` (``"none"``,
+      ``"bearer"``) → :class:`RemoteMCPConfigError`, raised at construction
+      time rather than left to deny every request at serve time
     * ``auth_type='none'`` on a non-loopback host → :class:`RemoteMCPConfigError`
     * ``auth_type='bearer'`` with an empty token on a non-loopback host →
       :class:`RemoteMCPConfigError`
@@ -266,12 +278,21 @@ class RemoteMCPConfig:
     host: str = "127.0.0.1"
     port: int = 8053
     path: str = "/mcp"
-    auth_type: str = "bearer"  # "none", "bearer", "oauth"
+    auth_type: str = "bearer"  # "none", "bearer"
     auth_token: str = ""
     cors_origins: list[str] = field(default_factory=lambda: list(_DEFAULT_CORS_ORIGINS))
 
     def __post_init__(self) -> None:
         """Enforce safe-by-default policy and pick up env-provided tokens."""
+        if self.auth_type not in _VALID_AUTH_TYPES:
+            msg = (
+                f"Refusing to start MCP remote transport: auth_type={self.auth_type!r} "
+                f"is not one of {_VALID_AUTH_TYPES!r}. Fixing this at startup, rather "
+                "than letting every request reach _authenticate and be denied, avoids "
+                "shipping a server that looks configured but refuses all traffic."
+            )
+            raise RemoteMCPConfigError(msg)
+
         # Pull token from env when not explicitly provided. Use object.__setattr__
         # because the dataclass is frozen.
         if self.auth_type == "bearer" and not self.auth_token:
@@ -1617,7 +1638,11 @@ class StreamableHTTPTransport:
             token = auth_header[7:]
             return _constant_time_eq(token, expected)
 
-        # Unknown auth type - deny.
+        # Unreachable through normal construction: __post_init__ already
+        # rejects any auth_type outside _VALID_AUTH_TYPES. Kept as defence in
+        # depth for a config that reached this frozen dataclass by some other
+        # path (e.g. object.__setattr__), so an unrecognised value still
+        # denies rather than falling open.
         return False
 
 

--- a/tests/unit/test_mcp_remote_transport.py
+++ b/tests/unit/test_mcp_remote_transport.py
@@ -180,6 +180,32 @@ class TestRemoteMCPConfig:
         cfg = RemoteMCPConfig(host="127.0.0.1", auth_type="none")
         assert cfg.host == "127.0.0.1"
 
+    def test_auth_type_oauth_rejected_at_construction(self, _clear_token_env: None) -> None:
+        """auth_type='oauth' is documented nowhere and must not construct.
+
+        Regression test for issue #3463: the field comment used to list
+        "oauth" as a supported value while ``_authenticate`` silently denied
+        it, so a server configured this way looked valid and refused every
+        request, including correctly authenticated ones. Construction must
+        fail loudly instead.
+        """
+        with pytest.raises(RemoteMCPConfigError, match="auth_type='oauth'"):
+            RemoteMCPConfig(host="127.0.0.1", auth_type="oauth")
+
+    def test_auth_type_unknown_value_rejected_at_construction(self, _clear_token_env: None) -> None:
+        """Any auth_type outside {'none', 'bearer'} is refused, not just 'oauth'."""
+        with pytest.raises(RemoteMCPConfigError, match="auth_type='totally-bogus'"):
+            RemoteMCPConfig(host="127.0.0.1", auth_type="totally-bogus")
+
+    def test_auth_type_oauth_rejected_even_on_public_bind(self, _clear_token_env: None) -> None:
+        """The auth_type check runs before the loopback/token checks.
+
+        A caller cannot dodge the auth_type validation by also supplying a
+        token and a public bind -- the invalid mode is refused on its own.
+        """
+        with pytest.raises(RemoteMCPConfigError, match="auth_type='oauth'"):
+            RemoteMCPConfig(host="0.0.0.0", auth_type="oauth", auth_token="whatever")
+
 
 # ---------------------------------------------------------------------------
 # Authentication tests
@@ -216,6 +242,16 @@ class TestAuthentication:
         t = StreamableHTTPTransport(config=cfg)
         assert t._authenticate({"authorization": "Bearer "}) is False
         assert t._authenticate({"authorization": "Bearer anything"}) is False
+
+    @pytest.mark.anyio
+    async def test_unknown_auth_type_denies_as_defence_in_depth(self, transport: StreamableHTTPTransport) -> None:
+        """An auth_type outside {'none', 'bearer'} must still deny at
+        _authenticate, even though __post_init__ already blocks it from
+        reaching a live config through normal construction (frozen dataclass
+        bypassed here via object.__setattr__ to exercise the fallback)."""
+        object.__setattr__(transport._config, "auth_type", "oauth")
+        assert transport._authenticate({}) is False
+        assert transport._authenticate({"authorization": "Bearer anything"}) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`RemoteMCPConfig.auth_type` documented three values (`src/bernstein/mcp/remote_transport.py`, field comment): `"none"`, `"bearer"`, `"oauth"`. `_authenticate` only implemented the first two; any other value (including `"oauth"`) fell through to an unconditional `return False`. A server configured with `auth_type="oauth"` therefore looked validly configured at startup and then refused every single request, including correctly authenticated ones.

`_authenticate` never validated an OAuth bearer token against an issuer or audience — there was no token-verification code path at all. Implementing `"oauth"` as "accept whatever token is presented" would be worse than the current refusal (a forged or wrong-issuer token would authenticate). Given the scope of building that safely (issuer binding, audience binding, uniform-refusal-shape testing) versus the size of this fix, I removed `"oauth"` from the documented and accepted `auth_type` values rather than implementing it, per the issue's stated alternative ("Decide between implementing the mode and removing it from the documented set").

The check now runs in `__post_init__`: an `auth_type` outside `{"none", "bearer"}` raises `RemoteMCPConfigError` at construction time instead of silently denying every request at serve time. This turns a confusing "server is up but refuses everything" failure mode into a fail-fast startup error.

The OAuth-2 discovery surface (`src/bernstein/mcp/oauth.py`: protected-resource metadata, the `WWW-Authenticate` challenge) is untouched — it exists to point a client at an external authorization server and is orthogonal to how this transport checks a presented token. Docs now say explicitly that the discovery handshake does not end in an accepted credential under any `auth_type`.

## Tests (enumerated before implementation)

- `test_auth_type_oauth_rejected_at_construction` — `auth_type="oauth"` raises `RemoteMCPConfigError` at construction, not just at request time.
- `test_auth_type_unknown_value_rejected_at_construction` — any value outside `{"none", "bearer"}` is refused, not just `"oauth"` specifically.
- `test_auth_type_oauth_rejected_even_on_public_bind` — the auth_type check runs before the loopback/token checks, so it can't be dodged by also supplying a token and a public bind.
- `test_unknown_auth_type_denies_as_defence_in_depth` — pins that `_authenticate`'s fallback deny still holds if a config somehow reaches it with an invalid `auth_type` (defense in depth; bypasses the frozen dataclass via `object.__setattr__` since `__post_init__` now blocks this through normal construction).

Verified the three construction-time tests fail on unmodified `remote_transport.py` (stashed the source change, ran the tests, saw 3 failures with "DID NOT RAISE", restored). Full `tests/unit/test_mcp_remote_transport.py` (102 tests) and `tests/unit/mcp/` + `tests/unit/protocols/mcp/` (436 tests) pass. `ruff check`, `ruff format --check`, and `mypy src/bernstein/mcp/remote_transport.py` are clean.

## Docs updated

- `docs/mcp/server.md` — Auth section now states the two supported modes explicitly, notes construction refuses anything else, and clarifies the OAuth discovery handshake does not end in an accepted credential.
- `docs/cloudflare/cloudflare-mcp.md` — `auth_type` config table row dropped `"oauth"`; added a note pointing to the Auth section for the full explanation.

## Left out of scope

- Actually implementing OAuth bearer-token validation (issuer/audience binding, JWKS-based signature verification) — the issue explicitly allows removal as an alternative to implementation, and doing token verification safely is a larger, separately-reviewable piece of work.
- `src/bernstein/core/protocols/mcp/mcp_client.py`'s own `auth_type="oauth"` — that's a different config class on the MCP *client* side (Bernstein connecting outward to a remote MCP server), already implemented, and unrelated to `RemoteMCPConfig` on the server side that this issue is about.

Closes #3463