### PR TITLE
fix(grpc): enforce cluster scopes and pin node identity on RegisterNode

### DIFF
--- a/docs/operations/cluster-mode.md
+++ b/docs/operations/cluster-mode.md
@@ -171,13 +171,47 @@ Default scopes, defined in `cluster_auth.py:23-25`:
 
 | Scope             | Required by                                         |
 | ----------------- | --------------------------------------------------- |
-| `node:register`   | `POST /cluster/nodes`                               |
-| `node:heartbeat`  | `POST /cluster/nodes/{id}/heartbeat`                |
-| `node:admin`      | `cordon`, `uncordon`, `drain`, `DELETE /cluster/nodes` |
+| `node:register`   | `POST /cluster/nodes`, `ClusterService.RegisterNode` |
+| `node:heartbeat`  | `POST /cluster/nodes/{id}/heartbeat`, `ClusterService.Heartbeat`, `ClusterService.StreamHeartbeats` |
+| `node:admin`      | `cordon`, `uncordon`, `drain`, `DELETE /cluster/nodes`, and their `ClusterService` counterparts |
 
 The worker side of the flow lives in `worker_cmd.py:134-164` (registration)
 and `:165-190` (heartbeat). On HTTP 404 from the heartbeat the worker
 re-registers automatically (eviction recovery).
+
+### The gRPC cluster surface
+
+`ClusterService` (`proto/bernstein/v1/cluster.proto`) mirrors the routes above
+for node-to-node traffic. It is not started by anything in `src/` today; the
+notes here apply once an operator wires `BernsteinGrpcServer.start()` into a
+deployment.
+
+- **Same scopes, gRPC status codes.** Pass the `ClusterAuthenticator` as
+  `start(..., cluster_authenticator=...)` and every mutating RPC verifies it.
+  A missing or invalid credential is refused `UNAUTHENTICATED`; a valid
+  credential without the required scope is refused `PERMISSION_DENIED`. Reads
+  (`ListNodes`, `GetClusterStatus`) are unauthenticated, matching
+  `GET /cluster/nodes` and `GET /cluster/status`.
+- **Where the credential goes.** In the `authorization` call metadata as
+  `Bearer <token>` -- the gRPC counterpart of the HTTP header. Set
+  `GrpcClientConfig.auth_token` to the cluster secret or an operator-minted
+  node JWT.
+- **`RegisterNodeResponse.auth_token`.** Populated with a node JWT minted
+  against the registered node id, carrying `node:register` and
+  `node:heartbeat` (not `node:admin`). `ClusterClient` adopts it for every
+  subsequent call, so heartbeats travel under the node's own token rather than
+  the join credential. With no authenticator wired the field stays empty --
+  nothing would verify a token minted there.
+- **Re-registration is idempotent on node identity.** `RegisterNode` resolves
+  an existing entry by `(name, url)` and updates it. A worker that restarts
+  therefore refreshes its row instead of adding one, and `GET /cluster/status`
+  keeps counting its capacity once. A blank `name` or `url` never matches, so
+  anonymous registrations stay distinct.
+- **Insecure port.** Without `tls_cert_path` / `tls_key_path` the server binds
+  an insecure port. Credential enforcement is unaffected -- it lives in the
+  servicer, not the transport -- but node tokens then cross the wire in
+  cleartext, and the server logs a warning saying so. Terminate TLS in front of
+  the port or configure the cert pair.
 
 ## Operational primitives: drain / cordon / uncordon / steal
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -62,6 +62,25 @@ landed since the newest one.
   orchestrator already generates. Both layers are kept: the validator stops
   new bad rows, the helper protects the sink from rows that already exist or
   arrive by another route.
+- The gRPC `ClusterService` now enforces the same credential scopes as the
+  equivalent REST cluster routes. `RegisterNode` requires `node:register`,
+  `Heartbeat` and `StreamHeartbeats` require `node:heartbeat`, and
+  `UnregisterNode` / `CordonNode` / `UncordonNode` / `DrainNode` require
+  `node:admin`; the credential travels in the `authorization` call metadata as
+  `Bearer <token>`. A missing or invalid credential is refused
+  `UNAUTHENTICATED`, a valid one lacking the scope `PERMISSION_DENIED`. Reads
+  (`ListNodes`, `GetClusterStatus`) stay unauthenticated, as on REST.
+  Enforcement lives in the servicer, so it holds on the insecure-port fallback
+  too - that path now also logs a warning that node credentials cross it in
+  cleartext. `RegisterNodeResponse.auth_token`, previously declared and read by
+  our own client but never populated, now carries a node JWT minted against the
+  registered node id (`node:register` + `node:heartbeat`, never `node:admin`),
+  which `ClusterClient` adopts for subsequent calls. **Behaviour change:**
+  `RegisterNode` is now idempotent on `(name, url)` - a restarting worker
+  updates its existing entry instead of adding one, so the registry no longer
+  accumulates a row per restart and `GET /cluster/status` no longer counts that
+  worker's capacity once per row. Nothing in `src/` starts the gRPC server, so
+  this surface only runs where an operator has wired it up. Refs #3537.
 
 ## Added
 

--- a/src/bernstein/core/protocols/cluster/cluster.py
+++ b/src/bernstein/core/protocols/cluster/cluster.py
@@ -211,6 +211,21 @@ class NodeRegistry:
         """Look up a node by ID."""
         return self._nodes.get(node_id)
 
+    def find_by_identity(self, name: str, url: str) -> NodeInfo | None:
+        """Look up a node by its operator-visible identity (name + url).
+
+        ``register`` keys on the node id, which a caller that mints a fresh
+        ``NodeInfo`` per attempt does not carry across a restart. Registration
+        surfaces use this to resolve the id an already-known worker was given,
+        so a restarting worker updates its entry instead of adding one.
+
+        A blank ``name`` or ``url`` never matches: those carry no identity, so
+        collapsing them would merge unrelated anonymous nodes into one entry.
+        """
+        if not name or not url:
+            return None
+        return next((n for n in self._nodes.values() if n.name == name and n.url == url), None)
+
     def list_nodes(self, status: NodeStatus | None = None) -> list[NodeInfo]:
         """List all nodes, optionally filtered by status."""
         nodes = list(self._nodes.values())

--- a/src/bernstein/core/protocols/cluster/cluster_auth.py
+++ b/src/bernstein/core/protocols/cluster/cluster_auth.py
@@ -44,6 +44,18 @@ class ClusterAuthError(Exception):
     """Raised when cluster authentication fails."""
 
 
+class ClusterAuthScopeError(ClusterAuthError):
+    """Raised when a verified credential lacks the scope a call requires.
+
+    Split out from the generic failure so a caller can tell "this credential
+    is not valid" from "this credential is valid but not allowed here". HTTP
+    collapses both onto 401; gRPC has distinct codes (``UNAUTHENTICATED`` vs
+    ``PERMISSION_DENIED``) and must not report a scope refusal as a bad
+    credential -- a worker would respond by re-minting a token that would be
+    refused identically.
+    """
+
+
 @dataclass(frozen=True)
 class ClusterAuthConfig:
     """Configuration for cluster JWT authentication.
@@ -186,7 +198,7 @@ class ClusterAuthenticator:
         # Check required scope
         if required_scope not in payload.scopes:
             _record_admission_failure("scope_denied")
-            raise ClusterAuthError(f"Token lacks required scope '{required_scope}' (has: {payload.scopes})")
+            raise ClusterAuthScopeError(f"Token lacks required scope '{required_scope}' (has: {payload.scopes})")
 
         return payload
 

--- a/src/bernstein/core/protocols/grpc/grpc_client.py
+++ b/src/bernstein/core/protocols/grpc/grpc_client.py
@@ -26,13 +26,21 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class GrpcClientConfig:
-    """Configuration for gRPC client connections."""
+    """Configuration for gRPC client connections.
+
+    ``auth_token`` is the credential a cluster node presents to join: the
+    cluster shared secret or an operator-minted node JWT. It is sent as the
+    ``authorization`` metadata entry, the gRPC counterpart of the REST
+    ``Authorization`` header. Leave it unset against a server that runs
+    without a cluster authenticator.
+    """
 
     server_address: str = "localhost:50051"
     tls_enabled: bool = False
     tls_ca_cert_path: str | None = None
     timeout_s: float = 10.0
     max_message_length: int = 16 * 1024 * 1024
+    auth_token: str | None = None
 
 
 @dataclass
@@ -180,6 +188,17 @@ class ClusterClient:
     config: GrpcClientConfig = field(default_factory=GrpcClientConfig)
     _channel: Any = field(default=None, init=False, repr=False)
     _stub: Any = field(default=None, init=False, repr=False)
+    _node_token: str | None = field(default=None, init=False, repr=False)
+
+    def _metadata(self) -> list[tuple[str, str]]:
+        """Build the call metadata carrying this node's credential.
+
+        The node token handed back by ``RegisterNode`` supersedes the join
+        credential once registration succeeds, so heartbeats travel under the
+        node's own least-privilege token rather than the shared secret.
+        """
+        token = self._node_token or self.config.auth_token
+        return [("authorization", f"Bearer {token}")] if token else []
 
     async def connect(self) -> None:
         if not GRPC_AVAILABLE:
@@ -206,6 +225,7 @@ class ClusterClient:
             await self._channel.close()
             self._channel = None
             self._stub = None
+            self._node_token = None
 
     async def register_node(
         self,
@@ -228,7 +248,9 @@ class ClusterClient:
             capacity=cap,
             labels=labels or {},
         )
-        resp = await self._stub.RegisterNode(req, timeout=self.config.timeout_s)
+        resp = await self._stub.RegisterNode(req, timeout=self.config.timeout_s, metadata=self._metadata())
+        if resp.auth_token:
+            self._node_token = resp.auth_token
         return {
             "node": self._node_to_dict(resp.node),
             "auth_token": resp.auth_token,
@@ -249,7 +271,7 @@ class ClusterClient:
                 active_agents=active_agents or 0,
             )
         req = cluster_pb2.HeartbeatRequest(node_id=node_id, capacity=cap)
-        resp = await self._stub.Heartbeat(req, timeout=self.config.timeout_s)
+        resp = await self._stub.Heartbeat(req, timeout=self.config.timeout_s, metadata=self._metadata())
         return {
             "acknowledged": resp.acknowledged,
             "node": self._node_to_dict(resp.node) if resp.HasField("node") else None,
@@ -259,7 +281,7 @@ class ClusterClient:
         from bernstein.core.grpc_gen import cluster_pb2
 
         req = cluster_pb2.UnregisterNodeRequest(node_id=node_id)
-        resp = await self._stub.UnregisterNode(req, timeout=self.config.timeout_s)
+        resp = await self._stub.UnregisterNode(req, timeout=self.config.timeout_s, metadata=self._metadata())
         return resp.removed
 
     async def cluster_status(self) -> dict[str, Any]:
@@ -282,7 +304,7 @@ class ClusterClient:
         from bernstein.core.grpc_gen import cluster_pb2
 
         req = cluster_pb2.StealTasksRequest(queue_depths=queue_depths)
-        resp = await self._stub.StealTasks(req, timeout=self.config.timeout_s)
+        resp = await self._stub.StealTasks(req, timeout=self.config.timeout_s, metadata=self._metadata())
         return {
             "actions": [
                 {

--- a/src/bernstein/core/protocols/grpc/grpc_server.py
+++ b/src/bernstein/core/protocols/grpc/grpc_server.py
@@ -27,6 +27,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     from bernstein.core.protocols.cluster import NodeRegistry
+    from bernstein.core.protocols.cluster.cluster_auth import ClusterAuthenticator
 
 logger = logging.getLogger(__name__)
 
@@ -223,14 +224,67 @@ class TaskServiceImpl:
 
 
 class ClusterServiceImpl:
-    """gRPC implementation of ClusterService, bridging to NodeRegistry."""
+    """gRPC implementation of ClusterService, bridging to NodeRegistry.
 
-    def __init__(self, node_registry: NodeRegistry) -> None:
+    Mutating RPCs carry the same credential scopes as the equivalent REST
+    routes in ``routes/task_cluster.py``: registration needs
+    ``node:register``, heartbeats need ``node:heartbeat``, and the lifecycle
+    verbs (unregister / cordon / uncordon / drain) need ``node:admin``. Reads
+    (``ListNodes``, ``GetClusterStatus``) are unauthenticated on both surfaces.
+
+    When no authenticator is passed, or one is passed with
+    ``require_auth=False``, every call is admitted -- the same escape hatch the
+    REST routes have, and the same one tests use.
+    """
+
+    def __init__(self, node_registry: NodeRegistry, authenticator: ClusterAuthenticator | None = None) -> None:
         self._registry = node_registry
+        self._auth = authenticator
+
+    def _bearer_from_metadata(self, context: Any) -> str | None:
+        """Return the ``authorization`` metadata value, or None when absent.
+
+        gRPC lowercases metadata keys on the wire, but a hand-built context may
+        not, so the lookup is case-insensitive.
+        """
+        metadata = context.invocation_metadata() or ()
+        for key, value in metadata:
+            if key.lower() == "authorization":
+                return str(value)
+        return None
+
+    async def _authorize(self, context: Any, required_scope: str) -> None:
+        """Abort the call unless the caller presents ``required_scope``.
+
+        Missing/invalid credentials abort ``UNAUTHENTICATED``; a valid
+        credential without the scope aborts ``PERMISSION_DENIED``.
+        """
+        if self._auth is None or not self._auth.require_auth:
+            return
+
+        from bernstein.core.protocols.cluster.cluster_auth import (
+            ClusterAuthError,
+            ClusterAuthScopeError,
+        )
+
+        try:
+            self._auth.verify_request(self._bearer_from_metadata(context), required_scope)
+        except ClusterAuthScopeError as exc:
+            await context.abort(grpc.StatusCode.PERMISSION_DENIED, str(exc))
+            # ``abort`` raises on a live grpc.aio context; the explicit raise
+            # keeps a context that only records the abort from falling through
+            # into the mutation below.
+            raise
+        except ClusterAuthError as exc:
+            await context.abort(grpc.StatusCode.UNAUTHENTICATED, str(exc))
+            raise
 
     async def RegisterNode(self, request: Any, context: Any) -> Any:  # NOSONAR - gRPC method name
         from bernstein.core.grpc_gen import cluster_pb2
         from bernstein.core.models import NodeCapacity, NodeInfo
+        from bernstein.core.protocols.cluster.cluster_auth import SCOPE_NODE_REGISTER
+
+        await self._authorize(context, SCOPE_NODE_REGISTER)
 
         if request.HasField("capacity"):
             # proto3 scalars carry no presence, so a supplied capacity is
@@ -248,21 +302,39 @@ class ClusterServiceImpl:
                 cap.supported_models = list(request.capacity.supported_models)
         else:
             cap = NodeCapacity()
-        node = self._registry.register(
-            NodeInfo(
-                name=request.name,
-                url=request.url,
-                capacity=cap,
-                labels=dict(request.labels) if request.labels else {},
-                cell_ids=list(request.cell_ids) if request.cell_ids else [],
-            )
+        # Re-registration is keyed on the node's operator-visible identity
+        # (name + url), not on a per-call id. A worker that restarts has no
+        # memory of the id the server gave it, so minting a fresh NodeInfo per
+        # call would leave the old entry behind: the registry would carry one
+        # row per restart and cluster_summary would count that worker's
+        # capacity once per row.
+        existing = self._registry.find_by_identity(request.name, request.url)
+        info = NodeInfo(
+            name=request.name,
+            url=request.url,
+            capacity=cap,
+            labels=dict(request.labels) if request.labels else {},
+            cell_ids=list(request.cell_ids) if request.cell_ids else [],
         )
+        if existing is not None:
+            info.id = existing.id
+        node = self._registry.register(info)
         resp = cluster_pb2.RegisterNodeResponse()
         self._fill_node_proto(resp.node, node)
+        # auth_token is the node's own credential for subsequent heartbeats,
+        # minted against the registered id -- the gRPC counterpart of
+        # AuthenticatedNodeRegistry.register. With no authenticator wired there
+        # is nothing to verify it against, so the field stays empty rather than
+        # handing back a token no handler would accept.
+        if self._auth is not None:
+            resp.auth_token = self._auth.issue_node_token(node.id)
         return resp
 
     async def Heartbeat(self, request: Any, context: Any) -> Any:  # NOSONAR - gRPC method name
         from bernstein.core.grpc_gen import cluster_pb2
+        from bernstein.core.protocols.cluster.cluster_auth import SCOPE_NODE_HEARTBEAT
+
+        await self._authorize(context, SCOPE_NODE_HEARTBEAT)
 
         node = self._registry.get(request.node_id)
         if node is None:
@@ -287,6 +359,11 @@ class ClusterServiceImpl:
 
     async def StreamHeartbeats(self, request_iterator: Any, context: Any) -> Any:  # NOSONAR - gRPC method name
         from bernstein.core.grpc_gen import cluster_pb2
+        from bernstein.core.protocols.cluster.cluster_auth import SCOPE_NODE_HEARTBEAT
+
+        # Verified once per stream, before the first message is read: the
+        # credential rides in the call's metadata, not in the message frames.
+        await self._authorize(context, SCOPE_NODE_HEARTBEAT)
 
         async for request in request_iterator:
             self._registry.heartbeat(request.node_id)
@@ -297,12 +374,18 @@ class ClusterServiceImpl:
 
     async def UnregisterNode(self, request: Any, context: Any) -> Any:  # NOSONAR - gRPC method name
         from bernstein.core.grpc_gen import cluster_pb2
+        from bernstein.core.protocols.cluster.cluster_auth import SCOPE_NODE_ADMIN
+
+        await self._authorize(context, SCOPE_NODE_ADMIN)
 
         removed = self._registry.unregister(request.node_id)
         return cluster_pb2.UnregisterNodeResponse(removed=removed)
 
     async def CordonNode(self, request: Any, context: Any) -> Any:  # NOSONAR - gRPC method name
         from bernstein.core.grpc_gen import cluster_pb2
+        from bernstein.core.protocols.cluster.cluster_auth import SCOPE_NODE_ADMIN
+
+        await self._authorize(context, SCOPE_NODE_ADMIN)
 
         node = self._registry.get(request.node_id)
         if node is None:
@@ -315,6 +398,9 @@ class ClusterServiceImpl:
 
     async def UncordonNode(self, request: Any, context: Any) -> Any:  # NOSONAR - gRPC method name
         from bernstein.core.grpc_gen import cluster_pb2
+        from bernstein.core.protocols.cluster.cluster_auth import SCOPE_NODE_ADMIN
+
+        await self._authorize(context, SCOPE_NODE_ADMIN)
 
         node = self._registry.get(request.node_id)
         if node is None:
@@ -327,6 +413,9 @@ class ClusterServiceImpl:
 
     async def DrainNode(self, request: Any, context: Any) -> Any:  # NOSONAR - gRPC method name
         from bernstein.core.grpc_gen import cluster_pb2
+        from bernstein.core.protocols.cluster.cluster_auth import SCOPE_NODE_ADMIN
+
+        await self._authorize(context, SCOPE_NODE_ADMIN)
 
         node = self._registry.get(request.node_id)
         if node is None:
@@ -401,6 +490,7 @@ class BernsteinGrpcServer:
         self,
         task_store: Any,
         node_registry: NodeRegistry | None = None,
+        cluster_authenticator: ClusterAuthenticator | None = None,
     ) -> None:
         if not GRPC_AVAILABLE:
             logger.warning("grpcio not installed - gRPC server disabled")
@@ -423,7 +513,10 @@ class BernsteinGrpcServer:
         if node_registry is not None:
             from bernstein.core.grpc_gen import cluster_pb2_grpc
 
-            cluster_pb2_grpc.add_ClusterServiceServicer_to_server(ClusterServiceImpl(node_registry), server)
+            cluster_pb2_grpc.add_ClusterServiceServicer_to_server(
+                ClusterServiceImpl(node_registry, cluster_authenticator),
+                server,
+            )
 
         if self.config.enable_reflection:
             try:
@@ -457,6 +550,15 @@ class BernsteinGrpcServer:
         else:
             server.add_insecure_port(bind)
             logger.info("gRPC server listening on %s (insecure)", bind)
+            if cluster_authenticator is not None and cluster_authenticator.require_auth:
+                # Credential enforcement still applies -- the servicer verifies
+                # every mutating call regardless of transport. The warning is
+                # about confidentiality: node tokens cross this port in
+                # cleartext, so anyone on the path can replay them.
+                logger.warning(
+                    "gRPC cluster auth is enabled but %s has no TLS: node credentials cross it in cleartext",
+                    bind,
+                )
 
         await server.start()
         self._server = server

--- a/tests/unit/test_grpc_cluster_auth.py
+++ b/tests/unit/test_grpc_cluster_auth.py
@@ -1,0 +1,541 @@
+"""Credential, token, and re-registration semantics of the gRPC cluster surface.
+
+Nothing in ``src/`` starts the gRPC server yet, so every test here drives the
+servicer object directly -- the same object ``add_ClusterServiceServicer_to_server``
+would receive.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import grpc
+import pytest
+from bernstein.core.models import ClusterConfig
+
+from bernstein.core.grpc_gen import cluster_pb2
+from bernstein.core.protocols.cluster import NodeRegistry
+from bernstein.core.protocols.cluster.cluster_auth import (
+    SCOPE_NODE_ADMIN,
+    SCOPE_NODE_HEARTBEAT,
+    SCOPE_NODE_REGISTER,
+    ClusterAuthConfig,
+    ClusterAuthenticator,
+)
+from bernstein.core.protocols.grpc.grpc_server import (
+    BernsteinGrpcServer,
+    ClusterServiceImpl,
+    GrpcServerConfig,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+SECRET = "cluster-shared-secret"
+
+
+class Aborted(Exception):
+    """What a live ``grpc.aio`` context raises out of ``abort``."""
+
+    def __init__(self, code: grpc.StatusCode, details: str) -> None:
+        super().__init__(details)
+        self.code = code
+        self.details = details
+
+
+class FakeContext:
+    """Servicer context that aborts the way ``grpc.aio`` does."""
+
+    def __init__(self, metadata: Sequence[tuple[str, str]] = ()) -> None:
+        self._metadata = tuple(metadata)
+
+    def invocation_metadata(self) -> tuple[tuple[str, str], ...]:
+        return self._metadata
+
+    async def abort(self, code: grpc.StatusCode, details: str) -> None:
+        raise Aborted(code, details)
+
+
+def _bearer(token: str) -> FakeContext:
+    return FakeContext([("authorization", f"Bearer {token}")])
+
+
+def _authenticator(require_auth: bool = True) -> ClusterAuthenticator:
+    return ClusterAuthenticator(ClusterAuthConfig(secret=SECRET, require_auth=require_auth))
+
+
+def _registry() -> NodeRegistry:
+    return NodeRegistry(ClusterConfig())
+
+
+def _register_request(name: str = "worker-a", url: str = "http://worker-a:8052", max_agents: int = 4) -> Any:
+    return cluster_pb2.RegisterNodeRequest(
+        name=name,
+        url=url,
+        capacity=cluster_pb2.NodeCapacity(
+            max_agents=max_agents,
+            available_slots=max_agents,
+            supported_models=["sonnet"],
+        ),
+        labels={"role": "worker"},
+    )
+
+
+async def _register_one(service: ClusterServiceImpl, context: FakeContext | None = None, **kwargs: Any) -> Any:
+    return await service.RegisterNode(_register_request(**kwargs), context or FakeContext())
+
+
+class TestMutatingHandlersRequireCredentials:
+    @pytest.mark.asyncio
+    async def test_register_node_without_credential_is_unauthenticated(self) -> None:
+        registry = _registry()
+        service = ClusterServiceImpl(registry, _authenticator())
+
+        with pytest.raises(Aborted) as excinfo:
+            await service.RegisterNode(_register_request(), FakeContext())
+
+        assert excinfo.value.code is grpc.StatusCode.UNAUTHENTICATED
+        assert registry.list_nodes() == []
+
+    @pytest.mark.asyncio
+    async def test_register_node_with_heartbeat_only_scope_is_permission_denied(self) -> None:
+        registry = _registry()
+        auth = _authenticator()
+        service = ClusterServiceImpl(registry, auth)
+        token = auth.issue_node_token("node-1", scopes=[SCOPE_NODE_HEARTBEAT])
+
+        with pytest.raises(Aborted) as excinfo:
+            await service.RegisterNode(_register_request(), _bearer(token))
+
+        assert excinfo.value.code is grpc.StatusCode.PERMISSION_DENIED
+        assert registry.list_nodes() == []
+
+    @pytest.mark.asyncio
+    async def test_register_node_with_register_scope_is_admitted(self) -> None:
+        registry = _registry()
+        auth = _authenticator()
+        service = ClusterServiceImpl(registry, auth)
+        token = auth.issue_node_token("node-1", scopes=[SCOPE_NODE_REGISTER])
+
+        await service.RegisterNode(_register_request(), _bearer(token))
+
+        assert [n.name for n in registry.list_nodes()] == ["worker-a"]
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_without_credential_is_unauthenticated(self) -> None:
+        registry = _registry()
+        auth = _authenticator()
+        node = (await _register_one(ClusterServiceImpl(registry), None)).node
+        service = ClusterServiceImpl(registry, auth)
+        before = registry.get(node.id).last_heartbeat
+
+        with pytest.raises(Aborted) as excinfo:
+            await service.Heartbeat(cluster_pb2.HeartbeatRequest(node_id=node.id), FakeContext())
+
+        assert excinfo.value.code is grpc.StatusCode.UNAUTHENTICATED
+        assert registry.get(node.id).last_heartbeat == before
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_with_register_only_scope_is_permission_denied(self) -> None:
+        registry = _registry()
+        auth = _authenticator()
+        node = (await _register_one(ClusterServiceImpl(registry), None)).node
+        service = ClusterServiceImpl(registry, auth)
+        token = auth.issue_node_token(node.id, scopes=[SCOPE_NODE_REGISTER])
+
+        with pytest.raises(Aborted) as excinfo:
+            await service.Heartbeat(cluster_pb2.HeartbeatRequest(node_id=node.id), _bearer(token))
+
+        assert excinfo.value.code is grpc.StatusCode.PERMISSION_DENIED
+
+    @pytest.mark.asyncio
+    async def test_stream_heartbeats_without_credential_is_unauthenticated(self) -> None:
+        registry = _registry()
+        auth = _authenticator()
+        node = (await _register_one(ClusterServiceImpl(registry), None)).node
+        service = ClusterServiceImpl(registry, auth)
+        before = registry.get(node.id).last_heartbeat
+
+        async def requests() -> Any:
+            yield cluster_pb2.HeartbeatRequest(node_id=node.id)
+
+        with pytest.raises(Aborted) as excinfo:
+            async for _ in service.StreamHeartbeats(requests(), FakeContext()):
+                pass
+
+        assert excinfo.value.code is grpc.StatusCode.UNAUTHENTICATED
+        assert registry.get(node.id).last_heartbeat == before
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method", "request_factory"),
+        [
+            ("UnregisterNode", cluster_pb2.UnregisterNodeRequest),
+            ("CordonNode", cluster_pb2.CordonRequest),
+            ("UncordonNode", cluster_pb2.UncordonRequest),
+            ("DrainNode", cluster_pb2.DrainRequest),
+        ],
+    )
+    async def test_lifecycle_verbs_without_credential_are_unauthenticated(
+        self, method: str, request_factory: Any
+    ) -> None:
+        registry = _registry()
+        node = (await _register_one(ClusterServiceImpl(registry), None)).node
+        service = ClusterServiceImpl(registry, _authenticator())
+
+        with pytest.raises(Aborted) as excinfo:
+            await getattr(service, method)(request_factory(node_id=node.id), FakeContext())
+
+        assert excinfo.value.code is grpc.StatusCode.UNAUTHENTICATED
+        assert registry.get(node.id) is not None
+        assert registry.get(node.id).status.value == "online"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method", "request_factory"),
+        [
+            ("UnregisterNode", cluster_pb2.UnregisterNodeRequest),
+            ("CordonNode", cluster_pb2.CordonRequest),
+            ("UncordonNode", cluster_pb2.UncordonRequest),
+            ("DrainNode", cluster_pb2.DrainRequest),
+        ],
+    )
+    async def test_lifecycle_verbs_reject_a_heartbeat_scoped_token(self, method: str, request_factory: Any) -> None:
+        registry = _registry()
+        auth = _authenticator()
+        node = (await _register_one(ClusterServiceImpl(registry), None)).node
+        service = ClusterServiceImpl(registry, auth)
+        token = auth.issue_node_token(node.id, scopes=[SCOPE_NODE_REGISTER, SCOPE_NODE_HEARTBEAT])
+
+        with pytest.raises(Aborted) as excinfo:
+            await getattr(service, method)(request_factory(node_id=node.id), _bearer(token))
+
+        assert excinfo.value.code is grpc.StatusCode.PERMISSION_DENIED
+        assert registry.get(node.id) is not None
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_verbs_accept_a_node_admin_token(self) -> None:
+        registry = _registry()
+        auth = _authenticator()
+        node = (await _register_one(ClusterServiceImpl(registry), None)).node
+        service = ClusterServiceImpl(registry, auth)
+        token = auth.issue_node_token("operator", scopes=[SCOPE_NODE_ADMIN])
+
+        resp = await service.CordonNode(cluster_pb2.CordonRequest(node_id=node.id), _bearer(token))
+
+        assert resp.status == cluster_pb2.NodeStatus.NODE_STATUS_CORDONED
+        assert registry.get(node.id).status.value == "cordoned"
+
+    @pytest.mark.asyncio
+    async def test_reads_stay_unauthenticated_like_the_rest_routes(self) -> None:
+        registry = _registry()
+        await _register_one(ClusterServiceImpl(registry), None)
+        service = ClusterServiceImpl(registry, _authenticator())
+
+        listed = await service.ListNodes(cluster_pb2.ListNodesRequest(), FakeContext())
+        status = await service.GetClusterStatus(cluster_pb2.ClusterStatusRequest(), FakeContext())
+
+        assert len(listed.nodes) == 1
+        assert status.total_nodes == 1
+
+    @pytest.mark.asyncio
+    async def test_handlers_are_open_when_no_authenticator_is_wired(self) -> None:
+        registry = _registry()
+        service = ClusterServiceImpl(registry)
+
+        await service.RegisterNode(_register_request(), FakeContext())
+
+        assert len(registry.list_nodes()) == 1
+
+    @pytest.mark.asyncio
+    async def test_handlers_are_open_when_require_auth_is_off(self) -> None:
+        registry = _registry()
+        service = ClusterServiceImpl(registry, _authenticator(require_auth=False))
+
+        await service.RegisterNode(_register_request(), FakeContext())
+
+        assert len(registry.list_nodes()) == 1
+
+    @pytest.mark.asyncio
+    async def test_shared_secret_authenticates_a_registration(self) -> None:
+        registry = _registry()
+        service = ClusterServiceImpl(registry, _authenticator())
+
+        await service.RegisterNode(_register_request(), _bearer(SECRET))
+
+        assert len(registry.list_nodes()) == 1
+
+    @pytest.mark.asyncio
+    async def test_refused_call_never_falls_through_when_abort_does_not_raise(self) -> None:
+        # A context that only records the abort must not let the handler run on
+        # into the mutation it was refused.
+        from bernstein.core.protocols.cluster.cluster_auth import ClusterAuthError
+
+        class RecordingContext(FakeContext):
+            code: grpc.StatusCode | None = None
+
+            async def abort(self, code: grpc.StatusCode, details: str) -> None:
+                self.code = code
+
+        registry = _registry()
+        service = ClusterServiceImpl(registry, _authenticator())
+        context = RecordingContext()
+
+        with pytest.raises(ClusterAuthError, match="Missing Authorization header"):
+            await service.RegisterNode(_register_request(), context)
+
+        assert registry.list_nodes() == []
+        assert context.code is grpc.StatusCode.UNAUTHENTICATED
+
+
+class TestRegisterNodeAuthToken:
+    @pytest.mark.asyncio
+    async def test_register_response_carries_a_token_the_server_accepts(self) -> None:
+        registry = _registry()
+        auth = _authenticator()
+        service = ClusterServiceImpl(registry, auth)
+
+        resp = await service.RegisterNode(_register_request(), _bearer(SECRET))
+
+        assert resp.auth_token
+        payload = auth.verify_request(f"Bearer {resp.auth_token}", SCOPE_NODE_HEARTBEAT)
+        assert payload.user_id == resp.node.id
+
+    @pytest.mark.asyncio
+    async def test_issued_token_authenticates_the_next_heartbeat(self) -> None:
+        registry = _registry()
+        auth = _authenticator()
+        service = ClusterServiceImpl(registry, auth)
+        resp = await service.RegisterNode(_register_request(), _bearer(SECRET))
+
+        beat = await service.Heartbeat(
+            cluster_pb2.HeartbeatRequest(node_id=resp.node.id),
+            _bearer(resp.auth_token),
+        )
+
+        assert beat.acknowledged is True
+        assert beat.node.id == resp.node.id
+
+    @pytest.mark.asyncio
+    async def test_issued_token_does_not_grant_admin_verbs(self) -> None:
+        registry = _registry()
+        auth = _authenticator()
+        service = ClusterServiceImpl(registry, auth)
+        resp = await service.RegisterNode(_register_request(), _bearer(SECRET))
+
+        with pytest.raises(Aborted) as excinfo:
+            await service.UnregisterNode(
+                cluster_pb2.UnregisterNodeRequest(node_id=resp.node.id),
+                _bearer(resp.auth_token),
+            )
+
+        assert excinfo.value.code is grpc.StatusCode.PERMISSION_DENIED
+
+    @pytest.mark.asyncio
+    async def test_auth_token_stays_empty_without_an_authenticator(self) -> None:
+        # Nothing could verify a token minted here, so the field is left unset
+        # rather than handing back a credential no handler would accept.
+        resp = await _register_one(ClusterServiceImpl(_registry()))
+
+        assert resp.auth_token == ""
+
+
+class TestReRegistrationIsIdempotent:
+    @pytest.mark.asyncio
+    async def test_reregistration_reuses_the_existing_node_id(self) -> None:
+        registry = _registry()
+        service = ClusterServiceImpl(registry)
+
+        first = await _register_one(service)
+        second = await _register_one(service)
+
+        assert second.node.id == first.node.id
+        assert len(registry.list_nodes()) == 1
+
+    @pytest.mark.asyncio
+    async def test_restarting_worker_does_not_inflate_cluster_capacity(self) -> None:
+        registry = _registry()
+        service = ClusterServiceImpl(registry)
+
+        for _ in range(3):
+            await _register_one(service, max_agents=4)
+
+        summary = registry.cluster_summary()
+        assert summary["total_nodes"] == 1
+        assert summary["total_capacity"] == 4
+
+    @pytest.mark.asyncio
+    async def test_reregistration_refreshes_capacity_on_the_existing_entry(self) -> None:
+        registry = _registry()
+        service = ClusterServiceImpl(registry)
+
+        first = await _register_one(service, max_agents=4)
+        await _register_one(service, max_agents=8)
+
+        node = registry.get(first.node.id)
+        assert node.capacity.max_agents == 8
+        assert len(registry.list_nodes()) == 1
+
+    @pytest.mark.asyncio
+    async def test_same_name_on_a_different_url_stays_a_separate_node(self) -> None:
+        registry = _registry()
+        service = ClusterServiceImpl(registry)
+
+        first = await _register_one(service, url="http://worker-a:8052")
+        second = await _register_one(service, url="http://worker-a:9052")
+
+        assert first.node.id != second.node.id
+        assert len(registry.list_nodes()) == 2
+
+    @pytest.mark.asyncio
+    async def test_blank_identity_never_collapses_two_registrations(self) -> None:
+        # An empty name/url carries no identity; merging on it would fold
+        # unrelated nodes into a single entry.
+        registry = _registry()
+        service = ClusterServiceImpl(registry)
+
+        first = await _register_one(service, name="", url="")
+        second = await _register_one(service, name="", url="")
+
+        assert first.node.id != second.node.id
+        assert len(registry.list_nodes()) == 2
+
+
+class TestNodeRegistryFindByIdentity:
+    def test_find_by_identity_matches_name_and_url(self) -> None:
+        from bernstein.core.models import NodeInfo
+
+        registry = _registry()
+        node = registry.register(NodeInfo(name="worker-a", url="http://worker-a:8052"))
+
+        assert registry.find_by_identity("worker-a", "http://worker-a:8052").id == node.id
+        assert registry.find_by_identity("worker-a", "http://worker-a:9052") is None
+        assert registry.find_by_identity("worker-b", "http://worker-a:8052") is None
+
+    def test_find_by_identity_refuses_blank_identity(self) -> None:
+        from bernstein.core.models import NodeInfo
+
+        registry = _registry()
+        registry.register(NodeInfo(name="", url=""))
+
+        assert registry.find_by_identity("", "") is None
+
+
+class _FakeAioServer:
+    def __init__(self) -> None:
+        self.insecure_ports: list[str] = []
+        self.secure_ports: list[str] = []
+        self.started = False
+
+    def add_insecure_port(self, bind: str) -> int:
+        self.insecure_ports.append(bind)
+        return 1
+
+    def add_secure_port(self, bind: str, _creds: Any) -> int:
+        self.secure_ports.append(bind)
+        return 1
+
+    async def start(self) -> None:
+        self.started = True
+
+
+class TestInsecurePortFallback:
+    @staticmethod
+    def _patch_wiring(monkeypatch: pytest.MonkeyPatch) -> tuple[_FakeAioServer, dict[str, Any]]:
+        from bernstein.core.grpc_gen import cluster_pb2_grpc, tasks_pb2_grpc
+        from bernstein.core.protocols.grpc import grpc_server as module
+
+        fake_server = _FakeAioServer()
+        captured: dict[str, Any] = {}
+
+        monkeypatch.setattr(module, "grpc_aio", MagicMock(server=lambda **_kwargs: fake_server))
+        monkeypatch.setattr(tasks_pb2_grpc, "add_TaskServiceServicer_to_server", lambda *_args: None)
+        monkeypatch.setattr(
+            cluster_pb2_grpc,
+            "add_ClusterServiceServicer_to_server",
+            lambda servicer, _server: captured.__setitem__("servicer", servicer),
+        )
+        return fake_server, captured
+
+    @pytest.mark.asyncio
+    async def test_insecure_fallback_still_enforces_cluster_auth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake_server, captured = self._patch_wiring(monkeypatch)
+        registry = _registry()
+        server = BernsteinGrpcServer(config=GrpcServerConfig(port=50999, enable_reflection=False))
+
+        await server.start(MagicMock(), node_registry=registry, cluster_authenticator=_authenticator())
+
+        assert fake_server.insecure_ports == ["0.0.0.0:50999"]
+        assert fake_server.secure_ports == []
+        # The servicer mounted on the insecure port is the enforcing one.
+        with pytest.raises(Aborted) as excinfo:
+            await captured["servicer"].RegisterNode(_register_request(), FakeContext())
+        assert excinfo.value.code is grpc.StatusCode.UNAUTHENTICATED
+        assert registry.list_nodes() == []
+
+    @pytest.mark.asyncio
+    async def test_insecure_fallback_warns_that_credentials_are_in_cleartext(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        self._patch_wiring(monkeypatch)
+        server = BernsteinGrpcServer(config=GrpcServerConfig(port=50999, enable_reflection=False))
+
+        with caplog.at_level(logging.WARNING, logger="bernstein.core.protocols.grpc.grpc_server"):
+            await server.start(MagicMock(), node_registry=_registry(), cluster_authenticator=_authenticator())
+
+        assert any("cleartext" in record.getMessage() for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_no_cleartext_warning_without_cluster_auth(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        self._patch_wiring(monkeypatch)
+        server = BernsteinGrpcServer(config=GrpcServerConfig(port=50999, enable_reflection=False))
+
+        with caplog.at_level(logging.WARNING, logger="bernstein.core.protocols.grpc.grpc_server"):
+            await server.start(MagicMock(), node_registry=_registry())
+
+        assert caplog.records == []
+
+
+class TestClusterClientCredentials:
+    @staticmethod
+    def _client(auth_token: str | None) -> Any:
+        from bernstein.core.protocols.grpc.grpc_client import ClusterClient, GrpcClientConfig
+
+        return ClusterClient(config=GrpcClientConfig(auth_token=auth_token))
+
+    def test_metadata_is_empty_without_a_credential(self) -> None:
+        assert self._client(None)._metadata() == []
+
+    def test_metadata_carries_the_configured_join_credential(self) -> None:
+        assert self._client("join-secret")._metadata() == [("authorization", "Bearer join-secret")]
+
+    @pytest.mark.asyncio
+    async def test_client_adopts_the_issued_node_token_after_registration(self) -> None:
+        client = self._client("join-secret")
+        registered = cluster_pb2.RegisterNodeResponse(auth_token="node-jwt")
+        registered.node.id = "node-1"
+        sent: list[Any] = []
+
+        class _Stub:
+            async def RegisterNode(self, _req: Any, **kwargs: Any) -> Any:  # NOSONAR - gRPC method name
+                sent.append(kwargs["metadata"])
+                return registered
+
+            async def Heartbeat(self, _req: Any, **kwargs: Any) -> Any:  # NOSONAR - gRPC method name
+                sent.append(kwargs["metadata"])
+                return cluster_pb2.HeartbeatResponse(acknowledged=True)
+
+        client._stub = _Stub()
+
+        result = await client.register_node(name="worker-a", url="http://worker-a:8052")
+        await client.heartbeat("node-1", available_slots=2)
+
+        assert result["auth_token"] == "node-jwt"
+        assert sent == [
+            [("authorization", "Bearer join-secret")],
+            [("authorization", "Bearer node-jwt")],
+        ]


### PR DESCRIPTION
## Root cause

The gRPC `ClusterService` mirrors the REST cluster routes but predates their hardening: no handler consulted a credential, `RegisterNodeResponse.auth_token` was declared in the proto and read by our own `ClusterClient` while nothing populated it, and `RegisterNode` built a fresh `NodeInfo` (fresh id) per call while `NodeRegistry.register` keys on that id — so a restarting worker added a row instead of updating its own, and `cluster_summary` counted its capacity once per row.

Confirmed against `origin/main` before changing anything: three `RegisterNode` calls for one worker with no credential produced 3 registry entries, `total_capacity` 12 instead of 4, `auth_token == ""`, and unauthenticated `CordonNode` / `UnregisterNode` both applied.

## What changed

- **Scopes.** `RegisterNode` requires `node:register`; `Heartbeat` and `StreamHeartbeats` require `node:heartbeat`; `UnregisterNode`, `CordonNode`, `UncordonNode`, `DrainNode` require `node:admin` — the same mapping `routes/task_cluster.py` uses. The credential is read from the `authorization` call metadata as `Bearer <token>`. Missing/invalid aborts `UNAUTHENTICATED`; valid-but-wrong-scope aborts `PERMISSION_DENIED`. `ListNodes` and `GetClusterStatus` stay unauthenticated, matching `GET /cluster/nodes` and `GET /cluster/status`. `ClusterAuthenticator.verify_request` now raises a `ClusterAuthScopeError` subclass on the scope branch so the two cases are distinguishable; REST behaviour is unchanged (both still map to 401).
- **`auth_token`: populated, not removed.** On successful registration the server mints a node JWT against the registered node id carrying `node:register` + `node:heartbeat` (never `node:admin`) — the gRPC counterpart of `AuthenticatedNodeRegistry.register`. `ClusterClient` adopts it for subsequent calls, so heartbeats travel under the node's own token rather than the join credential. With no authenticator wired the field stays empty rather than returning a token nothing could verify.
- **Idempotent re-registration.** `RegisterNode` resolves an existing entry by `(name, url)` through the new `NodeRegistry.find_by_identity` and reuses its id, so `register` takes its update path. A blank `name` or `url` never matches — those carry no identity and merging on them would fold unrelated nodes together.
- **Insecure port.** Enforcement lives in the servicer, not the transport, so it holds on the `add_insecure_port` fallback. That path now also logs a warning that node credentials cross it in cleartext.

## Tests

New file `tests/unit/test_grpc_cluster_auth.py` (37 tests). The surface is latent — nothing in `src/` starts the gRPC server — so every test drives the servicer object directly, against a real `NodeRegistry`, real generated protos, and a fake context that aborts the way `grpc.aio` does.

Credential enforcement:

- `test_register_node_without_credential_is_unauthenticated`
- `test_register_node_with_heartbeat_only_scope_is_permission_denied`
- `test_register_node_with_register_scope_is_admitted`
- `test_heartbeat_without_credential_is_unauthenticated`
- `test_heartbeat_with_register_only_scope_is_permission_denied`
- `test_stream_heartbeats_without_credential_is_unauthenticated`
- `test_lifecycle_verbs_without_credential_are_unauthenticated` (unregister/cordon/uncordon/drain)
- `test_lifecycle_verbs_reject_a_heartbeat_scoped_token` (same four)
- `test_lifecycle_verbs_accept_a_node_admin_token`
- `test_reads_stay_unauthenticated_like_the_rest_routes`
- `test_handlers_are_open_when_no_authenticator_is_wired`
- `test_handlers_are_open_when_require_auth_is_off`
- `test_shared_secret_authenticates_a_registration`
- `test_refused_call_never_falls_through_when_abort_does_not_raise`

`auth_token`:

- `test_register_response_carries_a_token_the_server_accepts`
- `test_issued_token_authenticates_the_next_heartbeat`
- `test_issued_token_does_not_grant_admin_verbs`
- `test_auth_token_stays_empty_without_an_authenticator`

Re-registration:

- `test_reregistration_reuses_the_existing_node_id`
- `test_restarting_worker_does_not_inflate_cluster_capacity`
- `test_reregistration_refreshes_capacity_on_the_existing_entry`
- `test_same_name_on_a_different_url_stays_a_separate_node`
- `test_blank_identity_never_collapses_two_registrations`
- `test_find_by_identity_matches_name_and_url`
- `test_find_by_identity_refuses_blank_identity`

Insecure-port fallback and client:

- `test_insecure_fallback_still_enforces_cluster_auth`
- `test_insecure_fallback_warns_that_credentials_are_in_cleartext`
- `test_no_cleartext_warning_without_cluster_auth`
- `test_metadata_is_empty_without_a_credential`
- `test_metadata_carries_the_configured_join_credential`
- `test_client_adopts_the_issued_node_token_after_registration`

Verified the tests fail before the fix: with `src/` stashed, 32 of the 37 fail (the 5 that pass are the no-authenticator / unauthenticated-read cases, which are unchanged behaviour). All 37 pass after.

Locally green: `run_tests.py -k cluster` (14 files), `-k grpc` (3), `-k worker` (18), `-k registry` (15), `-k node` (5), `-k fleet` (11), `-k drain` (2), `-k server_app`, plus the docs/release-notes guards. `ruff check .` and `ruff format --check .` clean; `mypy src` error count unchanged from the `origin/main` baseline (153), none in the changed modules.

## Out of scope

- The REST `POST /cluster/nodes` route has the same non-idempotent shape (it also mints a fresh `NodeInfo` per call). Changing it is a user-visible change to a live surface, so it is left alone here; `find_by_identity` is available if that is taken up separately.
- `StealTasks` is declared in the proto but has no server-side handler, so there was nothing to gate.
- No wiring is added to start the gRPC server. The surface stays latent; this closes the gaps so it can be turned on safely.

Closes #3537
