### PR TITLE
fix(security): check route permissions for every credential kind

### DIFF
--- a/docs/operations/cluster-mode.md
+++ b/docs/operations/cluster-mode.md
@@ -172,8 +172,17 @@ Default scopes, defined in `cluster_auth.py:23-25`:
 | Scope             | Required by                                         |
 | ----------------- | --------------------------------------------------- |
 | `node:register`   | `POST /cluster/nodes`                               |
-| `node:heartbeat`  | `POST /cluster/nodes/{id}/heartbeat`                |
-| `node:admin`      | `cordon`, `uncordon`, `drain`, `DELETE /cluster/nodes` |
+| `node:heartbeat`  | `POST /cluster/nodes/{id}/heartbeat`, `POST /cluster/claims/gossip` |
+| `node:admin`      | `cordon`, `uncordon`, `drain`, `DELETE /cluster/nodes`, `POST /cluster/steal` |
+
+`POST /cluster/steal` reassigns other nodes' claimed work from
+caller-reported queue depths, so it is scoped with the node-registry
+mutations rather than with gossip: gossip verifies each receipt's own
+Ed25519 signature and chain link inside the handler, so its bearer scope
+only has to establish fleet membership. A default node token carries
+register + heartbeat, so triggering a rebalance uses the cluster secret or
+an admin-scoped token — the same credential the drain and cordon primitives
+already need.
 
 The worker side of the flow lives in `worker_cmd.py:134-164` (registration)
 and `:165-190` (heartbeat). On HTTP 404 from the heartbeat the worker

--- a/docs/operations/security-and-identity.md
+++ b/docs/operations/security-and-identity.md
@@ -82,11 +82,33 @@ rejected.
    (`jwt_tokens.py:78-93`) which returns `None` on bad signature or
    expiry.
 3. Resolves the user (operator) or identity (agent), populates
-   `request.state.user` / `request.state.identity`, and enforces
-   `task_ids` scoping on every mutating request. The rule is applied to the
-   task the request acts on, not to a list of blessed URLs, so it holds
-   wherever that id comes from (see the table below).
-4. Returns `JSONResponse(401)` on any verification failure.
+   `request.state.user` / `request.state.identity`, and checks the
+   permission the requested route declares (see *Route permissions* below).
+4. Enforces `task_ids` scoping on every mutating request carrying an agent
+   identity. The rule is applied to the task the request acts on, not to a
+   list of blessed URLs, so it holds wherever that id comes from (see the
+   table below).
+5. Returns `JSONResponse(401)` on any verification failure, `403` when the
+   credential authenticates but does not hold the route's permission.
+
+**Route permissions.** Both credential kinds are gated on the permission
+`_get_required_permission(path, method)` resolves for the route, before the
+request reaches a handler: an SSO user against its RBAC role, an agent
+identity against the permission set its token pins. An agent that does not
+hold the permission gets `403` — a worker token reaches neither the agent
+log and stream reads (`agents:read`) nor the session-kill route
+(`agents:kill`), and neither the `/cluster` nor the `/bulletin` surface.
+Reads are gated as well as writes, because a read route's declared
+permission is what keeps one agent's output out of another agent's reach.
+
+Agent grants use a narrower vocabulary than the route map, and spell the
+per-task write authority `tasks:claim` where the route map says
+`tasks:write`. The two names denote the same authority and are resolved
+through `_AGENT_PERMISSION_EQUIVALENTS` in `auth_middleware.py`, so a worker
+still claims, progresses, completes and decomposes its own tasks — bounded
+by `task_ids` as before. Nothing else in the two vocabularies is treated as
+equivalent: a new agent-reachable surface needs its permission granted
+outright in `AGENT_ROLE_PERMISSIONS`.
 
 **Where the task id comes from.** A rule enforced on only some of these is
 enforced on an arbitrary subset, so all of them are covered:

--- a/docs/operations/security-and-identity.md
+++ b/docs/operations/security-and-identity.md
@@ -91,24 +91,56 @@ rejected.
 5. Returns `JSONResponse(401)` on any verification failure, `403` when the
    credential authenticates but does not hold the route's permission.
 
-**Route permissions.** Both credential kinds are gated on the permission
-`_get_required_permission(path, method)` resolves for the route, before the
-request reaches a handler: an SSO user against its RBAC role, an agent
-identity against the permission set its token pins. An agent that does not
-hold the permission gets `403` — a worker token reaches neither the agent
-log and stream reads (`agents:read`) nor the session-kill route
-(`agents:kill`), and neither the `/cluster` nor the `/bulletin` surface.
-Reads are gated as well as writes, because a read route's declared
-permission is what keeps one agent's output out of another agent's reach.
+**Route permissions.** Every credential that authenticates is gated on the
+permission `_get_required_permission(path, method)` resolves for the route,
+before the request reaches a handler. Each kind is checked against the
+authority it actually carries, and gets `403` when the route names one it
+does not hold:
 
-Agent grants use a narrower vocabulary than the route map, and spell the
-per-task write authority `tasks:claim` where the route map says
-`tasks:write`. The two names denote the same authority and are resolved
-through `_AGENT_PERMISSION_EQUIVALENTS` in `auth_middleware.py`, so a worker
-still claims, progresses, completes and decomposes its own tasks — bounded
-by `task_ids` as before. Nothing else in the two vocabularies is treated as
-equivalent: a new agent-reachable surface needs its permission granted
-outright in `AGENT_ROLE_PERMISSIONS`.
+| Credential | Checked against | Reaches |
+| --- | --- | --- |
+| SSO user JWT | the RBAC role's permissions | whatever the role grants |
+| Agent identity token | the signed permission set the token pins, plus `_AGENT_PERMISSION_EQUIVALENTS` | its own task work; not `/agents/*`, `/cluster/*` or `/bulletin` unless the grant says so |
+| Cluster worker secret | `_CLUSTER_SECRET_PERMISSIONS`, a fixed set | `cluster:write` / `cluster:read`, `tasks:write` / `tasks:read`, `status:read` — and nothing else |
+| Legacy static bearer | nothing — it is the operator credential | everything |
+
+Reads are gated as well as writes. A read route's declared permission is
+what keeps one agent's log and stream output out of another agent's reach,
+and it is the only thing that bounds a read at all: the separate
+operator-only (`admin:manage`) refusal that agent tokens and the cluster
+secret have always carried runs on non-read methods only.
+
+*Agent identities.* Agent grants use a narrower vocabulary than the route
+map, and spell the per-task write authority `tasks:claim` where the route
+map says `tasks:write`. The two names denote the same authority and are
+resolved through `_AGENT_PERMISSION_EQUIVALENTS` in `auth_middleware.py`, so
+a worker still claims, progresses, completes and decomposes its own tasks —
+bounded by `task_ids` as before. Nothing else in the two vocabularies is
+treated as equivalent: a new agent-reachable surface needs its permission
+granted outright in `AGENT_ROLE_PERMISSIONS`.
+
+*Cluster worker secret.* This credential has no record of its own to hang a
+grant on — it is one string handed to every node in the fleet, so it cannot
+be revoked per worker or narrowed per task. Its authority is therefore fixed
+in the middleware at what joining and working a cluster needs: the
+`/cluster` surface, the task pull-and-report cycle, and the `status:read`
+floor. It reaches neither the agent log, stream and session-kill routes nor
+the bulletin, `/auth` or `/webhooks`, because a worker drives its own agents
+through the local spawner and never touches those over HTTP. Widening this
+set widens it for the whole fleet at once; a deployment that needs one
+credential to do more should use an SSO user with the role that grants it.
+
+**Two layers on the cluster routes.** The middleware is the only gate on
+most paths. `_verify_cluster_auth` in `routes/task_cluster.py` adds a second,
+scope-checked layer, and it covers the mutating `/cluster/*` routes only —
+registration and heartbeat (`node:register` / `node:heartbeat`), claim
+gossip (`node:heartbeat`), and the node-registry mutations cordon, uncordon,
+drain, unregister and steal (`node:admin`). `POST /cluster/steal` reassigns
+other nodes' claimed work from caller-reported queue depths, so it is scoped
+with the other node-registry mutations rather than with gossip, whose bearer
+scope only has to establish fleet membership because each receipt carries
+its own Ed25519 signature. For `/tasks/*`, `/agents/*` and `/bulletin` there
+is no inner layer at all.
 
 **Where the task id comes from.** A rule enforced on only some of these is
 enforced on an arbitrary subset, so all of them are covered:

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -3374,7 +3374,7 @@
     "/cluster/steal": {
       "post": {
         "summary": "Steal Tasks",
-        "description": "Evaluate task stealing policy and reassign claimed tasks between nodes.\n\nWorkers report their queue depths; the server runs the steal policy and\nreturns a list of task reassignments.  Stolen tasks are reset to ``open``\nso the receiver node can claim them.",
+        "description": "Evaluate task stealing policy and reassign claimed tasks between nodes.\n\nWorkers report their queue depths; the server runs the steal policy and\nreturns a list of task reassignments.  Stolen tasks are reset to ``open``\nso the receiver node can claim them.\n\nAuthorisation requires the node-admin scope, like the other node-registry\nmutations (cordon, uncordon, drain, unregister) this sits beside in the\noperational-primitives table.  It is deliberately NOT the heartbeat scope\nthat ``POST /cluster/claims/gossip`` uses: gossip proves each receipt with\nits own Ed25519 signature and chain link inside the handler, so its bearer\nscope only has to establish fleet membership, whereas here the caller's\nreported queue depths drive ``force_claim`` directly with no further proof\nto check.",
         "operationId": "steal_tasks_cluster_steal_post",
         "requestBody": {
           "content": {
@@ -3396,6 +3396,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Cluster authentication failed"
           },
           "422": {
             "description": "Validation Error",
@@ -12187,7 +12190,7 @@
     "/api/v1/cluster/steal": {
       "post": {
         "summary": "Steal Tasks",
-        "description": "Evaluate task stealing policy and reassign claimed tasks between nodes.\n\nWorkers report their queue depths; the server runs the steal policy and\nreturns a list of task reassignments.  Stolen tasks are reset to ``open``\nso the receiver node can claim them.",
+        "description": "Evaluate task stealing policy and reassign claimed tasks between nodes.\n\nWorkers report their queue depths; the server runs the steal policy and\nreturns a list of task reassignments.  Stolen tasks are reset to ``open``\nso the receiver node can claim them.\n\nAuthorisation requires the node-admin scope, like the other node-registry\nmutations (cordon, uncordon, drain, unregister) this sits beside in the\noperational-primitives table.  It is deliberately NOT the heartbeat scope\nthat ``POST /cluster/claims/gossip`` uses: gossip proves each receipt with\nits own Ed25519 signature and chain link inside the handler, so its bearer\nscope only has to establish fleet membership, whereas here the caller's\nreported queue depths drive ``force_claim`` directly with no further proof\nto check.",
         "operationId": "steal_tasks_api_v1_cluster_steal_post",
         "requestBody": {
           "content": {
@@ -12209,6 +12212,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Cluster authentication failed"
           },
           "422": {
             "description": "Validation Error",

--- a/src/bernstein/core/routes/task_cluster.py
+++ b/src/bernstein/core/routes/task_cluster.py
@@ -276,16 +276,27 @@ def gossip_claims(body: ClaimGossipRequest, request: Request) -> ClaimGossipResp
     )
 
 
-@router.post("/cluster/steal")
+@router.post("/cluster/steal", responses=_AUTH_RESPONSES)
 async def steal_tasks(body: TaskStealRequest, request: Request) -> TaskStealResponse:
     """Evaluate task stealing policy and reassign claimed tasks between nodes.
 
     Workers report their queue depths; the server runs the steal policy and
     returns a list of task reassignments.  Stolen tasks are reset to ``open``
     so the receiver node can claim them.
+
+    Authorisation requires the node-admin scope, like the other node-registry
+    mutations (cordon, uncordon, drain, unregister) this sits beside in the
+    operational-primitives table.  It is deliberately NOT the heartbeat scope
+    that ``POST /cluster/claims/gossip`` uses: gossip proves each receipt with
+    its own Ed25519 signature and chain link inside the handler, so its bearer
+    scope only has to establish fleet membership, whereas here the caller's
+    reported queue depths drive ``force_claim`` directly with no further proof
+    to check.
     """
     from bernstein.core.cluster import TaskStealPolicy
+    from bernstein.core.cluster_auth import SCOPE_NODE_ADMIN
 
+    _verify_cluster_auth(request, SCOPE_NODE_ADMIN)
     node_registry = _get_node_registry(request)
     store = _get_store(request)
 

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -57,16 +57,34 @@ Route permission enforcement
 ----------------------------
 Every credential that authenticates is also gated on the permission the
 requested route declares (:func:`_get_required_permission`), before the
-request reaches a handler.  SSO users are checked against their RBAC role,
-agent identities against the signed permission set their token pins, and
-both are refused with HTTP 403 when the permission is not held.  Agent
-grants use a narrower vocabulary than the route map, so the one authority
-the two spell differently is resolved through
+request reaches a handler.  Each kind is checked against the authority it
+actually carries, and refused with HTTP 403 when the route names one it
+does not hold:
+
+=========================  ===========================================
+Credential                 Checked against
+=========================  ===========================================
+SSO user JWT               the RBAC role's permissions
+Agent identity token       the signed permission set the token pins,
+                           plus :data:`_AGENT_PERMISSION_EQUIVALENTS`
+Cluster worker secret      :data:`_CLUSTER_SECRET_PERMISSIONS`, a fixed
+                           set - one string serves the whole fleet, so
+                           there is no per-worker grant to read
+Legacy static bearer       nothing; it is the operator credential
+=========================  ===========================================
+
+Agent grants use a narrower vocabulary than the route map, so the one
+authority the two spell differently is resolved through
 :data:`_AGENT_PERMISSION_EQUIVALENTS`; nothing else is implied.
 
 The gate covers reads as well as writes, because a read route's declared
 permission is what keeps one agent's log and stream output out of another
 agent's reach.
+
+It is also the only gate on most paths.  The inner cluster route layer
+(``_verify_cluster_auth`` in ``routes/task_cluster.py``) covers the mutating
+``/cluster/*`` routes and nothing else, so for ``/agents/*``, ``/bulletin``
+and ``/tasks/*`` a credential that clears this check reaches the handler.
 
 Tenant scope binding
 --------------------
@@ -151,6 +169,10 @@ if TYPE_CHECKING:
 _PERM_TASKS_WRITE = "tasks:write"
 _PERM_ADMIN_MANAGE = "admin:manage"
 _PERM_TASKS_CLAIM = "tasks:claim"
+_PERM_TASKS_READ = "tasks:read"
+_PERM_CLUSTER_WRITE = "cluster:write"
+_PERM_CLUSTER_READ = "cluster:read"
+_PERM_STATUS_READ = "status:read"
 
 # Grants an agent identity may hold in place of a route-map permission.
 #
@@ -170,6 +192,43 @@ _PERM_TASKS_CLAIM = "tasks:claim"
 _AGENT_PERMISSION_EQUIVALENTS: Final[dict[str, frozenset[str]]] = {
     _PERM_TASKS_WRITE: frozenset({_PERM_TASKS_CLAIM}),
 }
+
+# Authority the cluster shared secret carries.
+#
+# Unlike an SSO user or an agent identity, this credential has no record of
+# its own to hang a grant on: it is one string handed to every worker in the
+# fleet, so it cannot be revoked per worker and cannot be narrowed per task.
+# Its authority is therefore fixed here, at exactly what joining and working
+# a cluster needs:
+#
+#   ``cluster:write`` / ``cluster:read``
+#       register, heartbeat, cordon, drain, unregister, gossip claim
+#       receipts, rebalance, and read the node registry
+#   ``tasks:write`` / ``tasks:read``
+#       pull the next task for a role and report it complete, failed or
+#       released - the work a worker node exists to do
+#   ``status:read``
+#       the read floor every credential holds; it is what
+#       :func:`_get_required_permission` returns for every read route the
+#       map does not name, including the liveness surfaces a worker polls
+#
+# Nothing else is implied.  ``agents:read`` and ``agents:kill`` are outside
+# the set on purpose: a worker drives its own agents through the local
+# spawner, never through the HTTP agent surface, so granting them would make
+# one fleet-wide string a read-and-terminate handle on every other session's
+# agent.  ``bulletin:write``, ``auth:manage`` and ``webhooks:manage`` are out
+# for the same reason - a worker never writes to those surfaces, and the
+# credential that fans out to the whole fleet is the wrong one to widen.
+# ``admin:manage`` keeps its own earlier, more specific refusal below.
+_CLUSTER_SECRET_PERMISSIONS: Final[frozenset[str]] = frozenset(
+    {
+        _PERM_CLUSTER_WRITE,
+        _PERM_CLUSTER_READ,
+        _PERM_TASKS_WRITE,
+        _PERM_TASKS_READ,
+        _PERM_STATUS_READ,
+    }
+)
 
 type _ExpectedResourceConfig = str | Sequence[str] | None
 
@@ -429,7 +488,7 @@ _RESOURCE_MALFORMED_CHALLENGE = 'Bearer error="invalid_token", error_description
 _ROUTE_PERMISSIONS: dict[str, str] = {
     "/tasks": _PERM_TASKS_WRITE,
     "/agents": "agents:write",
-    "/cluster": "cluster:write",
+    "/cluster": _PERM_CLUSTER_WRITE,
     "/bulletin": "bulletin:write",
     "/auth": "auth:manage",
     "/config": _PERM_ADMIN_MANAGE,
@@ -633,6 +692,26 @@ def _agent_holds_permission(agent_identity: Any, permission: str) -> bool:
     return any(agent_identity.has_permission(grant) for grant in _AGENT_PERMISSION_EQUIVALENTS.get(permission, ()))
 
 
+def _cluster_secret_holds_permission(permission: str) -> bool:
+    """Return True when the cluster shared secret covers *permission*.
+
+    The secret's authority is the fixed set in
+    :data:`_CLUSTER_SECRET_PERMISSIONS` rather than a per-credential grant,
+    because one string serves the whole worker fleet and there is no
+    per-worker record to attach a grant to.  A route naming any other
+    permission is refused: presenting the fleet credential is not evidence
+    of authority over a surface a worker does not use.
+
+    Args:
+        permission: Permission the route requires, from
+            :func:`_get_required_permission`.
+
+    Returns:
+        True when the cluster credential is authorised for the route.
+    """
+    return permission in _CLUSTER_SECRET_PERMISSIONS
+
+
 class SSOAuthMiddleware(BaseHTTPMiddleware):
     """Multi-strategy authentication middleware.
 
@@ -678,8 +757,10 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         self._agent_identity_store = agent_identity_store
         # The cluster shared secret is accepted as a worker credential so a
         # single token clears both this outer layer and the inner cluster
-        # route layer (#2805). It is barred from operator-only endpoints
-        # below, mirroring the agent-identity restriction.
+        # route layer (#2805). Its authority here is the fixed set in
+        # ``_CLUSTER_SECRET_PERMISSIONS``, checked against the route's
+        # declared permission below, and it keeps the separate operator-only
+        # refusal that mirrors the agent-identity restriction.
         self._cluster_secret = cluster_secret or None
         # Resolve opt-out from explicit arg > env var. Config-based opt-out
         # should be passed in via ``auth_disabled=True`` from the factory.
@@ -846,24 +927,46 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
                 return response
 
         # Strategy 3b: Cluster shared secret. A cluster worker presents the
-        # cluster secret to register, heartbeat, and pull tasks; it must clear
-        # this outer layer as well as the inner cluster route layer (#2805).
-        # Accepted like the legacy operator token but - like agent tokens -
-        # barred from operator-only (admin:manage) endpoints so it cannot
-        # shut down or reconfigure the server.
+        # cluster secret to register, heartbeat, and pull tasks; on the
+        # mutating ``/cluster/*`` routes it clears this outer layer as well as
+        # the inner cluster route layer (#2805), each of which enforces its
+        # own scope.  Everywhere else - ``/tasks/*``, ``/agents/*``,
+        # ``/bulletin`` - there is no inner cluster layer at all and this gate
+        # is the only one, so it is gated on the route's declared permission
+        # like every other credential kind rather than only on the
+        # operator-only refusal.
         if self._cluster_secret:
             import hmac
 
             if hmac.compare_digest(token, self._cluster_secret):
-                if (
-                    request.method not in _READ_METHODS
-                    and _get_required_permission(path, request.method) == _PERM_ADMIN_MANAGE
-                ):
+                required_permission = _get_required_permission(path, request.method)
+                if request.method not in _READ_METHODS and required_permission == _PERM_ADMIN_MANAGE:
                     return JSONResponse(
                         status_code=403,
                         content={
                             "detail": "Cluster credential cannot access operator-only endpoints",
                             "required_permission": _PERM_ADMIN_MANAGE,
+                        },
+                    )
+                # The fleet secret carries a fixed authority
+                # (``_CLUSTER_SECRET_PERMISSIONS``), so a route naming any
+                # other permission is refused here.  Without this the only
+                # bound on a fleet-wide string was the operator-only check on
+                # writes: it reached the session-kill route, another session's
+                # agent log and stream, and the bulletin write, holding none
+                # of the permissions those routes declare.  Reads are gated
+                # too, for the same reason they are on the agent path.
+                if required_permission and not _cluster_secret_holds_permission(required_permission):
+                    logger.warning(
+                        "Cluster credential denied %s (%s required)",
+                        sanitize_log(path),
+                        sanitize_log(required_permission),
+                    )
+                    return JSONResponse(
+                        status_code=403,
+                        content={
+                            "detail": f"Insufficient permissions. Required: {required_permission}",
+                            "required_permission": required_permission,
                         },
                     )
                 request.state.user = None  # type: ignore[attr-defined]

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -53,6 +53,21 @@ as unrestricted (manager / orchestrator tokens), and non-agent credentials
 (SSO users, the legacy operator bearer, the cluster secret) never reach this
 check at all.
 
+Route permission enforcement
+----------------------------
+Every credential that authenticates is also gated on the permission the
+requested route declares (:func:`_get_required_permission`), before the
+request reaches a handler.  SSO users are checked against their RBAC role,
+agent identities against the signed permission set their token pins, and
+both are refused with HTTP 403 when the permission is not held.  Agent
+grants use a narrower vocabulary than the route map, so the one authority
+the two spell differently is resolved through
+:data:`_AGENT_PERMISSION_EQUIVALENTS`; nothing else is implied.
+
+The gate covers reads as well as writes, because a read route's declared
+permission is what keeps one agent's log and stream output out of another
+agent's reach.
+
 Tenant scope binding
 --------------------
 Every credential the middleware accepts is bound to exactly one tenant
@@ -135,6 +150,26 @@ if TYPE_CHECKING:
 
 _PERM_TASKS_WRITE = "tasks:write"
 _PERM_ADMIN_MANAGE = "admin:manage"
+_PERM_TASKS_CLAIM = "tasks:claim"
+
+# Grants an agent identity may hold in place of a route-map permission.
+#
+# ``_ROUTE_PERMISSIONS`` names the authority a route needs in the RBAC
+# vocabulary the SSO principal is described in.  Agent identities are minted
+# from ``AGENT_ROLE_PERMISSIONS``, a deliberately narrower vocabulary scoped
+# to what a worker agent does, and it spells the per-task write authority
+# ``tasks:claim`` rather than ``tasks:write``: claiming, progressing,
+# completing, failing and blocking a task, plus decomposing it into subtasks,
+# are the writes the spawner issues that grant for.  The two names denote the
+# same authority, so the equivalence is recorded here instead of widening the
+# issued grant, which other subsystems read for their own decisions.
+#
+# Nothing else in either vocabulary overlaps: an agent that must reach the
+# ``/agents``, ``/cluster``, ``/bulletin``, ``/auth``, ``/webhooks`` or
+# operator surfaces has to hold that surface's permission outright.
+_AGENT_PERMISSION_EQUIVALENTS: Final[dict[str, frozenset[str]]] = {
+    _PERM_TASKS_WRITE: frozenset({_PERM_TASKS_CLAIM}),
+}
 
 type _ExpectedResourceConfig = str | Sequence[str] | None
 
@@ -571,6 +606,33 @@ def _get_required_permission(path: str, method: str) -> str | None:
     return _PERM_ADMIN_MANAGE
 
 
+def _agent_holds_permission(agent_identity: Any, permission: str) -> bool:
+    """Return True when an agent identity holds *permission* for a route.
+
+    Applies the identity's own signed permission set first.  The set is
+    pinned to the presented token - ``AgentIdentityStore.authenticate``
+    refuses a JWT whose ``scopes`` claim differs from the stored grant - so
+    it is authenticated state rather than request input.
+
+    When the route names a permission the agent vocabulary spells
+    differently, the grants listed for it in
+    :data:`_AGENT_PERMISSION_EQUIVALENTS` satisfy it too.  Anything else is
+    refused: an agent that does not hold the permission does not get the
+    route.
+
+    Args:
+        agent_identity: The authenticated ``AgentIdentity``.
+        permission: Permission the route requires, from
+            :func:`_get_required_permission`.
+
+    Returns:
+        True when the identity is authorised for the route.
+    """
+    if agent_identity.has_permission(permission):
+        return True
+    return any(agent_identity.has_permission(grant) for grant in _AGENT_PERMISSION_EQUIVALENTS.get(permission, ()))
+
+
 class SSOAuthMiddleware(BaseHTTPMiddleware):
     """Multi-strategy authentication middleware.
 
@@ -920,11 +982,13 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         credential = getattr(agent_identity, "credential", None)
         bind_request_tenant(request, getattr(credential, "tenant_id", None))
 
+        required_permission = _get_required_permission(path, request.method)
+
         # Agent identity JWTs - even manager-role / unrestricted ones - must
         # never reach operator-only endpoints (shutdown, broadcast, drain,
         # config writer).  These mutate process-wide state and require an
         # admin SSO user or the legacy operator bearer.
-        if request.method not in _READ_METHODS and _get_required_permission(path, request.method) == _PERM_ADMIN_MANAGE:
+        if request.method not in _READ_METHODS and required_permission == _PERM_ADMIN_MANAGE:
             logger.warning(
                 "Agent %s denied operator-only path %s (admin:manage required)",
                 sanitize_log(agent_identity.id),
@@ -935,6 +999,31 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
                 content={
                     "detail": "Agent tokens cannot access operator-only endpoints",
                     "required_permission": _PERM_ADMIN_MANAGE,
+                    "agent_id": agent_identity.id,
+                },
+            )
+
+        # Every other route is gated on the permission it declares, the same
+        # way the SSO principal is gated in ``_try_sso_auth``.  Without this
+        # an agent credential authenticated and then went straight to the
+        # handler, so the only thing a route's declared permission bounded
+        # was an SSO user: a task-scoped worker token reached the agent
+        # log/stream reads and the session-kill route while holding neither
+        # ``agents:read`` nor ``agents:kill``.  Reads are gated too - the
+        # permission a read route declares is what keeps one agent's output
+        # out of another agent's reach.
+        if required_permission and not _agent_holds_permission(agent_identity, required_permission):
+            logger.warning(
+                "Agent %s denied %s (%s required)",
+                sanitize_log(agent_identity.id),
+                sanitize_log(path),
+                sanitize_log(required_permission),
+            )
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "detail": f"Insufficient permissions. Required: {required_permission}",
+                    "required_permission": required_permission,
                     "agent_id": agent_identity.id,
                 },
             )

--- a/tests/unit/test_auth_middleware_agent_route_permissions.py
+++ b/tests/unit/test_auth_middleware_agent_route_permissions.py
@@ -48,6 +48,11 @@ _OPERATOR_TOKEN = "operator-token-for-route-permission-tests"
 # not about which session id the caller names.
 _VICTIM_SESSION = "backend-victim01"
 
+# Content of the bulletin message the refused writes try to append.  Read
+# back off the board to prove the refusal stopped the write, not just the
+# response.
+_BULLETIN_PROBE = "probe-that-must-not-be-published"
+
 
 @pytest.fixture
 def app(tmp_path: Path) -> FastAPI:
@@ -233,18 +238,42 @@ def test_cluster_rebalance_is_refused_without_cluster_write(app: FastAPI) -> Non
 
 
 def test_bulletin_post_is_refused_without_bulletin_write(app: FastAPI) -> None:
-    """A worker grant carries no bulletin permission, so the write is refused."""
+    """A worker grant carries no bulletin permission, so the write is refused.
+
+    The body is a valid :class:`BulletinPostRequest`, and the board is read
+    back afterwards: a request the schema rejects would 422 before the
+    handler either way, which would make this pass for a reason that has
+    nothing to do with authorisation, and a refusal that still appended the
+    message would have published it regardless of the status code.
+    """
     own_id = _create_task(app, 13, "own-bulletin")
     headers = _agent_headers(app, "session-bulletin", [own_id])
 
     response = _client(app, 14).post(
         "/bulletin",
         headers=headers,
-        json={"author": "session-bulletin", "message": "probe"},
+        json={"agent_id": "session-bulletin", "type": "status", "content": _BULLETIN_PROBE},
     )
 
     assert response.status_code == 403, response.text
     assert response.json()["required_permission"] == "bulletin:write"
+
+    board = _client(app, 24).get("/bulletin", headers=_operator_headers())
+    assert board.status_code == 200, board.text
+    assert all(message["content"] != _BULLETIN_PROBE for message in board.json())
+
+
+def test_bulletin_post_body_matches_the_route_schema() -> None:
+    """The refusal above is pinned to the real schema, not to a 422.
+
+    ``BulletinPostRequest`` is the model the route validates against.  If the
+    probe body drifts from it, the test above stops exercising the permission
+    gate and starts exercising body validation.
+    """
+    from bernstein.core.server.server_models import BulletinPostRequest
+
+    assert set(BulletinPostRequest.model_fields) == {"agent_id", "type", "content", "cell_id"}
+    BulletinPostRequest(agent_id="session-bulletin", type="status", content=_BULLETIN_PROBE)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_auth_middleware_agent_route_permissions.py
+++ b/tests/unit/test_auth_middleware_agent_route_permissions.py
@@ -1,0 +1,331 @@
+"""Route-permission enforcement for agent identity tokens.
+
+The middleware gates every credential on the permission the requested route
+declares (``_get_required_permission``).  The SSO principal has always been
+checked against that permission; an agent identity authenticated and then
+went straight to the handler, so the only bound the declared permission
+placed was on SSO users.
+
+The gap was not a missing entry in a denylist - it was the check itself.  A
+task-scoped worker token read another session's agent log and stream and
+requested that session's termination while holding neither ``agents:read``
+nor ``agents:kill``, and the same held for every other surface an agent
+grant does not cover (``/cluster``, ``/bulletin``, ...).
+
+These tests run against the real application and the real routes, because
+the property is about what an authenticated read actually returns: a stub
+handler would prove only that a stub was not called.  Each route class is
+pinned twice - refused for an identity that does not hold the permission,
+served for one that does - so the gate is shown to key on the held
+permission rather than on the path.
+"""
+
+# pyright: reportPrivateUsage=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bernstein.core.agents.agent_identity import permissions_for_role
+from bernstein.core.security.auth_middleware import _get_required_permission
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from fastapi import FastAPI
+
+# These tests exercise the secure-by-default middleware, so opt out of the
+# autouse fixture that sets ``BERNSTEIN_AUTH_DISABLED`` for the suite.
+pytestmark = pytest.mark.auth_enabled
+
+_OPERATOR_TOKEN = "operator-token-for-route-permission-tests"
+
+# The session an agent token tries to read, stream, or kill.  It is never the
+# caller's own session, which is the point: the gate is about the permission,
+# not about which session id the caller names.
+_VICTIM_SESSION = "backend-victim01"
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> FastAPI:
+    """The real application, with an operator bearer token for fixture setup."""
+    from bernstein.core.server import create_app
+
+    return create_app(
+        jsonl_path=tmp_path / ".sdd" / "runtime" / "tasks.jsonl",
+        auth_token=_OPERATOR_TOKEN,
+        plan_mode=True,
+    )
+
+
+def _client(application: FastAPI, index: int) -> TestClient:
+    """A client with a distinct peer address so the write rate limiter allows it."""
+    return TestClient(application, client=(f"10.40.{index // 256}.{index % 256}", 43000 + index))
+
+
+def _operator_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_OPERATOR_TOKEN}"}
+
+
+def _agent_headers(
+    application: FastAPI,
+    session: str,
+    task_ids: list[str],
+    *,
+    role: str = "backend",
+    extra_permissions: frozenset[str] | None = None,
+) -> dict[str, str]:
+    """Mint an agent identity token scoped to *task_ids*."""
+    identity_store: Any = application.state.identity_store
+    _, token = identity_store.create_identity(
+        session,
+        role,
+        task_ids=task_ids,
+        extra_permissions=extra_permissions,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_task(application: FastAPI, index: int, title: str) -> str:
+    """Create a task with the operator credential and return its id."""
+    response = _client(application, index).post(
+        "/tasks",
+        headers=_operator_headers(),
+        json={"title": title, "description": title, "role": "backend"},
+    )
+    assert response.status_code == 201, response.text
+    return str(response.json()["id"])
+
+
+# ---------------------------------------------------------------------------
+# The grant a worker agent actually carries
+# ---------------------------------------------------------------------------
+
+
+def test_worker_role_grant_covers_neither_agents_read_nor_agents_kill() -> None:
+    """The premise of every refusal below: a worker grant omits both.
+
+    Without this the refusals could pass for a reason unrelated to the
+    permission - a role that happened to hold ``agents:read`` would make the
+    ``/agents`` assertions vacuous the day the grant changed.
+    """
+    backend = permissions_for_role("backend")
+
+    assert "agents:read" not in backend
+    assert "agents:kill" not in backend
+    assert "cluster:write" not in backend
+    assert "bulletin:write" not in backend
+
+
+def test_agent_log_and_kill_routes_declare_the_permissions_they_are_checked_against() -> None:
+    """The route map names ``agents:read`` for the reads and ``agents:kill`` for the kill."""
+    assert _get_required_permission(f"/agents/{_VICTIM_SESSION}/logs", "GET") == "agents:read"
+    assert _get_required_permission(f"/agents/{_VICTIM_SESSION}/stream", "GET") == "agents:read"
+    assert _get_required_permission(f"/agents/{_VICTIM_SESSION}/kill", "POST") == "agents:kill"
+
+
+# ---------------------------------------------------------------------------
+# Route class: agent log / stream reads (``agents:read``)
+# ---------------------------------------------------------------------------
+
+
+def test_agent_log_read_is_refused_without_agents_read(app: FastAPI) -> None:
+    """A worker token cannot read another session's agent log."""
+    own_id = _create_task(app, 1, "own-log-read")
+    headers = _agent_headers(app, "session-log-read", [own_id])
+
+    response = _client(app, 2).get(f"/agents/{_VICTIM_SESSION}/logs", headers=headers)
+
+    assert response.status_code == 403, response.text
+    body = response.json()
+    assert body["required_permission"] == "agents:read"
+    # The refusal replaces the payload rather than accompanying it.
+    assert "content" not in body
+
+
+def test_agent_stream_read_is_refused_without_agents_read(app: FastAPI) -> None:
+    """The SSE stream of another session's output is refused on the same grant."""
+    own_id = _create_task(app, 3, "own-stream-read")
+    headers = _agent_headers(app, "session-stream-read", [own_id])
+
+    response = _client(app, 4).get(f"/agents/{_VICTIM_SESSION}/stream", headers=headers)
+
+    assert response.status_code == 403, response.text
+    assert response.json()["required_permission"] == "agents:read"
+
+
+def test_agent_log_read_is_served_when_agents_read_is_held(app: FastAPI) -> None:
+    """Holding the declared permission reaches the handler.
+
+    Pins that the refusals above come from the permission check and not from
+    a blanket ban on ``/agents`` for agent credentials.
+    """
+    own_id = _create_task(app, 5, "own-log-granted")
+    headers = _agent_headers(
+        app,
+        "session-log-granted",
+        [own_id],
+        extra_permissions=frozenset({"agents:read"}),
+    )
+
+    response = _client(app, 6).get(f"/agents/{_VICTIM_SESSION}/logs", headers=headers)
+
+    # 404 is the handler answering for a session with no log file on disk -
+    # the request reached it, which is what this pins.
+    assert response.status_code in {200, 404}, response.text
+
+
+# ---------------------------------------------------------------------------
+# Route class: session kill (``agents:kill``)
+# ---------------------------------------------------------------------------
+
+
+def test_session_kill_is_refused_without_agents_kill(app: FastAPI, tmp_path: Path) -> None:
+    """A worker token cannot request termination of another session.
+
+    Asserts the side effect as well as the status: the route's whole
+    behaviour is writing a ``.kill`` signal file the orchestrator polls, so
+    a refusal that still wrote the file would terminate the session anyway.
+    """
+    own_id = _create_task(app, 7, "own-kill")
+    headers = _agent_headers(app, "session-kill", [own_id])
+    runtime_dir = tmp_path / ".sdd" / "runtime"
+
+    response = _client(app, 8).post(f"/agents/{_VICTIM_SESSION}/kill", headers=headers)
+
+    assert response.status_code == 403, response.text
+    assert response.json()["required_permission"] == "agents:kill"
+    assert not (runtime_dir / f"{_VICTIM_SESSION}.kill").exists()
+
+
+def test_session_kill_is_accepted_when_agents_kill_is_held(app: FastAPI) -> None:
+    """An identity granted ``agents:kill`` still reaches the kill route."""
+    own_id = _create_task(app, 9, "own-kill-granted")
+    headers = _agent_headers(
+        app,
+        "session-kill-granted",
+        [own_id],
+        extra_permissions=frozenset({"agents:kill"}),
+    )
+
+    response = _client(app, 10).post(f"/agents/{_VICTIM_SESSION}/kill", headers=headers)
+
+    assert response.status_code == 200, response.text
+
+
+# ---------------------------------------------------------------------------
+# Route class: other surfaces an agent grant does not cover
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_rebalance_is_refused_without_cluster_write(app: FastAPI) -> None:
+    """Cluster redistribution belongs to the cluster credential, not a worker token."""
+    own_id = _create_task(app, 11, "own-cluster")
+    headers = _agent_headers(app, "session-cluster", [own_id])
+
+    response = _client(app, 12).post("/cluster/steal", headers=headers, json={"queue_depths": {}})
+
+    assert response.status_code == 403, response.text
+    assert response.json()["required_permission"] == "cluster:write"
+
+
+def test_bulletin_post_is_refused_without_bulletin_write(app: FastAPI) -> None:
+    """A worker grant carries no bulletin permission, so the write is refused."""
+    own_id = _create_task(app, 13, "own-bulletin")
+    headers = _agent_headers(app, "session-bulletin", [own_id])
+
+    response = _client(app, 14).post(
+        "/bulletin",
+        headers=headers,
+        json={"author": "session-bulletin", "message": "probe"},
+    )
+
+    assert response.status_code == 403, response.text
+    assert response.json()["required_permission"] == "bulletin:write"
+
+
+# ---------------------------------------------------------------------------
+# Routes a worker agent must keep reaching
+# ---------------------------------------------------------------------------
+
+
+def test_task_scoped_agent_still_completes_its_own_task(app: FastAPI) -> None:
+    """``tasks:claim`` is the worker grant for the write ``/complete`` performs.
+
+    The route declares ``tasks:write``; the spawner issues ``tasks:claim``
+    for the same authority, and the task-scope gate keeps it bound to the
+    agent's own tasks.  A gate that read the two names as different
+    permissions would lock every worker out of finishing its work.
+    """
+    own_id = _create_task(app, 15, "own-complete")
+    headers = _agent_headers(app, "session-complete", [own_id])
+    claimed = _client(app, 16).post(f"/tasks/{own_id}/claim", headers=headers)
+    assert claimed.status_code == 200, claimed.text
+
+    response = _client(app, 17).post(f"/tasks/{own_id}/complete", headers=headers, json={"result_summary": "done"})
+
+    assert response.status_code == 200, response.text
+
+
+def test_task_scoped_agent_still_creates_subtasks(app: FastAPI) -> None:
+    """``POST /tasks`` is in the agent contract and stays reachable."""
+    own_id = _create_task(app, 18, "own-subtask-parent")
+    headers = _agent_headers(app, "session-subtask", [own_id])
+
+    response = _client(app, 19).post(
+        "/tasks",
+        headers=headers,
+        json={"title": "subtask", "description": "subtask", "role": "backend"},
+    )
+
+    assert response.status_code == 201, response.text
+
+
+def test_status_read_stays_reachable_for_a_worker_token(app: FastAPI) -> None:
+    """``status:read`` is in every agent role grant, so ``/status`` is unaffected."""
+    own_id = _create_task(app, 20, "own-status")
+    headers = _agent_headers(app, "session-status", [own_id])
+
+    response = _client(app, 21).get("/status", headers=headers)
+
+    assert response.status_code == 200, response.text
+
+
+def test_operator_only_route_keeps_its_operator_specific_refusal(app: FastAPI) -> None:
+    """The pre-existing ``admin:manage`` refusal is not replaced by the general one.
+
+    Both gates would refuse ``/shutdown``; the operator-only message is the
+    more specific one and has to keep winning.
+    """
+    own_id = _create_task(app, 22, "own-shutdown")
+    headers = _agent_headers(app, "session-shutdown", [own_id])
+
+    response = _client(app, 23).post("/shutdown", headers=headers)
+
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Agent tokens cannot access operator-only endpoints"
+
+
+# ---------------------------------------------------------------------------
+# The equivalence itself
+# ---------------------------------------------------------------------------
+
+
+def test_task_write_equivalence_does_not_leak_into_unrelated_permissions() -> None:
+    """``tasks:claim`` stands in for ``tasks:write`` and for nothing else."""
+    from types import SimpleNamespace
+
+    from bernstein.core.security.auth_middleware import _agent_holds_permission
+
+    held = {"tasks:claim", "tasks:read", "status:read"}
+    identity = SimpleNamespace(has_permission=lambda perm: perm in held)
+
+    assert _agent_holds_permission(identity, "tasks:write")
+    assert _agent_holds_permission(identity, "tasks:read")
+    assert not _agent_holds_permission(identity, "agents:read")
+    assert not _agent_holds_permission(identity, "agents:kill")
+    assert not _agent_holds_permission(identity, "cluster:write")
+    assert not _agent_holds_permission(identity, "admin:manage")

--- a/tests/unit/test_auth_middleware_cluster_secret_route_permissions.py
+++ b/tests/unit/test_auth_middleware_cluster_secret_route_permissions.py
@@ -1,0 +1,434 @@
+"""Route-permission enforcement for the cluster shared secret.
+
+The cluster secret is a worker credential: one string handed to every node
+in the fleet so that a single token clears both the outer middleware and the
+inner cluster route layer (#2805).  It authenticated and then went straight
+to ``call_next``, bounded only by the operator-only (``admin:manage``)
+refusal on writes, so the permission a route declares constrained every
+credential kind except this one - the broadest one.
+
+The fleet secret now carries a fixed authority
+(``_CLUSTER_SECRET_PERMISSIONS``): what joining and working a cluster needs,
+and nothing a worker never does.  Each surface is pinned twice - refused for
+a permission outside the set, served for one inside it - so the gate is
+shown to key on the declared permission rather than on the path or on the
+credential kind.
+
+The inner layer is covered here too: ``POST /cluster/steal`` was the one
+mutating ``/cluster/*`` route with no ``_verify_cluster_auth`` call, so the
+outer check was its only gate while the surrounding routes had two.
+"""
+
+# pyright: reportPrivateUsage=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from bernstein.core.models import ClusterConfig
+from fastapi.testclient import TestClient
+
+from bernstein.core.security.auth_middleware import (
+    _CLUSTER_SECRET_PERMISSIONS,
+    _get_required_permission,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from fastapi import FastAPI
+
+# These tests exercise the secure-by-default middleware, so opt out of the
+# autouse fixture that sets ``BERNSTEIN_AUTH_DISABLED`` for the suite.
+pytestmark = pytest.mark.auth_enabled
+
+_OPERATOR_TOKEN = "operator-token-for-cluster-secret-tests"  # NOSONAR - test fixture
+_CLUSTER_SECRET = "cluster-shared-secret-for-route-permission-tests"  # NOSONAR - test fixture
+
+# The session the fleet credential tries to read, stream, or kill.  No worker
+# reaches another session's agent over HTTP; that is what makes this the
+# surface a fleet-wide string must not carry.
+_VICTIM_SESSION = "backend-victim02"
+
+# Content of the bulletin message the refused write tries to append, read
+# back off the board to prove the refusal stopped the write.
+_BULLETIN_PROBE = "cluster-probe-that-must-not-be-published"
+
+_NODE_PAYLOAD: dict[str, Any] = {
+    "name": "worker-perm-1",
+    "url": "",
+    "capacity": {
+        "max_agents": 4,
+        "available_slots": 4,
+        "active_agents": 0,
+        "gpu_available": False,
+        "supported_models": ["sonnet"],
+    },
+    "labels": {},
+    "cell_ids": [],
+}
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> FastAPI:
+    """The real application with cluster mode on and both credentials wired."""
+    from bernstein.core.server import create_app
+
+    return create_app(
+        jsonl_path=tmp_path / ".sdd" / "runtime" / "tasks.jsonl",
+        auth_token=_OPERATOR_TOKEN,
+        cluster_config=ClusterConfig(enabled=True, auth_token=_CLUSTER_SECRET),
+        plan_mode=True,
+    )
+
+
+def _client(application: FastAPI, index: int) -> TestClient:
+    """A client with a distinct peer address so the write rate limiter allows it."""
+    return TestClient(application, client=(f"10.41.{index // 256}.{index % 256}", 44000 + index))
+
+
+def _cluster_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_CLUSTER_SECRET}"}
+
+
+def _operator_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_OPERATOR_TOKEN}"}
+
+
+def _create_task(application: FastAPI, index: int, title: str) -> str:
+    """Create a task with the operator credential and return its id."""
+    response = _client(application, index).post(
+        "/tasks",
+        headers=_operator_headers(),
+        json={"title": title, "description": title, "role": "backend"},
+    )
+    assert response.status_code == 201, response.text
+    return str(response.json()["id"])
+
+
+# ---------------------------------------------------------------------------
+# The authority the fleet credential carries
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_secret_authority_covers_cluster_and_task_work_only() -> None:
+    """The premise of every refusal below, stated as the set itself.
+
+    Without this the refusals could pass for a reason unrelated to the
+    permission, and a later widening of the set would go unnoticed because
+    every refusal would simply stop being reached.
+    """
+    expected = {
+        "cluster:write",  # register, heartbeat, cordon, drain, unregister, gossip, rebalance
+        "cluster:read",  # the node registry a worker reads back
+        "tasks:write",  # complete / fail / release the work it pulled
+        "tasks:read",  # pull the next task for a role
+        "status:read",  # the read floor every credential holds
+    }
+
+    assert set(_CLUSTER_SECRET_PERMISSIONS) == expected
+
+
+def test_cluster_secret_authority_excludes_the_agent_and_operator_surfaces() -> None:
+    """Named individually, because each one is a route class refused below."""
+    for permission in (
+        "agents:read",
+        "agents:kill",
+        "agents:write",
+        "bulletin:write",
+        "bulletin:read",
+        "auth:manage",
+        "webhooks:manage",
+        "admin:read",
+        "admin:manage",
+    ):
+        assert permission not in _CLUSTER_SECRET_PERMISSIONS, permission
+
+
+def test_routes_refused_below_declare_the_permissions_they_are_checked_against() -> None:
+    """The route map names the permissions the assertions below quote."""
+    assert _get_required_permission(f"/agents/{_VICTIM_SESSION}/logs", "GET") == "agents:read"
+    assert _get_required_permission(f"/agents/{_VICTIM_SESSION}/stream", "GET") == "agents:read"
+    assert _get_required_permission(f"/agents/{_VICTIM_SESSION}/kill", "POST") == "agents:kill"
+    assert _get_required_permission("/bulletin", "POST") == "bulletin:write"
+    assert _get_required_permission("/bulletin", "GET") == "bulletin:read"
+
+
+# ---------------------------------------------------------------------------
+# Route class: agent session control (``agents:kill``)
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_secret_cannot_kill_an_agent_session_without_agents_kill(app: FastAPI, tmp_path: Path) -> None:
+    """The fleet credential cannot request termination of an agent session.
+
+    Asserts the side effect as well as the status: the route's whole
+    behaviour is writing a ``.kill`` signal file the orchestrator polls, so a
+    refusal that still wrote the file would terminate the session anyway.
+    """
+    runtime_dir = tmp_path / ".sdd" / "runtime"
+
+    response = _client(app, 1).post(f"/agents/{_VICTIM_SESSION}/kill", headers=_cluster_headers())
+
+    assert response.status_code == 403, response.text
+    assert response.json()["required_permission"] == "agents:kill"
+    assert not (runtime_dir / f"{_VICTIM_SESSION}.kill").exists()
+
+
+# ---------------------------------------------------------------------------
+# Route class: agent log / stream reads (``agents:read``)
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_secret_cannot_read_an_agent_log_without_agents_read(app: FastAPI) -> None:
+    """A worker drives its own agents locally; the HTTP log surface is not its own."""
+    response = _client(app, 2).get(f"/agents/{_VICTIM_SESSION}/logs", headers=_cluster_headers())
+
+    assert response.status_code == 403, response.text
+    body = response.json()
+    assert body["required_permission"] == "agents:read"
+    # The refusal replaces the payload rather than accompanying it.
+    assert "content" not in body
+
+
+def test_cluster_secret_cannot_stream_an_agent_session_without_agents_read(app: FastAPI) -> None:
+    """The SSE stream of a session's output is refused on the same authority."""
+    response = _client(app, 3).get(f"/agents/{_VICTIM_SESSION}/stream", headers=_cluster_headers())
+
+    assert response.status_code == 403, response.text
+    assert response.json()["required_permission"] == "agents:read"
+
+
+# ---------------------------------------------------------------------------
+# Route class: bulletin write (``bulletin:write``)
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_secret_cannot_post_to_the_bulletin_without_bulletin_write(app: FastAPI) -> None:
+    """A fleet credential cannot publish to the board agents coordinate on.
+
+    The body is a valid ``BulletinPostRequest`` and the board is read back
+    afterwards, so this fails on the authorisation and not on schema
+    validation, and a refusal that still appended would be caught.
+    """
+    response = _client(app, 4).post(
+        "/bulletin",
+        headers=_cluster_headers(),
+        json={"agent_id": "worker-perm-1", "type": "status", "content": _BULLETIN_PROBE},
+    )
+
+    assert response.status_code == 403, response.text
+    assert response.json()["required_permission"] == "bulletin:write"
+
+    board = _client(app, 5).get("/bulletin", headers=_operator_headers())
+    assert board.status_code == 200, board.text
+    assert all(message["content"] != _BULLETIN_PROBE for message in board.json())
+
+
+# ---------------------------------------------------------------------------
+# Route class: operator surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_secret_cannot_read_the_bulletin_without_bulletin_read(app: FastAPI) -> None:
+    """Reads are gated too, on a route that really returns the data.
+
+    The pre-existing operator-only refusal ran on non-read methods only, so a
+    read of a surface the fleet credential holds nothing for was a gap that
+    check could not close by construction. The board carries what every agent
+    posts, so a fleet-wide string reading it is the whole coordination
+    history, not an empty 404.
+    """
+    posted = _client(app, 6).post(
+        "/bulletin",
+        headers=_operator_headers(),
+        json={"agent_id": "operator", "type": "status", "content": _BULLETIN_PROBE},
+    )
+    assert posted.status_code == 201, posted.text
+
+    response = _client(app, 17).get("/bulletin", headers=_cluster_headers())
+
+    assert response.status_code == 403, response.text
+    assert response.json()["required_permission"] == "bulletin:read"
+    assert _BULLETIN_PROBE not in response.text
+
+
+def test_cluster_secret_keeps_its_operator_specific_refusal(app: FastAPI) -> None:
+    """The pre-existing ``admin:manage`` message is not replaced by the general one.
+
+    Both gates would refuse ``/shutdown``; the operator-only message is the
+    more specific one and has to keep winning.
+    """
+    response = _client(app, 7).post("/shutdown", headers=_cluster_headers(), json={})
+
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "Cluster credential cannot access operator-only endpoints"
+
+
+# ---------------------------------------------------------------------------
+# What a worker must keep reaching
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_secret_still_registers_and_heartbeats_a_node(app: FastAPI) -> None:
+    """Node join is the credential's reason to exist and stays reachable.
+
+    Also the positive control for the refusals above: the gate keys on the
+    permission a route declares, not on the credential kind.
+    """
+    registered = _client(app, 8).post("/cluster/nodes", headers=_cluster_headers(), json=_NODE_PAYLOAD)
+    assert registered.status_code == 201, registered.text
+    node_id = registered.json()["id"]
+
+    heartbeat = _client(app, 9).post(
+        f"/cluster/nodes/{node_id}/heartbeat",
+        headers=_cluster_headers(),
+        json={"capacity": None},
+    )
+    assert heartbeat.status_code == 200, heartbeat.text
+
+
+def test_cluster_secret_still_reads_the_node_registry(app: FastAPI) -> None:
+    """``cluster:read`` is in the set, so the fleet view stays readable."""
+    response = _client(app, 10).get("/cluster/status", headers=_cluster_headers())
+
+    assert response.status_code == 200, response.text
+
+
+def test_cluster_secret_still_claims_and_completes_a_task(app: FastAPI) -> None:
+    """Pulling work and reporting it done is what a worker node does.
+
+    A gate that refused ``tasks:write`` for this credential would leave every
+    worker able to join a cluster and unable to finish anything in it.
+    """
+    task_id = _create_task(app, 11, "cluster-secret-completes")
+
+    claimed = _client(app, 12).post(f"/tasks/{task_id}/claim", headers=_cluster_headers())
+    assert claimed.status_code == 200, claimed.text
+
+    completed = _client(app, 13).post(
+        f"/tasks/{task_id}/complete",
+        headers=_cluster_headers(),
+        json={"result_summary": "done"},
+    )
+    assert completed.status_code == 200, completed.text
+
+
+def test_cluster_secret_still_pulls_the_next_task_for_a_role(app: FastAPI) -> None:
+    """``tasks:read`` covers the claim-next pull the worker loop polls."""
+    _create_task(app, 14, "cluster-secret-pulls")
+
+    response = _client(app, 15).get("/tasks/next/backend", headers=_cluster_headers())
+
+    assert response.status_code not in {401, 403}, response.text
+
+
+def test_cluster_secret_still_reads_status(app: FastAPI) -> None:
+    """``status:read`` is the read floor every credential keeps."""
+    response = _client(app, 16).get("/status", headers=_cluster_headers())
+
+    assert response.status_code == 200, response.text
+
+
+# ---------------------------------------------------------------------------
+# The inner cluster layer on POST /cluster/steal
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def inner_layer_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    """Cluster auth on, outer bearer auth off, to reach the inner layer alone.
+
+    The outer middleware refuses a node JWT outright - it is neither the raw
+    secret nor any other credential it knows - so with both layers on, a
+    scope refusal from the inner layer could never be observed.
+    """
+    from bernstein.core.server import create_app
+
+    monkeypatch.setenv("BERNSTEIN_AUTH_DISABLED", "1")
+    return create_app(
+        jsonl_path=tmp_path / ".sdd" / "runtime" / "tasks.jsonl",
+        cluster_config=ClusterConfig(enabled=True, auth_token=_CLUSTER_SECRET),
+        plan_mode=True,
+    )
+
+
+def test_cluster_steal_refuses_an_unauthenticated_request_like_its_sibling_routes(
+    inner_layer_app: FastAPI,
+) -> None:
+    """``POST /cluster/steal`` had no inner check while every sibling had one.
+
+    Register, heartbeat, cordon, uncordon, drain, unregister and gossip all
+    call ``_verify_cluster_auth``; steal did not, so on a cluster-auth
+    deployment it was the one mutating cluster route reachable with no
+    cluster credential at all.
+    """
+    response = TestClient(inner_layer_app).post("/cluster/steal", json={"queue_depths": {}})
+
+    assert response.status_code == 401, response.text
+
+
+def test_cluster_steal_refuses_a_node_token_without_the_node_admin_scope(
+    inner_layer_app: FastAPI,
+) -> None:
+    """Steal is a node-registry mutation, scoped like cordon / drain / unregister.
+
+    An issued node token carries register + heartbeat, which is enough to
+    join and stay in the fleet and deliberately not enough to reassign other
+    nodes' claimed work.
+    """
+    from bernstein.core.cluster_auth import SCOPE_NODE_HEARTBEAT
+
+    authenticator: Any = inner_layer_app.state.cluster_authenticator
+    token = authenticator.issue_node_token("worker-perm-2", scopes=[SCOPE_NODE_HEARTBEAT])
+
+    response = TestClient(inner_layer_app).post(
+        "/cluster/steal",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"queue_depths": {}},
+    )
+
+    assert response.status_code == 401, response.text
+
+
+def test_cluster_steal_is_served_for_a_credential_holding_the_node_admin_scope(
+    inner_layer_app: FastAPI,
+) -> None:
+    """The positive control: the shared secret carries the full node scope set."""
+    response = TestClient(inner_layer_app).post(
+        "/cluster/steal",
+        headers={"Authorization": f"Bearer {_CLUSTER_SECRET}"},
+        json={"queue_depths": {}},
+    )
+
+    assert response.status_code == 200, response.text
+
+
+def test_every_mutating_cluster_route_verifies_cluster_auth() -> None:
+    """The property the steal fix restores, read off the router itself.
+
+    Enumerating the registered routes rather than a hand-kept list is the
+    point: a mutating ``/cluster/*`` route added later and missing the inner
+    check fails here, instead of shipping with the outer gate as its only
+    layer the way steal did.
+    """
+    import inspect
+
+    from starlette.routing import Route
+
+    from bernstein.core.routes import task_cluster
+
+    read_methods = {"GET", "HEAD", "OPTIONS"}
+    checked: list[str] = []
+    for route in task_cluster.router.routes:
+        assert isinstance(route, Route)
+        if not route.path.startswith("/cluster") or not (set(route.methods or ()) - read_methods):
+            continue
+        source = inspect.getsource(route.endpoint)
+        assert "_verify_cluster_auth(request," in source, route.path
+        checked.append(route.path)
+
+    # The enumeration itself has to be non-vacuous.
+    assert "/cluster/steal" in checked
+    assert len(checked) >= 8

--- a/tests/unit/test_auth_middleware_task_scope_indirect.py
+++ b/tests/unit/test_auth_middleware_task_scope_indirect.py
@@ -114,14 +114,16 @@ def _task(application: FastAPI, task_id: str) -> Any:
 
 
 def _grant_non_admin_permission(monkeypatch: pytest.MonkeyPatch, prefix: str) -> None:
-    """Stop *prefix* falling through to the fail-closed ``admin:manage``.
+    """Give *prefix* a permission the agent under test holds.
 
-    Agent tokens are refused outright on any write whose required permission
-    is ``admin:manage``, which would answer 403 whatever the task scope says.
-    Giving the prefix ``tasks:write`` for the duration of a test isolates the
-    task-scope rule, and states the invariant the rule has to hold under: the
-    scoping must not depend on which prefixes are absent from
-    ``_ROUTE_PERMISSIONS``.
+    An agent token is refused outright on any route whose required
+    permission it does not hold - ``admin:manage`` for a prefix missing from
+    ``_ROUTE_PERMISSIONS``, ``cluster:write`` for ``/cluster``, and so on -
+    which would answer 403 whatever the task scope says.  Giving the prefix
+    ``tasks:write`` for the duration of a test isolates the task-scope rule
+    from the permission gate, and states the invariant the rule has to hold
+    under: the scoping must not depend on which permission a prefix carries
+    in ``_ROUTE_PERMISSIONS``.
     """
     from bernstein.core.security import auth_middleware
 
@@ -410,7 +412,7 @@ def _register_node(application: FastAPI, index: int, name: str, slots: int) -> s
     return str(response.json()["id"])
 
 
-def test_cluster_steal_denies_an_out_of_scope_task(app: FastAPI) -> None:
+def test_cluster_steal_denies_an_out_of_scope_task(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
     """Steal reassigns tasks the caller never named; the ids are still bound.
 
     ``POST /cluster/steal`` reaches ``force_claim`` on tasks the policy picks,
@@ -418,6 +420,7 @@ def test_cluster_steal_denies_an_out_of_scope_task(app: FastAPI) -> None:
     path gate.  The check runs on the ids the policy resolved, so a
     task-scoped token cannot reset a task it does not hold.
     """
+    _grant_non_admin_permission(monkeypatch, "/cluster")
     victim_id = _create_task(app, 28, "victim-steal")
     own_id = _create_task(app, 29, "own-steal")
     claimed = _client(app, 30).post(f"/tasks/{victim_id}/claim", headers=_operator_headers())
@@ -441,8 +444,9 @@ def test_cluster_steal_denies_an_out_of_scope_task(app: FastAPI) -> None:
     assert after.version == before.version
 
 
-def test_cluster_steal_is_unrestricted_for_an_unscoped_token(app: FastAPI) -> None:
+def test_cluster_steal_is_unrestricted_for_an_unscoped_token(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
     """A manager token (``task_ids == []``) redistributes as before."""
+    _grant_non_admin_permission(monkeypatch, "/cluster")
     victim_id = _create_task(app, 34, "manager-steal")
     claimed = _client(app, 35).post(f"/tasks/{victim_id}/claim", headers=_operator_headers())
     assert claimed.status_code == 200, claimed.text


### PR DESCRIPTION
## Root cause

`_get_required_permission(path, method)` names the authority every route needs, but only `_try_sso_auth` ever checked a credential against it. The other two credential kinds authenticated and went straight to `call_next`, so the route map bounded the SSO principal alone:

| Credential | What actually bounded it | Reached anyway |
| --- | --- | --- |
| Agent identity token | operator-only (`admin:manage`) refusal on writes, `task_ids` scope on writes | agent log/stream reads, `POST /agents/{id}/kill`, `/cluster`, `/bulletin` — holding neither `agents:read` nor `agents:kill` |
| Cluster worker secret | operator-only refusal on writes, nothing else | the same set, on a credential that is one string shared by the whole worker fleet |

Both are the same defect, one credential type apart: the check itself was missing, not an entry in a denylist. The operator-only refusal could not close it by construction — it runs on non-read methods only, so every read of an unheld surface was outside it.

## Change

Resolve the route's permission once after each credential authenticates and refuse with 403 when it is not held, so every credential kind clears the same gate. The existing operator-only refusals keep their more specific messages and still run first.

**Agent identities** are checked against the signed permission set their token pins. Agent grants (`AGENT_ROLE_PERMISSIONS`) use a narrower vocabulary than the route map and spell the per-task write authority `tasks:claim` where the route map says `tasks:write`. The two names denote the same authority, so they are resolved through one explicit equivalence (`_AGENT_PERMISSION_EQUIVALENTS`) rather than by widening the issued grant, which other subsystems read for their own decisions. Workers keep claiming, progressing, completing and decomposing their own tasks — still bounded by `task_ids`.

**The cluster worker secret** is checked against a fixed set, `_CLUSTER_SECRET_PERMISSIONS`. It is the one credential with no record of its own to hang a grant on: one string handed to every node, so it cannot be revoked per worker or narrowed per task.

| Permission | Why it is in the set |
| --- | --- |
| `cluster:write` | register, heartbeat, cordon, drain, unregister, gossip, rebalance |
| `cluster:read` | the node registry a worker and `bernstein cluster status` read back |
| `tasks:write` | complete / fail / release the work it pulled |
| `tasks:read` | `GET /tasks/next/{role}`, the worker loop's claim-next pull |
| `status:read` | the read floor every credential holds — what `_get_required_permission` returns for every read route the map does not name, including the liveness surfaces a worker polls |

Everything else is refused, including `agents:read`, `agents:kill`, `bulletin:*`, `auth:manage`, `webhooks:manage` and the `admin:*` surface. The set is deliberately not widened to `admin:manage`, and deliberately not given the agent surface: a worker drives its own agents through the local spawner and never touches the HTTP agent routes, so granting them would make one fleet-wide string a read-and-terminate handle on every other session's agent. Widening this credential widens it for every node at once; a deployment that needs one credential to do more should use an SSO user with the role that grants it.

**`POST /cluster/steal`** was the one mutating `/cluster/*` route with no `_verify_cluster_auth` call — register, heartbeat, cordon, uncordon, drain, unregister and gossip all have one, so the outer gate was steal's only layer while every sibling had two. It now requires `SCOPE_NODE_ADMIN`, matching the node-registry mutations it sits beside in the operational-primitives table rather than the heartbeat scope `POST /cluster/claims/gossip` uses: gossip verifies each receipt's own Ed25519 signature and chain link inside the handler, so its bearer scope only has to establish fleet membership, whereas steal drives `force_claim` straight from caller-reported queue depths with no further proof to check. A default node token carries register + heartbeat, so triggering a rebalance uses the cluster secret or an admin-scoped token — the same credential drain and cordon already need.

The middleware comment that claimed defense-in-depth everywhere is corrected to name where the inner layer actually exists: the mutating `/cluster/*` routes, and nowhere else.

No route was re-shaped beyond that one missing call, and no permission grant was widened.

## Tests

Two files, both running against the real application and the real routes, because the property is about what an authenticated request actually returns — a stub handler would prove only that a stub was not called. Each route class is pinned twice: refused for a credential that does not hold the permission, served for one that does, so the gate is shown to key on the held permission rather than on the path or on the credential kind.

### `tests/unit/test_auth_middleware_agent_route_permissions.py`

Premise:

| Test | Property |
| --- | --- |
| `test_worker_role_grant_covers_neither_agents_read_nor_agents_kill` | a worker grant really omits `agents:read`, `agents:kill`, `cluster:write`, `bulletin:write` — without this the refusals below could pass vacuously |
| `test_agent_log_and_kill_routes_declare_the_permissions_they_are_checked_against` | the route map names `agents:read` for the reads and `agents:kill` for the kill |
| `test_bulletin_post_body_matches_the_route_schema` | the bulletin probe body is a valid `BulletinPostRequest`, so the refusal below cannot pass as a 422 |

Enforcement, one per affected route class:

| Test | Property |
| --- | --- |
| `test_agent_log_read_is_refused_without_agents_read` | another session's agent log is not readable, and the refusal replaces the payload |
| `test_agent_stream_read_is_refused_without_agents_read` | the SSE stream of another session's output is refused on the same grant |
| `test_session_kill_is_refused_without_agents_kill` | the kill is refused **and** no `.kill` signal file is written — a refusal that still wrote it would terminate the session anyway |
| `test_cluster_rebalance_is_refused_without_cluster_write` | `POST /cluster/steal` needs the cluster credential, not a worker token |
| `test_bulletin_post_is_refused_without_bulletin_write` | a worker grant carries no bulletin permission, and the board is read back to prove nothing was appended |
| `test_task_write_equivalence_does_not_leak_into_unrelated_permissions` | `tasks:claim` stands in for `tasks:write` and for nothing else |

Positive control and no-regression cases are unchanged: `test_agent_log_read_is_served_when_agents_read_is_held`, `test_session_kill_is_accepted_when_agents_kill_is_held`, `test_task_scoped_agent_still_completes_its_own_task`, `test_task_scoped_agent_still_creates_subtasks`, `test_status_read_stays_reachable_for_a_worker_token`, `test_operator_only_route_keeps_its_operator_specific_refusal`.

### `tests/unit/test_auth_middleware_cluster_secret_route_permissions.py` (new)

Premise:

| Test | Property |
| --- | --- |
| `test_cluster_secret_authority_covers_cluster_and_task_work_only` | the set itself, stated literally, so a later widening fails here rather than silently stopping the refusals from being reached |
| `test_cluster_secret_authority_excludes_the_agent_and_operator_surfaces` | each excluded permission named individually |
| `test_routes_refused_below_declare_the_permissions_they_are_checked_against` | the route map names the permissions the assertions quote |

Enforcement:

| Test | Property |
| --- | --- |
| `test_cluster_secret_cannot_kill_an_agent_session_without_agents_kill` | refused **and** no `.kill` signal file written |
| `test_cluster_secret_cannot_read_an_agent_log_without_agents_read` | the log read is refused and the refusal replaces the payload |
| `test_cluster_secret_cannot_stream_an_agent_session_without_agents_read` | the SSE stream is refused |
| `test_cluster_secret_cannot_post_to_the_bulletin_without_bulletin_write` | refused, and the board is read back to prove nothing was appended |
| `test_cluster_secret_cannot_read_the_bulletin_without_bulletin_read` | reads are gated too, on a route that really returns data — the board carries what every agent posts |
| `test_cluster_secret_keeps_its_operator_specific_refusal` | the `admin:manage` message is not replaced by the general one |

Inner layer on steal:

| Test | Property |
| --- | --- |
| `test_cluster_steal_refuses_an_unauthenticated_request_like_its_sibling_routes` | with cluster auth on, steal no longer answers a request carrying no cluster credential |
| `test_cluster_steal_refuses_a_node_token_without_the_node_admin_scope` | a register+heartbeat node token can join and stay in the fleet, and cannot reassign other nodes' claimed work |
| `test_cluster_steal_is_served_for_a_credential_holding_the_node_admin_scope` | positive control: the shared secret carries the full node scope set |
| `test_every_mutating_cluster_route_verifies_cluster_auth` | read off the router rather than a hand-kept list, so a mutating `/cluster/*` route added later that forgets the inner check fails here |

No regression on what a worker must keep reaching:

| Test | Property |
| --- | --- |
| `test_cluster_secret_still_registers_and_heartbeats_a_node` | node join, the credential's reason to exist |
| `test_cluster_secret_still_reads_the_node_registry` | `GET /cluster/status` |
| `test_cluster_secret_still_claims_and_completes_a_task` | claim + complete, or every worker could join a cluster and finish nothing in it |
| `test_cluster_secret_still_pulls_the_next_task_for_a_role` | `GET /tasks/next/{role}` |
| `test_cluster_secret_still_reads_status` | the `status:read` floor |

### Falsification

Both files were run against the pre-change `auth_middleware.py` and `task_cluster.py` restored from `main`. Every enforcement test fails, and each fails with the symptom it names rather than with an incidental error:

| Test | Pre-change result |
| --- | --- |
| `test_cluster_secret_cannot_kill_an_agent_session_without_agents_kill` | `200 {"session_id": "...", "kill_requested": true}` |
| `test_cluster_secret_cannot_stream_an_agent_session_without_agents_read` | `200`, SSE stream open |
| `test_cluster_secret_cannot_read_an_agent_log_without_agents_read` | `404` from the handler — the read was authorised, the session had no log file |
| `test_cluster_secret_cannot_post_to_the_bulletin_without_bulletin_write` | `201 Created`, message on the board |
| `test_cluster_secret_cannot_read_the_bulletin_without_bulletin_read` | `200`, board contents returned |
| `test_bulletin_post_is_refused_without_bulletin_write` | `201 Created`, message on the board — this is the repair: it previously posted `author`/`message` against a schema expecting `agent_id`/`content`, so it failed pre-change on 422 body validation, which is not the property it claims to test |
| `test_cluster_steal_refuses_an_unauthenticated_request_…` / `…_without_the_node_admin_scope` | `200 {"actions": [], "total_stolen": 0}` |
| `test_every_mutating_cluster_route_verifies_cluster_auth` | fails naming `/cluster/steal` |

## Verification

- `tests/unit/test_auth_middleware*.py` + `test_auth.py` + `test_rbac.py` + `test_cluster_worker_join_auth.py` + `test_tenant_scope_http_isolation.py` — 307 passed
- `tests/unit -k cluster` — 264 passed
- `tests/unit -k "openapi or route_table or bulletin or steal"` — 112 passed
- docs-guard suites — 43 passed
- `uv run ruff check` and `ruff format --check` on the changed files — clean
- `uv run mypy src` — no errors in either changed module

## Docs

`docs/operations/security-and-identity.md` — the *Route permissions* section now carries a per-credential table (what each kind is checked against and what it reaches), a paragraph on why the cluster secret's authority is fixed rather than granted, and a *Two layers on the cluster routes* paragraph naming exactly which routes carry the inner scope check and which have only the middleware.

`docs/operations/cluster-mode.md` — the scope table gains `POST /cluster/claims/gossip` under `node:heartbeat` and `POST /cluster/steal` under `node:admin`, with the reasoning for the split and a note that a default node token cannot trigger a rebalance.

`docs/reference/openapi.json` — regenerated for the steal route's documented 401 and its updated description. Unrelated pre-existing snapshot drift (some `/costs/*` descriptions, an `artifact_spec` request-body field) was left alone rather than folded into this diff.

## Deliberately out of scope

- **Reads are still exempt from the `task_ids` scope gate.** A worker holding `tasks:read` can read a task outside its scope. That is the pre-existing task-scope design (`_try_agent_jwt` only scope-checks non-read methods) and changing it is a separate decision.
- **`AGENT_ROLE_PERMISSIONS` is left as issued.** The `tasks:claim` / `tasks:write` mismatch is resolved in the middleware rather than by editing the grant, because `permissions_for_role` feeds capability tokens and delegation narrowing, and widening it there would widen those too.
- **No route was given a dependency-level permission check.** The middleware stays the single gate for everything outside the mutating `/cluster/*` routes.
- **`GET /cluster/nodes` and `GET /cluster/status` still have no inner scope check.** They are reads of the node registry and are gated by `cluster:read` at the middleware; adding the inner layer to reads is a separate change with its own compatibility question for existing dashboards.
- **`status:read` is broader than its name.** It is the fallback `_get_required_permission` returns for every read route `_ROUTE_PERMISSIONS` does not name, so it currently covers `/events`, `/approvals`, `/costs/*`, `/traces`, `/plans` and more. Both the agent grants and this credential hold it, so neither is newly widened — but narrowing what a fleet credential reads means naming those routes in the map, which changes what every credential kind resolves for them and belongs in its own change.
- **`_ROUTE_PERMISSIONS` still prefix-matches the raw path, so the `/api/v<n>` mirror does not resolve to the same permission as the root mount.** `POST /api/v1/cluster/nodes` and `POST /api/v1/tasks` fall through to the `admin:manage` fail-closed default, so a worker pointed at the versioned mirror is refused. This predates the branch — the operator-only refusal already blocked both credential kinds there — and it fails closed rather than open, so it is a usability sharp edge rather than a hole. Fixing it means teaching the resolver about the mirror, which touches every route class at once.
