### PR TITLE
fix(security): apply the request tenant scope on the remaining task sinks

### DIFF
--- a/src/bernstein/core/routes/batch_ops.py
+++ b/src/bernstein/core/routes/batch_ops.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from bernstein.core.routes.task_crud import require_tenant_scope_for_ids
 from bernstein.core.security.auth_middleware import enforce_agent_task_scope_for_ids
 
 if TYPE_CHECKING:
@@ -173,6 +174,12 @@ async def batch_operations(body: BatchRequest, request: Request) -> BatchResult:
     # let the rewrite carry an id past the check.
     task_ids = [re.sub(r"[^\w\-]", "", raw_id)[:64] for raw_id in body.ids]
     enforce_agent_task_scope_for_ids(request, task_ids)
+    # The gate above pins an *agent* credential to its own task ids and says
+    # nothing about any other credential type, so on its own it leaves every
+    # action below reachable across tenants.  Applied here, beside it, rather
+    # than inside the loop: each action mutates, so a per-item check would let
+    # a mixed batch apply its in-scope half before refusing the rest.
+    require_tenant_scope_for_ids(request, task_ids)
 
     store = _get_store(request)
     result = BatchResult()

--- a/src/bernstein/core/routes/export.py
+++ b/src/bernstein/core/routes/export.py
@@ -118,8 +118,20 @@ def export_tasks(
             ``TaskStore.list_tasks`` so large stores no longer materialise
             the whole table (issue #1728 finding 3).
         offset: Optional number of tasks to skip before returning rows.
+
+    The export is a whole-store read, so it narrows to the caller's tenant
+    scope the same way the paginated task list does. The scope is pushed into
+    ``list_tasks`` rather than applied to the returned rows so that it is
+    ``limit``/``offset`` that page through the caller's own tasks: filtering
+    after the slice would page through every tenant's and return short pages.
     """
-    all_tasks = _get_store(request).list_tasks(limit=limit, offset=offset)
+    from bernstein.core.routes.task_crud import _resolve_request_tenant_scope
+
+    all_tasks = _get_store(request).list_tasks(
+        limit=limit,
+        offset=offset,
+        tenant_id=_resolve_request_tenant_scope(request),
+    )
     rows = [_task_to_export_dict(t) for t in all_tasks]
 
     if format == "csv":

--- a/src/bernstein/core/routes/graphql_api.py
+++ b/src/bernstein/core/routes/graphql_api.py
@@ -141,17 +141,19 @@ def _extract_task_fields(task: dict[str, Any], fields: list[str]) -> dict[str, A
     return row
 
 
-def _resolve_tasks(parsed: ParsedQuery, store: Any) -> list[dict[str, Any]]:
-    """Resolve a tasks query against the store.
+def _resolve_tasks(parsed: ParsedQuery, store: Any, tenant_id: str) -> list[dict[str, Any]]:
+    """Resolve a tasks query against the store, narrowed to *tenant_id*.
 
     Args:
         parsed: Parsed query with optional status filter and field selection.
         store: TaskStore (or mock) with a ``list_tasks()`` method.
+        tenant_id: The effective tenant scope the query is answered under.
+            Pushed into ``list_tasks`` so rows outside it are never read.
 
     Returns:
         List of task dicts with only the requested fields.
     """
-    tasks = store.list_tasks()
+    tasks = store.list_tasks(tenant_id=tenant_id)
     status_filter = parsed.args.get("status")
 
     results: list[dict[str, Any]] = []
@@ -182,6 +184,7 @@ def _resolve_status(parsed: ParsedQuery, store: Any) -> dict[str, Any]:
 def execute_graphql(
     query: str,
     store: Any,
+    tenant_id: str,
     variables: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Execute a GraphQL query against the store.
@@ -192,6 +195,10 @@ def execute_graphql(
     Args:
         query: GraphQL query string.
         store: TaskStore instance (or compatible mock).
+        tenant_id: The effective tenant scope to answer the query under.
+            Required rather than defaulted: this is a second front door onto
+            the task table, and a default would make "every tenant" the
+            behaviour a caller gets by forgetting to say anything.
         variables: Optional query variables (reserved for future use).
 
     Returns:
@@ -204,7 +211,7 @@ def execute_graphql(
 
     match parsed.operation:
         case "tasks":
-            data = _resolve_tasks(parsed, store)
+            data = _resolve_tasks(parsed, store, tenant_id)
             return {"data": {"tasks": data}}
         case "status":
             data_status = _resolve_status(parsed, store)
@@ -230,5 +237,12 @@ async def graphql_endpoint(req: GraphQLRequest, request: Request) -> dict[str, A
     Returns:
         GraphQL response with ``data`` or ``errors``.
     """
+    from bernstein.core.routes.task_crud import _resolve_request_tenant_scope
+
     store = request.app.state.store
-    return execute_graphql(req.query, store=store, variables=req.variables)
+    return execute_graphql(
+        req.query,
+        store=store,
+        tenant_id=_resolve_request_tenant_scope(request),
+        variables=req.variables,
+    )

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -304,6 +304,26 @@ def _enforce_parent_task_scope(request: Request, parent_task_ids: Sequence[str |
         _require_parent_tenant_scope(request, named)
 
 
+def require_tenant_scope_for_ids(request: Request, task_ids: Sequence[str]) -> None:
+    """Reject any of *task_ids* that resolves outside the caller's tenant scope.
+
+    The by-id counterpart to :func:`_require_task_access`, for the routes that
+    take a list of ids rather than one in the path.  It is deliberately an
+    all-or-nothing gate over the whole list: checking the ids together, before
+    anything acts on them, is what stops a caller smuggling one row past the
+    boundary by burying it among ids it does hold.
+
+    An id that does not resolve at all is left to the caller's existing
+    behaviour - this guard narrows scope, it does not add an existence check.
+    """
+    store = _get_store(request)
+    effective_tenant = _resolve_request_tenant_scope(request)
+    for task_id in task_ids:
+        task = store.get_task(task_id)
+        if task is not None and task.tenant_id != effective_tenant:
+            raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
+
+
 def _require_parent_tenant_scope(request: Request, parent_task_ids: Sequence[str]) -> None:
     """Reject a parent association that reaches outside the caller's scope.
 
@@ -314,16 +334,8 @@ def _require_parent_tenant_scope(request: Request, parent_task_ids: Sequence[str
     onto a parent resolved outside that scope would let one scope's write
     drive another's subtree lifecycle.  The parent has to sit where the child
     lands.
-
-    A parent that does not resolve at all is left to the caller's existing
-    behaviour - this guard narrows scope, it does not add an existence check.
     """
-    store = _get_store(request)
-    effective_tenant = _resolve_request_tenant_scope(request)
-    for parent_id in parent_task_ids:
-        parent = store.get_task(parent_id)
-        if parent is not None and parent.tenant_id != effective_tenant:
-            raise HTTPException(status_code=404, detail=f"Task '{parent_id}' not found")
+    require_tenant_scope_for_ids(request, parent_task_ids)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/routes/task_detail.py
+++ b/src/bernstein/core/routes/task_detail.py
@@ -511,6 +511,14 @@ async def task_diff(request: Request, task_id: str) -> TaskDiffResponse:
     if task is None:
         raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
 
+    # The same gate the task-detail and log-stream routes apply.  The task is
+    # what resolves the working branch below, and the response carries that
+    # branch's contents, so an ungated read hands over the source changes as
+    # well as the row.
+    from bernstein.core.routes.task_crud import _require_task_access
+
+    _require_task_access(task, request)
+
     workdir = _get_workdir(request)
     base_ref = await asyncio.to_thread(_resolve_base_ref, workdir)
     branch = await asyncio.to_thread(_resolve_branch_for_task, workdir, task.assigned_agent)

--- a/tests/unit/test_route_graphql.py
+++ b/tests/unit/test_route_graphql.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from bernstein.core.tenanting import DEFAULT_TENANT_ID
 
 from bernstein.core.routes.graphql_api import (
     GraphQLRequest,
@@ -19,13 +20,20 @@ from bernstein.core.routes.graphql_api import (
 
 
 class _MockStore:
-    """Minimal mock for testing GraphQL resolvers."""
+    """Minimal mock for testing GraphQL resolvers.
+
+    ``list_tasks`` narrows on ``tenant_id`` the way the real store does, so a
+    resolver that stopped passing the scope through shows up here as rows it
+    should not have seen rather than as a silently ignored argument.
+    """
 
     def __init__(self, tasks: list[dict[str, Any]]) -> None:
         self._tasks = tasks
 
-    def list_tasks(self) -> list[dict[str, Any]]:
-        return self._tasks
+    def list_tasks(self, tenant_id: str | None = None) -> list[dict[str, Any]]:
+        if tenant_id is None:
+            return self._tasks
+        return [t for t in self._tasks if t.get("tenant_id", DEFAULT_TENANT_ID) == tenant_id]
 
     def status_summary(self) -> dict[str, Any]:
         return {
@@ -106,7 +114,7 @@ class TestExecuteGraphQL:
                 {"id": "t1", "title": "Task 1", "status": "open", "role": "backend"},
             ]
         )
-        result = execute_graphql("{ tasks { id title status } }", store=mock_store)
+        result = execute_graphql("{ tasks { id title status } }", store=mock_store, tenant_id=DEFAULT_TENANT_ID)
         assert "errors" not in result
         assert len(result["data"]["tasks"]) == 1
         assert result["data"]["tasks"][0]["id"] == "t1"
@@ -117,7 +125,7 @@ class TestExecuteGraphQL:
                 {"id": "t1", "title": "Task 1", "status": "open", "role": "backend"},
             ]
         )
-        result = execute_graphql("{ tasks { id } }", store=mock_store)
+        result = execute_graphql("{ tasks { id } }", store=mock_store, tenant_id=DEFAULT_TENANT_ID)
         task = result["data"]["tasks"][0]
         assert "id" in task
         assert "title" not in task
@@ -132,54 +140,73 @@ class TestExecuteGraphQL:
         result = execute_graphql(
             '{ tasks(status: "open") { id title status } }',
             store=mock_store,
+            tenant_id=DEFAULT_TENANT_ID,
         )
         assert len(result["data"]["tasks"]) == 1
         assert result["data"]["tasks"][0]["id"] == "t1"
 
     def test_tasks_query_missing_field_is_none(self) -> None:
         mock_store = _MockStore([{"id": "t1"}])
-        result = execute_graphql("{ tasks { id cost_usd } }", store=mock_store)
+        result = execute_graphql("{ tasks { id cost_usd } }", store=mock_store, tenant_id=DEFAULT_TENANT_ID)
         task = result["data"]["tasks"][0]
         assert task["id"] == "t1"
         assert task["cost_usd"] is None
 
     def test_tasks_agent_virtual_field(self) -> None:
         mock_store = _MockStore([{"id": "t1", "assigned_agent": "a1", "provider": "claude"}])
-        result = execute_graphql("{ tasks { id agent } }", store=mock_store)
+        result = execute_graphql("{ tasks { id agent } }", store=mock_store, tenant_id=DEFAULT_TENANT_ID)
         task = result["data"]["tasks"][0]
         assert task["agent"]["id"] == "a1"
         assert task["agent"]["provider"] == "claude"
 
     def test_status_query(self) -> None:
         mock_store = _MockStore([])
-        result = execute_graphql("{ status { total completed } }", store=mock_store)
+        result = execute_graphql("{ status { total completed } }", store=mock_store, tenant_id=DEFAULT_TENANT_ID)
         assert "data" in result
         assert result["data"]["status"]["total"] == 0
         assert result["data"]["status"]["completed"] == 0
 
     def test_agents_query(self) -> None:
         mock_store = _MockStore([])
-        result = execute_graphql("{ agents { id provider status } }", store=mock_store)
+        result = execute_graphql("{ agents { id provider status } }", store=mock_store, tenant_id=DEFAULT_TENANT_ID)
         assert "data" in result
         assert result["data"]["agents"] == []
 
     def test_costs_query(self) -> None:
         mock_store = _MockStore([])
-        result = execute_graphql("{ costs { total_usd } }", store=mock_store)
+        result = execute_graphql("{ costs { total_usd } }", store=mock_store, tenant_id=DEFAULT_TENANT_ID)
         assert "data" in result
         assert result["data"]["costs"]["total_usd"] == pytest.approx(0.0)
 
     def test_unknown_operation(self) -> None:
         mock_store = _MockStore([])
-        result = execute_graphql("{ unknown { id } }", store=mock_store)
+        result = execute_graphql("{ unknown { id } }", store=mock_store, tenant_id=DEFAULT_TENANT_ID)
         assert "errors" in result
         assert "Unknown operation" in result["errors"][0]["message"]
 
     def test_unparseable_query(self) -> None:
         mock_store = _MockStore([])
-        result = execute_graphql("garbage", store=mock_store)
+        result = execute_graphql("garbage", store=mock_store, tenant_id=DEFAULT_TENANT_ID)
         assert "errors" in result
         assert "Could not parse" in result["errors"][0]["message"]
+
+    def test_tasks_query_resolves_only_the_named_tenant(self) -> None:
+        """The scope reaches the store, rather than being accepted and dropped.
+
+        ``tenant_id`` is a required argument, so a regression here is not a
+        forgotten call site but a resolver that takes the scope and then reads
+        the table without it.
+        """
+        mock_store = _MockStore(
+            [
+                {"id": "t1", "title": "Task 1", "status": "open", "tenant_id": "tenant-a"},
+                {"id": "t2", "title": "Task 2", "status": "open", "tenant_id": "tenant-b"},
+            ]
+        )
+
+        result = execute_graphql("{ tasks { id title status } }", store=mock_store, tenant_id="tenant-a")
+
+        assert [task["id"] for task in result["data"]["tasks"]] == ["t1"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_tenant_scope_http_isolation.py
+++ b/tests/unit/test_tenant_scope_http_isolation.py
@@ -1315,6 +1315,8 @@ async def test_task_diff_still_serves_a_task_in_the_callers_scope(
 
     assert response.status_code == 200, f"{credential_name} lost the diff for its own tenant"
     assert response.json()["task_id"] == own_task_id
+
+
 # Cost-history trend scoping (issue #3702)
 # ---------------------------------------------------------------------------
 # The 30/90-day trend behind /costs/alerts (and the legacy /costs/history

--- a/tests/unit/test_tenant_scope_http_isolation.py
+++ b/tests/unit/test_tenant_scope_http_isolation.py
@@ -1053,3 +1053,264 @@ async def test_scoped_cost_responses_name_their_scope(
 
     assert response.status_code == 200
     assert response.json()["tenant_id"] == DEFAULT_TENANT_ID
+
+
+# ---------------------------------------------------------------------------
+# Bulk task readers and the batch mutator
+#
+# The routes above reach one task by id.  These reach the task table itself -
+# a whole-store export, a GraphQL collection resolver, a batch mutator taking
+# a list of ids, and the diff sibling of the task-detail route.  Each one
+# resolves task rows without going through ``GET /tasks/{id}``, so the scope
+# the request resolves to has to be applied at each of them separately.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize("credential_name", READ_CREDENTIALS)
+@pytest.mark.parametrize("export_format", ["json", "csv"])
+async def test_export_tasks_omits_rows_outside_the_callers_scope(
+    fx: Fixture,
+    client: AsyncClient,
+    credential_name: str,
+    export_format: str,
+) -> None:
+    """The task export is a whole-store read and has to narrow before it serialises.
+
+    Both renderings are asserted because the narrowing has to happen on the
+    row set, not in one formatter: a filter applied while building the JSON
+    body would leave the CSV attachment carrying the same rows.
+    """
+    credential = _credential(fx, credential_name)
+
+    response = await client.get(
+        f"/export/tasks?format={export_format}",
+        headers=credential.headers,
+    )
+
+    assert response.status_code == 200, f"{credential_name} could not export its own tenant"
+    body = response.text
+    assert fx.task_b_id not in body, f"{credential_name} exported an out-of-scope task id ({export_format})"
+    assert "tenant B work" not in body, f"{credential_name} exported an out-of-scope task title ({export_format})"
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize(("credential_name", "own_tenant"), READ_CREDENTIALS_WITH_OWN_TENANT)
+async def test_export_tasks_still_returns_the_callers_own_rows(
+    fx: Fixture,
+    client: AsyncClient,
+    credential_name: str,
+    own_tenant: str,
+) -> None:
+    """Positive control: narrowing the export does not empty it.
+
+    Without this, the leak assertion above would be satisfied by an export
+    that returned nothing to anybody.
+    """
+    credential = _credential(fx, credential_name)
+    own_task_id = fx.task_a_id if own_tenant == TENANT_A else fx.task_default_id
+
+    response = await client.get("/export/tasks?format=json", headers=credential.headers)
+
+    assert response.status_code == 200
+    assert own_task_id in {row["id"] for row in response.json()}, (
+        f"{credential_name} lost its own tenant's rows from the export"
+    )
+
+
+# ``POST /graphql`` is not in the middleware's route-permission table, so it
+# lands on the fail-closed ``admin:manage`` default and only the operator
+# bearer reaches it.  That credential binds to ``DEFAULT_TENANT_ID``, which is
+# a tenant like any other rather than a wildcard - so it is still the wrong
+# answer for it to resolve a named tenant's rows.
+GRAPHQL_CREDENTIALS = ["legacy_bearer"]
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize("credential_name", GRAPHQL_CREDENTIALS)
+async def test_graphql_tasks_query_omits_rows_outside_the_callers_scope(
+    fx: Fixture,
+    client: AsyncClient,
+    credential_name: str,
+) -> None:
+    """The GraphQL collection resolver reads the same table the REST list does.
+
+    It is a second front door onto ``list_tasks`` with its own resolver, so
+    narrowing the REST list alone leaves this one answering for every tenant.
+    """
+    credential = _credential(fx, credential_name)
+
+    response = await client.post(
+        "/graphql",
+        headers=credential.headers,
+        json={"query": "{ tasks { id title status } }"},
+    )
+
+    assert response.status_code == 200, f"{credential_name} could not query its own tenant"
+    returned = {row["id"] for row in response.json()["data"]["tasks"]}
+    assert fx.task_b_id not in returned, f"{credential_name} resolved an out-of-scope task through GraphQL"
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize("credential_name", GRAPHQL_CREDENTIALS)
+async def test_graphql_tasks_query_still_returns_the_callers_own_rows(
+    fx: Fixture,
+    client: AsyncClient,
+    credential_name: str,
+) -> None:
+    """Positive control: the GraphQL resolver still answers for the bound scope."""
+    credential = _credential(fx, credential_name)
+
+    response = await client.post(
+        "/graphql",
+        headers=credential.headers,
+        json={"query": "{ tasks { id title status } }"},
+    )
+
+    assert response.status_code == 200
+    assert fx.task_default_id in {row["id"] for row in response.json()["data"]["tasks"]}, (
+        f"{credential_name} lost its own tenant's rows from the GraphQL resolver"
+    )
+
+
+# Every batch action that reaches an existing row, with the body it needs.
+BATCH_ACTIONS = [
+    ("cancel", {}),
+    ("retry", {}),
+    ("reprioritize", {"priority": 0}),
+    ("tag", {"tags": ["injected"]}),
+]
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize("credential_name", WRITE_CREDENTIALS)
+@pytest.mark.parametrize(("action", "extra"), BATCH_ACTIONS)
+async def test_batch_ops_refuses_a_task_outside_the_callers_scope(
+    fx: Fixture,
+    client: AsyncClient,
+    credential_name: str,
+    action: str,
+    extra: dict[str, Any],
+) -> None:
+    """Every batch action is a mutation and each one has to clear the scope gate.
+
+    The route already pins an *agent* credential to its own task ids, which
+    says nothing about any other credential type, so the tenant boundary is
+    the only thing that can refuse these.  The assertion covers the stored row
+    as well as the status: a refusal that still wrote would pass a status-only
+    check, and ``tag`` and ``reprioritize`` in particular mutate in place.
+    """
+    credential = _credential(fx, credential_name)
+    store: Any = fx.app.state.store
+    before = store.get_task(fx.task_b_id)
+    assert before is not None
+    before_state = (before.status.value, before.priority, dict(before.metadata))
+
+    response = await client.post(
+        "/tasks/batch-ops",
+        headers=credential.headers,
+        json={"action": action, "ids": [fx.task_b_id], **extra},
+    )
+
+    assert response.status_code in REJECTION_STATUSES, (
+        f"{credential_name} ran batch {action} on an out-of-scope task: got {response.status_code}"
+    )
+    after = store.get_task(fx.task_b_id)
+    assert after is not None
+    assert (after.status.value, after.priority, dict(after.metadata)) == before_state, (
+        f"{credential_name} mutated an out-of-scope task via batch {action} despite the refusal"
+    )
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize("credential_name", WRITE_CREDENTIALS)
+async def test_batch_ops_refuses_the_whole_batch_when_one_id_is_out_of_scope(
+    fx: Fixture,
+    client: AsyncClient,
+    credential_name: str,
+) -> None:
+    """An out-of-scope id poisons the batch rather than being skipped inside it.
+
+    This is the shape the route's pre-existing agent-scope gate already has:
+    the ids are checked together, before the loop, so a caller cannot smuggle
+    one row past the boundary by burying it among ids it does hold.
+    """
+    credential = _credential(fx, credential_name)
+    store: Any = fx.app.state.store
+    before_priority = store.get_task(fx.task_a_id).priority
+
+    response = await client.post(
+        "/tasks/batch-ops",
+        headers=credential.headers,
+        json={"action": "reprioritize", "ids": [fx.task_a_id, fx.task_b_id], "priority": 0},
+    )
+
+    assert response.status_code in REJECTION_STATUSES, (
+        f"{credential_name} ran a mixed-scope batch: got {response.status_code}"
+    )
+    assert store.get_task(fx.task_a_id).priority == before_priority, (
+        f"{credential_name} applied a mixed-scope batch to the in-scope half"
+    )
+
+
+@pytest.mark.anyio()
+async def test_batch_ops_still_mutates_a_task_in_the_callers_scope(
+    fx: Fixture,
+    client: AsyncClient,
+) -> None:
+    """Positive control: the gate does not refuse the caller's own rows."""
+    credential = _credential(fx, "legacy_bearer")
+    store: Any = fx.app.state.store
+
+    response = await client.post(
+        "/tasks/batch-ops",
+        headers=credential.headers,
+        json={"action": "reprioritize", "ids": [fx.task_default_id], "priority": 7},
+    )
+
+    assert response.status_code == 200, f"batch-ops refused an in-scope task: got {response.status_code}"
+    assert response.json()["succeeded"] == [fx.task_default_id]
+    assert store.get_task(fx.task_default_id).priority == 7
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize("credential_name", READ_CREDENTIALS)
+async def test_task_diff_requires_the_callers_scope(
+    fx: Fixture,
+    client: AsyncClient,
+    credential_name: str,
+) -> None:
+    """The diff route applies the same gate its task-detail sibling applies.
+
+    It reads the task to resolve the working branch and then returns that
+    branch's contents, so an ungated read hands over another tenant's source
+    changes as well as the row.
+    """
+    credential = _credential(fx, credential_name)
+
+    response = await client.get(
+        f"/dashboard/tasks/{fx.task_b_id}/diff",
+        headers=credential.crossing_headers(),
+    )
+
+    assert response.status_code in REJECTION_STATUSES, (
+        f"{credential_name} read the diff of an out-of-scope task: got {response.status_code}"
+    )
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize(("credential_name", "own_tenant"), READ_CREDENTIALS_WITH_OWN_TENANT)
+async def test_task_diff_still_serves_a_task_in_the_callers_scope(
+    fx: Fixture,
+    client: AsyncClient,
+    credential_name: str,
+    own_tenant: str,
+) -> None:
+    """Positive control: the caller's own task still resolves a diff."""
+    credential = _credential(fx, credential_name)
+    own_task_id = fx.task_a_id if own_tenant == TENANT_A else fx.task_default_id
+
+    response = await client.get(f"/dashboard/tasks/{own_task_id}/diff", headers=credential.headers)
+
+    assert response.status_code == 200, f"{credential_name} lost the diff for its own tenant"
+    assert response.json()["task_id"] == own_task_id


### PR DESCRIPTION
## Root cause

The tenant scope a request resolves to is applied on the task routes that reach a row by id, but four sinks that reach task rows another way were never narrowed to it: `export_tasks` and the GraphQL `tasks` resolver call `list_tasks()` with no scope at all, `batch-ops` checks only the agent-credential task-id pin (which says nothing about any other credential type), and `task_diff` is the one member of its trio that never applies the access check its `task_detail` and `task_log_stream` siblings already do.

This tightens each of those four to match the containment check the surrounding code already uses.

## What changed

| File | Sink | Change |
|---|---|---|
| `routes/export.py` | `list_tasks()` | effective tenant pushed into the store call, before `limit`/`offset` slice |
| `routes/graphql_api.py` | `list_tasks()` | scope threaded through `execute_graphql` → `_resolve_tasks` |
| `routes/batch_ops.py` | `get_task()` ×3 | id list gated beside the existing agent-scope gate |
| `routes/task_detail.py` | `get_task()` | `_require_task_access` added to `task_diff` |
| `routes/task_crud.py` | — | `_require_parent_tenant_scope` generalised into a shared `require_tenant_scope_for_ids` |

Two deliberate shape choices:

- **The batch gate is whole-list, not per-item.** Every batch action mutates, so a per-item check would let a mixed list apply its in-scope half before refusing the rest. This matches the shape the route's pre-existing `enforce_agent_task_scope_for_ids` gate already has.
- **`execute_graphql` takes the scope as a required argument**, not a defaulted one. It is a second front door onto the task table; a default would make "every tenant" the behaviour a caller gets by forgetting to say anything.

Scope narrowing is pushed into `list_tasks` rather than applied to returned rows, so `limit`/`offset` page through the caller's own tasks instead of paging through every tenant's and returning short pages.

## Tests

All added to `tests/unit/test_tenant_scope_http_isolation.py` unless noted — the real `create_app` middleware chain, real auth, real `TaskStore`, nothing mocked.

Refusal / non-leak:

- `test_export_tasks_omits_rows_outside_the_callers_scope` — parametrized over all 5 read credentials × `json`/`csv`, so narrowing must happen on the row set rather than in one formatter
- `test_graphql_tasks_query_omits_rows_outside_the_callers_scope`
- `test_batch_ops_refuses_a_task_outside_the_callers_scope` — all 5 write credentials × all 4 actions (`cancel`/`retry`/`reprioritize`/`tag`), asserting the stored row is unchanged as well as the status code
- `test_batch_ops_refuses_the_whole_batch_when_one_id_is_out_of_scope` — an out-of-scope id poisons the batch instead of being skipped inside it
- `test_task_diff_requires_the_callers_scope`
- `test_tasks_query_resolves_only_the_named_tenant` (`test_route_graphql.py`) — the scope reaches the store rather than being accepted and dropped

Positive controls, so none of the above is satisfied by a server that refuses everything:

- `test_export_tasks_still_returns_the_callers_own_rows`
- `test_graphql_tasks_query_still_returns_the_callers_own_rows`
- `test_batch_ops_still_mutates_a_task_in_the_callers_scope`
- `test_task_diff_still_serves_a_task_in_the_callers_scope`

Verified by stashing only the `src/` change: **41 failed** before, **339 passed** after across the 11 affected suites. `ruff check`/`format` clean; `mypy --config-file mypy.gate.ini src/bernstein/core/routes/` reports 18 errors both before and after (unchanged baseline, none in the touched files).

## Out of scope

- `_resolve_status` in `graphql_api.py` calls `store.status_summary()`, which takes no tenant argument. Narrowing it needs a store-level change rather than a route-level one, so it is left alone here.
- `/export/agents` reads a runtime JSON snapshot that carries no tenant field; nothing to narrow against without a format change.
- Other ungated `list_tasks()` callers exist (`observability.py`, `status_dashboard.py`, `team_dashboard.py`, `status_events.py`, `agents.py`). They are the same class of gap but a different set of surfaces, and folding them in would make this change hard to review.