### PR TITLE
fix(tenanting): route path containment through the shared barrier

### DIFF
--- a/src/bernstein/core/security/tenanting.py
+++ b/src/bernstein/core/security/tenanting.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final, cast
 
 from bernstein.core.persistence.anchored_write import AnchoredDir, mkdir_anchored
+from bernstein.core.security.path_containment import PathContainmentError, contained_path
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -306,7 +307,7 @@ def resolve_tenant_scope(
     return target
 
 
-def _assert_contained(base: Path, derived: Path, tenant_id: str) -> None:
+def _assert_contained(base: Path, *segments: str, tenant_id: str) -> None:
     """Refuse a derived directory that does not sit strictly under *base*.
 
     A cheap invariant check on the layout as it stands, run before anything is
@@ -314,12 +315,22 @@ def _assert_contained(base: Path, derived: Path, tenant_id: str) -> None:
     it pointed when it was resolved, and the write happens later -- but it
     keeps the derivation honest on its own terms, and it is what fails first if
     the identifier rule is ever widened.
+
+    Delegates the realpath-containment check itself to
+    :func:`bernstein.core.security.path_containment.contained_path`, the same
+    barrier the rest of the codebase asserts through (#3692), rather than
+    re-deriving the check here. Its refusal is translated into
+    `InvalidTenantIdError` so existing callers -- which already treat a bad
+    tenant id as a `LookupError` via that type's `LookupError` base -- keep
+    working unchanged.
     """
 
-    resolved_derived = derived.resolve()
-    resolved_base = base.resolve()
-    if resolved_derived == resolved_base or not resolved_derived.is_relative_to(resolved_base):
-        raise InvalidTenantIdError(f"tenant id {_describe_tenant_id(str(tenant_id))} resolves outside the tenant root")
+    try:
+        contained_path(base, *segments, label="tenant id")
+    except PathContainmentError as exc:
+        raise InvalidTenantIdError(
+            f"tenant id {_describe_tenant_id(str(tenant_id))} resolves outside the tenant root"
+        ) from exc
 
 
 def tenant_paths(sdd_dir: Path, tenant_id: str) -> TenantPaths:
@@ -353,7 +364,7 @@ def tenant_paths(sdd_dir: Path, tenant_id: str) -> TenantPaths:
 
     normalized = normalize_tenant_id(tenant_id)
     root = sdd_dir / normalized
-    _assert_contained(sdd_dir, root, tenant_id)
+    _assert_contained(sdd_dir, normalized, tenant_id=tenant_id)
     return TenantPaths(
         root=root,
         backlog_dir=root / "backlog",
@@ -414,7 +425,7 @@ def _tenant_metrics_anchor(metrics_dir: Path, tenant_id: str) -> AnchoredDir:
         base, parts = metrics_dir.parent, (normalized, "metrics")
     else:
         base, parts = metrics_dir, (normalized,)
-    _assert_contained(base, base.joinpath(*parts), tenant_id)
+    _assert_contained(base, *parts, tenant_id=tenant_id)
     return AnchoredDir(root=base, parts=parts)
 
 

--- a/tests/unit/security/test_tenanting_containment.py
+++ b/tests/unit/security/test_tenanting_containment.py
@@ -190,6 +190,99 @@ class TestMetricsDirContract:
             tenanting.tenant_metrics_dir(metrics, "..")
 
 
+class TestContainmentRoutedThroughPathContainment:
+    """`tenanting.py` delegates its realpath check to `path_containment`.
+
+    `tenant_paths` and `_tenant_metrics_anchor` must call
+    `bernstein.core.security.path_containment.contained_path` for the
+    containment check itself rather than re-deriving it locally (#3693: the
+    same shape #3692 removed elsewhere). Patching that name out from under
+    `tenanting` and asserting it fires is what proves the call site actually
+    routes through it, as opposed to merely producing an equivalent result
+    via independent logic.
+    """
+
+    def test_tenant_paths_delegates_the_containment_check_to_contained_path(
+        self, sdd_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from bernstein.core.security import path_containment, tenanting
+
+        calls: list[tuple[object, ...]] = []
+
+        def spy_contained_path(base: Path, *segments: str, label: str = "identifier") -> Path:
+            calls.append((base, *segments))
+            raise path_containment.PathContainmentError("forced for test")
+
+        monkeypatch.setattr(tenanting, "contained_path", spy_contained_path)
+
+        with pytest.raises(InvalidTenantIdError):
+            tenanting.tenant_paths(sdd_dir, "acme")
+        assert calls == [(sdd_dir, "acme")]
+
+    def test_tenant_metrics_dir_delegates_the_containment_check_to_contained_path(
+        self, sdd_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from bernstein.core.security import path_containment, tenanting
+
+        metrics = sdd_dir / "metrics"
+        metrics.mkdir()
+        calls: list[tuple[object, ...]] = []
+
+        def spy_contained_path(base: Path, *segments: str, label: str = "identifier") -> Path:
+            calls.append((base, *segments))
+            raise path_containment.PathContainmentError("forced for test")
+
+        monkeypatch.setattr(tenanting, "contained_path", spy_contained_path)
+
+        with pytest.raises(InvalidTenantIdError):
+            tenanting.tenant_metrics_dir(metrics, "acme")
+        assert calls == [(sdd_dir, "acme", "metrics")]
+
+    def test_tenant_paths_refuses_an_escaping_id_without_touching_the_filesystem(
+        self, sdd_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from bernstein.core.security import tenanting
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (sdd_dir / "acme").symlink_to(outside, target_is_directory=True)
+        monkeypatch.setattr(tenanting, "normalize_tenant_id", lambda raw: str(raw))
+
+        with pytest.raises(InvalidTenantIdError):
+            tenanting.tenant_paths(sdd_dir, "acme")
+        assert list(outside.iterdir()) == []
+
+    def test_ensure_tenant_layout_refuses_an_escaping_id_before_any_mkdir(
+        self, sdd_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from bernstein.core.security import tenanting
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (sdd_dir / "acme").symlink_to(outside, target_is_directory=True)
+        monkeypatch.setattr(tenanting, "normalize_tenant_id", lambda raw: str(raw))
+
+        with pytest.raises(InvalidTenantIdError):
+            tenanting.ensure_tenant_layout(sdd_dir, "acme")
+        assert list(outside.iterdir()) == []
+
+    def test_tenant_metrics_dir_refuses_an_escaping_id_via_symlinked_tenant_segment(
+        self, sdd_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from bernstein.core.security import tenanting
+
+        metrics = sdd_dir / "metrics"
+        metrics.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (sdd_dir / "acme").symlink_to(outside, target_is_directory=True)
+        monkeypatch.setattr(tenanting, "normalize_tenant_id", lambda raw: str(raw))
+
+        with pytest.raises(InvalidTenantIdError):
+            tenanting.tenant_metrics_dir(metrics, "acme")
+        assert not (outside / "metrics").exists()
+
+
 def test_layout_is_created_when_the_sdd_directory_does_not_exist_yet(tmp_path: Path) -> None:
     """A first run in an empty project must create the layout, not refuse it.
 


### PR DESCRIPTION
Closes #3693.

## Root cause

`tenant_paths` and `_tenant_metrics_anchor` in `src/bernstein/core/security/tenanting.py`
had their own local containment check (`_assert_contained`, resolve()-based) instead of
routing through `bernstein.core.security.path_containment.contained_path`, the shared
realpath-containment barrier added in #3692. Two independent implementations of the
same check drift over time; this is a call-site change only, no new machinery.

## Fix

`_assert_contained` now delegates its realpath-containment check to `contained_path`,
translating `PathContainmentError` into `InvalidTenantIdError` so existing callers
(which already treat a bad tenant id as a `LookupError`) are unaffected. `tenant_paths`
and `_tenant_metrics_anchor` pass their segments straight through instead of
pre-joining a `Path` for the check.

## Tests

- `test_tenant_paths_delegates_the_containment_check_to_contained_path` -- proves
  `tenant_paths` actually calls `contained_path` (not an equivalent local check) by
  patching it out and asserting it was invoked with the expected arguments.
- `test_tenant_metrics_dir_delegates_the_containment_check_to_contained_path` -- same,
  for `_tenant_metrics_anchor` / `tenant_metrics_dir`.
- `test_tenant_paths_refuses_an_escaping_id_without_touching_the_filesystem` -- a
  normalized tenant id (identifier rule bypassed via monkeypatch) whose root is
  pre-symlinked outside `.sdd` is refused by `tenant_paths` itself, before any mkdir.
- `test_ensure_tenant_layout_refuses_an_escaping_id_before_any_mkdir` -- same case
  through the full `ensure_tenant_layout` path; nothing is created outside the base.
- `test_tenant_metrics_dir_delegates_the_containment_check_to_contained_path` sibling
  `test_tenant_metrics_dir_refuses_an_escaping_id_via_symlinked_tenant_segment` -- same
  property for the metrics-dir call site.

Verified the delegation tests fail on the pre-fix code (`AttributeError: tenanting has
no attribute 'contained_path'`) and pass after.

## Out of scope

The issue's later addendum ("per-entry, not per-call" containment, preferring the
anchored `dir_fd`/`O_NOFOLLOW` writers over a `realpath` check between derivation and
write) is already implemented on main via `AnchoredDir` / `mkdir_anchored` /
`anchored_append`, which `ensure_tenant_layout` and its write-side callers already use
-- this PR only touches the up-front derivation check `tenant_paths` and
`tenant_metrics_dir` do before that walk starts.

## Verification

```
uv run python scripts/run_tests.py  (tenanting + tenant isolation suites)
uv run ruff check src/bernstein/core/security/tenanting.py tests/unit/security/test_tenanting_containment.py
uv run ruff format --check <same files>
uv run mypy src/bernstein/core/security/tenanting.py
```
