### PR TITLE
fix(security): align vuln_disclosure defaults with SECURITY.md

### DIFF
--- a/src/bernstein/core/security/vuln_disclosure.py
+++ b/src/bernstein/core/security/vuln_disclosure.py
@@ -1,10 +1,19 @@
-"""Coordinated vulnerability disclosure with non-monetary recognition.
+"""Coordinated vulnerability disclosure per the project's SECURITY.md policy.
 
 Provides structured vulnerability report handling, triage workflows,
 coordinated disclosure timelines, and RFC 9116 security.txt generation.
-Recognition for valid reports is non-monetary - severity maps to a
-recognition tier (acknowledgment, public credit, CVE credit, hall of
-fame) rather than a cash payout.
+
+Recognition is non-monetary and uniform: every valid, first-reported issue
+gets the same credit - name/handle/link in the release notes of the fixing
+release, plus reporter credit on the published GitHub Security Advisory
+(which may carry a CVE). There is no severity-based recognition ladder and
+no bug bounty.
+
+There is no fix deadline. Severity sets the order reports are worked on, not
+a promised delivery date. The only date this module commits to is the first
+substantive response, due within ``response_sla_hours`` of submission (up to
+90 days per SECURITY.md), and the public-disclosure date, which the reporter
+may exercise unilaterally regardless of fix status.
 
 Usage::
 
@@ -64,18 +73,16 @@ class ReportStatus(StrEnum):
 
 
 class RecognitionTier(StrEnum):
-    """Non-monetary recognition granted for a valid disclosure.
+    """Non-monetary recognition granted for a disclosure.
 
-    The project is non-commercial and runs no paid bounty; researchers are
-    recognized through acknowledgment, public credit, CVE credit, and the
-    hall of fame rather than a cash reward.
+    Recognition does not vary by severity: every valid, first-reported issue
+    receives the same credit (release notes plus GitHub Security Advisory
+    credit). A report that is rejected, or that is not the first report of
+    a duplicate, receives none.
     """
 
     NONE = "none"
-    ACKNOWLEDGMENT = "acknowledgment"
-    PUBLIC_CREDIT = "public-credit"
-    CVE_CREDIT = "cve-credit"
-    HALL_OF_FAME = "hall-of-fame"
+    CREDITED = "credited"
 
 
 @dataclass(frozen=True)
@@ -109,46 +116,39 @@ class VulnReport:
 class DisclosureScope:
     """Scope definition for the coordinated disclosure program.
 
-    Recognition is non-monetary: ``recognition`` maps a severity level to a
-    :class:`RecognitionTier` value rather than a cash amount.
-
     Attributes:
         in_scope: Components or endpoints that are in scope.
         out_of_scope: Components explicitly out of scope.
-        recognition: Mapping from severity level to recognition tier.
-        response_sla_hours: Maximum hours before initial triage response.
+        response_sla_hours: Maximum hours before the first substantive
+            response. SECURITY.md states this as "up to 90 days"
+            (``90 * 24 = 2160`` hours); this is a maintained-alone project's
+            outer bound, not a target most reports will take that long.
     """
 
     in_scope: tuple[str, ...] = ()
     out_of_scope: tuple[str, ...] = ()
-    recognition: dict[str, str] = field(
-        default_factory=lambda: {
-            "low": RecognitionTier.ACKNOWLEDGMENT.value,
-            "medium": RecognitionTier.PUBLIC_CREDIT.value,
-            "high": RecognitionTier.CVE_CREDIT.value,
-            "critical": RecognitionTier.HALL_OF_FAME.value,
-        }
-    )
-    response_sla_hours: int = 48
+    response_sla_hours: int = 2160
 
 
 @dataclass(frozen=True)
 class DisclosureTimeline:
     """Coordinated disclosure timeline milestones.
 
+    There is no fix-deadline milestone: SECURITY.md promises a first
+    response, not a fix date.
+
     Attributes:
         report_id: The associated vulnerability report.
-        triage_date: When the report was initially triaged.
         vendor_notified: When the vendor was first notified.
-        fix_deadline: Expected date for a fix to be available.
-        public_disclosure: Date when the vulnerability will be publicly disclosed.
+        first_response_due: Deadline for the first substantive response.
+        public_disclosure: Date the reporter may disclose unilaterally,
+            with or without a shipped fix.
         milestones: All milestone dates with labels.
     """
 
     report_id: str
-    triage_date: datetime
     vendor_notified: datetime
-    fix_deadline: datetime
+    first_response_due: datetime
     public_disclosure: datetime
     milestones: dict[str, datetime] = field(default_factory=dict)
 
@@ -224,20 +224,14 @@ class VulnerabilityDisclosureManager:
     """Manages the full lifecycle of vulnerability disclosure.
 
     Handles report submission, triage, fix tracking, and coordinated
-    disclosure timelines. Classifies each report into a non-monetary
-    recognition tier based on the disclosure scope.
+    disclosure timelines. Recognition is a single uniform credit path -
+    there is no severity-based tier to classify into.
 
     Usage::
 
         mgr = VulnerabilityDisclosureManager(
             scope=DisclosureScope(
                 in_scope=("/api/v1/*", "/api/v2/*"),
-                recognition={
-                    "low": "acknowledgment",
-                    "medium": "public-credit",
-                    "high": "cve-credit",
-                    "critical": "hall-of-fame",
-                },
             ),
         )
         report_id = mgr.submit_report(report)
@@ -248,15 +242,11 @@ class VulnerabilityDisclosureManager:
         self,
         scope: DisclosureScope | None = None,
         *,
-        triage_sla_hours: int = 48,
-        fix_deadline_days: int = 90,
-        disclosure_delay_days: int = 30,
+        disclosure_days: int = 90,
     ) -> None:
         self._scope = scope or DisclosureScope()
         self._reports: dict[str, VulnReport] = {}
-        self._triage_sla_hours = triage_sla_hours
-        self._fix_deadline_days = fix_deadline_days
-        self._disclosure_delay_days = disclosure_delay_days
+        self._disclosure_days = disclosure_days
 
     @property
     def scope(self) -> DisclosureScope:
@@ -417,12 +407,15 @@ class VulnerabilityDisclosureManager:
     def generate_disclosure_timeline(self, report_id: str) -> DisclosureTimeline:
         """Generate a coordinated disclosure timeline for a report.
 
-        Computes milestones based on the SLA and deadline configuration:
+        Computes milestones directly from the submission date. There is no
+        fix-deadline milestone: SECURITY.md promises a first response, not a
+        fix date.
 
-        1. **Triage** - within ``triage_sla_hours`` of submission.
-        2. **Vendor notified** - at submission time.
-        3. **Fix deadline** - ``fix_deadline_days`` after submission.
-        4. **Public disclosure** - ``disclosure_delay_days`` after fix deadline.
+        1. **Vendor notified** - at submission time.
+        2. **First response due** - within ``response_sla_hours`` of
+           submission.
+        3. **Public disclosure** - ``disclosure_days`` after submission,
+           available to the reporter regardless of fix status.
 
         Args:
             report_id: Tracking ID of the report.
@@ -438,23 +431,20 @@ class VulnerabilityDisclosureManager:
             raise KeyError(f"Report {report_id!r} not found")
 
         submitted = report.submitted_at
-        triage_date = submitted + timedelta(hours=self._triage_sla_hours)
-        fix_deadline = submitted + timedelta(days=self._fix_deadline_days)
-        public_disclosure = fix_deadline + timedelta(days=self._disclosure_delay_days)
+        first_response_due = submitted + timedelta(hours=self._scope.response_sla_hours)
+        public_disclosure = submitted + timedelta(days=self._disclosure_days)
 
         milestones = {
             "submitted": submitted,
-            "triage": triage_date,
             "vendor_notified": submitted,
-            "fix_deadline": fix_deadline,
+            "first_response_due": first_response_due,
             "public_disclosure": public_disclosure,
         }
 
         return DisclosureTimeline(
             report_id=report_id,
-            triage_date=triage_date,
             vendor_notified=submitted,
-            fix_deadline=fix_deadline,
+            first_response_due=first_response_due,
             public_disclosure=public_disclosure,
             milestones=milestones,
         )
@@ -462,11 +452,11 @@ class VulnerabilityDisclosureManager:
     # -- Recognition classification -------------------------------------------
 
     def classify_recognition(self, report_id: str) -> str:
-        """Classify a triaged report into a non-monetary recognition tier.
+        """Classify a report into its (uniform) recognition state.
 
-        Looks up the severity in the disclosure scope's recognition table.
-        Returns :attr:`RecognitionTier.NONE` (``"none"``) if the severity is
-        not in the table.
+        Recognition does not depend on severity: every report that has not
+        been rejected is credited the same way (release notes plus GitHub
+        Security Advisory credit). A rejected report gets none.
 
         Args:
             report_id: Tracking ID of the report.
@@ -481,19 +471,25 @@ class VulnerabilityDisclosureManager:
         if report is None:
             raise KeyError(f"Report {report_id!r} not found")
 
-        return self._scope.recognition.get(report.severity, RecognitionTier.NONE.value)
+        if report.status == ReportStatus.REJECTED.value:
+            return RecognitionTier.NONE.value
+        return RecognitionTier.CREDITED.value
 
     # -- SLA compliance -------------------------------------------------------
 
     def check_sla_compliance(self, report_id: str) -> dict[str, bool]:
-        """Check whether SLA deadlines are met for a report.
+        """Check whether the first-response SLA has been met.
+
+        There is no fix deadline to check against - only the first
+        substantive response is a commitment SECURITY.md makes.
 
         Args:
             report_id: Tracking ID of the report.
 
         Returns:
-            Dictionary with keys ``triage_within_sla``, ``fix_within_sla``,
-            and ``disclosure_within_sla``, each a boolean.
+            Dictionary with key ``response_within_sla``: ``True`` if the
+            report has moved past ``new`` (i.e. a response has occurred) or
+            the response SLA window has not yet elapsed.
 
         Raises:
             KeyError: If the report does not exist.
@@ -503,15 +499,9 @@ class VulnerabilityDisclosureManager:
             raise KeyError(f"Report {report_id!r} not found")
 
         now = datetime.now(UTC)
-        fix_deadline = report.submitted_at + timedelta(days=self._fix_deadline_days)
+        response_deadline = report.submitted_at + timedelta(hours=self._scope.response_sla_hours)
+        responded = report.status != ReportStatus.NEW.value
 
         return {
-            "triage_within_sla": True,
-            "fix_within_sla": report.status
-            in (
-                ReportStatus.RESOLVED.value,
-                ReportStatus.DISCLOSED.value,
-            )
-            or now <= fix_deadline,
-            "disclosure_within_sla": True,  # disclosure is future-dated
+            "response_within_sla": responded or now <= response_deadline,
         }

--- a/tests/unit/test_vuln_disclosure.py
+++ b/tests/unit/test_vuln_disclosure.py
@@ -1,8 +1,9 @@
 """Tests for bernstein.core.security.vuln_disclosure.
 
 Covers vulnerability report lifecycle, triage, disclosure timelines,
-non-monetary recognition classification, SLA compliance, and
-security.txt generation.
+uniform (non-severity-based) recognition, SLA compliance, and
+security.txt generation. The defaults here track SECURITY.md: a 90-day
+first-response window, no fix deadline, and one uniform credit path.
 """
 
 from __future__ import annotations
@@ -46,25 +47,13 @@ def sample_scope() -> DisclosureScope:
     return DisclosureScope(
         in_scope=("/api/v1/*", "/api/v2/*"),
         out_of_scope=("/static/*", "/docs/*"),
-        recognition={
-            "low": "acknowledgment",
-            "medium": "public-credit",
-            "high": "cve-credit",
-            "critical": "hall-of-fame",
-        },
-        response_sla_hours=48,
     )
 
 
 @pytest.fixture
 def manager(sample_scope: DisclosureScope) -> VulnerabilityDisclosureManager:
     """Create a disclosure manager with the sample scope."""
-    return VulnerabilityDisclosureManager(
-        scope=sample_scope,
-        triage_sla_hours=48,
-        fix_deadline_days=90,
-        disclosure_delay_days=30,
-    )
+    return VulnerabilityDisclosureManager(scope=sample_scope, disclosure_days=90)
 
 
 # ---------------------------------------------------------------------------
@@ -254,9 +243,26 @@ class TestFixTracking:
 
 
 class TestDisclosureTimeline:
-    """Tests for coordinated disclosure timeline generation."""
+    """Tests for coordinated disclosure timeline generation.
 
-    def test_timeline_has_all_milestones(
+    SECURITY.md promises a first response, not a fix date, so the timeline
+    must carry no fix-deadline milestone.
+    """
+
+    def test_timeline_has_no_fix_deadline_field(self) -> None:
+        """DisclosureTimeline no longer models a fix deadline at all."""
+        assert not hasattr(DisclosureTimeline, "__dataclass_fields__") or (
+            "fix_deadline" not in DisclosureTimeline.__dataclass_fields__
+        )
+
+    def test_timeline_milestones_have_no_fix_deadline_key(
+        self, manager: VulnerabilityDisclosureManager, sample_report: VulnReport
+    ) -> None:
+        manager.submit_report(sample_report)
+        timeline = manager.generate_disclosure_timeline("VR-001")
+        assert "fix_deadline" not in timeline.milestones
+
+    def test_timeline_has_response_and_disclosure_milestones(
         self, manager: VulnerabilityDisclosureManager, sample_report: VulnReport
     ) -> None:
         manager.submit_report(sample_report)
@@ -264,34 +270,34 @@ class TestDisclosureTimeline:
         assert isinstance(timeline, DisclosureTimeline)
         assert timeline.report_id == "VR-001"
         assert "submitted" in timeline.milestones
-        assert "triage" in timeline.milestones
-        assert "fix_deadline" in timeline.milestones
+        assert "vendor_notified" in timeline.milestones
+        assert "first_response_due" in timeline.milestones
         assert "public_disclosure" in timeline.milestones
 
-    def test_triage_deadline_respects_sla(
+    def test_first_response_due_respects_scope_sla(
         self, manager: VulnerabilityDisclosureManager, sample_report: VulnReport
     ) -> None:
         manager.submit_report(sample_report)
         timeline = manager.generate_disclosure_timeline("VR-001")
-        expected_triage = sample_report.submitted_at + timedelta(hours=48)
-        assert timeline.triage_date == expected_triage
+        expected = sample_report.submitted_at + timedelta(hours=manager.scope.response_sla_hours)
+        assert timeline.first_response_due == expected
 
-    def test_fix_deadline_respects_config(
+    def test_public_disclosure_is_ninety_days_after_submission_by_default(
         self, manager: VulnerabilityDisclosureManager, sample_report: VulnReport
     ) -> None:
+        """Matches SECURITY.md: reporter may disclose 90 days after report,
+        independent of fix status."""
         manager.submit_report(sample_report)
         timeline = manager.generate_disclosure_timeline("VR-001")
-        expected_fix = sample_report.submitted_at + timedelta(days=90)
-        assert timeline.fix_deadline == expected_fix
-
-    def test_public_disclosure_after_fix_deadline(
-        self, manager: VulnerabilityDisclosureManager, sample_report: VulnReport
-    ) -> None:
-        manager.submit_report(sample_report)
-        timeline = manager.generate_disclosure_timeline("VR-001")
-        assert timeline.public_disclosure > timeline.fix_deadline
-        expected_disclosure = sample_report.submitted_at + timedelta(days=120)
+        expected_disclosure = sample_report.submitted_at + timedelta(days=90)
         assert timeline.public_disclosure == expected_disclosure
+
+    def test_public_disclosure_respects_custom_disclosure_days(self, sample_report: VulnReport) -> None:
+        mgr = VulnerabilityDisclosureManager(disclosure_days=45)
+        mgr.submit_report(sample_report)
+        timeline = mgr.generate_disclosure_timeline("VR-001")
+        expected = sample_report.submitted_at + timedelta(days=45)
+        assert timeline.public_disclosure == expected
 
     def test_timeline_nonexistent_raises(self, manager: VulnerabilityDisclosureManager) -> None:
         with pytest.raises(KeyError):
@@ -304,62 +310,69 @@ class TestDisclosureTimeline:
 
 
 class TestRecognitionClassification:
-    """Tests for non-monetary recognition classification."""
+    """Tests for uniform (non-severity-based) recognition classification."""
 
-    def test_high_severity_recognition(
+    def test_recognition_tier_has_no_severity_ladder(self) -> None:
+        """RecognitionTier carries exactly the uniform states, no per-severity
+        tiers and no hall-of-fame (removed with the page in #3689)."""
+        values = {t.value for t in RecognitionTier}
+        assert values == {"none", "credited"}
+        assert not hasattr(RecognitionTier, "HALL_OF_FAME")
+        assert not hasattr(RecognitionTier, "PUBLIC_CREDIT")
+        assert not hasattr(RecognitionTier, "CVE_CREDIT")
+        assert not hasattr(RecognitionTier, "ACKNOWLEDGMENT")
+
+    def test_high_severity_is_credited(
         self, manager: VulnerabilityDisclosureManager, sample_report: VulnReport
     ) -> None:
         manager.submit_report(sample_report)
         manager.triage_report("VR-001")
-        assert manager.classify_recognition("VR-001") == "cve-credit"
+        assert manager.classify_recognition("VR-001") == RecognitionTier.CREDITED.value
 
-    def test_critical_severity_recognition(self, manager: VulnerabilityDisclosureManager) -> None:
-        report = VulnReport(
-            report_id="VR-CRIT",
-            severity="critical",
-            title="RCE",
-            description="Remote code execution",
-            reporter_email="a@b.com",
-        )
-        manager.submit_report(report)
-        manager.triage_report("VR-CRIT")
-        assert manager.classify_recognition("VR-CRIT") == "hall-of-fame"
-
-    def test_unknown_severity_no_recognition(self, manager: VulnerabilityDisclosureManager) -> None:
-        """A severity not in the recognition table maps to 'none'."""
-        scope = DisclosureScope(
-            in_scope=("/api/*",),
-            recognition={"high": "cve-credit", "critical": "hall-of-fame"},
-        )
-        mgr = VulnerabilityDisclosureManager(scope=scope)
-        report = VulnReport(
+    def test_low_severity_is_credited_the_same_as_critical(self, manager: VulnerabilityDisclosureManager) -> None:
+        """Credit is uniform - a low-severity report is credited identically
+        to a critical one, since SECURITY.md states one credit path."""
+        low = VulnReport(
             report_id="VR-LOW",
             severity="low",
             title="Info leak",
             description="Information disclosure",
             reporter_email="a@b.com",
         )
-        mgr.submit_report(report)
-        mgr.triage_report("VR-LOW")
-        assert mgr.classify_recognition("VR-LOW") == RecognitionTier.NONE.value
+        critical = VulnReport(
+            report_id="VR-CRIT",
+            severity="critical",
+            title="RCE",
+            description="Remote code execution",
+            reporter_email="c@d.com",
+        )
+        manager.submit_report(low)
+        manager.submit_report(critical)
+        manager.triage_report("VR-LOW")
+        manager.triage_report("VR-CRIT")
+        assert manager.classify_recognition("VR-LOW") == manager.classify_recognition("VR-CRIT") == "credited"
 
-    def test_custom_recognition_mapping(self, manager: VulnerabilityDisclosureManager) -> None:
-        """A custom recognition mapping is honoured verbatim."""
-        scope = DisclosureScope(
-            in_scope=("/api/*",),
-            recognition={"medium": "public-credit"},
+    def test_rejected_report_gets_no_recognition(
+        self, manager: VulnerabilityDisclosureManager, sample_report: VulnReport
+    ) -> None:
+        manager.submit_report(sample_report)
+        # No status transition to "rejected" is exposed on the manager yet;
+        # exercise the classification directly against a rejected VulnReport
+        # stored via triage's returned dataclass semantics.
+        report = manager.triage_report("VR-001")
+        rejected = VulnReport(
+            report_id=report.report_id,
+            severity=report.severity,
+            title=report.title,
+            description=report.description,
+            reporter_email=report.reporter_email,
+            submitted_at=report.submitted_at,
+            status=ReportStatus.REJECTED.value,
+            cve_id=report.cve_id,
+            affected_components=report.affected_components,
         )
-        mgr = VulnerabilityDisclosureManager(scope=scope)
-        report = VulnReport(
-            report_id="VR-MED",
-            severity="medium",
-            title="SSRF",
-            description="Server-side request forgery",
-            reporter_email="a@b.com",
-        )
-        mgr.submit_report(report)
-        mgr.triage_report("VR-MED")
-        assert mgr.classify_recognition("VR-MED") == "public-credit"
+        manager._reports[report.report_id] = rejected  # exercising internal state directly
+        assert manager.classify_recognition("VR-001") == RecognitionTier.NONE.value
 
     def test_classify_nonexistent_raises(self, manager: VulnerabilityDisclosureManager) -> None:
         with pytest.raises(KeyError):
@@ -372,20 +385,51 @@ class TestRecognitionClassification:
 
 
 class TestSLACompliance:
-    """Tests for SLA compliance checking."""
+    """Tests for first-response SLA compliance checking.
 
-    def test_new_report_triage_sla_ok(self, manager: VulnerabilityDisclosureManager, sample_report: VulnReport) -> None:
+    There is no fix deadline, so ``check_sla_compliance`` reports only the
+    first-response SLA - no ``fix_within_sla`` or ``disclosure_within_sla``
+    keys.
+    """
+
+    def _submit_fresh_report(self, manager: VulnerabilityDisclosureManager, report_id: str) -> None:
+        """Submit a report timestamped now, so the 90-day SLA window has not
+        elapsed regardless of when the test suite runs."""
+        report = VulnReport(
+            report_id=report_id,
+            severity="high",
+            title="Fresh report",
+            description="desc",
+            reporter_email="a@b.com",
+            submitted_at=datetime.now(UTC),
+        )
+        manager.submit_report(report)
+
+    def test_new_report_response_sla_ok(self, manager: VulnerabilityDisclosureManager) -> None:
+        self._submit_fresh_report(manager, "VR-FRESH-1")
+        compliance = manager.check_sla_compliance("VR-FRESH-1")
+        assert compliance["response_within_sla"] is True
+
+    def test_compliance_dict_has_no_fix_or_disclosure_keys(self, manager: VulnerabilityDisclosureManager) -> None:
+        self._submit_fresh_report(manager, "VR-FRESH-2")
+        compliance = manager.check_sla_compliance("VR-FRESH-2")
+        assert set(compliance.keys()) == {"response_within_sla"}
+
+    def test_triaged_report_response_sla_ok(self, manager: VulnerabilityDisclosureManager) -> None:
+        self._submit_fresh_report(manager, "VR-FRESH-3")
+        manager.triage_report("VR-FRESH-3")
+        compliance = manager.check_sla_compliance("VR-FRESH-3")
+        assert compliance["response_within_sla"] is True
+
+    def test_old_new_report_past_sla_window_is_out_of_compliance(
+        self, manager: VulnerabilityDisclosureManager, sample_report: VulnReport
+    ) -> None:
+        """A report still at status=new, submitted more than 90 days ago
+        (``sample_report`` is dated 2026-01-15), has missed the first
+        response SLA."""
         manager.submit_report(sample_report)
         compliance = manager.check_sla_compliance("VR-001")
-        assert compliance["triage_within_sla"] is True
-
-    def test_resolved_report_all_ok(self, manager: VulnerabilityDisclosureManager, sample_report: VulnReport) -> None:
-        manager.submit_report(sample_report)
-        manager.triage_report("VR-001")
-        manager.mark_fixing("VR-001")
-        manager.mark_resolved("VR-001")
-        compliance = manager.check_sla_compliance("VR-001")
-        assert compliance["fix_within_sla"] is True
+        assert compliance["response_within_sla"] is False
 
     def test_nonexistent_raises(self, manager: VulnerabilityDisclosureManager) -> None:
         with pytest.raises(KeyError):
@@ -448,18 +492,23 @@ class TestVulnReport:
 class TestDisclosureScope:
     """Tests for the DisclosureScope dataclass."""
 
-    def test_default_recognition(self) -> None:
-        scope = DisclosureScope(in_scope=("/api/*",))
-        assert scope.recognition["low"] == RecognitionTier.ACKNOWLEDGMENT.value
-        assert scope.recognition["critical"] == RecognitionTier.HALL_OF_FAME.value
+    def test_default_response_sla_matches_ninety_day_policy(self) -> None:
+        """SECURITY.md states up to 90 days for a first substantive
+        response; the default must be that value in hours, not the
+        retired 48-hour triage SLA."""
+        scope = DisclosureScope()
+        assert scope.response_sla_hours == 90 * 24
 
-    def test_custom_recognition(self) -> None:
-        scope = DisclosureScope(
-            in_scope=("/api/*",),
-            recognition={"low": "acknowledgment", "high": "cve-credit"},
-        )
-        assert scope.recognition.get("low") == "acknowledgment"
-        assert scope.recognition.get("high") == "cve-credit"
+    def test_custom_response_sla(self) -> None:
+        scope = DisclosureScope(in_scope=("/api/*",), response_sla_hours=24)
+        assert scope.response_sla_hours == 24
+
+    def test_no_recognition_field(self) -> None:
+        """The scope no longer carries a severity-keyed recognition table -
+        credit is uniform and lives in classify_recognition, not scope
+        configuration."""
+        scope = DisclosureScope(in_scope=("/api/*",))
+        assert not hasattr(scope, "recognition")
 
     def test_no_monetary_fields(self) -> None:
         """The scope carries no dollar-denominated reward fields."""
@@ -475,7 +524,6 @@ class TestDisclosureScope:
         """
         scope = DisclosureScope()
         assert scope.in_scope == ()
-        assert scope.recognition["critical"] == RecognitionTier.HALL_OF_FAME.value
 
     def test_manager_default_scope_is_constructible(self) -> None:
         """VulnerabilityDisclosureManager() works with no scope argument."""
@@ -486,3 +534,15 @@ class TestDisclosureScope:
         scope = DisclosureScope(in_scope=("/api/*",))
         with pytest.raises(AttributeError):
             scope.response_sla_hours = 999  # type: ignore[misc]
+
+    def test_manager_has_no_fix_deadline_days_param(self) -> None:
+        """fix_deadline_days is gone from the constructor - passing it must
+        raise, not silently no-op."""
+        with pytest.raises(TypeError):
+            VulnerabilityDisclosureManager(fix_deadline_days=90)  # type: ignore[call-arg]
+
+    def test_manager_has_no_triage_sla_hours_param(self) -> None:
+        """triage_sla_hours duplicated scope.response_sla_hours with a
+        different (stale) default; it is gone from the constructor."""
+        with pytest.raises(TypeError):
+            VulnerabilityDisclosureManager(triage_sla_hours=48)  # type: ignore[call-arg]


### PR DESCRIPTION
Closes #3694

## Root cause

`vuln_disclosure.py` encoded a retired disclosure programme: a 48-hour
response SLA default, a four-tier severity-to-recognition ladder
(including hall-of-fame, whose page was removed in #3689), and
fix-deadline arithmetic in `check_sla_compliance()` and
`generate_disclosure_timeline()`. Current `SECURITY.md` states a 90-day
first-response window, no fix deadline, and one uniform credit path
(release notes plus GitHub Security Advisory credit). This module is
importable public API, so these were the defaults a downstream operator
got before configuring anything.

## Changes

- `DisclosureScope.response_sla_hours` defaults to `2160` (90 days), not `48`.
- `RecognitionTier` drops `ACKNOWLEDGMENT`/`PUBLIC_CREDIT`/`CVE_CREDIT`/
  `HALL_OF_FAME` for a uniform `NONE`/`CREDITED` pair. `classify_recognition()`
  no longer looks up severity, since credit is uniform.
- `DisclosureScope.recognition` (the severity->tier map) is removed.
- `DisclosureTimeline` drops `triage_date`/`fix_deadline` for
  `first_response_due`/`public_disclosure`, both computed straight from
  submission time. `public_disclosure` is `submission + disclosure_days`
  (default 90) - the reporter's unilateral disclosure right, not a delay
  after a fix deadline that no longer exists.
- `VulnerabilityDisclosureManager` drops `triage_sla_hours` (it duplicated
  `scope.response_sla_hours` with a different, stale default) and
  `fix_deadline_days`/`disclosure_delay_days`; adds `disclosure_days`.
- `check_sla_compliance()` now returns only `response_within_sla` - no
  `fix_within_sla`/`disclosure_within_sla` keys, since there is no fix
  deadline to check against. Confirmed nothing else in the repo (`src/`,
  `docs/`) consumes those keys, so this was a straight removal rather than
  a deprecation.

## Tests

`tests/unit/test_vuln_disclosure.py`, 47 cases. New/changed assertions:

- `test_default_response_sla_matches_ninety_day_policy`
- `test_recognition_tier_has_no_severity_ladder`
- `test_low_severity_is_credited_the_same_as_critical`
- `test_rejected_report_gets_no_recognition`
- `test_timeline_has_no_fix_deadline_field`
- `test_timeline_milestones_have_no_fix_deadline_key`
- `test_first_response_due_respects_scope_sla`
- `test_public_disclosure_is_ninety_days_after_submission_by_default`
- `test_public_disclosure_respects_custom_disclosure_days`
- `test_compliance_dict_has_no_fix_or_disclosure_keys`
- `test_old_new_report_past_sla_window_is_out_of_compliance`
- `test_manager_has_no_fix_deadline_days_param`
- `test_manager_has_no_triage_sla_hours_param`
- `test_no_recognition_field`

Plus the pre-existing submit/triage/fix-tracking/security.txt coverage,
updated where fixtures relied on the retired constructor args.

Verified the new tests fail against the pre-fix module (7 failed, 27
errored on removed constructor kwargs) and pass after the fix (47 passed).

`ruff check`, `ruff format --check`, and `mypy` are clean on both changed
files; pre-push lint/import-linter/typecheck ran clean on push.

## Left out of scope

`mark_resolved()`'s docstring already only claims "fix deployed," not
advisory production, so it needed no change.