### PR TITLE
fix(cost): scope the /metrics/predictions forecast by tenant (#3800)

### DIFF
--- a/src/bernstein/core/observability/predictive_alerts.py
+++ b/src/bernstein/core/observability/predictive_alerts.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.tenanting import DEFAULT_TENANT_ID, normalize_tenant_id, try_normalize_tenant_id
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -603,15 +605,44 @@ class PredictiveAlertEngine:
 # ---------------------------------------------------------------------------
 
 
-def load_cost_history(metrics_dir: Path) -> list[tuple[float, float]]:
+def _record_tenant(rec: dict[str, Any]) -> str:
+    """Return the tenant a persisted cost-efficiency point is attributed to.
+
+    The metrics collector writes the tenant under ``labels.tenant_id``,
+    already normalized.  A point recorded before per-tenant attribution
+    existed - no ``labels`` dict, or no ``tenant_id`` inside it - or one
+    whose stored value cannot be read as a tenant id is treated as the
+    **default** tenant's spend.  On the only install that can hold such
+    points (a legacy single-tenant one), every point was that one tenant's
+    spend, so folding them into the default scope is what keeps that
+    install's numbers unchanged.  This is deliberately the opposite of the
+    ``cost_history.jsonl`` reader's choice (#3702), whose acceptance bar was
+    a fresh install starting empty; here it is a legacy install keeping its
+    numbers, so absence names the one tenant the install can have had.
+    """
+    labels = rec.get("labels")
+    if isinstance(labels, dict):
+        normalized = try_normalize_tenant_id(labels.get("tenant_id"))
+        if normalized is not None:
+            return normalized
+    return DEFAULT_TENANT_ID
+
+
+def load_cost_history(metrics_dir: Path, tenant_id: str | None = None) -> list[tuple[float, float]]:
     """Read cumulative spend time-series from metrics JSONL files.
 
     Args:
         metrics_dir: Path to ``.sdd/metrics/`` directory.
+        tenant_id: When given, narrow to cost points attributed to exactly
+            this tenant (see :func:`_record_tenant`); every other point is
+            skipped.  Leaving it unset returns every point regardless of
+            attribution, for callers that genuinely want the whole install's
+            series.
 
     Returns:
         List of ``(timestamp, cumulative_spend_usd)`` pairs, ascending.
     """
+    scope = normalize_tenant_id(tenant_id) if tenant_id is not None else None
     points: list[tuple[float, float]] = []
     running_total = 0.0
 
@@ -625,6 +656,8 @@ def load_cost_history(metrics_dir: Path) -> list[tuple[float, float]]:
                 try:
                     rec: dict[str, Any] = json.loads(line)
                 except json.JSONDecodeError:
+                    continue
+                if scope is not None and _record_tenant(rec) != scope:
                     continue
                 ts = float(rec.get("timestamp", 0))
                 value = float(rec.get("value", 0))

--- a/src/bernstein/core/routes/predictive.py
+++ b/src/bernstein/core/routes/predictive.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, Annotated, Any
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
 from bernstein.core.predictive_alerts import (
@@ -16,9 +16,17 @@ from bernstein.core.predictive_alerts import (
     load_completion_timestamps,
     load_cost_history,
 )
+from bernstein.core.tenanting import (
+    request_tenant_cross_scope,
+    request_tenant_id,
+    requested_tenant_override,
+    resolve_tenant_scope,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from bernstein.core.tenanting import TenantRegistry
 
 router = APIRouter()
 
@@ -27,6 +35,33 @@ _engine = PredictiveAlertEngine()
 
 def _get_sdd_dir(request: Request) -> Any:
     return getattr(request.app.state, "sdd_dir", None)
+
+
+def _get_tenant_registry(request: Request) -> TenantRegistry | None:
+    registry = getattr(request.app.state, "tenant_registry", None)
+    return registry if registry is not None else None
+
+
+def _resolve_request_tenant_scope(request: Request) -> str:
+    """Resolve the tenant scope for the current request.
+
+    Same rule as the rest of the cost surface: the bound tenant comes from
+    the authenticated principal, and a caller-supplied selector (the
+    ``X-Tenant-Id`` header) is authorized against it - naming your own scope
+    is fine, naming a different one needs the operator scope.
+    """
+    override = requested_tenant_override(request)
+    try:
+        return resolve_tenant_scope(
+            request_tenant_id(request),
+            override,
+            registry=_get_tenant_registry(request),
+            allow_cross_tenant=request_tenant_cross_scope(request),
+        )
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 def _read_task_counts(request: Request) -> tuple[int, int]:
@@ -94,6 +129,13 @@ def get_predictions(
     Use ``budget_cap`` to enable the budget forecast. The run duration
     forecast requires at least one completed task.
 
+    The budget forecast is scoped to ``tenant_id``: the spend series it is
+    built from is narrowed to cost points recorded for the caller's tenant,
+    the same way the rest of the cost surface is (see
+    ``load_cost_history``).  Cost points written before per-tenant
+    attribution existed are treated as the default tenant's spend, so a
+    legacy single-tenant install keeps its existing numbers.
+
     Returns a list of ``alerts`` ordered by severity (critical first).
     Each alert has: ``kind``, ``severity``, ``message``,
     ``minutes_until_impact``, ``confidence``.
@@ -101,13 +143,14 @@ def get_predictions(
 
     sdd_dir = _get_sdd_dir(request)
     metrics_dir: Path | None = sdd_dir / "metrics" if sdd_dir is not None else None
+    tenant_id = _resolve_request_tenant_scope(request)
 
     cost_history: list[tuple[float, float]] = []
     completion_timestamps: list[float] = []
 
     if metrics_dir is not None and metrics_dir.exists():
         if budget_cap > 0:
-            cost_history = load_cost_history(metrics_dir)
+            cost_history = load_cost_history(metrics_dir, tenant_id=tenant_id)
         completion_timestamps = load_completion_timestamps(metrics_dir)
 
     tasks_done, tasks_remaining = _read_task_counts(request)

--- a/tests/unit/test_predictive_alerts.py
+++ b/tests/unit/test_predictive_alerts.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import time
+from pathlib import Path
 
 import pytest
 from bernstein.core.predictive_alerts import (
@@ -12,7 +14,9 @@ from bernstein.core.predictive_alerts import (
     forecast_budget_exhaustion,
     forecast_completion_rate,
     forecast_run_duration,
+    load_cost_history,
 )
+from bernstein.core.tenanting import DEFAULT_TENANT_ID
 
 
 class TestOLS:
@@ -281,3 +285,69 @@ class TestPredictiveAlertEngine:
                 assert severity_order.get(str(alerts[i].severity), 9) <= severity_order.get(
                     str(alerts[i + 1].severity), 9
                 )
+
+
+def _point(ts: float, value: float, tenant_id: str | None = None) -> dict[str, object]:
+    """A cost-efficiency metric point as the collector writes it."""
+    labels: dict[str, str] = {"task_id": "t", "role": "backend", "model": "m"}
+    if tenant_id is not None:
+        labels["tenant_id"] = tenant_id
+    return {"timestamp": ts, "metric_type": "cost_efficiency", "value": value, "labels": labels}
+
+
+def _write_points(tmp_path: Path, points: list[dict[str, object]]) -> None:
+    metrics_dir = tmp_path / "metrics"
+    metrics_dir.mkdir(parents=True, exist_ok=True)
+    with (metrics_dir / "cost_efficiency_2026-08-14.jsonl").open("a", encoding="utf-8") as fh:
+        for point in points:
+            fh.write(json.dumps(point) + "\n")
+
+
+class TestLoadCostHistory:
+    """Tenant narrowing of the cumulative spend series (issue #3800)."""
+
+    def test_narrows_to_requested_tenant_only(self, tmp_path: Path) -> None:
+        _write_points(
+            tmp_path,
+            [
+                _point(1000.0, 1.0, "tenant-a"),
+                _point(1100.0, 1.0, "tenant-a"),
+                _point(1200.0, 1.0, "tenant-b"),
+                _point(1300.0, 1.0, "tenant-b"),
+            ],
+        )
+
+        series = load_cost_history(tmp_path / "metrics", tenant_id="tenant-a")
+
+        assert series == [(1000.0, 1.0), (1100.0, 2.0)]
+
+    def test_untagged_rows_are_treated_as_default_tenant(self, tmp_path: Path) -> None:
+        # A legacy single-tenant install's records predate any tenant field;
+        # folding them into the default scope is what keeps its numbers.
+        _write_points(
+            tmp_path,
+            [
+                _point(1000.0, 1.0),  # no tenant label at all
+                _point(1100.0, 2.0),
+                _point(1200.0, 3.0, DEFAULT_TENANT_ID),
+            ],
+        )
+
+        default_series = load_cost_history(tmp_path / "metrics", tenant_id=DEFAULT_TENANT_ID)
+        other_series = load_cost_history(tmp_path / "metrics", tenant_id="tenant-b")
+
+        assert default_series == [(1000.0, 1.0), (1100.0, 3.0), (1200.0, 6.0)]
+        assert other_series == []
+
+    def test_without_tenant_filter_returns_every_record(self, tmp_path: Path) -> None:
+        _write_points(
+            tmp_path,
+            [
+                _point(1000.0, 1.0, "tenant-a"),
+                _point(1100.0, 1.0, "tenant-b"),
+            ],
+        )
+
+        series = load_cost_history(tmp_path / "metrics")
+
+        assert series == [(1000.0, 1.0), (1100.0, 2.0)]

--- a/tests/unit/test_tenant_scope_http_isolation.py
+++ b/tests/unit/test_tenant_scope_http_isolation.py
@@ -1407,3 +1407,149 @@ async def test_costs_alerts_trend_still_reports_the_callers_own_history(
     body = response.json()
     assert body["history_days"] == 1
     assert body["trend"]["avg_30d_usd"] == pytest.approx(4.0)
+
+
+# ---------------------------------------------------------------------------
+# Predictive forecast scoping (issue #3800)
+#
+# The budget-exhaustion forecast behind GET /metrics/predictions is built
+# from .sdd/metrics/cost_efficiency_*.jsonl points. Like the /costs/alerts
+# trend before #3702, it used to mix every tenant's spend into one series;
+# these cases pin that it is now narrowed to the caller's tenant the same
+# way the rest of the cost surface is.
+# ---------------------------------------------------------------------------
+
+_BASE_TS = 1_700_000_000.0
+
+
+def _write_cost_efficiency_point(metrics_dir: Path, ts: float, value: float, tenant_id: str | None) -> None:
+    """Append one cost-efficiency JSONL point to the shared metrics dir."""
+    import json
+
+    labels: dict[str, str] = {"task_id": "t", "role": "backend", "model": "m"}
+    if tenant_id is not None:
+        labels["tenant_id"] = tenant_id
+    record = {
+        "timestamp": ts,
+        "metric_type": "cost_efficiency",
+        "value": value,
+        "labels": labels,
+    }
+    metrics_dir.mkdir(parents=True, exist_ok=True)
+    path = metrics_dir / "cost_efficiency_2026-08-14.jsonl"
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+
+def _prediction_view(body: dict[str, Any]) -> dict[str, Any]:
+    """The prediction body with the per-call clock fields stripped.
+
+    ``timestamp`` at the top level and ``timestamp`` / ``predicted_at`` on
+    each alert are wall-clock values that legitimately differ between two
+    requests; everything else is a pure function of the cost series.
+    """
+    view = {k: v for k, v in body.items() if k != "timestamp"}
+    view["alerts"] = [
+        {k: v for k, v in alert.items() if k not in ("predicted_at", "timestamp")} for alert in view["alerts"]
+    ]
+    return view
+
+
+@pytest.mark.anyio()
+async def test_predictions_forecast_excludes_another_tenants_spend(
+    fx: Fixture,
+    client: AsyncClient,
+    sdd_dir: Path,
+) -> None:
+    """Tenant A's forecast does not move when tenant B's spend arrives.
+
+    The caller scoped to tenant A reads the endpoint, then tenant B's spend
+    is recorded and the endpoint is read again.  The forecast is asserted
+    identical across the two reads - the numbers prove the narrowing, not a
+    filter call.
+    """
+    metrics_dir = sdd_dir / "metrics"
+    for i, value in enumerate([1.0, 1.5, 2.0]):
+        _write_cost_efficiency_point(metrics_dir, _BASE_TS + i * 60, value, TENANT_A)
+
+    credential = _credential(fx, "sso_viewer")
+    before = await client.get("/metrics/predictions?budget_cap=5.0", headers=credential.headers)
+    assert before.status_code == 200
+
+    for i, value in enumerate([100.0, 100.0, 100.0]):
+        _write_cost_efficiency_point(metrics_dir, _BASE_TS + 1000 + i * 60, value, TENANT_B)
+
+    after = await client.get("/metrics/predictions?budget_cap=5.0", headers=credential.headers)
+    assert after.status_code == 200
+
+    assert _prediction_view(after.json()) == _prediction_view(before.json())
+
+
+@pytest.mark.anyio()
+async def test_predictions_forecast_reaches_the_callers_own_spend(
+    fx: Fixture,
+    client: AsyncClient,
+    sdd_dir: Path,
+) -> None:
+    """Positive control: tenant A's own rows still reach the forecast.
+
+    Without this, the leak assertion above would be satisfied by an endpoint
+    that returned nothing to anyone.
+    """
+    from bernstein.core.predictive_alerts import forecast_budget_exhaustion
+
+    metrics_dir = sdd_dir / "metrics"
+    values = [1.0, 1.5, 2.0]
+    series = [(_BASE_TS + i * 60, sum(values[: i + 1])) for i in range(len(values))]
+    for i, value in enumerate(values):
+        _write_cost_efficiency_point(metrics_dir, _BASE_TS + i * 60, value, TENANT_A)
+
+    expected = forecast_budget_exhaustion(series, 5.0)
+    assert expected is not None
+
+    credential = _credential(fx, "sso_viewer")
+    response = await client.get("/metrics/predictions?budget_cap=5.0", headers=credential.headers)
+    assert response.status_code == 200
+
+    budget_alerts = [a for a in response.json()["alerts"] if a["kind"] == "budget_exhaustion"]
+    assert budget_alerts, "tenant A's own cost rows produced no budget forecast"
+    meta = budget_alerts[0]["metadata"]
+    assert meta["current_spend_usd"] == pytest.approx(expected.current_spend_usd)
+    assert meta["velocity_usd_per_min"] == pytest.approx(expected.spend_velocity_usd_per_min)
+    assert budget_alerts[0]["minutes_until_impact"] == pytest.approx(expected.minutes_until_exhaustion, abs=0.05)
+    assert budget_alerts[0]["confidence"] == pytest.approx(expected.confidence, abs=0.001)
+
+
+@pytest.mark.anyio()
+async def test_predictions_default_scope_keeps_legacy_install_numbers(
+    fx: Fixture,
+    client: AsyncClient,
+    sdd_dir: Path,
+) -> None:
+    """A legacy default-tenant install keeps its current numbers.
+
+    cost_efficiency records written before per-tenant attribution carry no
+    tenant label.  On the only install that holds such records - a legacy
+    single-tenant one - every row was the one tenant's spend, so the default
+    scope keeps folding them in rather than letting the forecast go empty.
+    """
+    from bernstein.core.predictive_alerts import forecast_budget_exhaustion
+
+    metrics_dir = sdd_dir / "metrics"
+    values = [1.0, 2.0, 3.0, 4.0]
+    for i, value in enumerate(values):
+        tenant = DEFAULT_TENANT_ID if i >= 2 else None
+        _write_cost_efficiency_point(metrics_dir, _BASE_TS + i * 60, value, tenant)
+
+    expected = forecast_budget_exhaustion([(_BASE_TS + i * 60, sum(values[: i + 1])) for i in range(len(values))], 20.0)
+    assert expected is not None
+
+    credential = _credential(fx, "legacy_bearer")
+    response = await client.get("/metrics/predictions?budget_cap=20.0", headers=credential.headers)
+    assert response.status_code == 200
+
+    budget_alerts = [a for a in response.json()["alerts"] if a["kind"] == "budget_exhaustion"]
+    assert budget_alerts, "default-tenant forecast dropped pre-migration rows"
+    meta = budget_alerts[0]["metadata"]
+    assert meta["current_spend_usd"] == pytest.approx(expected.current_spend_usd)
+    assert meta["velocity_usd_per_min"] == pytest.approx(expected.spend_velocity_usd_per_min)


### PR DESCRIPTION
## Description

GET /metrics/predictions computes its forecast across every tenant's cost history. The fix is minimal: `from bernstein.core.tenanting import DEFAULT_TENANT_ID, normalize_tenant_id, try_normalize_tenant_id` in `predictive_alerts.py`.

## What changed

- Fixed the issue in `src/bernstein/core/observability/predictive_alerts.py`.
- Fixed the issue in `src/bernstein/core/routes/predictive.py`.
- Fixed the issue in `tests/unit/test_predictive_alerts.py`.
- Fixed the issue in `tests/unit/test_tenant_scope_http_isolation.py`.

## Testing

Ran the test suite: OK — /usr/bin/python3 -m pytest -q (broad suite timed out after 240s (environmental) — targeted tests passed) [targeted+timeout].

Fixes #3800