### PR TITLE
fix(multimodal): decide attachment worktree access from authenticated rows

### DIFF
--- a/docs/operations/run.md
+++ b/docs/operations/run.md
@@ -83,6 +83,15 @@ attachment back to bytes; the resolver raises
 `WorktreeAccessDenied` on cross-worktree attempts. This protects
 session-shared state where multiple worktrees coexist.
 
+The resolver reads the `multimodal.attach` events through the
+chain's authenticated scan, so the worktree it grants access to is
+one the HMAC linkage actually attests. If the chain does not verify
+-- for example because something appended an attach row into the
+audit directory without the audit key -- the lookup refuses with
+`AttachmentChainUnverified` rather than trusting the row. Run
+`bernstein audit verify` to see the per-entry errors behind the
+refusal.
+
 ### Task YAML
 
 Plan-file steps accept an `attachments:` list:

--- a/src/bernstein/core/agents/multimodal_attestation.py
+++ b/src/bernstein/core/agents/multimodal_attestation.py
@@ -371,9 +371,14 @@ class _VerifiedAttachIndex:
         with self._lock:
             result = chain.scan_verified(self._cursor, event_type=EVENT_MULTIMODAL_ATTACH)
             if not result.ok:
-                # Leave the cursor where it was: a failed scan consumed bytes
-                # it could not authenticate, so advancing past them would let
-                # the next lookup treat the damaged span as verified history.
+                # Leave the cursor where it was by not adopting ``result.cursor``:
+                # the failed scan consumed bytes it could not authenticate, so
+                # advancing past them would let the next lookup treat the damaged
+                # span as verified history and go quiet about a break it already
+                # found. ``scan_verified`` walks a copy of what it is handed
+                # (:meth:`ChainScanCursor.working_copy`), so ``self._cursor``
+                # really is still the pre-scan resume point here and the next
+                # lookup re-verifies -- and re-refuses -- the same bytes.
                 raise AttachmentChainUnverified(sha256=sha256, errors=result.errors)
             if result.rescanned:
                 self._owners.clear()

--- a/src/bernstein/core/agents/multimodal_attestation.py
+++ b/src/bernstein/core/agents/multimodal_attestation.py
@@ -31,7 +31,13 @@ to bytes for workers in the same worktree it was attached from. The
 worktree id is embedded in the ``multimodal.attach`` event payload;
 :func:`resolve_attachment_for_worker` consults the chain on lookup
 and raises :class:`WorktreeAccessDenied` for any cross-worktree
-attempt.
+attempt. That lookup reads through
+:meth:`AuditChainStore.scan_verified`, so the access decision rests
+only on rows whose HMAC linkage held: a ``multimodal.attach`` row
+appended by a writer without the audit key names a worktree the chain
+never authenticated, and the resolve fails closed with
+:class:`AttachmentChainUnverified` instead of handing over another
+worktree's bytes.
 """
 
 from __future__ import annotations
@@ -39,9 +45,11 @@ from __future__ import annotations
 import base64
 import hashlib
 import logging
+import threading
 from dataclasses import dataclass
 from pathlib import Path  # runtime use in encode_one
 from typing import TYPE_CHECKING
+from weakref import WeakKeyDictionary
 
 from bernstein.core.agents.multimodal import (
     MultiModalContext,
@@ -60,6 +68,7 @@ from bernstein.core.security.audit_chain import (
 
 if TYPE_CHECKING:
     from bernstein.core.persistence.cas_store import CASStore
+    from bernstein.core.security.audit import ChainScanCursor
     from bernstein.core.security.audit_chain import AuditChainStore
 
 logger = logging.getLogger(__name__)
@@ -295,6 +304,27 @@ def encode_one(file_path: str | Path) -> tuple[str, str, str]:
 # ---------------------------------------------------------------------------
 
 
+class AttachmentChainUnverified(RuntimeError):
+    """Raised when the chain backing an attachment lookup does not authenticate.
+
+    The worktree pin is only as strong as the rows it is read from. When the
+    HMAC linkage over the audit chain does not hold, no ``multimodal.attach``
+    row can be attributed to a worktree, so the resolve refuses rather than
+    falling back to whatever the log happens to contain.
+
+    Attributes:
+        sha256: Digest whose resolve was refused.
+        errors: Per-entry verification errors reported by the chain scan.
+    """
+
+    def __init__(self, sha256: str, errors: list[str]) -> None:
+        self.sha256 = sha256
+        self.errors = errors
+        super().__init__(
+            f"Refusing to resolve attachment {sha256[:12]}... from an unverified audit chain: " + "; ".join(errors[:3])
+        )
+
+
 class WorktreeAccessDenied(RuntimeError):
     """Raised when a worker in worktree B requests an attachment from A."""
 
@@ -310,6 +340,73 @@ class WorktreeAccessDenied(RuntimeError):
         )
 
 
+class _VerifiedAttachIndex:
+    """Attaching worktrees per digest, built only from authenticated rows.
+
+    The index is fed by :meth:`AuditChainStore.scan_verified`, which
+    recomputes the HMAC of exactly the bytes it reads and refuses the whole
+    scan when the linkage breaks. Keeping the returned cursor here is what
+    makes an authenticated read affordable on this path: the first lookup
+    walks the chain once, and every later lookup verifies and parses only the
+    bytes appended since, so a per-attachment resolve costs O(new rows)
+    instead of O(entire chain).
+
+    The index lives beside the cursor because the two must be discarded
+    together: when a scan reports ``rescanned`` the history under the cursor
+    changed, and any mapping derived from the old prefix is no longer backed
+    by rows this process authenticated.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._cursor: ChainScanCursor | None = None
+        self._owners: dict[str, set[str]] = {}
+
+    def owners_of(self, chain: AuditChainStore, sha256: str) -> frozenset[str]:
+        """Return the worktree ids that verifiably attached *sha256*.
+
+        Raises:
+            AttachmentChainUnverified: The chain scan did not authenticate.
+        """
+        with self._lock:
+            result = chain.scan_verified(self._cursor, event_type=EVENT_MULTIMODAL_ATTACH)
+            if not result.ok:
+                # Leave the cursor where it was: a failed scan consumed bytes
+                # it could not authenticate, so advancing past them would let
+                # the next lookup treat the damaged span as verified history.
+                raise AttachmentChainUnverified(sha256=sha256, errors=result.errors)
+            if result.rescanned:
+                self._owners.clear()
+            for event in result.events:
+                if event.event_type != EVENT_MULTIMODAL_ATTACH:
+                    continue
+                digest = str(event.details.get("sha256", ""))
+                if not digest:
+                    continue
+                self._owners.setdefault(digest, set()).add(str(event.details.get("worktree_id", "")))
+            self._cursor = result.cursor
+            return frozenset(self._owners.get(sha256, frozenset()))
+
+
+#: One index per :class:`AuditChainStore` instance. The cursor is only
+#: meaningful against the chain it was produced from, so the store is the
+#: correct owner; the mapping is weak-keyed so a store that goes out of scope
+#: takes its cursor and index with it rather than pinning them for the life of
+#: the process.
+_ATTACH_INDEXES: WeakKeyDictionary[AuditChainStore, _VerifiedAttachIndex] = WeakKeyDictionary()
+_ATTACH_INDEXES_LOCK = threading.Lock()
+
+
+def _attach_index_for(chain: AuditChainStore) -> _VerifiedAttachIndex:
+    """Return (creating on first use) the authenticated attach index for *chain*."""
+    with _ATTACH_INDEXES_LOCK:
+        index = _ATTACH_INDEXES.get(chain)
+        if index is None:
+            index = _VerifiedAttachIndex()
+            _ATTACH_INDEXES[chain] = index
+        return index
+
+
 def resolve_attachment_for_worker(
     *,
     sha256: str,
@@ -319,10 +416,19 @@ def resolve_attachment_for_worker(
 ) -> bytes:
     """Return attached bytes if the requesting worktree owns the attach.
 
-    Looks up the most recent ``multimodal.attach`` event matching
-    ``sha256``. If that event's ``worktree_id`` matches
-    ``requesting_worktree_id`` the bytes are returned from CAS;
-    otherwise :class:`WorktreeAccessDenied` is raised.
+    Looks up the ``multimodal.attach`` events matching ``sha256``. If one of
+    them pins the attachment to ``requesting_worktree_id`` the bytes are
+    returned from CAS; otherwise :class:`WorktreeAccessDenied` is raised.
+
+    Events are read through :meth:`AuditChainStore.scan_verified`, never
+    through ``query()``. ``query()`` performs no HMAC checking, so a
+    ``multimodal.attach`` row appended by anything that can write the audit
+    directory -- without the audit key, and therefore without valid chain
+    linkage -- would name any worktree it likes and hand that worktree another
+    worktree's attachment bytes. The scan authenticates the rows it returns and
+    the lookup fails closed when the linkage does not hold. The cursor behind
+    the scan is kept per audit-chain store (see :class:`_VerifiedAttachIndex`)
+    so the authenticated read stays incremental on this per-attachment path.
 
     Args:
         sha256: Hex digest of the requested attachment.
@@ -334,15 +440,13 @@ def resolve_attachment_for_worker(
         The raw attachment bytes.
 
     Raises:
+        AttachmentChainUnverified: The audit chain did not verify, so no
+            attach row can be attributed to a worktree.
         WorktreeAccessDenied: The attach event's worktree id differs
             from the requesting worktree id.
         FileNotFoundError: No attach event exists for the SHA, or the
             CAS lookup misses.
     """
-    entries = audit_chain.query(event_type=EVENT_MULTIMODAL_ATTACH)
-    matches = [e for e in entries if e.details.get("sha256") == sha256]
-    if not matches:
-        raise FileNotFoundError(f"No multimodal.attach event for {sha256[:12]}...")
     # Resolve by (sha256, worktree_id) so concurrent attaches in
     # different worktrees of the same bytes do not poison each other.
     # If any historical attach in the requesting worktree exists for
@@ -350,11 +454,11 @@ def resolve_attachment_for_worker(
     # attaching worktrees (for the structured error) is built from
     # every historical event so the operator sees the full picture.
     # (bot-ack: 3284182761 -- CodeRabbit major.)
-    in_worktree = [e for e in matches if str(e.details.get("worktree_id", "")) == requesting_worktree_id]
-    if not in_worktree:
-        seen_worktrees = sorted(
-            {str(e.details.get("worktree_id", "")) for e in matches if e.details.get("worktree_id")}
-        )
+    attaching_worktrees = _attach_index_for(audit_chain).owners_of(audit_chain, sha256)
+    if not attaching_worktrees:
+        raise FileNotFoundError(f"No multimodal.attach event for {sha256[:12]}...")
+    if requesting_worktree_id not in attaching_worktrees:
+        seen_worktrees = sorted(w for w in attaching_worktrees if w)
         raise WorktreeAccessDenied(
             sha256=sha256,
             attached_worktree=", ".join(seen_worktrees) or "<unknown>",
@@ -381,6 +485,7 @@ def worker_lineage_parents(result: AttachmentBuildResult) -> list[str]:
 
 __all__ = [
     "AttachmentBuildResult",
+    "AttachmentChainUnverified",
     "AttachmentResolution",
     "CapabilityRefusal",
     "WorktreeAccessDenied",

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -1235,6 +1235,31 @@ class ChainScanCursor:
     complete: set[str] = field(default_factory=set)
     fingerprint: dict[str, tuple[int, int]] = field(default_factory=dict)
 
+    def working_copy(self) -> ChainScanCursor:
+        """Return an independent cursor for a scan that has no verdict yet.
+
+        A scan advances its cursor *while* walking the new tail and only
+        decides ``ok`` once the whole walk is done, so at the moment the bytes
+        that fail to authenticate are consumed the scan does not yet know they
+        failed. Handing the walk the caller's own object would therefore move
+        that object past a span the scan went on to refuse: the caller drops
+        the result, but its cursor has already adopted the damaged offsets, and
+        the next resumed scan skips those bytes and reports a clean chain for a
+        span nothing ever verified -- one refusal, then silence.
+
+        :meth:`AuditLog.scan_verified` walks this copy instead and returns it,
+        which makes ``result.cursor`` the only way to advance: a caller that
+        adopts it only on the verdict it wants keeps a failure re-detectable on
+        every later call.
+        """
+        return ChainScanCursor(
+            prev_hmac=self.prev_hmac,
+            consumed=dict(self.consumed),
+            order=list(self.order),
+            complete=set(self.complete),
+            fingerprint=dict(self.fingerprint),
+        )
+
 
 @dataclass
 class ChainScanResult:
@@ -1910,14 +1935,24 @@ class AuditLog:
           attacker with write access to the audit directory cannot forge an
           entry, and any unusable index simply degrades to a full walk (#2648).
 
+        The cursor passed in is never mutated. The scan walks a copy and
+        returns it, so ``result.cursor`` is the only thing that advances a
+        caller's resume point. That is what keeps a refusal repeatable: a
+        caller that adopts the returned cursor only when ``ok`` re-verifies the
+        same bytes -- and reports the same break -- on every later call,
+        instead of resuming past a span it never authenticated.
+
         Args:
             cursor: Resume point from a previous call, or ``None`` to scan all.
+                Left untouched by this call.
             event_type: If set, only return events of this type, and enable the
                 segment index (which retains only the filtered rows).
 
         Returns:
             A :class:`ChainScanResult` whose ``events`` are the newly consumed
-            rows and whose ``cursor`` should be passed to the next call.
+            rows and whose ``cursor`` should be passed to the next call. Adopt
+            it only on the verdict you are willing to treat as verified
+            history; on ``ok is False`` keep the cursor you already had.
         """
         segments: list[tuple[str, Path, bool]] = [
             (_segment_stem(p), p, True) for p in _archived_segment_paths(self._audit_dir)
@@ -1932,7 +1967,11 @@ class AuditLog:
             if not set(cursor.order).issubset(set(stems)) or stems[: len(cursor.order)] != cursor.order:
                 resume = False
 
-        active = cursor if resume and cursor is not None else ChainScanCursor()
+        # Never walk the caller's cursor object: the walk advances it before it
+        # knows whether the bytes it just consumed authenticate, so mutating a
+        # caller-owned cursor would let a refused scan silently advance the
+        # caller past the damage (see :meth:`ChainScanCursor.working_copy`).
+        active = cursor.working_copy() if resume and cursor is not None else ChainScanCursor()
         errors: list[str] = []
         events: list[AuditEvent] = []
 

--- a/tests/unit/test_clearance_gate_hardening.py
+++ b/tests/unit/test_clearance_gate_hardening.py
@@ -994,6 +994,51 @@ def test_incremental_scan_still_catches_tampering(tmp_path: Path) -> None:
     assert not cold.ok, "a tampered row survived the indexed scan"
 
 
+def test_a_failed_scan_does_not_advance_a_caller_owned_cursor(tmp_path: Path) -> None:
+    """A refused scan must stay refused for every caller that kept its cursor.
+
+    The scan advances its cursor while walking the new tail and only decides
+    ``ok`` afterwards. If it walked the caller's object, a caller that declines
+    to adopt ``result.cursor`` on failure would still have been moved past the
+    bytes that failed, and the next resumed scan -- with nothing appended --
+    would take the "already == total" fast path and report a clean chain for a
+    span nothing authenticated.
+    """
+    from bernstein.core.security.audit import AuditLog
+
+    audit = tmp_path / "audit"
+    log = AuditLog(audit, key=b"k" * 32)
+    for i in range(10):
+        log.log(event_type="task.transition", actor="x", resource_type="task", resource_id=f"t{i}", details={})
+
+    warm = log.scan_verified(event_type="task.transition")
+    assert warm.ok, warm.errors
+    kept = warm.cursor
+    before = (kept.prev_hmac, dict(kept.consumed), list(kept.order))
+
+    # Append a row whose HMAC an attacker without the key cannot compute.
+    segment = next(iter(sorted(audit.glob("*.jsonl"))))
+    rows = [json.loads(line) for line in segment.read_text().splitlines() if line.strip()]
+    forged = json.loads(json.dumps(rows[-1]))
+    forged["actor"] = "forger"
+    forged["prev_hmac"] = rows[-1]["hmac"]
+    forged["hmac"] = "f" * 64
+    with segment.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(forged, sort_keys=True) + "\n")
+
+    failed = log.scan_verified(kept, event_type="task.transition")
+    assert not failed.ok, "the forged row was not caught"
+    assert (kept.prev_hmac, dict(kept.consumed), list(kept.order)) == before, (
+        "the failed scan mutated the cursor the caller still owns"
+    )
+
+    # Nothing appended since: a caller that kept its cursor must see the break
+    # again rather than resume past it.
+    again = log.scan_verified(kept, event_type="task.transition")
+    assert not again.ok, "the tamper went unreported on the next scan from the same cursor"
+    assert again.errors == failed.errors
+
+
 def test_a_forged_segment_index_is_ignored(tmp_path: Path) -> None:
     """An attacker with write access to the audit dir cannot forge the index."""
     from bernstein.core.security.audit import AuditLog

--- a/tests/unit/test_multimodal_attestation.py
+++ b/tests/unit/test_multimodal_attestation.py
@@ -877,6 +877,53 @@ class TestAuthenticatedAttachReads:
                 audit_chain=chain,
             )
 
+    def test_tamper_is_still_refused_and_reported_after_a_failed_scan(self, tmp_path: Path) -> None:
+        """A warm cursor must not turn a refusal into a one-shot event.
+
+        Fail-closed is only useful if it holds on every lookup. The sequence
+        that matters is warm cursor -> failing scan -> another lookup with
+        nothing appended in between: if the failed scan is allowed to advance
+        the kept cursor past the bytes it could not authenticate, the next
+        lookup resumes beyond the damage, sees no new bytes, and reports a
+        clean chain for a span nothing ever verified.
+        """
+        digest, cas, chain = self._attach(tmp_path)
+        # 1. Warm the kept cursor on a chain that verifies.
+        assert resolve_attachment_for_worker(
+            sha256=digest,
+            requesting_worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        _append_forged_attach(tmp_path / "audit", sha256=digest, worktree_id="wt-b")
+        # 2. The scan that first meets the forged row must refuse.
+        with pytest.raises(AttachmentChainUnverified) as first:
+            resolve_attachment_for_worker(
+                sha256=digest,
+                requesting_worktree_id="wt-a",
+                cas=cas,
+                audit_chain=chain,
+            )
+        assert first.value.errors, "the first refusal must name what failed"
+        # 3. Nothing appended since. The same store must refuse again, with the
+        #    same evidence -- not go quiet about a break it already found.
+        with pytest.raises(AttachmentChainUnverified) as second:
+            resolve_attachment_for_worker(
+                sha256=digest,
+                requesting_worktree_id="wt-a",
+                cas=cas,
+                audit_chain=chain,
+            )
+        assert second.value.errors == first.value.errors
+        # And the forged worktree stays refused on the repeat too.
+        with pytest.raises(AttachmentChainUnverified):
+            resolve_attachment_for_worker(
+                sha256=digest,
+                requesting_worktree_id="wt-b",
+                cas=cas,
+                audit_chain=chain,
+            )
+
     def test_repeat_resolve_resumes_from_the_kept_cursor(self, tmp_path: Path) -> None:
         """The per-attachment path must not re-walk the whole chain on every lookup."""
         digest, cas, chain = self._attach(tmp_path)

--- a/tests/unit/test_multimodal_attestation.py
+++ b/tests/unit/test_multimodal_attestation.py
@@ -15,6 +15,7 @@ Covers:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -25,6 +26,7 @@ from bernstein.core.agents.multimodal import (
     is_multimodal_capable,
 )
 from bernstein.core.agents.multimodal_attestation import (
+    AttachmentChainUnverified,
     AttachmentResolution,
     CapabilityRefusal,
     WorktreeAccessDenied,
@@ -793,3 +795,138 @@ class TestTaskFromDictAttachmentsType:
         }
         task = Task.from_dict(raw)
         assert task.attachments == ["a.png", "b.png"]
+
+
+# ---------------------------------------------------------------------------
+# Authenticated attach reads (issue #3567)
+# ---------------------------------------------------------------------------
+
+
+def _canonical_line(row: dict[str, object]) -> str:
+    """Serialise *row* exactly as the audit log writes its entries."""
+    return json.dumps(row, sort_keys=True) + "\n"
+
+
+def _append_forged_attach(audit_dir: Path, *, sha256: str, worktree_id: str) -> None:
+    """Append a shape-valid ``multimodal.attach`` row whose HMAC linkage is wrong.
+
+    This is what a writer with filesystem access to the audit directory but
+    without the audit key can produce: correct canonical JSON, correct field
+    names, a plausible ``prev_chain_digest`` -- and an HMAC it cannot compute.
+    """
+    segments = sorted(audit_dir.glob("*.jsonl"))
+    assert segments, "expected a live audit segment"
+    segment = segments[-1]
+    rows = [json.loads(line) for line in segment.read_text(encoding="utf-8").splitlines()]
+    template = next(r for r in rows if r.get("event_type") == EVENT_MULTIMODAL_ATTACH)
+    forged = json.loads(json.dumps(template))
+    forged["actor"] = "forger"
+    forged["details"]["sha256"] = sha256
+    forged["details"]["worktree_id"] = worktree_id
+    forged["details"]["worker_id"] = "forger"
+    forged["details"]["prev_chain_digest"] = template["hmac"]
+    forged["hmac"] = "f" * 64
+    with segment.open("a", encoding="utf-8") as handle:
+        handle.write(_canonical_line(forged))
+
+
+class TestAuthenticatedAttachReads:
+    """The worktree pin must rest only on rows whose HMAC linkage held."""
+
+    def _attach(self, tmp_path: Path) -> tuple[str, CASStore, AuditChainStore]:
+        img = _make_image(tmp_path / "shot.png")
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        return result.resolutions[0].sha256, cas, chain
+
+    def test_forged_attach_row_does_not_grant_cross_worktree_access(self, tmp_path: Path) -> None:
+        """A ``multimodal.attach`` row without valid HMAC linkage grants nothing."""
+        digest, cas, chain = self._attach(tmp_path)
+        _append_forged_attach(tmp_path / "audit", sha256=digest, worktree_id="wt-b")
+        # Sanity: the forged row is exactly what an unauthenticated read admits.
+        assert any(
+            str(e.details.get("worktree_id")) == "wt-b"
+            for e in chain.query(event_type=EVENT_MULTIMODAL_ATTACH)
+            if e.details.get("sha256") == digest
+        )
+        with pytest.raises(AttachmentChainUnverified):
+            resolve_attachment_for_worker(
+                sha256=digest,
+                requesting_worktree_id="wt-b",
+                cas=cas,
+                audit_chain=chain,
+            )
+
+    def test_broken_chain_also_refuses_the_owning_worktree(self, tmp_path: Path) -> None:
+        """Verification failure fails the lookup closed, it does not merely drop the bad row."""
+        digest, cas, chain = self._attach(tmp_path)
+        _append_forged_attach(tmp_path / "audit", sha256=digest, worktree_id="wt-b")
+        with pytest.raises(AttachmentChainUnverified):
+            resolve_attachment_for_worker(
+                sha256=digest,
+                requesting_worktree_id="wt-a",
+                cas=cas,
+                audit_chain=chain,
+            )
+
+    def test_repeat_resolve_resumes_from_the_kept_cursor(self, tmp_path: Path) -> None:
+        """The per-attachment path must not re-walk the whole chain on every lookup."""
+        digest, cas, chain = self._attach(tmp_path)
+        seen: list[tuple[object, bool]] = []
+        real_scan = chain.scan_verified
+
+        def recording_scan(cursor=None, *, event_type=None):  # type: ignore[no-untyped-def]
+            result = real_scan(cursor, event_type=event_type)
+            seen.append((cursor, result.rescanned))
+            return result
+
+        chain.scan_verified = recording_scan  # type: ignore[method-assign]
+        for _ in range(3):
+            resolve_attachment_for_worker(
+                sha256=digest,
+                requesting_worktree_id="wt-a",
+                cas=cas,
+                audit_chain=chain,
+            )
+        assert len(seen) == 3
+        assert seen[0][0] is None, "first lookup starts cold"
+        assert all(cursor is not None for cursor, _ in seen[1:]), "later lookups must resume"
+        assert all(not rescanned for _, rescanned in seen[1:]), "resumed scans must not re-walk the chain"
+
+    def test_attach_recorded_after_a_resolve_is_visible_to_the_next_resolve(self, tmp_path: Path) -> None:
+        """A kept cursor must not freeze the view: later attaches still resolve."""
+        digest, cas, chain = self._attach(tmp_path)
+        assert resolve_attachment_for_worker(
+            sha256=digest,
+            requesting_worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        # Same bytes attached again, this time from wt-b, after the index warmed.
+        img_b = _make_image(tmp_path / "b.png")
+        second = build_attachment_context(
+            attachments=[str(img_b)],
+            worker_id="wkr-2",
+            turn_seq=1,
+            worktree_id="wt-b",
+            cas=cas,
+            audit_chain=chain,
+        )
+        assert second.resolutions[0].sha256 == digest
+        assert (
+            resolve_attachment_for_worker(
+                sha256=digest,
+                requesting_worktree_id="wt-b",
+                cas=cas,
+                audit_chain=chain,
+            )
+            == img_b.read_bytes()
+        )


### PR DESCRIPTION
## Root cause

`resolve_attachment_for_worker` decided worktree access from `multimodal.attach`
events read via `AuditChainStore.query()`, which returns rows without checking
HMAC linkage. Anything able to write the audit directory — without the audit key,
and therefore without valid chain linkage — could append a shape-valid attach row
naming any `worktree_id`, and the resolver would hand that worktree another
worktree's attachment bytes.

### Reachability, stated plainly

**This is not a reachable exploit in this snapshot.** `resolve_attachment_for_worker`
has no production caller: it is referenced only by its own module, by
`tests/unit/test_multimodal_attestation.py` and `tests/integration/test_run_attach.py`,
and by `docs/operations/run.md`. The same is true of `WorktreeAccessDenied` and of the
write side, `build_attachment_context`. The only wired part of `--attach` is the
pre-spawn capability gate in `src/bernstein/cli/run_bootstrap.py`, which calls
`refuse_when_incapable` and then stashes the paths in `BERNSTEIN_RUN_ATTACHMENTS` — an
env var nothing currently reads. `Task.attachments` is parsed and serialised in
`core/tasks/models.py` but no spawn path consumes it.

So this PR fixes the resolver **before** it is wired into a caller, not a live hole.
Treat it as making the surface safe to wire, not as closing an exploitable path.

## Fix

The lookup now reads through `AuditChainStore.scan_verified()`, which recomputes
the HMAC of exactly the bytes it reads and reports the whole scan as failed when
the linkage breaks. The resolve fails closed with a new `AttachmentChainUnverified`
instead of trusting the row.

### Where the cursor lives, and why

`scan_verified` without a cursor costs O(entire chain) per call, which is wrong for
a per-attachment lookup. The cursor is kept in a `_VerifiedAttachIndex` held in a
module-level `WeakKeyDictionary` keyed by the `AuditChainStore` instance:

- **Keyed by the store, not by the function call or by the audit directory.** A cursor
  is only meaningful against the chain that produced it, and the store is the object
  whose lifetime matches that chain. `resolve_attachment_for_worker` is a public
  keyword-only function with no `self` to hang state on, so the store is the only
  correct owner available without changing the signature.
- **Weak-keyed** so a store that goes out of scope takes its cursor and derived index
  with it, rather than pinning them for the life of the process.
- **The derived sha256 → worktree-ids mapping sits next to the cursor**, because the two
  must be discarded together: when a scan reports `rescanned`, the history under the
  cursor changed and any mapping derived from the old prefix is no longer backed by
  rows this process authenticated.
- **On a failed scan the cursor is not advanced**, so a later lookup re-verifies the
  damaged span rather than treating it as verified history. This now actually holds —
  see below.

### `scan_verified` no longer mutates a caller-owned cursor

Review caught that the bullet above was asserted but not delivered. `AuditLog.scan_verified`
aliased the caller's `ChainScanCursor` (`active = cursor`) and mutated `consumed`,
`prev_hmac`, `fingerprint` and `order` in place *while* walking the new tail, deciding
`ok` only afterwards. Declining to adopt `result.cursor` on failure was therefore a no-op:
the caller's cursor **was** `result.cursor`, already advanced past the bytes that failed
to authenticate. Reproduced end to end — warm cursor, scan fails on a forged row, then a
third lookup with nothing appended takes the `already == total` fast path and returns
`ok=True`, zero events, `rescanned=False`. One refusal, then silence about the same break.

Fixed at the boundary rather than at the one call site: `scan_verified` now walks
`cursor.working_copy()`, so `result.cursor` is the only thing that advances a caller's
resume point, and a caller that adopts it only when `ok` re-detects the same tamper on
every later call.

Checked every `scan_verified` caller before choosing the wider fix — none relied on
in-place mutation, all already adopt `result.cursor`:

| Caller | Cursor use | Was affected |
|---|---|---|
| `core/agents/multimodal_attestation.py` | keeps one, adopts on `ok` | yes — the reproduced defect |
| `core/communication/signal_actions.py` | keeps one, adopts after the `ok` check | yes, same latent shape — also fixed |
| `core/security/native_toolcall_evidence.py` | keeps one, adopts after the `ok` check | yes, same latent shape — also fixed |
| `core/tasks/suspension.py` | no cursor (cold each call) | no |
| `core/quality/janitor.py` | `scan_verified(None)` | no |
| `scripts/bench_audit_chain.py` | re-adopts `res.cursor` each iteration | no |

The copy is per-segment-stem state (a handful of dict/list/set entries), so it costs
nothing next to the byte walk it guards.

Follows the shape of #3566/#3569.

## Tests

Added to `tests/unit/test_multimodal_attestation.py` as `TestAuthenticatedAttachReads`.
The forged row is written in canonical form (`json.dumps(row, sort_keys=True)`) with
correct field names and a plausible `prev_chain_digest` — only the HMAC is wrong, which
is exactly what a writer without the audit key can produce.

| Test | Property it protects | Before |
|---|---|---|
| `test_forged_attach_row_does_not_grant_cross_worktree_access` | A row without valid HMAC linkage grants no worktree access | fails (`DID NOT RAISE`; bytes returned to wt-b) |
| `test_broken_chain_also_refuses_the_owning_worktree` | Verification failure fails the lookup closed, rather than silently dropping the bad row and continuing | fails |
| `test_tamper_is_still_refused_and_reported_after_a_failed_scan` | Fail-closed holds on *every* lookup: warm cursor → failing scan → third lookup with nothing appended still refuses, with the same errors | fails (`DID NOT RAISE` on the third call) |
| `test_repeat_resolve_resumes_from_the_kept_cursor` | Repeat lookups resume from the kept cursor instead of re-walking the chain (observes the real store's `scan_verified` arguments and `rescanned` flag — no stubbed chain) | fails |
| `test_attach_recorded_after_a_resolve_is_visible_to_the_next_resolve` | A kept cursor must not freeze the view: an attach recorded after the index warmed still resolves | passes before and after — a regression guard on the caching this PR introduces |

The boundary invariant is guarded at the layer that now owns it, in
`tests/unit/test_clearance_gate_hardening.py` beside the existing `scan_verified` cursor
tests: `test_a_failed_scan_does_not_advance_a_caller_owned_cursor` asserts the caller's
cursor is byte-identical after a refused scan and that the next scan from it refuses
again with the same errors. Both new tests were confirmed red with only the one-line
`working_copy()` call reverted.

Green: `tests/unit/test_multimodal_attestation.py` (43), `tests/unit/test_clearance_gate_hardening.py` (47),
`tests/integration/test_run_attach.py` (13), `tests/unit/security/` + `test_signal_actions.py`
+ `test_task_suspension.py` + `test_janitor.py` (802), the `test_audit*` core log files (139),
`test_audit_chain_migration.py`, `test_bench_audit_chain.py`. Plus `ruff check`,
`ruff format --check`, and `mypy src` (153 pre-existing errors, unchanged, none in the
touched files).

## Behaviour changes worth flagging

- New exception `AttachmentChainUnverified` (exported in `__all__`) on the resolve path.
  Callers that only caught `WorktreeAccessDenied` / `FileNotFoundError` now see a refusal
  where they previously got bytes off an unverified chain.
- `scan_verified` covers archived `*.jsonl.gz` segments; the old `query()` call did not pass
  `include_archived`. An attach event that has since been archived now resolves where it
  previously raised `FileNotFoundError`.
- `scan_verified(event_type=...)` maintains the signed segment index in the audit directory,
  so this read path now writes that derived file. Same as the other `scan_verified` callers.
- `AuditLog.scan_verified` no longer mutates the cursor it is handed. Any future caller must
  advance via `result.cursor`; relying on in-place mutation would now silently never advance.
  No current caller does.

## Out of scope

- The other `AuditChainStore.query()` readers elsewhere in the tree; this PR only covers the
  attachment resolve path named in the issue.
- `build_attachment_context` is unchanged — it is the write side and already appends through
  the chain.
- Wiring the attachment pipeline into a spawn path. `docs/operations/run.md` documents the
  `--attach` flow (CAS storage, `multimodal.attach` event, lineage parent, worktree pinning)
  as if it runs end to end; only the capability gate is currently wired. That docs/reality
  gap predates this PR and wants its own change.

Closes #3567
