### PR TITLE
fix(openapi): refresh the snapshot and guard schema property names

### DIFF
--- a/docs/reference/openapi-reference.md
+++ b/docs/reference/openapi-reference.md
@@ -15,7 +15,7 @@ uv run python scripts/generate_openapi.py
 
 Run this after adding or modifying any API route, Pydantic model, or response schema, then commit the updated JSON. The hosted Redoc page reads the spec at load time, so the rendered reference updates automatically once the JSON is committed.
 
-Forgetting the step is a CI failure, not a silent rot: `tests/unit/test_openapi_snapshot_drift.py` rebuilds the app, diffs its paths and component schemas against the committed snapshot, and names whatever moved.
+Forgetting the step is a CI failure, not a silent rot: `tests/unit/test_openapi_snapshot_drift.py` rebuilds the app and diffs it against the committed snapshot, naming whatever moved. It compares paths, component schema names, the property names inside those schemas, and each operation's response codes and media types. Prose is deliberately excluded, so rewording a handler docstring never forces a snapshot commit -- but it does mean a description-only change reaches the published reference on the next regeneration, whenever that is.
 
 **Alternative -- inspect the spec from a running server:**
 

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -4466,7 +4466,7 @@
     "/costs/current": {
       "get": {
         "summary": "Get Cost Current",
-        "description": "Return real-time cost snapshot for the active run + GUI rollups.\n\nUpdated after each agent completion.  Designed for TUI sidebar polling\nand lightweight dashboard widgets.  Returns per-model input/output/cache\ntoken breakdown alongside spend and budget status.\n\nWeb GUI (Costs.tsx §6.05) consumes the additive ``today_usd``,\n``week_usd``, ``projected_month_usd``, ``budget_usd``, ``used_pct``,\n``prior_week_usd``, ``delta_hour_usd``, ``resets_at`` and\n``last_sync_at`` fields. Existing TUI/CLI callers keep reading\n``spent_usd`` / ``percentage_used`` etc. unchanged.",
+        "description": "Return real-time cost snapshot for the active run + GUI rollups.\n\nUpdated after each agent completion.  Designed for TUI sidebar polling\nand lightweight dashboard widgets.  Returns per-model input/output/cache\ntoken breakdown alongside spend and budget status.\n\nWeb GUI (Costs.tsx §6.05) consumes the additive ``today_usd``,\n``week_usd``, ``projected_month_usd``, ``budget_usd``, ``used_pct``,\n``prior_week_usd``, ``delta_hour_usd``, ``resets_at`` and\n``last_sync_at`` fields. Existing TUI/CLI callers keep reading\n``spent_usd`` / ``percentage_used`` etc. unchanged.\n\nScope: every figure here is the caller's tenant's, not the run's or the\ndeployment's - spend is replayed from the caller's scope only, and the\ncap it is measured against is that tenant's configured cap where one is\nconfigured.  ``tenant_id`` in the response names the scope, so a client\naggregating across tenants can tell these apart from run-wide totals.",
         "operationId": "get_cost_current_costs_current_get",
         "responses": {
           "200": {
@@ -4483,7 +4483,7 @@
     "/costs/alerts": {
       "get": {
         "summary": "Get Cost Alerts",
-        "description": "Return active budget alerts and 30d/90d cost trends.\n\nReads the live cost data for the most recent run, checks whether spend\nhas reached the 80% or 95% alert threshold, and returns trend data\ncomputed from ``.sdd/metrics/cost_history.jsonl``.",
+        "description": "Return active budget alerts and 30d/90d cost trends.\n\nReads the live cost data for the most recent run, checks whether spend\nhas reached the 80% or 95% alert threshold, and returns trend data\ncomputed from ``.sdd/metrics/cost_history.jsonl``.\n\nBoth halves of this response are scoped to ``tenant_id``: ``alerts`` is\ncomputed from the caller's tenant's spend against the caller's tenant's\ncap, and ``trend`` / ``history_days`` are narrowed to snapshots recorded\nfor that same tenant.  A history snapshot written before per-tenant\nattribution existed carries no tenant and is excluded from every scoped\ntrend, so a fresh deployment's 30/90-day averages start empty and fill in\nas new, attributed snapshots accumulate.",
         "operationId": "get_cost_alerts_costs_alerts_get",
         "responses": {
           "200": {
@@ -4500,7 +4500,7 @@
     "/costs/history": {
       "get": {
         "summary": "Get Cost History",
-        "description": "Return cost history for chart visualization.\n\nTwo response modes share one endpoint:\n\n* ``GET /costs/history?hours=24&granularity=hour`` (web GUI sparkline) -\n  returns a flat ``[{ts, usd}]`` array bucketed from cost-tracker\n  usages over the last *hours* window.\n* ``GET /costs/history`` *or* ``?envelope=1`` (legacy/CLI) - returns the\n  original ``{history, trend, burn_rate_*, history_days}`` envelope\n  built from ``.sdd/metrics/cost_history.jsonl`` daily snapshots.\n\nThe sparkline branch lets the GUI feed `recharts` directly without\nunwrapping a ``.history`` field.",
+        "description": "Return cost history for chart visualization.\n\nTwo response modes share one endpoint:\n\n* ``GET /costs/history?hours=24&granularity=hour`` (web GUI sparkline) -\n  returns a flat ``[{ts, usd}]`` array bucketed from cost-tracker\n  usages over the last *hours* window.\n* ``GET /costs/history`` *or* ``?envelope=1`` (legacy/CLI) - returns the\n  original ``{history, trend, burn_rate_*, history_days}`` envelope\n  built from ``.sdd/metrics/cost_history.jsonl`` daily snapshots, narrowed\n  to the caller's tenant the same way ``/costs/alerts`` is.\n\nThe sparkline branch lets the GUI feed `recharts` directly without\nunwrapping a ``.history`` field.",
         "operationId": "get_cost_history_costs_history_get",
         "parameters": [
           {
@@ -4904,7 +4904,7 @@
     "/costs/{run_id}": {
       "get": {
         "summary": "Get Cost Budget",
-        "description": "Return budget status for a specific run.\n\nLoads the persisted cost tracker from ``.sdd/runtime/costs/{run_id}.json``\nand returns its ``BudgetStatus`` as JSON.",
+        "description": "Return budget status for a specific run, within the caller's scope.\n\nLoads the persisted cost tracker from ``.sdd/runtime/costs/{run_id}.json``\nand returns its ``BudgetStatus`` as JSON.\n\nScope: every figure is the caller's tenant's share of the run, not the\nrun's total - the run file holds the spend of every tenant that spent\nagainst it, and only the caller's is replayed.  ``tenant_id`` in the\nresponse names the scope the figures belong to.",
         "operationId": "get_cost_budget_costs__run_id__get",
         "parameters": [
           {
@@ -7049,7 +7049,7 @@
     "/export/tasks": {
       "get": {
         "summary": "Export Tasks",
-        "description": "Export tasks as CSV or JSON.\n\nQuery params:\n    format: ``csv`` or ``json`` (default ``json``).\n    limit: Optional max number of tasks to return. Pushed into\n        ``TaskStore.list_tasks`` so large stores no longer materialise\n        the whole table (issue #1728 finding 3).\n    offset: Optional number of tasks to skip before returning rows.",
+        "description": "Export tasks as CSV or JSON.\n\nQuery params:\n    format: ``csv`` or ``json`` (default ``json``).\n    limit: Optional max number of tasks to return. Pushed into\n        ``TaskStore.list_tasks`` so large stores no longer materialise\n        the whole table (issue #1728 finding 3).\n    offset: Optional number of tasks to skip before returning rows.\n\nThe export is a whole-store read, so it narrows to the caller's tenant\nscope the same way the paginated task list does. The scope is pushed into\n``list_tasks`` rather than applied to the returned rows so that it is\n``limit``/``offset`` that page through the caller's own tasks: filtering\nafter the slice would page through every tenant's and return short pages.",
         "operationId": "export_tasks_export_tasks_get",
         "parameters": [
           {
@@ -13282,7 +13282,7 @@
     "/api/v1/costs/current": {
       "get": {
         "summary": "Get Cost Current",
-        "description": "Return real-time cost snapshot for the active run + GUI rollups.\n\nUpdated after each agent completion.  Designed for TUI sidebar polling\nand lightweight dashboard widgets.  Returns per-model input/output/cache\ntoken breakdown alongside spend and budget status.\n\nWeb GUI (Costs.tsx §6.05) consumes the additive ``today_usd``,\n``week_usd``, ``projected_month_usd``, ``budget_usd``, ``used_pct``,\n``prior_week_usd``, ``delta_hour_usd``, ``resets_at`` and\n``last_sync_at`` fields. Existing TUI/CLI callers keep reading\n``spent_usd`` / ``percentage_used`` etc. unchanged.",
+        "description": "Return real-time cost snapshot for the active run + GUI rollups.\n\nUpdated after each agent completion.  Designed for TUI sidebar polling\nand lightweight dashboard widgets.  Returns per-model input/output/cache\ntoken breakdown alongside spend and budget status.\n\nWeb GUI (Costs.tsx §6.05) consumes the additive ``today_usd``,\n``week_usd``, ``projected_month_usd``, ``budget_usd``, ``used_pct``,\n``prior_week_usd``, ``delta_hour_usd``, ``resets_at`` and\n``last_sync_at`` fields. Existing TUI/CLI callers keep reading\n``spent_usd`` / ``percentage_used`` etc. unchanged.\n\nScope: every figure here is the caller's tenant's, not the run's or the\ndeployment's - spend is replayed from the caller's scope only, and the\ncap it is measured against is that tenant's configured cap where one is\nconfigured.  ``tenant_id`` in the response names the scope, so a client\naggregating across tenants can tell these apart from run-wide totals.",
         "operationId": "get_cost_current_api_v1_costs_current_get",
         "responses": {
           "200": {
@@ -13299,7 +13299,7 @@
     "/api/v1/costs/alerts": {
       "get": {
         "summary": "Get Cost Alerts",
-        "description": "Return active budget alerts and 30d/90d cost trends.\n\nReads the live cost data for the most recent run, checks whether spend\nhas reached the 80% or 95% alert threshold, and returns trend data\ncomputed from ``.sdd/metrics/cost_history.jsonl``.",
+        "description": "Return active budget alerts and 30d/90d cost trends.\n\nReads the live cost data for the most recent run, checks whether spend\nhas reached the 80% or 95% alert threshold, and returns trend data\ncomputed from ``.sdd/metrics/cost_history.jsonl``.\n\nBoth halves of this response are scoped to ``tenant_id``: ``alerts`` is\ncomputed from the caller's tenant's spend against the caller's tenant's\ncap, and ``trend`` / ``history_days`` are narrowed to snapshots recorded\nfor that same tenant.  A history snapshot written before per-tenant\nattribution existed carries no tenant and is excluded from every scoped\ntrend, so a fresh deployment's 30/90-day averages start empty and fill in\nas new, attributed snapshots accumulate.",
         "operationId": "get_cost_alerts_api_v1_costs_alerts_get",
         "responses": {
           "200": {
@@ -13316,7 +13316,7 @@
     "/api/v1/costs/history": {
       "get": {
         "summary": "Get Cost History",
-        "description": "Return cost history for chart visualization.\n\nTwo response modes share one endpoint:\n\n* ``GET /costs/history?hours=24&granularity=hour`` (web GUI sparkline) -\n  returns a flat ``[{ts, usd}]`` array bucketed from cost-tracker\n  usages over the last *hours* window.\n* ``GET /costs/history`` *or* ``?envelope=1`` (legacy/CLI) - returns the\n  original ``{history, trend, burn_rate_*, history_days}`` envelope\n  built from ``.sdd/metrics/cost_history.jsonl`` daily snapshots.\n\nThe sparkline branch lets the GUI feed `recharts` directly without\nunwrapping a ``.history`` field.",
+        "description": "Return cost history for chart visualization.\n\nTwo response modes share one endpoint:\n\n* ``GET /costs/history?hours=24&granularity=hour`` (web GUI sparkline) -\n  returns a flat ``[{ts, usd}]`` array bucketed from cost-tracker\n  usages over the last *hours* window.\n* ``GET /costs/history`` *or* ``?envelope=1`` (legacy/CLI) - returns the\n  original ``{history, trend, burn_rate_*, history_days}`` envelope\n  built from ``.sdd/metrics/cost_history.jsonl`` daily snapshots, narrowed\n  to the caller's tenant the same way ``/costs/alerts`` is.\n\nThe sparkline branch lets the GUI feed `recharts` directly without\nunwrapping a ``.history`` field.",
         "operationId": "get_cost_history_api_v1_costs_history_get",
         "parameters": [
           {
@@ -13720,7 +13720,7 @@
     "/api/v1/costs/{run_id}": {
       "get": {
         "summary": "Get Cost Budget",
-        "description": "Return budget status for a specific run.\n\nLoads the persisted cost tracker from ``.sdd/runtime/costs/{run_id}.json``\nand returns its ``BudgetStatus`` as JSON.",
+        "description": "Return budget status for a specific run, within the caller's scope.\n\nLoads the persisted cost tracker from ``.sdd/runtime/costs/{run_id}.json``\nand returns its ``BudgetStatus`` as JSON.\n\nScope: every figure is the caller's tenant's share of the run, not the\nrun's total - the run file holds the spend of every tenant that spent\nagainst it, and only the caller's is replayed.  ``tenant_id`` in the\nresponse names the scope the figures belong to.",
         "operationId": "get_cost_budget_api_v1_costs__run_id__get",
         "parameters": [
           {
@@ -15865,7 +15865,7 @@
     "/api/v1/export/tasks": {
       "get": {
         "summary": "Export Tasks",
-        "description": "Export tasks as CSV or JSON.\n\nQuery params:\n    format: ``csv`` or ``json`` (default ``json``).\n    limit: Optional max number of tasks to return. Pushed into\n        ``TaskStore.list_tasks`` so large stores no longer materialise\n        the whole table (issue #1728 finding 3).\n    offset: Optional number of tasks to skip before returning rows.",
+        "description": "Export tasks as CSV or JSON.\n\nQuery params:\n    format: ``csv`` or ``json`` (default ``json``).\n    limit: Optional max number of tasks to return. Pushed into\n        ``TaskStore.list_tasks`` so large stores no longer materialise\n        the whole table (issue #1728 finding 3).\n    offset: Optional number of tasks to skip before returning rows.\n\nThe export is a whole-store read, so it narrows to the caller's tenant\nscope the same way the paginated task list does. The scope is pushed into\n``list_tasks`` rather than applied to the returned rows so that it is\n``limit``/``offset`` that page through the caller's own tasks: filtering\nafter the slice would page through every tenant's and return short pages.",
         "operationId": "export_tasks_api_v1_export_tasks_get",
         "parameters": [
           {
@@ -21198,6 +21198,18 @@
               }
             ],
             "title": "Max Turns"
+          },
+          "artifact_spec": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artifact Spec"
           }
         },
         "type": "object",
@@ -22035,6 +22047,18 @@
               }
             ],
             "title": "Max Turns"
+          },
+          "artifact_spec": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artifact Spec"
           }
         },
         "type": "object",
@@ -22908,6 +22932,18 @@
               }
             ],
             "title": "Max Turns"
+          },
+          "artifact_spec": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artifact Spec"
           }
         },
         "type": "object",

--- a/tests/unit/test_openapi_snapshot_drift.py
+++ b/tests/unit/test_openapi_snapshot_drift.py
@@ -18,6 +18,13 @@ and ``/plans*`` from 503 to 404 on the same day -- 30 operations went stale
 without a single test going red. Comparing the declared status codes closes
 that hole while still ignoring prose (summaries, descriptions, examples), so
 editing a docstring does not force a snapshot commit.
+
+Schema property names are compared for the same reason, one level further in.
+Three models gained an ``artifact_spec`` field while the snapshot kept the
+older field list; the schema *names* still matched, so every check above
+stayed green and both the published reference and the generated SDK omitted
+the field. Field names only -- their titles and descriptions stay out, so the
+prose rule above holds throughout.
 """
 
 from __future__ import annotations
@@ -121,6 +128,44 @@ def test_snapshot_schema_names_match_live_app() -> None:
 
     assert live == committed, "docs/reference/openapi.json component schemas are stale.\n" + _format(
         "schema", live - committed, committed - live
+    )
+
+
+def _schema_properties(spec: dict[str, Any]) -> set[str]:
+    """Flatten component schemas into ``Schema.property`` strings."""
+    return {
+        f"{name}.{field}"
+        for name, schema in (spec.get("components", {}).get("schemas") or {}).items()
+        if isinstance(schema, dict)
+        for field in (schema.get("properties") or {})
+    }
+
+
+def test_snapshot_schema_properties_match_live_app() -> None:
+    """Fields inside each documented model track the app's models.
+
+    Comparing schema *names* leaves a hole one level down. ``artifact_spec``
+    was added to ``TaskCreate``, ``TaskResponse`` and ``WebhookTaskCreate``
+    while the snapshot kept the older field list: the three names still
+    matched, so every guard above stayed green and the omission survived
+    until someone regenerated the file by hand. A field that never reaches
+    the snapshot never reaches the published reference or the SDK generated
+    from it, so callers cannot see the field exists and generated clients
+    drop it on the way out.
+
+    Every component schema is compared, not just request bodies. Response
+    models rot the same way -- ``TaskResponse`` above is one -- and they seed
+    the same generated client.
+
+    Only property *names* are compared, so this stays on the prose-free side
+    of the line the module docstring draws: retitling or re-describing a
+    field does not demand a snapshot commit.
+    """
+    live = _schema_properties(_live_spec())
+    committed = _schema_properties(_committed_spec())
+
+    assert live == committed, "docs/reference/openapi.json schema properties are stale.\n" + _format(
+        "schema property", live - committed, committed - live
     )
 
 


### PR DESCRIPTION
## What drifted

`docs/reference/openapi.json` had fallen behind the app in two ways that `tests/unit/test_openapi_snapshot_drift.py` cannot see. That guard compares paths, component schema names, and response codes/media types - all three matched, so it stayed green.

Regenerating with `uv run python scripts/generate_openapi.py` changes **13 leaf values**, nothing else:

| Kind | Count | Where |
|---|---|---|
| Handler descriptions | 10 | `/costs/current`, `/costs/alerts`, `/costs/history`, `/costs/{run_id}`, `/export/tasks` + their `/api/v1` mirrors |
| `artifact_spec` property | 3 | `TaskCreate`, `TaskResponse`, `WebhookTaskCreate` |

The descriptions are docstring-derived: the handlers gained tenant-scope paragraphs that never reached the snapshot, so the published reference still describes those figures as run-wide or store-wide.

`artifact_spec` is a real field on the models in `src/bernstein/core/server/server_models.py`, so the reference - and any SDK generated from the snapshot - omits a field the API accepts and returns.

## Nothing was removed

Verified structurally, by walking both documents and classifying every leaf difference rather than reading the diff:

```
paths      old=459 new=459  removed=[]  added=[]
schemas    old=121 new=121  removed=[]  added=[]
operations old=485 new=485  removed=[]  added=[]
responses  old=1053 new=1053 removed=[]  added=[]
TOTAL leaf differences: 13
REMOVALS / arity changes: 0
```

Re-running the generator produces a byte-identical file, so the committed content is exactly what the script emits.

## Closing the hole

`test_snapshot_schema_properties_match_live_app` compares the property names inside every component schema. Run against the pre-refresh snapshot it is the only test in the file that fails, and it names all three fields:

```
docs/reference/openapi.json schema properties are stale.
  3 live schema property(s) absent from the snapshot:
    + TaskCreate.artifact_spec
    + TaskResponse.artifact_spec
    + WebhookTaskCreate.artifact_spec
  Regenerate with: uv run python scripts/generate_openapi.py
```

Two scope decisions worth flagging for review:

- **All component schemas, not only request bodies.** `TaskResponse` is one of the three, response models rot the same way, and both kinds seed the same generated client.
- **Property names only.** Field titles and descriptions stay out, so the prose exclusion the module docstring explains still holds: rewording a handler docstring must not force a snapshot commit. That is also why the 10 description changes in this PR trip no test - they reach the reference on the next regeneration, whenever that is. `required` lists are not compared either; that is a separate class and no drift exists there today (369 entries on both sides).

## Docs

`docs/reference/openapi-reference.md` described the guard as diffing "paths and component schemas". Updated to name all four axes it actually compares and to state the prose exclusion and its consequence.

## Verification

| Check | Result |
|---|---|
| `pytest tests/unit/test_openapi_snapshot_drift.py` | 6 passed |
| Same, default random ordering | 6 passed |
| `scripts/run_tests.py -k openapi_snapshot_drift` | 6 passed |
| New test against pre-refresh snapshot | fails alone, naming the 3 fields |
| `ruff check` / `ruff format --check` | clean |
| `mypy` | no issues |