### PR TITLE
release: v3.15.1

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "description": "Deterministic orchestrator for CLI coding agents. Spawn parallel agents in per-task git worktrees, verify their work, and merge results; no model in the coordination loop, so runs replay byte-identically.",
   "author": {
     "name": "chernistry",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,7 +32,7 @@ keywords:
   - gemini-cli
   - aider
   - software-engineering
-version: "3.15.0"
+version: "3.15.1"
 date-released: "2026-08-14"
 preferred-citation:
   type: software

--- a/docs/release-notes/v3.15.1.md
+++ b/docs/release-notes/v3.15.1.md
@@ -1,0 +1,111 @@
+# v3.15.1
+
+A patch release, and the first one this project has cut on a theme rather than
+on a count. v3.15.0 closed the trust boundary where it was leaking; this one
+walks the same boundary looking for the places the fix did not reach — the
+credential that authenticates and is then asked nothing further, the reader
+that narrows its answer for one caller and not the next, the surface that was
+hardened in REST and left as it was in gRPC.
+
+Nine changes, seven of them the same sentence in different subsystems: derive
+what you are allowed to see from what you proved, and check it at the place
+that reads, not at the place that asks.
+
+## Security
+
+- **Every credential kind now clears the same route gate (#3797).** An agent
+  identity authenticated and then proceeded without the per-route permission
+  check the other principal paths apply, so a task-scoped token reached log
+  and stream reads and session-kill routes it held no permission for. The
+  middleware now resolves the required permission for every authenticated
+  request and refuses when the credential does not hold it. The fleet-wide
+  cluster secret is bound the same way in the same change — review of the
+  first patch found it carrying the identical shape, and shipping half of
+  this would have been worse than shipping none of it.
+- **Task reads and mutations narrow to the caller's tenant (#3799).** The
+  export, the GraphQL collection resolver, the batch mutator and the task
+  detail and diff routes each resolved rows without passing through the
+  scoped single-task path, so a valid credential could read and mutate
+  another tenant's tasks. Each now applies the effective tenant derived from
+  authenticated state, with a cross-tenant refusal test per surface and a
+  positive control per surface — a leak assertion that an empty response
+  would satisfy is not an assertion.
+- **The gRPC cluster surface is hardened to the REST surface's level
+  (#3537).** Mutating handlers require the scopes their REST equivalents
+  require; `RegisterNodeResponse.auth_token` is populated with a node JWT
+  carrying `node:register` and `node:heartbeat` and never `node:admin`;
+  re-registration resolves an existing node by identity instead of adding a
+  row, so a restarting worker stops inflating cluster capacity. Verified
+  against main first: three registrations of one worker produced three
+  entries and a capacity of 12 where 4 was correct. The surface is latent —
+  nothing in `src/` starts the server — which is exactly why it was worth
+  closing before it is not.
+- **Attachment worktree access rests only on authenticated rows (#3567).**
+  The access decision read `multimodal.attach` events through the
+  unverified query path, so a forged row could name another worktree as an
+  owner. It now reads through the verified scan with a kept cursor.
+  Reviewing that fix turned up a defect in the cursor primitive itself: a
+  failed scan mutated the caller's cursor before the verdict existed, so a
+  store that detected tampering once went quiet about it afterwards. The
+  scan now walks a working copy and the caller's cursor advances only on a
+  verdict it accepted. Two other subsystems — signal actions and native
+  tool-call evidence — carried the same latent bug and are fixed by the same
+  change. Stated plainly: the attachment surface has no production caller
+  yet, so this makes it safe to wire rather than closing a live hole.
+- **Tenant directory derivation goes through the shared containment barrier
+  (#3693).** `tenant_paths` and `tenant_metrics_dir` asserted containment
+  with their own local check instead of `path_containment.contained_path`.
+  One invariant with two implementations is one invariant waiting to drift.
+  Sixteen further call sites still hold their own copy; #3802 tracks them.
+
+## Behaviour changes (read before upgrading)
+
+- **`auth_type="oauth"` on a remote MCP server now fails at construction
+  (#3463).** It was documented as supported, implemented nowhere, and fell
+  through to refusing every request — a server that looked configured and
+  answered nothing. There is no issuer or audience binding in that code
+  path, so accepting a token would have been worse than refusing one. The
+  value is removed from the documented and accepted set, and an unknown
+  `auth_type` raises `RemoteMCPConfigError` at construction rather than
+  denying silently at serve time. A config carrying `"oauth"` must move to
+  `"bearer"` or `"none"`.
+- **Cost-history rows with no tenant attribution are excluded from every
+  tenant-scoped query (#3702).** `DailyCostSnapshot` gains a tenant field so
+  the 30- and 90-day trend behind `/costs/alerts` can be narrowed at all.
+  Every row written before this release loads with no attribution, and
+  absence is treated as a sentinel rather than as the default tenant:
+  crediting unverified spend to one tenant is a worse answer than omitting
+  it. A single-tenant install sees its trend start from rows written after
+  the upgrade. `upsert_daily_snapshot` also matches on date *and* tenant,
+  where a same-day upsert could previously clobber another tenant's row.
+- **Disclosure defaults match the published policy (#3694).** The module
+  encoded a programme the project no longer runs: a 48-hour response SLA, a
+  four-tier recognition ladder including a hall of fame whose page was
+  removed in #3689, and fix-deadline arithmetic. `SECURITY.md` states a
+  90-day first-response window, no fix deadline, and one uniform credit
+  path; the defaults now say the same thing. Anything reading
+  `response_sla_hours`, the recognition tiers, or the fix-deadline keys in
+  the compliance and timeline outputs will see the new shape.
+
+## Release engineering
+
+- **A rawhide build no longer holds the RPM channel (#3791).** The v3.15.0
+  publish went red while every released chroot published: fedora 43 and 44
+  and epel 9 and 10 all shipped, and only rawhide failed, on a dependency
+  with no wheel for its interpreter falling back to a source build with no
+  `g++` present. Copr reports one state per build and that state is failed
+  when any single chroot is, which contradicted the workflow's own stated
+  intent. The watcher now decides a failed build on its gating chroots and
+  the spec carries a C++ toolchain, so rawhide builds instead of merely
+  stopping short of blocking. Tolerating rawhide did not widen into
+  tolerating a bad build: a failure on a released chroot, a build that
+  published nothing, and an unreadable chroot list all still fail.
+
+Upgrade in place. Things worth checking first: any remote MCP server
+configured with `auth_type="oauth"` (it now raises at construction, #3463),
+anything reading the cost-history trend on a multi-tenant install (untagged
+historical rows are excluded, #3702), anything reading disclosure SLA or
+recognition fields (#3694), any client holding an agent identity or the
+cluster secret that reached a route it had no permission for (it now gets a
+403, #3797), and any caller that relied on a task read answering across
+tenants (#3799).

--- a/docs/release-notes/v3.15.1.md
+++ b/docs/release-notes/v3.15.1.md
@@ -7,9 +7,12 @@ credential that authenticates and is then asked nothing further, the reader
 that narrows its answer for one caller and not the next, the surface that was
 hardened in REST and left as it was in gRPC.
 
-Nine changes, seven of them the same sentence in different subsystems: derive
+Eleven changes, eight of them the same sentence in different subsystems: derive
 what you are allowed to see from what you proved, and check it at the place
 that reads, not at the place that asks.
+
+Two of the eleven were not on the list when this release was cut. They were
+found by reviewing the other nine, which is the argument for reviewing them.
 
 ## Security
 
@@ -30,6 +33,35 @@ that reads, not at the place that asks.
   authenticated state, with a cross-tenant refusal test per surface and a
   positive control per surface — a leak assertion that an empty response
   would satisfy is not an assertion.
+- **The dashboard, observability and export readers narrow the same way
+  (#3808).** The change above closed the task routes and named a second set
+  of readers it deliberately left, on the grounds that folding them in would
+  have made it unreviewable. That was the right call about review and a bad
+  place to stop. Those readers were then checked one at a time against a
+  running two-tenant server rather than by reading the code, and twelve of
+  the thirteen handed an authenticated caller another tenant's task ids and
+  titles: `/status` and its duration predictions, `/recap`,
+  `/dashboard/data`, the team dashboard, the dependency graph, the agent and
+  token-breakdown views, `/agents` and its comparison, `/export/agents`,
+  `/badge.json`, and the GraphQL status summary. The thirteenth — the
+  `/events` stream — turned out to subscribe to the event bus and never
+  touch the task table, so it is closed with that evidence and no change to
+  it. Each of the twelve now derives its tenant from authenticated state.
+  `status_summary()` gains a tenant argument rather than the surface quietly
+  ceasing to be a per-tenant figure, and runtime records that carry no
+  tenant of their own — agent sessions, token sidecars — derive one from the
+  task they name; an id that resolves to nothing is kept rather than
+  dropped, because dropping it would be an existence check wearing a scope
+  check's clothes.
+- **The budget forecast is scoped to the caller's tenant (#3809).**
+  `/metrics/predictions` built its spend series from every tenant's cost
+  points, so one tenant's spend moved another's exhaustion forecast. It is
+  now narrowed the way the rest of the cost surface is. A cost point written
+  before per-tenant attribution existed reads as the default tenant's spend,
+  which is not a second policy sitting next to #3702's but agreement with
+  the writer: the metric collector already resolves an absent tenant label
+  to the default when it picks the file to write to. Reported and fixed by
+  @BinarySpecter.
 - **The gRPC cluster surface is hardened to the REST surface's level
   (#3537).** Mutating handlers require the scopes their REST equivalents
   require; `RegisterNodeResponse.auth_token` is populated with a node JWT
@@ -109,3 +141,10 @@ recognition fields (#3694), any client holding an agent identity or the
 cluster secret that reached a route it had no permission for (it now gets a
 403, #3797), and any caller that relied on a task read answering across
 tenants (#3799).
+
+The one to check properly on a multi-tenant install is the operator view.
+Dashboards, the recap, the dependency graph, the agent and token views,
+`/export/agents`, `/badge.json` and the budget forecast now answer for one
+tenant rather than for the install (#3808, #3809). If you were reading any of
+those as a whole-fleet figure, the number will drop, and it was never the
+number you thought it was. A single-tenant install sees no change.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -520,6 +520,7 @@ nav:
       - Release notes:
           - Changelog: CHANGELOG.md
           - Unreleased: release-notes/unreleased.md
+          - v3.15.1: release-notes/v3.15.1.md
           - v3.15.0: release-notes/v3.15.0.md
           - v3.14.159: release-notes/v3.14.159.md
           - v3.13.0: release-notes/v3.13.0.md

--- a/plugin.json
+++ b/plugin.json
@@ -17,5 +17,5 @@
   "license": "Apache-2.0",
   "name": "bernstein",
   "repository": "https://github.com/sipyourdrink-ltd/bernstein",
-  "version": "3.15.0"
+  "version": "3.15.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.15.0"
+version = "3.15.1"
 description = "Deterministic orchestrator for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40+ more). No model in the coordination loop, so parallel runs in per-task git worktrees replay byte-identically. Signed lineage plus an opt-in HMAC audit chain a reviewer checks offline, without rerunning it. Cluster mode, air-gap deploy."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -7,19 +7,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.15.0",
+  "version": "3.15.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.15.0",
+      "version": "3.15.1",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.15.0",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.15.1",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -364,7 +364,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.15.0"
+version = "3.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Patch release cut on a theme rather than a count: v3.15.0 closed the trust boundary where it was leaking, and this one walks the same boundary looking for the places that fix did not reach.

Nine changes landed since `v3.15.0`:

| PR | Change |
|---|---|
| #3797 | every credential kind clears the same route-permission gate |
| #3799 | task read and mutate sinks narrow to the caller's tenant |
| #3796 | gRPC cluster surface hardened to the REST surface's level |
| #3794 | attachment worktree access decided from authenticated rows |
| #3795 | tenant directory derivation routed through the shared containment barrier |
| #3792 | undocumented `auth_type` values rejected at construction |
| #3798 | daily cost-history trend scoped by tenant |
| #3793 | disclosure defaults aligned with `SECURITY.md` |
| #3791 | rawhide churn no longer holds the RPM channel |

Milestone [v3.15.1](https://github.com/sipyourdrink-ltd/bernstein/milestone/22) is empty: all six issues closed.

Three behaviour changes are called out in the notes for anyone upgrading: `auth_type="oauth"` on a remote MCP server now raises at construction (#3463), cost-history rows written before this release carry no tenant attribution and are excluded from tenant-scoped queries (#3702), and the disclosure module's SLA and recognition fields changed shape (#3694).

Contents: the bump via `scripts/bump_version.py` (pyproject, lockfile, distribution manifests), `docs/release-notes/v3.15.1.md`, and its `mkdocs.yml` nav entry.

---

## Scope added after this PR was opened

Two more changes were folded in, both found by reviewing the nine already
listed rather than from the milestone:

| PR | Closes | What |
|---|---|---|
| #3808 | #3806 | Dashboard, observability and export readers narrow to the caller's tenant |
| #3809 | #3800 | `/metrics/predictions` budget forecast scoped by tenant |

#3808 is the reason this release waited. #3799 closed the task routes and
named a second set of readers it deliberately left; checked one at a time
against a running two-tenant server, twelve of thirteen returned another
tenant's task ids and titles to an authenticated caller. Shipping the notes
as written — "task reads and mutations narrow to the caller's tenant" —
without it would have told operators the boundary was closed while the
operator views were still open.

The thirteenth, `/events`, was refuted: it subscribes to the event bus and
never reads the task table. Closed with that evidence, unchanged.

Release notes updated to match.
