### PR TITLE
fix(cost): scope the daily cost-history trend by tenant

### DIFF
--- a/src/bernstein/core/cost/cost_history.py
+++ b/src/bernstein/core/cost/cost_history.py
@@ -17,6 +17,8 @@ from dataclasses import asdict, dataclass
 from datetime import date, timedelta
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.tenanting import InvalidTenantIdError, normalize_tenant_id
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -37,6 +39,32 @@ _HISTORY_FILE = "cost_history.jsonl"
 # ---------------------------------------------------------------------------
 
 
+def _read_tenant_id(d: dict[str, Any]) -> str | None:
+    """Read a persisted snapshot's tenant, treating absence as unattributed.
+
+    This is deliberately stricter than :func:`~bernstein.core.security.tenanting.
+    normalize_tenant_id`, which is built for *request-facing* input: there,
+    a caller who did not specify a tenant is treated as wanting the default
+    one, which is the right call for an authenticated request that has to
+    resolve to *some* scope. A persisted snapshot is different - a *missing*
+    ``tenant_id`` key means the record predates per-tenant attribution
+    entirely, and defaulting it to the default tenant would silently credit
+    (or blame) that one tenant for spend that was never verified to be its
+    own. So here, absence, ``null``, a blank string, a non-string value, and
+    a value that fails the identifier rules all map to the same ``None`` -
+    "cannot attribute" - rather than to a guess.
+    """
+    if "tenant_id" not in d:
+        return None
+    raw = d["tenant_id"]
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    try:
+        return normalize_tenant_id(raw)
+    except InvalidTenantIdError:
+        return None
+
+
 @dataclass
 class DailyCostSnapshot:
     """Aggregated cost snapshot for a single calendar day.
@@ -47,6 +75,16 @@ class DailyCostSnapshot:
         budget_usd: Configured daily budget (0 = unlimited).
         run_count: Number of orchestrator runs that contributed spend.
         timestamp: Unix timestamp when the snapshot was written.
+        tenant_id: Tenant this snapshot's spend is attributed to, or
+            ``None`` for a record written before this field existed (or one
+            whose stored value could not be read as a tenant id - see
+            :func:`_read_tenant_id`). ``None`` is a genuine absence marker,
+            not a stand-in for the default tenant: unlike a caller-supplied
+            request selector, where a blank value means "no preference, use
+            the default tenant", a pre-migration snapshot's spend was never
+            attributed to any one tenant, so it must not surface in *any*
+            tenant-scoped trend - including the default tenant's - once one
+            is asked for. See :func:`load_history`.
     """
 
     date_str: str
@@ -54,6 +92,7 @@ class DailyCostSnapshot:
     budget_usd: float
     run_count: int
     timestamp: float
+    tenant_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -66,6 +105,7 @@ class DailyCostSnapshot:
             budget_usd=float(d.get("budget_usd", 0.0)),
             run_count=int(d.get("run_count", 1)),
             timestamp=float(d.get("timestamp", 0.0)),
+            tenant_id=_read_tenant_id(d),
         )
 
 
@@ -143,6 +183,7 @@ def append_daily_snapshot(
     budget_usd: float = 0.0,
     run_count: int = 1,
     snapshot_date: date | None = None,
+    tenant_id: str | None = None,
 ) -> DailyCostSnapshot:
     """Append a daily cost snapshot to the history file.
 
@@ -156,6 +197,13 @@ def append_daily_snapshot(
         budget_usd: Configured daily budget (0 = unlimited).
         run_count: Number of runs contributing to this day's spend.
         snapshot_date: Date to record; defaults to today (UTC).
+        tenant_id: Tenant this snapshot's spend is attributed to. Pass the
+            resolved request-scope tenant when the caller has one. A caller
+            with no request scope to draw from (a deployment-wide rollup run
+            outside any request) should pass ``None`` explicitly rather than
+            guessing - an unattributed snapshot is simply excluded from every
+            tenant-scoped trend later, which is the correct outcome when the
+            tenant genuinely is not known.
 
     Returns:
         The newly written :class:`DailyCostSnapshot`.
@@ -169,6 +217,7 @@ def append_daily_snapshot(
         budget_usd=round(budget_usd, 6),
         run_count=run_count,
         timestamp=time.time(),
+        tenant_id=normalize_tenant_id(tenant_id) if tenant_id is not None else None,
     )
     path = _history_path(sdd_dir)
     with path.open("a") as fh:
@@ -184,11 +233,13 @@ def upsert_daily_snapshot(
     budget_usd: float = 0.0,
     run_count: int = 1,
     snapshot_date: date | None = None,
+    tenant_id: str | None = None,
 ) -> DailyCostSnapshot:
-    """Update today's snapshot in-place (last-write-wins by date).
+    """Update today's snapshot in-place (last-write-wins by date and tenant).
 
-    Loads the full history, replaces any existing entry for *snapshot_date*,
-    rewrites the file, and prunes entries older than 6 months.
+    Loads the full history, replaces any existing entry for *snapshot_date*
+    that carries the same *tenant_id*, rewrites the file, and prunes entries
+    older than 6 months.
 
     Args:
         sdd_dir: The ``.sdd`` directory.
@@ -196,6 +247,11 @@ def upsert_daily_snapshot(
         budget_usd: Configured daily budget (0 = unlimited).
         run_count: Number of runs contributing to this day's spend.
         snapshot_date: Date to record; defaults to today (UTC).
+        tenant_id: Tenant this snapshot's spend is attributed to. See
+            :func:`append_daily_snapshot` for how ``None`` is handled. Only
+            an existing entry for the same date **and** the same tenant is
+            replaced - a same-day upsert for one tenant must not clobber
+            another tenant's snapshot for that date.
 
     Returns:
         The upserted :class:`DailyCostSnapshot`.
@@ -209,13 +265,19 @@ def upsert_daily_snapshot(
         budget_usd=round(budget_usd, 6),
         run_count=run_count,
         timestamp=time.time(),
+        tenant_id=normalize_tenant_id(tenant_id) if tenant_id is not None else None,
     )
 
     existing = load_history(sdd_dir)
-    # Replace any same-date entry; keep the rest within the 6-month window.
+    # Replace only the same (date, tenant) entry; keep the rest within the
+    # 6-month window. Matching on date alone would let one tenant's upsert
+    # overwrite another tenant's snapshot for the same calendar day.
     cutoff = date.today() - timedelta(days=_HISTORY_DAYS)
     updated: list[DailyCostSnapshot] = [
-        s for s in existing if s.date_str != snap.date_str and date.fromisoformat(s.date_str) >= cutoff
+        s
+        for s in existing
+        if not (s.date_str == snap.date_str and s.tenant_id == snap.tenant_id)
+        and date.fromisoformat(s.date_str) >= cutoff
     ]
     updated.append(snap)
     updated.sort(key=lambda s: s.date_str)
@@ -227,21 +289,37 @@ def upsert_daily_snapshot(
     return snap
 
 
-def load_history(sdd_dir: Path, days: int = _HISTORY_DAYS) -> list[DailyCostSnapshot]:
+def load_history(
+    sdd_dir: Path,
+    days: int = _HISTORY_DAYS,
+    *,
+    tenant_id: str | None = None,
+) -> list[DailyCostSnapshot]:
     """Load cost history snapshots from disk.
 
     Args:
         sdd_dir: The ``.sdd`` directory.
         days: Maximum age of snapshots to return (default: 180).
+        tenant_id: When given, narrow to snapshots attributed to exactly this
+            tenant. A snapshot with no tenant attribution (``tenant_id`` is
+            ``None`` - see :class:`DailyCostSnapshot`) never matches a scoped
+            read, however *tenant_id* is set: it predates per-tenant
+            attribution, so its spend is not verified to belong to any one
+            tenant and must not be folded into whichever tenant happens to
+            ask. Leaving *tenant_id* unset returns every snapshot in the
+            window regardless of attribution, for callers that genuinely want
+            the whole install's history.
 
     Returns:
         List of :class:`DailyCostSnapshot` sorted oldest-first, limited to
-        the last *days* calendar days.
+        the last *days* calendar days and, when *tenant_id* is given, to that
+        tenant's own snapshots.
     """
     path = _history_path(sdd_dir)
     if not path.exists():
         return []
 
+    scope = normalize_tenant_id(tenant_id) if tenant_id is not None else None
     cutoff = date.today() - timedelta(days=days)
     snapshots: list[DailyCostSnapshot] = []
     try:
@@ -252,6 +330,8 @@ def load_history(sdd_dir: Path, days: int = _HISTORY_DAYS) -> list[DailyCostSnap
             try:
                 d = json.loads(line)
                 snap = DailyCostSnapshot.from_dict(d)
+                if scope is not None and snap.tenant_id != scope:
+                    continue
                 if date.fromisoformat(snap.date_str) >= cutoff:
                     snapshots.append(snap)
             except Exception as exc:

--- a/src/bernstein/core/routes/costs.py
+++ b/src/bernstein/core/routes/costs.py
@@ -496,12 +496,13 @@ def get_cost_alerts(request: Request) -> JSONResponse:
     has reached the 80% or 95% alert threshold, and returns trend data
     computed from ``.sdd/metrics/cost_history.jsonl``.
 
-    Scope: the two halves of this response are scoped differently, and
-    ``tenant_id`` names the scope of the first.  ``alerts`` is computed from
-    the caller's tenant's spend against the caller's tenant's cap.  ``trend``
-    and ``history_days`` come from the run-wide cost history file, which is
-    not tenant-partitioned, so they describe the deployment rather than the
-    caller's scope.
+    Both halves of this response are scoped to ``tenant_id``: ``alerts`` is
+    computed from the caller's tenant's spend against the caller's tenant's
+    cap, and ``trend`` / ``history_days`` are narrowed to snapshots recorded
+    for that same tenant.  A history snapshot written before per-tenant
+    attribution existed carries no tenant and is excluded from every scoped
+    trend, so a fresh deployment's 30/90-day averages start empty and fill in
+    as new, attributed snapshots accumulate.
     """
     from bernstein.core.cost_history import compute_trends, get_active_alerts, load_history
     from bernstein.core.cost_tracker import CostTracker
@@ -523,7 +524,7 @@ def get_cost_alerts(request: Request) -> JSONResponse:
                 budget_usd = tracker.budget_usd
 
     alerts = get_active_alerts(sdd_dir, spent_usd, budget_usd)
-    history = load_history(sdd_dir)
+    history = load_history(sdd_dir, tenant_id=tenant_id)
     trend = compute_trends(history)
 
     return JSONResponse(
@@ -532,10 +533,10 @@ def get_cost_alerts(request: Request) -> JSONResponse:
             "trend": trend.to_dict(),
             "history_days": len(history),
             "tenant_id": tenant_id,
-            # ``trend`` and ``history_days`` are read from the run-wide cost
-            # history file, which carries no tenant, so they are not narrowed
-            # to ``tenant_id`` the way ``alerts`` is.
-            "trend_scope": "run-wide",
+            # Both halves are now narrowed to ``tenant_id``; this label
+            # stays so an existing consumer that special-cased "run-wide"
+            # sees the scope change rather than silently reinterpreting it.
+            "trend_scope": "tenant",
         }
     )
 
@@ -592,7 +593,8 @@ def get_cost_history(
       usages over the last *hours* window.
     * ``GET /costs/history`` *or* ``?envelope=1`` (legacy/CLI) - returns the
       original ``{history, trend, burn_rate_*, history_days}`` envelope
-      built from ``.sdd/metrics/cost_history.jsonl`` daily snapshots.
+      built from ``.sdd/metrics/cost_history.jsonl`` daily snapshots, narrowed
+      to the caller's tenant the same way ``/costs/alerts`` is.
 
     The sparkline branch lets the GUI feed `recharts` directly without
     unwrapping a ``.history`` field.
@@ -610,8 +612,9 @@ def get_cost_history(
         series = _bucket_usages(sdd_dir, costs_dir, since_ts=since, granularity=gran, tenant_id=tenant_id)
         return JSONResponse(content=series)
 
-    # Legacy envelope - unchanged shape so TUI / CLI keep working.
-    history = load_history(sdd_dir)
+    # Legacy envelope - shape unchanged so TUI / CLI keep working; the
+    # snapshots feeding it are now narrowed to the caller's tenant.
+    history = load_history(sdd_dir, tenant_id=tenant_id)
     trend = compute_trends(history)
     recent_7d = history[-7:] if len(history) >= 7 else history
     daily_avg = sum(s.spent_usd for s in recent_7d) / len(recent_7d) if recent_7d else 0.0

--- a/tests/unit/test_cost_history.py
+++ b/tests/unit/test_cost_history.py
@@ -111,3 +111,126 @@ def test_get_active_alerts_emits_expected_thresholds(tmp_path: Path) -> None:
     assert warn[0].alert_type == "budget_80pct"
     assert critical[0].alert_type == "budget_95pct"
     assert unlimited == []
+
+
+# ---------------------------------------------------------------------------
+# Tenant attribution (issue #3702)
+# ---------------------------------------------------------------------------
+
+
+def test_append_daily_snapshot_persists_tenant_id(tmp_path: Path) -> None:
+    """A snapshot appended with a tenant id round-trips through load_history."""
+    sdd_dir = _sdd_dir(tmp_path)
+
+    append_daily_snapshot(sdd_dir, spent_usd=4.0, snapshot_date=date.today(), tenant_id="acme")
+
+    snapshots = load_history(sdd_dir, tenant_id="acme")
+    assert [s.tenant_id for s in snapshots] == ["acme"]
+    assert snapshots[0].spent_usd == pytest.approx(4.0)
+
+
+def test_from_dict_treats_missing_tenant_key_as_unattributed(tmp_path: Path) -> None:
+    """A JSONL row written before the tenant field existed loads with tenant_id=None.
+
+    This is the "records written before the change must still load" contract:
+    the row is not rejected, and it is not silently attributed to any tenant.
+    """
+    sdd_dir = _sdd_dir(tmp_path)
+    history_file = sdd_dir / "metrics" / "cost_history.jsonl"
+    history_file.write_text(
+        json.dumps({"date_str": date.today().isoformat(), "spent_usd": 1.0, "budget_usd": 0.0, "timestamp": 1.0})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    snapshots = load_history(sdd_dir)
+
+    assert len(snapshots) == 1
+    assert snapshots[0].tenant_id is None
+    assert snapshots[0].spent_usd == pytest.approx(1.0)
+
+
+def test_from_dict_treats_non_string_tenant_as_unattributed(tmp_path: Path) -> None:
+    """A stored tenant_id of the wrong type is read as unattributed, not coerced.
+
+    str(True) == "True" and str(123) == "123" both pass the identifier rules,
+    so coercing would attribute the row to a tenant that never wrote it.
+    """
+    sdd_dir = _sdd_dir(tmp_path)
+    history_file = sdd_dir / "metrics" / "cost_history.jsonl"
+    history_file.write_text(
+        json.dumps(
+            {
+                "date_str": date.today().isoformat(),
+                "spent_usd": 1.0,
+                "budget_usd": 0.0,
+                "timestamp": 1.0,
+                "tenant_id": True,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    snapshots = load_history(sdd_dir)
+
+    assert snapshots[0].tenant_id is None
+
+
+def test_load_history_excludes_unattributed_records_from_every_scoped_query(tmp_path: Path) -> None:
+    """An unattributed historical record never appears in a scoped result -
+
+    not even the default tenant's. Defaulting it to "default" would silently
+    credit that one tenant with spend that was never verified as its own.
+    """
+    sdd_dir = _sdd_dir(tmp_path)
+    append_daily_snapshot(sdd_dir, spent_usd=9.0, snapshot_date=date.today())  # no tenant_id -> unattributed
+    append_daily_snapshot(sdd_dir, spent_usd=2.0, snapshot_date=date.today() - timedelta(days=1), tenant_id="default")
+
+    default_scoped = load_history(sdd_dir, tenant_id="default")
+    acme_scoped = load_history(sdd_dir, tenant_id="acme")
+
+    assert [s.spent_usd for s in default_scoped] == [2.0]
+    assert acme_scoped == []
+
+
+def test_load_history_narrows_to_requested_tenant_only(tmp_path: Path) -> None:
+    """A tenant's scoped read returns its own snapshots, not another tenant's."""
+    sdd_dir = _sdd_dir(tmp_path)
+    append_daily_snapshot(sdd_dir, spent_usd=3.0, snapshot_date=date.today(), tenant_id="tenant-a")
+    append_daily_snapshot(sdd_dir, spent_usd=99.0, snapshot_date=date.today() - timedelta(days=1), tenant_id="tenant-b")
+
+    scoped = load_history(sdd_dir, tenant_id="tenant-a")
+
+    assert [s.spent_usd for s in scoped] == [3.0]
+    assert all(s.tenant_id == "tenant-a" for s in scoped)
+
+
+def test_load_history_without_tenant_filter_returns_every_record(tmp_path: Path) -> None:
+    """Omitting tenant_id keeps the unscoped, whole-install read available."""
+    sdd_dir = _sdd_dir(tmp_path)
+    append_daily_snapshot(sdd_dir, spent_usd=1.0, snapshot_date=date.today())
+    append_daily_snapshot(sdd_dir, spent_usd=2.0, snapshot_date=date.today() - timedelta(days=1), tenant_id="acme")
+
+    snapshots = load_history(sdd_dir)
+
+    assert sorted(s.spent_usd for s in snapshots) == [1.0, 2.0]
+
+
+def test_upsert_daily_snapshot_does_not_clobber_another_tenants_same_day_entry(tmp_path: Path) -> None:
+    """A same-day upsert for one tenant must not overwrite another tenant's snapshot.
+
+    Matching the replace target on date alone - the pre-tenant behaviour -
+    would let tenant A's daily write erase tenant B's snapshot for that day.
+    """
+    sdd_dir = _sdd_dir(tmp_path)
+    today = date.today()
+    append_daily_snapshot(sdd_dir, spent_usd=5.0, snapshot_date=today, tenant_id="tenant-a")
+    append_daily_snapshot(sdd_dir, spent_usd=7.0, snapshot_date=today, tenant_id="tenant-b")
+
+    upsert_daily_snapshot(sdd_dir, spent_usd=50.0, snapshot_date=today, tenant_id="tenant-a")
+
+    tenant_a_snapshots = load_history(sdd_dir, tenant_id="tenant-a")
+    tenant_b_snapshots = load_history(sdd_dir, tenant_id="tenant-b")
+    assert [s.spent_usd for s in tenant_a_snapshots] == [50.0]
+    assert [s.spent_usd for s in tenant_b_snapshots] == [7.0]

--- a/tests/unit/test_tenant_scope_http_isolation.py
+++ b/tests/unit/test_tenant_scope_http_isolation.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -1053,3 +1054,96 @@ async def test_scoped_cost_responses_name_their_scope(
 
     assert response.status_code == 200
     assert response.json()["tenant_id"] == DEFAULT_TENANT_ID
+
+
+# ---------------------------------------------------------------------------
+# Cost-history trend scoping (issue #3702)
+# ---------------------------------------------------------------------------
+# The 30/90-day trend behind /costs/alerts (and the legacy /costs/history
+# envelope) is read from .sdd/metrics/cost_history.jsonl, which historically
+# carried no tenant field at all, so it could not be narrowed and mixed every
+# tenant's daily spend into one figure. These cases pin that it is now
+# narrowed the same way the rest of the cost surface is.
+
+OUTSIDER_HISTORY_SPEND_USD = 741.852963
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize("endpoint", ["/costs/alerts", "/costs/history"])
+async def test_cost_history_trend_excludes_another_tenants_snapshots(
+    fx: Fixture,
+    client: AsyncClient,
+    sdd_dir: Path,
+    endpoint: str,
+) -> None:
+    """The trend/history figures behind these endpoints narrow by tenant.
+
+    Two tenants each get a daily snapshot in the shared history file; the
+    caller bound to the default tenant must see only its own.
+    """
+    from bernstein.core.cost_history import append_daily_snapshot
+
+    own_spend = 3.25
+    append_daily_snapshot(sdd_dir, spent_usd=own_spend, tenant_id=DEFAULT_TENANT_ID)
+    append_daily_snapshot(sdd_dir, spent_usd=OUTSIDER_HISTORY_SPEND_USD, tenant_id=TENANT_B)
+
+    credential = _credential(fx, "legacy_bearer")
+    response = await client.get(endpoint, headers=credential.headers)
+
+    assert response.status_code == 200
+    body = response.text
+    assert str(OUTSIDER_HISTORY_SPEND_USD) not in body, f"{endpoint} leaked another tenant's daily snapshot"
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize("endpoint", ["/costs/alerts", "/costs/history"])
+async def test_cost_history_trend_excludes_unattributed_pre_migration_snapshots(
+    fx: Fixture,
+    client: AsyncClient,
+    sdd_dir: Path,
+    endpoint: str,
+) -> None:
+    """A snapshot written before the tenant field existed never surfaces in a scoped trend.
+
+    Not even the default tenant's - the record's spend was never verified to
+    belong to any one tenant, default included, so folding it in would credit
+    a scope it cannot be shown to belong to.
+    """
+    from bernstein.core.cost_history import append_daily_snapshot
+
+    unattributed_spend = 615.243978
+    # A recent date, well inside the 180-day retention window, so the only
+    # thing that can exclude it from a scoped response is tenant narrowing -
+    # not the window cutoff.
+    append_daily_snapshot(sdd_dir, spent_usd=unattributed_spend, snapshot_date=date.today())  # no tenant_id
+
+    credential = _credential(fx, "legacy_bearer")
+    response = await client.get(endpoint, headers=credential.headers)
+
+    assert response.status_code == 200
+    body = response.text
+    assert str(unattributed_spend) not in body, f"{endpoint} attributed a pre-migration record to the default tenant"
+
+
+@pytest.mark.anyio()
+async def test_costs_alerts_trend_still_reports_the_callers_own_history(
+    fx: Fixture,
+    client: AsyncClient,
+    sdd_dir: Path,
+) -> None:
+    """Narrowing does not over-refuse: the caller's own snapshot still counts.
+
+    The companion to the leak assertions above - a trend reader that dropped
+    every snapshot would satisfy those and be useless.
+    """
+    from bernstein.core.cost_history import append_daily_snapshot
+
+    append_daily_snapshot(sdd_dir, spent_usd=4.0, tenant_id=DEFAULT_TENANT_ID)
+
+    credential = _credential(fx, "legacy_bearer")
+    response = await client.get("/costs/alerts", headers=credential.headers)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["history_days"] == 1
+    assert body["trend"]["avg_30d_usd"] == pytest.approx(4.0)


### PR DESCRIPTION
Closes #3702.

## Root cause

`DailyCostSnapshot` (the record behind `.sdd/metrics/cost_history.jsonl`) carried no tenant field, so the 30/90-day trend behind `/costs/alerts` (and the legacy `/costs/history` envelope) was computed across every tenant's daily spend with no way to narrow it - even though the rest of those responses were already scoped to the caller.

## What changed

- `DailyCostSnapshot` gains `tenant_id: str | None`.
- `append_daily_snapshot` / `upsert_daily_snapshot` accept `tenant_id`; callers with no request scope pass `None` explicitly rather than guessing.
- `load_history(sdd_dir, tenant_id=...)` narrows by tenant. A record with no attribution - every row written before this change, or one whose stored value fails the identifier rules - loads as `tenant_id=None` and is excluded from **every** tenant-scoped query, including the default tenant's. Defaulting it to `"default"` would silently credit that one tenant with spend that was never verified as its own, so absence is a genuine sentinel, not a stand-in for the default scope.
- `upsert_daily_snapshot` now matches the replace target on `(date, tenant)` instead of date alone - a same-day upsert for one tenant could otherwise clobber another tenant's snapshot for that date.
- `/costs/alerts` and the legacy `/costs/history` envelope now call `load_history` with the caller's resolved tenant.

**Migration decision:** no file rewrite. Existing rows still load (they just carry `tenant_id=None`), and because that value never matches a live scope, they simply age out of every tenant-scoped trend over the normal retention window as new, attributed snapshots accumulate. A fresh deployment's 30/90-day averages start empty and fill in from there. `/costs/alerts` already carries a `trend_scope` field so a client can tell scoped and unscoped periods apart; its value is now `"tenant"` instead of `"run-wide"`.

## Tests

`tests/unit/test_cost_history.py` (unit level):
- `test_append_daily_snapshot_persists_tenant_id`
- `test_from_dict_treats_missing_tenant_key_as_unattributed`
- `test_from_dict_treats_non_string_tenant_as_unattributed`
- `test_load_history_excludes_unattributed_records_from_every_scoped_query`
- `test_load_history_narrows_to_requested_tenant_only`
- `test_load_history_without_tenant_filter_returns_every_record`
- `test_upsert_daily_snapshot_does_not_clobber_another_tenants_same_day_entry`

`tests/unit/test_tenant_scope_http_isolation.py` (HTTP level, real app/auth/routing):
- `test_cost_history_trend_excludes_another_tenants_snapshots` (`/costs/alerts`, `/costs/history`)
- `test_cost_history_trend_excludes_unattributed_pre_migration_snapshots` (`/costs/alerts`, `/costs/history`)
- `test_costs_alerts_trend_still_reports_the_callers_own_history`

Each of the above fails on unmodified `main` (confirmed by stashing the source change and re-running) and passes after the fix.

## Verification

- `uv run python -m pytest` on all touched/affected files (cost history, tenant HTTP isolation, predictive alerts, evidence pack, dashboard helpers, OWASP maps, fleet aggregator/rollup, OpenAPI drift guard): 187 passed.
- `uv run ruff check .` / `uv run ruff format --check .`: clean.
- `uv run mypy src`: 153 pre-existing errors, identical count and files on unmodified `main` - this change adds none.

## Out of scope

- `append_daily_snapshot` / `upsert_daily_snapshot` have no production caller yet (only tests exercise them today) - whatever eventually writes daily snapshots will need to resolve and pass its own `tenant_id`. Wiring that writer is a separate piece of work.
- The OpenAPI snapshot (`docs/reference/openapi.json`) was not regenerated: the drift guard (`tests/unit/test_openapi_snapshot_drift.py`) explicitly ignores docstring/description changes, and this PR doesn't add or rename a route or change a status code.