### PR TITLE
fix(multimodal): run the attachment pipeline from the spawn path

### DIFF
--- a/docs/operations/run.md
+++ b/docs/operations/run.md
@@ -60,20 +60,53 @@ verify exact bytes regardless of provider.
 
 ### Provenance
 
-For each `--attach` invocation the orchestrator:
+At spawn time, for every attachment declared for a worker, the
+orchestrator:
 
 1. Hashes the raw bytes (SHA-256) and stores them once in the
-   content-addressed blob store at `.sdd/cas/`.
+   content-addressed blob store at `.sdd/cas/`. The hash is taken over
+   the bytes that actually travel to the model API, so a source file
+   edited between encode and attest cannot desynchronise the record.
 2. Appends a `multimodal.attach` event to the HMAC-chained audit log
    carrying `(sha256, mime, operator_install_id_sig, worker_id,
    turn_seq, worktree_id, prev_chain_digest)`. Tampering with the
    on-disk log fails verification.
-3. Adds the digest to the worker's lineage v1 receipt as a
-   `multimodal-attachment://<sha256>` parent so any artefact produced
-   this turn carries the input image's hash in its lineage.
+3. Stamps the resolved digests on the session and its tasks. When such
+   a task completes through the artifact path, its signed lineage entry
+   carries them in `attachment_digests`, so the receipt names every
+   input the turn consumed and not only the code it read.
+
+CAS and the audit chain live under the run's `.sdd/`, not under a
+per-session worktree: one shared chain is what lets a cross-worktree
+read be refused rather than merely missed.
 
 Replay over the exported chain reproduces the exact bytes the model
 API saw on the original turn. Substituting bytes breaks the chain.
+
+`attachment_digests` is an additive, optional field: an entry recorded
+for a task with no attachments omits it entirely and keeps the exact
+entry hash, HMAC and signature it had before attachments were wired.
+The digests are deliberately *not* recorded in `parent_hashes` --
+that list is the artefact's own ancestry, and the tip projection reads
+two or more parents as a fork merge, so an attached image recorded
+there would both mis-type the relation and make every attached linear
+write look like a merge.
+
+> The `multimodal-attachment://<sha256>` URI built by
+> `lineage_signer.build_attachment_parent_uri` targets the `parents`
+> list of the WAL-backed `persistence.lineage.LineageWriter` record,
+> which is deprecated and carries no such field. It is unused by the
+> shipping path; `attachment_digests` on the signed entry is what a
+> verifier reads.
+
+### Isolation modes
+
+Attachments are carried by the direct-subprocess spawn path, where the
+capable adapter inlines the encoded bytes from inside its `spawn()`
+call. The container, sandbox, runtime-bridge and in-process paths
+render their own command or speak a protocol with no attachment slot,
+so a run that combines them with attachments is refused up front rather
+than silently dropping the bytes between the audit event and the model.
 
 ### Worktree pinning
 
@@ -92,6 +125,14 @@ audit directory without the audit key -- the lookup refuses with
 `bernstein audit verify` to see the per-entry errors behind the
 refusal.
 
+Crash resume is what reads through that resolver in normal operation.
+A resumed worker rebuilds its attachments from CAS rather than
+re-reading the operator's files, which may have been edited or deleted
+by the crashed agent: the attested bytes are the ones the original turn
+sent, so the resumed turn is byte-identical. The read is pinned like
+any other, so a resume that lands in a different worktree, or against a
+chain that no longer verifies, fails rather than substituting bytes.
+
 ### Task YAML
 
 Plan-file steps accept an `attachments:` list:
@@ -108,25 +149,34 @@ stages:
           - ./architecture.svg
 ```
 
-The list is parsed and shape-validated at plan load and stored on
-the resulting task. It is not yet forwarded to the worker spawn
-path: the capability gate, audit-chain event, lineage receipt, and
-worktree pinning described above currently apply to the CLI
-`--attach` flag only. #3555 tracks wiring plan-declared attachments
-through that same path.
+Plan-declared attachments go through the same dispatch as `--attach`:
+CAS storage, the `multimodal.attach` event, the worktree pin, and the
+recorded digests all apply. The difference is scope -- a `--attach`
+entry applies to every worker the run spawns, a step's `attachments:`
+list only to the workers spawned for that task. A path declared both
+ways is stored and attested once.
+
+Unlike `--attach`, which Click validates as an existing file, a
+plan-declared path is only checked when the worker is about to spawn.
+A path that does not resolve to a readable file aborts that spawn with
+the offending paths named, rather than running the agent text-only.
 
 `attachments` must be a list: a scalar value (e.g.
 `attachments: ./screenshot.png`) fails the plan load with
 `PlanLoadError`, and an explicit `null` loads as no attachments.
 Non-string list items are currently coerced to strings at load
-rather than rejected (#3555; #3552 tracks the full
+rather than rejected (#3552 tracks the full
 accepted/rejected/defaulted table for plan fields).
 
 ## References
 
-* `src/bernstein/core/agents/multimodal_attestation.py` -- spawn-time
-  resolver, capability gate, and worktree pinning.
+* `src/bernstein/core/agents/multimodal_attestation.py` -- the
+  attachment primitives: CAS + chain write, capability gate, and the
+  authenticated worktree-pinned resolver.
+* `src/bernstein/core/agents/attachment_dispatch.py` -- the spawn-path
+  seam that calls them, collects the declared paths, stamps the
+  digests, and rebuilds the context on resume.
 * `src/bernstein/core/security/audit_chain.py` -- the
   `multimodal.attach` event type and the `AuditChainStore` facade.
-* `src/bernstein/core/persistence/lineage_signer.py` --
-  `register_attachment_parents` for lineage receipt augmentation.
+* `src/bernstein/core/lineage/entry.py` -- `attachment_digests` on the
+  signed lineage entry.

--- a/src/bernstein/core/agents/attachment_dispatch.py
+++ b/src/bernstein/core/agents/attachment_dispatch.py
@@ -1,0 +1,392 @@
+"""Spawn-path dispatch for operator attachments (issue #1797, #3555).
+
+:mod:`bernstein.core.agents.multimodal_attestation` owns the attachment
+primitives -- CAS storage, the ``multimodal.attach`` audit-chain event,
+the worktree pin, and the authenticated resolver. This module is the
+seam that calls them from the agent spawn path, the way
+:mod:`bernstein.core.agents.context_attachments` is the seam for declared
+context files.
+
+Two operator surfaces feed one dispatch:
+
+* ``bernstein run --attach <path>`` sets :data:`ENV_RUN_ATTACHMENTS`, a
+  run-level list that applies to every worker the run spawns.
+* A plan step's ``attachments:`` list lands on ``Task.attachments`` and
+  applies only to the workers spawned for that task.
+
+Both are collected by :func:`collect_declared_attachments` in a stable
+order -- run-level first, then per-task in task order, deduplicated by
+path -- so the digests a run records are a function of its inputs and not
+of dict iteration order.
+
+Where the state lives
+---------------------
+CAS and the audit chain are rooted at the *run* root (``<workdir>/.sdd``),
+never at the per-session worktree, while the pin recorded in the event is
+the worktree id of the spawning worker. That split is what makes the pin
+mean anything: one shared chain that every worktree reads, with each
+attach row naming the single worktree allowed to resolve it. Per-worktree
+chains would turn a cross-worktree read into "no such attachment" instead
+of the refusal :class:`WorktreeAccessDenied` is there to raise.
+
+Resume
+------
+:func:`rebuild_context_for_resume` rebuilds a crashed worker's context
+from CAS through :func:`resolve_attachment_for_worker` rather than
+re-reading the operator's files. The source file may have been edited or
+deleted since the original spawn; the CAS bytes are the ones the chain
+attests, so the resumed turn sends byte-identical input and the resolve
+is subject to the same worktree pin as any other read.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from bernstein.core.agents.multimodal import (
+    ModalityType,
+    MultiModalContext,
+    MultiModalInput,
+    detect_modality,
+    primary_modality,
+)
+from bernstein.core.agents.multimodal_attestation import (
+    AttachmentChainUnverified,
+    WorktreeAccessDenied,
+    build_attachment_context,
+    resolve_attachment_for_worker,
+)
+from bernstein.core.persistence.cas_store import CASStore
+from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.skills.catalog.lockfile import worktree_id_for
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from bernstein.core.agents.multimodal_attestation import AttachmentResolution
+    from bernstein.core.tasks.models import AgentSession, Task
+
+logger = logging.getLogger(__name__)
+
+#: Run-level attachment paths exported by ``bernstein run --attach``,
+#: ``os.pathsep``-joined. Written by the CLI, read here.
+ENV_RUN_ATTACHMENTS = "BERNSTEIN_RUN_ATTACHMENTS"
+
+#: Key under which resolved attachment provenance is stamped onto
+#: ``Task.metadata``. Mirrors the ``injected_skills`` stamp so the
+#: completion and resume paths can read back what the spawn recorded
+#: without re-hashing files that may since have changed.
+ATTACHMENT_METADATA_KEY = "multimodal_attachments"
+
+#: Turn sequence recorded for the spawn-time attach. A resumed worker
+#: resolves the existing rows rather than appending new ones, so this is
+#: the only turn that attaches.
+_SPAWN_TURN_SEQ = 0
+
+
+class AttachmentDispatchError(RuntimeError):
+    """Raised when declared attachments cannot be dispatched to a worker.
+
+    Carried to the operator instead of spawning a worker whose input
+    silently lacks the bytes -- or the provenance -- that were declared.
+    """
+
+
+@dataclass(frozen=True)
+class DispatchedAttachments:
+    """What a spawn recorded for its attachments.
+
+    Attributes:
+        context: The context to hand the adapter.
+        resolutions: Per-attachment provenance in declared order.
+        worktree_id: The worktree the attachments are pinned to.
+    """
+
+    context: MultiModalContext
+    resolutions: tuple[AttachmentResolution, ...]
+    worktree_id: str
+
+    @property
+    def digests(self) -> list[str]:
+        """SHA-256 digests in declared order."""
+        return [r.sha256 for r in self.resolutions]
+
+
+def collect_declared_attachments(
+    tasks: Sequence[Task],
+    *,
+    env: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Return every attachment path declared for *tasks*, deduplicated.
+
+    Run-level ``--attach`` entries come first (in flag order), then each
+    task's declared ``attachments`` in task order. A path declared twice
+    -- run-level and again by a task, or by two grouped tasks -- is kept
+    once, at its first position, so the same inputs always produce the
+    same digest order.
+
+    Args:
+        tasks: The tasks being spawned as one worker.
+        env: Environment to read :data:`ENV_RUN_ATTACHMENTS` from;
+            defaults to ``os.environ``.
+
+    Returns:
+        Declared attachment paths in stable order.
+    """
+    source = os.environ if env is None else env
+    declared: list[str] = []
+    seen: set[str] = set()
+
+    raw_run_level = source.get(ENV_RUN_ATTACHMENTS, "")
+    for entry in raw_run_level.split(os.pathsep):
+        path = entry.strip()
+        if path and path not in seen:
+            declared.append(path)
+            seen.add(path)
+
+    for task in tasks:
+        for entry in getattr(task, "attachments", ()) or ():
+            path = str(entry).strip()
+            if path and path not in seen:
+                declared.append(path)
+                seen.add(path)
+
+    return declared
+
+
+def _require_readable(declared: Sequence[str]) -> None:
+    """Refuse the spawn when a declared attachment is not a readable file.
+
+    ``build_multimodal_context`` logs and skips a missing path, which is
+    the right behaviour for an optional context file but the wrong one
+    for an explicit ``--attach``: the worker would run text-only, with no
+    attach event, and nothing but a log line to say so. Plan-declared
+    paths never pass through Click's ``exists=True`` check, so this is
+    the only place a typo in ``attachments:`` is caught.
+    """
+    missing = [p for p in declared if not Path(p).is_file()]
+    if missing:
+        raise AttachmentDispatchError("declared attachment(s) not found or not a file: " + ", ".join(sorted(missing)))
+
+
+def dispatch_for_spawn(
+    *,
+    declared: Sequence[str],
+    session_id: str,
+    worktree_path: Path,
+    run_root: Path,
+) -> DispatchedAttachments:
+    """Store, attest, and pin the attachments declared for a spawn.
+
+    Args:
+        declared: Attachment paths from :func:`collect_declared_attachments`.
+            Taken as an argument rather than re-derived so the caller's
+            emptiness check and this call cannot disagree about what was
+            declared if the environment changes between them.
+        session_id: The worker id recorded as the attaching actor.
+        worktree_path: The worktree the worker will run in; its id is the
+            pin recorded in the audit-chain event.
+        run_root: The run's working directory. CAS and the audit chain
+            live under ``<run_root>/.sdd`` so every worktree shares one
+            chain.
+
+    Returns:
+        The dispatch record.
+
+    Raises:
+        AttachmentDispatchError: *declared* is empty, a declared path is
+            missing, or the provenance could not be recorded.
+    """
+    if not declared:
+        raise AttachmentDispatchError("dispatch_for_spawn called with no declared attachments")
+
+    _require_readable(declared)
+
+    sdd = Path(run_root) / ".sdd"
+    worktree_id = worktree_id_for(Path(worktree_path))
+    try:
+        result = build_attachment_context(
+            attachments=list(declared),
+            worker_id=session_id,
+            turn_seq=_SPAWN_TURN_SEQ,
+            worktree_id=worktree_id,
+            cas=CASStore(sdd / "cas"),
+            audit_chain=AuditChainStore(sdd / "audit"),
+        )
+    except OSError as exc:
+        # A failure to store the bytes or append the event means the
+        # worker would consume an image with no provenance behind it.
+        # That is the exact gap this path exists to close, so it fails
+        # the spawn rather than proceeding unattested.
+        raise AttachmentDispatchError(f"could not record attachment provenance: {exc}") from exc
+
+    if len(result.resolutions) != len(declared):
+        recorded = {r.source_path for r in result.resolutions}
+        dropped = [p for p in declared if str(Path(p)) not in recorded]
+        raise AttachmentDispatchError("attachment(s) could not be encoded or attested: " + ", ".join(sorted(dropped)))
+
+    logger.info(
+        "Attached %d file(s) for session %s pinned to worktree %s: %s",
+        len(result.resolutions),
+        session_id,
+        worktree_id,
+        ", ".join(r.sha256[:12] for r in result.resolutions),
+    )
+    return DispatchedAttachments(
+        context=result.context,
+        resolutions=result.resolutions,
+        worktree_id=worktree_id,
+    )
+
+
+def stamp_dispatch(
+    session: AgentSession,
+    tasks: Sequence[Task],
+    dispatched: DispatchedAttachments,
+) -> None:
+    """Record *dispatched* on the session and every task it covers.
+
+    The stamp is what later phases read instead of re-deriving digests
+    from disk: :func:`attachment_digests_for_tasks` supplies them to the
+    signed lineage entry at artifact-completion time, and
+    :func:`rebuild_context_for_resume` reads it to resolve the bytes back
+    out of CAS. Mirrors the ``injected_skills`` stamp, and inherits its
+    limitation: the record is only as durable as the last persisted task
+    write.
+    """
+    record = [
+        {
+            "sha256": r.sha256,
+            "mime": r.mime,
+            "worktree_id": r.worktree_id,
+            "source_path": r.source_path,
+            "modality": str(detect_modality(r.source_path)),
+        }
+        for r in dispatched.resolutions
+    ]
+    session.multimodal_attachments = [dict(entry) for entry in record]
+    for task in tasks:
+        task.metadata[ATTACHMENT_METADATA_KEY] = [dict(entry) for entry in record]
+
+
+def _stamped_records(task: Task) -> list[dict[str, str]]:
+    """Return the attachment records stamped on *task*, or an empty list.
+
+    Tolerant of a malformed stamp: task metadata round-trips through the
+    backlog YAML, so an operator-edited file can put anything here. A
+    non-conforming payload yields no records rather than raising in the
+    completion path.
+    """
+    raw: object = task.metadata.get(ATTACHMENT_METADATA_KEY)
+    if not isinstance(raw, list):
+        return []
+    records: list[dict[str, str]] = []
+    for entry in cast("list[object]", raw):
+        if isinstance(entry, dict):
+            records.append({str(k): str(v) for k, v in cast("dict[object, object]", entry).items()})
+    return records
+
+
+def attachment_digests_for_tasks(tasks: Sequence[Task]) -> list[str]:
+    """Return the attachment digests stamped across *tasks*, deduplicated."""
+    digests: list[str] = []
+    seen: set[str] = set()
+    for task in tasks:
+        for entry in _stamped_records(task):
+            digest = str(entry.get("sha256", ""))
+            if digest and digest not in seen:
+                digests.append(digest)
+                seen.add(digest)
+    return digests
+
+
+def rebuild_context_for_resume(
+    *,
+    tasks: Sequence[Task],
+    worktree_path: Path,
+    run_root: Path,
+) -> MultiModalContext | None:
+    """Rebuild a resumed worker's attachment context from attested bytes.
+
+    Reads through :func:`resolve_attachment_for_worker`, so the resume is
+    held to the same worktree pin and the same authenticated-chain
+    requirement as any other attachment read: a resume in a different
+    worktree, or against a chain whose HMAC linkage no longer holds, gets
+    no bytes rather than unverified ones.
+
+    Args:
+        tasks: The tasks being resumed.
+        worktree_path: The preserved worktree the worker resumes in.
+        run_root: The run's working directory.
+
+    Returns:
+        The rebuilt context, or ``None`` when the tasks recorded no
+        attachments.
+
+    Raises:
+        AttachmentDispatchError: The recorded bytes could not be
+            resolved back for this worktree.
+    """
+    records: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for task in tasks:
+        for entry in _stamped_records(task):
+            digest = str(entry.get("sha256", ""))
+            if digest and digest not in seen:
+                records.append(entry)
+                seen.add(digest)
+    if not records:
+        return None
+
+    sdd = Path(run_root) / ".sdd"
+    cas = CASStore(sdd / "cas")
+    chain = AuditChainStore(sdd / "audit")
+    requesting_worktree_id = worktree_id_for(Path(worktree_path))
+
+    inputs: list[MultiModalInput] = []
+    for entry in records:
+        digest = str(entry["sha256"])
+        try:
+            raw = resolve_attachment_for_worker(
+                sha256=digest,
+                requesting_worktree_id=requesting_worktree_id,
+                cas=cas,
+                audit_chain=chain,
+            )
+        except (WorktreeAccessDenied, AttachmentChainUnverified, FileNotFoundError) as exc:
+            raise AttachmentDispatchError(f"could not resolve attachment {digest[:12]}... on resume: {exc}") from exc
+        source_path = str(entry.get("source_path", ""))
+        raw_modality = str(entry.get("modality", ""))
+        try:
+            modality = ModalityType(raw_modality)
+        except ValueError:
+            modality = detect_modality(source_path) if source_path else ModalityType.TEXT
+        inputs.append(
+            MultiModalInput(
+                modality=modality,
+                content_path=Path(source_path) if source_path else None,
+                content_base64=base64.b64encode(raw).decode("ascii"),
+                mime_type=str(entry.get("mime", "application/octet-stream")),
+                description=Path(source_path).name if source_path else digest[:12],
+            )
+        )
+
+    return MultiModalContext(inputs=tuple(inputs), primary_modality=primary_modality(inputs))
+
+
+__all__ = [
+    "ATTACHMENT_METADATA_KEY",
+    "ENV_RUN_ATTACHMENTS",
+    "AttachmentDispatchError",
+    "DispatchedAttachments",
+    "attachment_digests_for_tasks",
+    "collect_declared_attachments",
+    "dispatch_for_spawn",
+    "rebuild_context_for_resume",
+    "stamp_dispatch",
+]

--- a/src/bernstein/core/agents/multimodal.py
+++ b/src/bernstein/core/agents/multimodal.py
@@ -17,6 +17,10 @@ import mimetypes
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -194,23 +198,32 @@ def build_multimodal_context(files: list[str | Path]) -> MultiModalContext:
         except FileNotFoundError:
             logger.warning("Skipping missing file: %s", fp)
 
-    if not inputs:
-        return MultiModalContext(inputs=(), primary_modality=ModalityType.TEXT)
+    return MultiModalContext(inputs=tuple(inputs), primary_modality=primary_modality(inputs))
 
-    # Majority-vote for primary modality.
+
+def primary_modality(inputs: Sequence[MultiModalInput]) -> ModalityType:
+    """Return the dominant modality across *inputs* by majority vote.
+
+    Ties are broken by ``ModalityType`` declaration order (TEXT < IMAGE <
+    DIAGRAM < AUDIO), and an empty input list resolves to TEXT. Split out
+    of :func:`build_multimodal_context` so a context rebuilt from stored
+    bytes rather than from disk -- the crash-resume path in
+    :mod:`bernstein.core.agents.attachment_dispatch` -- ranks its
+    modalities by exactly the same rule instead of a second copy of it.
+    """
+    if not inputs:
+        return ModalityType.TEXT
+
     counts: dict[ModalityType, int] = {}
     for inp in inputs:
         counts[inp.modality] = counts.get(inp.modality, 0) + 1
 
     max_count = max(counts.values())
     # Among tied modalities, pick the first in ModalityType declaration order.
-    primary = ModalityType.TEXT
     for m in ModalityType:
         if counts.get(m, 0) == max_count:
-            primary = m
-            break
-
-    return MultiModalContext(inputs=tuple(inputs), primary_modality=primary)
+            return m
+    return ModalityType.TEXT
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/agents/multimodal_attestation.py
+++ b/src/bernstein/core/agents/multimodal_attestation.py
@@ -12,9 +12,21 @@ This module wires the operator-supplied ``--attach <path>`` flow into:
   records an HMAC-chained ``multimodal.attach`` event carrying the
   bytes' SHA-256, MIME, worker identity, turn sequence, worktree id,
   the operator install signature, and the prior chain digest.
-* :mod:`bernstein.core.persistence.lineage_signer` -- the worker's
-  lineage v1 receipt is augmented with attachment digests in its
-  ``parents`` list via :func:`worker_lineage_parents`.
+* :mod:`bernstein.core.lineage.entry` -- the signed lineage entry for
+  an artefact produced by an attached turn carries the digests in its
+  ``attachment_digests`` field, so the receipt names every input the
+  turn consumed. :mod:`bernstein.core.agents.attachment_dispatch` is
+  the seam that calls this module from the spawn path and stamps those
+  digests for the completion and resume paths.
+
+  :func:`worker_lineage_parents` builds
+  ``multimodal-attachment://<sha256>`` URIs for the ``parents`` list of
+  the WAL-backed ``persistence.lineage.LineageWriter`` record. That
+  writer is deprecated and its ``LineageRecord`` has no ``parents``
+  field, so the helper has no live consumer. The digests are
+  deliberately not folded into a signed entry's ``parent_hashes``
+  either: that list is the artefact's own ancestry, and the tip
+  projection reads two or more parents as a fork merge.
 
 The :func:`refuse_when_incapable` helper performs capability gating
 BEFORE any process is launched: if the selected adapter does not

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -28,6 +28,14 @@ from bernstein.adapters.skills_injector import inject_skills
 from bernstein.agents.registry import AgentRegistry, get_registry
 from bernstein.bridges.base import AgentState, BridgeError, RuntimeBridge, SpawnRequest
 from bernstein.core.agents.adapter_health import AdapterHealthMonitor
+from bernstein.core.agents.attachment_dispatch import (
+    AttachmentDispatchError,
+    DispatchedAttachments,
+    collect_declared_attachments,
+    dispatch_for_spawn,
+    rebuild_context_for_resume,
+    stamp_dispatch,
+)
 from bernstein.core.agents.container import ContainerConfig, ContainerError, ContainerManager
 from bernstein.core.agents.context_attachments import (
     collect_declared_context_files,
@@ -4162,6 +4170,14 @@ class AgentSpawner:
             except Exception as exc:  # pragma: no cover - best-effort, never blocks spawn
                 logger.warning("Failed to write task-specific CLAUDE.md for %s: %s", session_id, exc)
 
+            # Issue #1797: store, attest, and pin the operator's attachments
+            # before the process launches. Unlike the context-file stamp above
+            # this is not best-effort: an attachment that reaches the model
+            # with no CAS bytes and no chain event behind it is precisely the
+            # provenance gap the dispatch exists to close, so a failure here
+            # aborts the spawn instead of running the worker unattested.
+            _attachments = self._resolve_and_stamp_attachments(session, tasks, spawn_cwd)
+
             # Inject role-specific skills into the worktree before spawn so the
             # agent picks up orchestration protocol and role-specific instructions.
             # Skills survive context compaction and reduce prompt boilerplate.
@@ -4443,6 +4459,24 @@ class AgentSpawner:
                                 _extra_spawn_kwargs["task_id"] = tasks[0].id
                             if "task_title" in _spawn_params:
                                 _extra_spawn_kwargs["task_title"] = tasks[0].title
+                            # Issue #1797: hand the attested attachments to the
+                            # adapter. Only passed when something was declared,
+                            # so an unattached spawn calls exactly the argument
+                            # list it always did. A capable adapter inlines the
+                            # bytes; an incapable one raises CapabilityRefusal
+                            # from its own spawn() before launching a process.
+                            # An adapter whose spawn() predates the parameter
+                            # cannot carry them at all, and dropping them
+                            # silently is the failure this wiring exists to
+                            # remove - so that refuses here instead.
+                            if _attachments is not None:
+                                if "multimodal_context" not in _spawn_params:
+                                    raise AttachmentDispatchError(
+                                        f"adapter {adapter_name!r} cannot carry attachments: its spawn() "
+                                        "does not accept multimodal_context. Use a multimodal-capable "
+                                        "adapter (claude, gemini) or drop the attachments."
+                                    )
+                                _extra_spawn_kwargs["multimodal_context"] = _attachments.context
                             # Cacheable prefix extraction is deferred to adapters
                             # that support provider-specific caching.
                             result = target_adapter.spawn(
@@ -4691,6 +4725,77 @@ class AgentSpawner:
                     )
         return declared
 
+    def _attachment_routing_refusal(self) -> str | None:
+        """Name the active execution path that cannot carry attachments.
+
+        Only the direct-subprocess path reaches ``adapter.spawn()`` with a
+        ``multimodal_context``; the capable adapters inline the encoded bytes
+        into the prompt from inside that call. Every other route either
+        renders its own command from a prompt file (container, sandbox) or
+        speaks a protocol with no attachment slot (runtime bridge,
+        in-process), so an attachment handed to them would be dropped
+        between the audit-chain event and the model. Returns ``None`` when
+        the spawn is on the path that carries them.
+        """
+        if self._in_process is not None and self._backend == AgentBackend.IN_PROCESS:
+            return "the in-process backend"
+        if self._runtime_bridge is not None:
+            return f"the {self._runtime_bridge.name()} runtime bridge"
+        if self._sandbox_session_routing_active():
+            return "a sandbox session"
+        if self._sandbox is not None:
+            return "a Docker/Podman sandbox"
+        if self._container_mgr is not None:
+            return "a container"
+        return None
+
+    def _resolve_and_stamp_attachments(
+        self,
+        session: AgentSession,
+        tasks: list[Task],
+        worktree_path: Path,
+    ) -> DispatchedAttachments | None:
+        """Dispatch declared attachments for this spawn (issue #1797).
+
+        Collects the run-level ``--attach`` list and any plan-declared
+        ``Task.attachments``, stores the bytes in the run's CAS, appends a
+        ``multimodal.attach`` event pinned to *worktree_path*, and stamps the
+        resulting digests onto the session and its tasks so the completion
+        path can carry them into the artefact's lineage receipt and the resume
+        path can resolve the same bytes back.
+
+        Returns the dispatch record, or ``None`` when nothing was declared -
+        in which case no CAS directory, no chain event, and no adapter
+        argument are produced, leaving an unattached spawn exactly as it was.
+
+        Raises:
+            AttachmentDispatchError: Attachments were declared but this
+                spawn is routed through an execution path that cannot carry
+                them (see :meth:`_attachment_routing_refusal`). The check
+                runs before anything is written, so a refused spawn leaves
+                no orphan blob or attach event behind.
+        """
+        declared = collect_declared_attachments(tasks)
+        if not declared:
+            return None
+
+        refusal = self._attachment_routing_refusal()
+        if refusal is not None:
+            raise AttachmentDispatchError(
+                f"--attach is not supported when agents run via {refusal}: that path builds its own "
+                "command instead of calling the adapter's spawn(), so the attachment bytes would "
+                "never reach the model. Re-run without the attachments, or without that isolation mode."
+            )
+
+        dispatched = dispatch_for_spawn(
+            declared=declared,
+            session_id=session.id,
+            worktree_path=worktree_path,
+            run_root=self._workdir,
+        )
+        stamp_dispatch(session, tasks, dispatched)
+        return dispatched
+
     def _resolve_and_stamp_injected_skills(self, session: AgentSession, tasks: list[Task]) -> None:
         """Carry the injected-skill audit set forward on resume (issue #3382).
 
@@ -4857,6 +4962,17 @@ class AgentSpawner:
         # any edits the crashed agent made to the declared files.
         self._resolve_and_stamp_context_files(session, tasks, worktree_path)
         self._resolve_and_stamp_injected_skills(session, tasks)
+        # Issue #1797: rebuild the attachment context from CAS rather than
+        # re-reading the operator's files. The crashed agent may have edited
+        # or deleted them, and the bytes the chain attests -- not whatever is
+        # on disk now -- are what the original turn sent. The read goes
+        # through the worktree-pinned, authenticated resolver, so a resume
+        # that somehow lands in another worktree gets nothing.
+        _resume_attachments = rebuild_context_for_resume(
+            tasks=tasks,
+            worktree_path=worktree_path,
+            run_root=self._workdir,
+        )
 
         _scope_order = {"small": 0, "medium": 1, "large": 2}
         resume_scope = max((t.scope.value for t in tasks), key=lambda s: _scope_order.get(s, 1))
@@ -4868,6 +4984,13 @@ class AgentSpawner:
             _resume_extra["task_id"] = tasks[0].id
         if "task_title" in _resume_params:
             _resume_extra["task_title"] = tasks[0].title
+        if _resume_attachments is not None:
+            if "multimodal_context" not in _resume_params:
+                raise AttachmentDispatchError(
+                    f"adapter {self._adapter.name()!r} cannot carry attachments on resume: its "
+                    "spawn() does not accept multimodal_context."
+                )
+            _resume_extra["multimodal_context"] = _resume_attachments
         result = self._adapter.spawn(
             prompt=prompt,
             workdir=worktree_path,

--- a/src/bernstein/core/lineage/AGENTS.md
+++ b/src/bernstein/core/lineage/AGENTS.md
@@ -25,17 +25,12 @@ that every adapter artifact write routes through.
   shape breaks head-hash verification for existing runs.
 - The spine's HMAC tag reuses the audit-chain key
   (`../security/audit.py`); key handling rules from that module apply.
-- A new `LineageEntry` field must be optional, default `None`, and be
-  dropped from `_canonical_body` when `None` (see `trust_class`,
-  `attachment_digests`). That is what keeps every historical entry's
-  bytes, HMAC and JWS valid. Add the matching read in
-  `store._entry_from_dict` too, or the field will not survive a
-  round-trip.
-- `parent_hashes` is the artefact's own ancestry and nothing else.
-  `store._compute_tips_from_entries` reads a length of two or more as a
-  *fork merge*, so recording an unrelated input there (an attachment, a
-  source reference) both mis-types the relation and corrupts the tip
-  projection. Give such inputs their own field.
+- A new `LineageEntry` field must be optional, default `None`, dropped
+  from `_canonical_body` when `None`, and read back in
+  `_entry_from_dict` (cf. `attachment_digests`) - that is what keeps
+  every historical entry's bytes, HMAC and JWS valid.
+- `parent_hashes` is the artefact's ancestry only: tip projection reads
+  two or more as a *fork merge*, so other inputs need their own field.
 - Design rationale: `docs/decisions/009-lineage-v1.md`.
 
 ## Testing

--- a/src/bernstein/core/lineage/AGENTS.md
+++ b/src/bernstein/core/lineage/AGENTS.md
@@ -25,6 +25,17 @@ that every adapter artifact write routes through.
   shape breaks head-hash verification for existing runs.
 - The spine's HMAC tag reuses the audit-chain key
   (`../security/audit.py`); key handling rules from that module apply.
+- A new `LineageEntry` field must be optional, default `None`, and be
+  dropped from `_canonical_body` when `None` (see `trust_class`,
+  `attachment_digests`). That is what keeps every historical entry's
+  bytes, HMAC and JWS valid. Add the matching read in
+  `store._entry_from_dict` too, or the field will not survive a
+  round-trip.
+- `parent_hashes` is the artefact's own ancestry and nothing else.
+  `store._compute_tips_from_entries` reads a length of two or more as a
+  *fork merge*, so recording an unrelated input there (an attachment, a
+  source reference) both mis-types the relation and corrupts the tip
+  projection. Give such inputs their own field.
 - Design rationale: `docs/decisions/009-lineage-v1.md`.
 
 ## Testing

--- a/src/bernstein/core/lineage/artifact_record.py
+++ b/src/bernstein/core/lineage/artifact_record.py
@@ -147,6 +147,7 @@ def record_artifact(
     agent_card: AgentCard,
     private_key_pem: str,
     ts_ns: int = 0,
+    attachment_digests: list[str] | None = None,
 ) -> ArtifactReceipt:
     """Canonicalise, record, and persist a non-coding artifact.
 
@@ -164,6 +165,11 @@ def record_artifact(
         agent_id, agent_card, private_key_pem: Signing identity.
         ts_ns: Logical entry timestamp. Fixed (default ``0``) so the signed
             entry is a deterministic projection of the inputs.
+        attachment_digests: Hex SHA-256 digests of the operator attachments
+            the producing task was spawned with (issue #1797), recorded on the
+            signed entry so the receipt names every input the turn consumed.
+            Omitted by default, which keeps an unattached artefact's entry
+            hash byte-identical to what it was before attachments were wired.
 
     Raises:
         ValueError: When ``kind`` is ``code_diff``.
@@ -194,6 +200,7 @@ def record_artifact(
         tool_call_id=_artifact_tool_call_id(task_id),
         span_id=_artifact_span_id(task_id, k.value),
         artefact_kind=k.value,
+        attachment_digests=attachment_digests,
         ts_ns=ts_ns,
     )
 

--- a/src/bernstein/core/lineage/entry.py
+++ b/src/bernstein/core/lineage/entry.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import hmac as _hmac
 import json
+import re
 from dataclasses import asdict, dataclass
 
 LINEAGE_ENTRY_VERSION = 1
@@ -51,6 +52,9 @@ ARTEFACT_KINDS: frozenset[str] = frozenset(
 #: :mod:`bernstein.core.lineage.provenance`.
 TRUST_CLASSES: frozenset[str] = frozenset({"operator", "workspace", "first_party", "third_party", "public"})
 
+#: Shape of a bare hex SHA-256, used to validate recorded attachment digests.
+_HEX64: re.Pattern[str] = re.compile(r"\A[0-9a-f]{64}\Z")
+
 
 @dataclass(frozen=True, slots=True)
 class LineageEntry:
@@ -75,6 +79,18 @@ class LineageEntry:
     # bytes so every historical entry keeps its exact wire form, signature and
     # HMAC. A tool-result provenance record sets this to one of TRUST_CLASSES.
     trust_class: str | None = None
+    # Additive, optional (issue #1797), dropped when ``None`` on the same rule
+    # as ``trust_class``. Hex SHA-256 digests of the operator attachments the
+    # producing turn was handed, so the receipt names every input the model
+    # saw and not only the artefacts it read.
+    #
+    # Deliberately NOT folded into ``parent_hashes``: that list is the
+    # artefact's own ancestry, and ``_compute_tips_from_entries`` reads a
+    # length of two or more as a fork merge. An attached image is an input to
+    # the turn, not a prior version of the output, so recording it there would
+    # both mis-type the relation and make every attached linear write look
+    # like a merge in the tip projection.
+    attachment_digests: list[str] | None = None
 
     def __post_init__(self) -> None:
         if self.v != LINEAGE_ENTRY_VERSION:
@@ -88,6 +104,12 @@ class LineageEntry:
                 raise ValueError(f"parent_hash must start with 'sha256:', got {p!r}")
         if self.trust_class is not None and self.trust_class not in TRUST_CLASSES:
             raise ValueError(f"unknown trust_class: {self.trust_class!r}")
+        if self.attachment_digests is not None:
+            if not self.attachment_digests:
+                raise ValueError("attachment_digests must be omitted rather than empty")
+            for d in self.attachment_digests:
+                if len(d) != 64 or not _HEX64.match(d):
+                    raise ValueError(f"attachment digest must be 64 lower-case hex chars, got {d!r}")
 
 
 def _canonical_body(entry: LineageEntry) -> dict[str, object]:
@@ -104,6 +126,8 @@ def _canonical_body(entry: LineageEntry) -> dict[str, object]:
     body = asdict(entry)
     if body.get("trust_class") is None:
         body.pop("trust_class", None)
+    if body.get("attachment_digests") is None:
+        body.pop("attachment_digests", None)
     return body
 
 

--- a/src/bernstein/core/lineage/signed_write.py
+++ b/src/bernstein/core/lineage/signed_write.py
@@ -138,6 +138,7 @@ def seal_write(
     artefact_kind: str = "file",
     trust_class: str | None = None,
     extra_parents: list[str] | None = None,
+    attachment_digests: list[str] | None = None,
     ts_ns: int | None = None,
 ) -> str:
     """Seal a single signed lineage write into ``store``. Returns the entry hash.
@@ -180,6 +181,13 @@ def seal_write(
             the artefact's own tip. This is the cross-artefact lineage edge that
             anchors a derived artefact (or a quarantine extraction) back to the
             tainted source it was produced from.
+        attachment_digests: Optional hex SHA-256 digests of the operator
+            attachments the producing turn consumed (issue #1797). Recorded in
+            their own field rather than as parents: ``parent_hashes`` is the
+            artefact's ancestry, and a second parent there reads as a fork
+            merge in the tip projection. ``None`` is dropped from the
+            canonical bytes, so an unattached write keeps its exact historical
+            entry hash, HMAC and signature.
         ts_ns: Optional deterministic entry timestamp (nanoseconds). When
             ``None`` the wall clock is stamped. Artifact-mode callers pass a
             logical timestamp so two operators with equal inputs produce a
@@ -230,6 +238,7 @@ def seal_write(
         ts_ns=entry_ts_ns,
         operator_hmac="",
         trust_class=trust_class,
+        attachment_digests=attachment_digests,
     )
     operator_hmac = compute_operator_hmac(unsigned_entry, operator_hmac_key)
 
@@ -246,6 +255,7 @@ def seal_write(
         ts_ns=entry_ts_ns,
         operator_hmac=operator_hmac,
         trust_class=trust_class,
+        attachment_digests=attachment_digests,
     )
 
     # Sign the JCS-canonical entry bytes. The auditor verifies the same bytes
@@ -314,6 +324,7 @@ class SignedLineageLog:
         artefact_kind: str = "file",
         trust_class: str | None = None,
         extra_parents: list[str] | None = None,
+        attachment_digests: list[str] | None = None,
         ts_ns: int | None = None,
     ) -> str:
         """Seal one artefact write into the bound store. Returns the entry hash.
@@ -334,6 +345,7 @@ class SignedLineageLog:
             artefact_kind=artefact_kind,
             trust_class=trust_class,
             extra_parents=extra_parents,
+            attachment_digests=attachment_digests,
             ts_ns=ts_ns,
         )
 

--- a/src/bernstein/core/lineage/store.py
+++ b/src/bernstein/core/lineage/store.py
@@ -35,7 +35,7 @@ import sys
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 # ``fcntl`` is POSIX-only. On Windows the module doesn't exist; the lock
 # context manager below becomes a no-op (Windows CI runs are single-process
@@ -335,6 +335,20 @@ class LineageStore:
         return _compute_tips_from_entries(sequence)
 
 
+def _optional_str_list(raw: object) -> list[str] | None:
+    """Coerce an optional JSON list field into ``list[str] | None``.
+
+    An absent field reads back as ``None``, which canonicalises to the exact
+    bytes that were read, so the entry hash round-trips for entries written
+    before the field existed.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        raise ValueError(f"expected a list, got {type(raw).__name__}")
+    return [str(item) for item in cast("list[object]", raw)]
+
+
 def _entry_from_dict(payload: dict[str, object]) -> LineageEntry:
     """Reconstruct a ``LineageEntry`` from its JSON dict form."""
     # All canonical-field names map 1:1 onto the dataclass kwargs. Cast through
@@ -354,6 +368,8 @@ def _entry_from_dict(payload: dict[str, object]) -> LineageEntry:
         # Additive (issue #2513): absent on pre-feature entries -> None, which
         # canonicalises back to the exact bytes read, so entry_hash round-trips.
         trust_class=(None if payload.get("trust_class") is None else str(payload["trust_class"])),
+        # Additive (issue #1797), same absent -> None round-trip rule.
+        attachment_digests=_optional_str_list(payload.get("attachment_digests")),
     )
 
 

--- a/src/bernstein/core/tasks/artifact_completion.py
+++ b/src/bernstein/core/tasks/artifact_completion.py
@@ -466,6 +466,15 @@ def complete_artifact_task(
     from bernstein.core.lineage.artifact_record import record_artifact
 
     card, private_pem = load_artifact_identity(sdd)
+    # Issue #1797: an artefact produced by a worker that was handed an image
+    # records that image's digest on its signed entry, so the receipt names
+    # every input the turn saw and not just the code it read. The digests come
+    # from what the spawn stamped on the task -- the same records behind the
+    # ``multimodal.attach`` chain rows -- rather than a fresh hash of files
+    # that may have changed since. Empty for an unattached task, which leaves
+    # its entry hash unchanged.
+    from bernstein.core.agents.attachment_dispatch import attachment_digests_for_tasks
+
     try:
         receipt = record_artifact(
             recorder=_build_signed_log(sdd, operator_hmac_key),
@@ -476,6 +485,7 @@ def complete_artifact_task(
             agent_id=card.agent_id,
             agent_card=card,
             private_key_pem=private_pem,
+            attachment_digests=attachment_digests_for_tasks([task]) or None,
             ts_ns=ts_ns,
         )
     except (CanonicalisationError, ValueError) as exc:

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1211,6 +1211,13 @@ class AgentSession:
     # whether the human-readable activation log is enabled. Empty when
     # nothing was injected (not absent).
     injected_skills: list[dict[str, str]] = field(default_factory=list)
+    # Operator attachments resolved at spawn (issue #1797). Each entry is
+    # ``{"sha256", "mime", "worktree_id", "source_path", "modality"}`` in
+    # declared order. Stamped by the spawner from the same dispatch that
+    # stored the bytes in CAS and appended the ``multimodal.attach`` chain
+    # event, so the session record names exactly the digests the chain
+    # attests. Empty when the session's tasks declare no attachments.
+    multimodal_attachments: list[dict[str, str]] = field(default_factory=list)
 
 
 class IsolationMode(StrEnum):

--- a/tests/unit/lineage/test_artifact_record.py
+++ b/tests/unit/lineage/test_artifact_record.py
@@ -56,6 +56,75 @@ def _write_card(cards_dir: Path, card: AgentCard) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Attachment parents (issue #1797)
+# ---------------------------------------------------------------------------
+
+
+def test_attachment_digests_land_on_the_entry(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    """An artefact produced from an attached image records that image's digest.
+
+    This is the lineage half of the ``--attach`` promise: the receipt for
+    whatever the worker produced names the input image, so an auditor reading
+    the entry sees every input the turn consumed.
+    """
+    card, priv = identity
+    digest = "a" * 64
+    store = LineageStore(tmp_path / "run" / "lineage")
+
+    record_artifact(
+        recorder=SignedLineageLog(store=store, operator_hmac_key=_HMAC_KEY),
+        sink_root=tmp_path / "run" / "artifacts",
+        task_id="T-attach",
+        kind=ArtifactKind.REPORT,
+        artifact="findings",
+        agent_id=card.agent_id,
+        agent_card=card,
+        private_key_pem=priv,
+        attachment_digests=[digest],
+    )
+
+    entries = [entry for entry, _raw in store.read_log()]
+    assert len(entries) == 1
+    assert entries[0].attachment_digests == [digest]
+    # The digest is an input to the turn, not the artefact's own ancestry:
+    # recording it as a parent would read as a fork merge in the tip
+    # projection and mis-type the relation.
+    assert entries[0].parent_hashes == []
+
+
+def test_entry_hash_unchanged_without_attachments(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    """Omitting attachments reproduces the pre-wiring entry byte-for-byte.
+
+    ``extra_parents`` defaults to ``None``, so every artefact recorded by a
+    task that declared no attachments must hash exactly as it did before the
+    parameter existed.
+    """
+    card, priv = identity
+    common = {
+        "task_id": "T-1",
+        "kind": ArtifactKind.REPORT,
+        "artifact": "findings",
+        "agent_id": card.agent_id,
+        "agent_card": card,
+        "private_key_pem": priv,
+    }
+
+    without = record_artifact(
+        recorder=_recorder(tmp_path / "a"),
+        sink_root=tmp_path / "a" / "artifacts",
+        **common,  # type: ignore[arg-type]
+    )
+    explicit_none = record_artifact(
+        recorder=_recorder(tmp_path / "b"),
+        sink_root=tmp_path / "b" / "artifacts",
+        attachment_digests=None,
+        **common,  # type: ignore[arg-type]
+    )
+
+    assert without.entry_hash == explicit_none.entry_hash
+
+
+# ---------------------------------------------------------------------------
 # Determinism: same input -> byte-identical content_hash AND entry_hash
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/tasks/test_artifact_completion.py
+++ b/tests/unit/tasks/test_artifact_completion.py
@@ -541,3 +541,45 @@ def test_a_signal_less_coding_task_still_skips_the_pass(tmp_path: Path) -> None:
 
     task = Task(id="T-code", title="t", description="d", role="backend")
     assert _enqueue_alive_exit_janitor_pass(_FakeOrch(tmp_path), task, reason="alive_exit_tick") is None
+
+
+# ---------------------------------------------------------------------------
+# Attachment digests on the completion receipt (issue #1797)
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_entry_carries_the_spawn_stamped_attachment_digests(tmp_path: Path) -> None:
+    """A task spawned with an image completes into an entry naming that image.
+
+    This is the far end of the ``--attach`` chain: the spawn stamps the
+    digests it stored in CAS and attested in the audit chain, and the
+    completion path carries them onto the signed entry rather than re-hashing
+    files that may have changed since.
+    """
+    from bernstein.core.agents.attachment_dispatch import ATTACHMENT_METADATA_KEY
+    from bernstein.core.lineage.store import LineageStore
+
+    digest = "b" * 64
+    task = _task(output_path="out/report.md")
+    task.metadata[ATTACHMENT_METADATA_KEY] = [
+        {"sha256": digest, "mime": "image/png", "worktree_id": "wt", "source_path": "shot.png"}
+    ]
+    _write(tmp_path, "out/report.md", "the summary")
+
+    result = _run(tmp_path, task)
+
+    assert result.ok, result.failures
+    entries = [entry for entry, _raw in LineageStore(tmp_path / ".sdd" / "lineage").read_log()]
+    assert [e.attachment_digests for e in entries] == [[digest]]
+
+
+def test_receipt_entry_omits_the_field_without_attachments(tmp_path: Path) -> None:
+    """An unattached task records no attachment field at all."""
+    from bernstein.core.lineage.store import LineageStore
+
+    task = _task(output_path="out/report.md")
+    _write(tmp_path, "out/report.md", "the summary")
+
+    assert _run(tmp_path, task).ok
+    entries = [entry for entry, _raw in LineageStore(tmp_path / ".sdd" / "lineage").read_log()]
+    assert [e.attachment_digests for e in entries] == [None]

--- a/tests/unit/test_attachment_spawn_wiring.py
+++ b/tests/unit/test_attachment_spawn_wiring.py
@@ -1,0 +1,334 @@
+"""Spawn-path wiring for operator attachments (issue #1797, #3555).
+
+``docs/operations/run.md`` promises that an attached image is stored in
+CAS, recorded as a ``multimodal.attach`` audit-chain event, pinned to the
+attaching worktree, and named by the produced artefact's signed lineage
+entry.
+
+The primitives for all of that live in
+:mod:`bernstein.core.agents.multimodal_attestation`, but nothing called
+them: ``--attach`` set an env var that no reader consumed and
+``Task.attachments`` was parsed and then dropped, so a run produced no
+bytes, no event, and no lineage record. These tests drive the spawner
+itself rather than the primitives, so the wiring -- not just the
+building blocks -- is what is under test.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from bernstein.core.spawner import AgentSpawner
+
+from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.core.agents.attachment_dispatch import AttachmentDispatchError
+from bernstein.core.agents.multimodal_attestation import WorktreeAccessDenied
+from bernstein.core.persistence.cas_store import CASStore
+from bernstein.core.security.audit_chain import (
+    EVENT_MULTIMODAL_ATTACH,
+    AuditChainStore,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.tasks.models import ModelConfig
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"attachment-under-test"
+
+
+class RecordingAdapter(CLIAdapter):
+    """Stub adapter with a real ``spawn`` signature.
+
+    ``MagicMock(spec=CLIAdapter)`` erases the signature to ``(*args,
+    **kwargs)``, which is exactly what the spawner introspects to decide
+    whether an adapter can carry attachments. A real subclass is
+    therefore required to exercise the capable-adapter path.
+    """
+
+    default_model = "sonnet"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.captured_multimodal: Any = None
+        self.captured_prompt: str = ""
+        self.spawn_calls: int = 0
+
+    def name(self) -> str:
+        return "claude"
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = 3600,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+        multimodal_context: Any | None = None,
+    ) -> SpawnResult:
+        self.spawn_calls += 1
+        self.captured_prompt = prompt
+        self.captured_multimodal = multimodal_context
+        return SpawnResult(pid=4242, log_path=workdir / "agent.log")
+
+
+class IncapableAdapter(RecordingAdapter):
+    """Adapter whose ``spawn`` cannot carry attachments at all."""
+
+    def name(self) -> str:
+        return "aider"
+
+    def spawn(  # type: ignore[override]
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = 3600,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        self.spawn_calls += 1
+        return SpawnResult(pid=4243, log_path=workdir / "agent.log")
+
+
+@pytest.fixture
+def templates_dir(tmp_path: Path) -> Path:
+    """Minimal role template tree the spawner can render from."""
+    roles = tmp_path / "templates" / "roles"
+    (roles / "backend").mkdir(parents=True)
+    (roles / "backend" / "config.yaml").write_text("default_model: sonnet\ndefault_effort: medium\n")
+    (roles / "backend" / "prompt.md").write_text("You are a backend agent.\n")
+    return roles
+
+
+@pytest.fixture
+def attachment(tmp_path: Path) -> Path:
+    """An on-disk PNG the operator would pass to ``--attach``."""
+    path = tmp_path / "screenshot.png"
+    path.write_bytes(PNG_BYTES)
+    return path
+
+
+def _digest() -> str:
+    return hashlib.sha256(PNG_BYTES).hexdigest()
+
+
+class TestSpawnPathConsumesAttachments:
+    """The documented provenance must be produced by an actual spawn."""
+
+    def test_task_attachments_reach_the_adapter(
+        self, tmp_path: Path, templates_dir: Path, attachment: Path, make_task
+    ) -> None:
+        """A task declaring attachments hands the adapter a multimodal context."""
+        adapter = RecordingAdapter()
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)  # type: ignore[arg-type]
+
+        task = make_task(role="backend")
+        task.attachments = [str(attachment)]
+
+        spawner.spawn_for_tasks([task])
+
+        assert adapter.spawn_calls == 1
+        ctx = adapter.captured_multimodal
+        assert ctx is not None, "spawner dropped the declared attachments"
+        assert [Path(str(i.content_path)).name for i in ctx.inputs] == ["screenshot.png"]
+
+    def test_spawn_stores_bytes_in_cas(self, tmp_path: Path, templates_dir: Path, attachment: Path, make_task) -> None:
+        """Attachment bytes land in ``.sdd/cas/`` addressed by SHA-256."""
+        adapter = RecordingAdapter()
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)  # type: ignore[arg-type]
+
+        task = make_task(role="backend")
+        task.attachments = [str(attachment)]
+        spawner.spawn_for_tasks([task])
+
+        cas = CASStore(tmp_path / ".sdd" / "cas")
+        assert cas.get(_digest()) == PNG_BYTES
+
+    def test_spawn_records_multimodal_attach_event(
+        self, tmp_path: Path, templates_dir: Path, attachment: Path, make_task
+    ) -> None:
+        """A ``multimodal.attach`` event is appended to the audit chain."""
+        adapter = RecordingAdapter()
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)  # type: ignore[arg-type]
+
+        task = make_task(role="backend")
+        task.attachments = [str(attachment)]
+        spawner.spawn_for_tasks([task])
+
+        chain = AuditChainStore(tmp_path / ".sdd" / "audit")
+        events = chain.query(event_type=EVENT_MULTIMODAL_ATTACH)
+        assert len(events) == 1
+        assert events[0].details["sha256"] == _digest()
+        assert events[0].details["worktree_id"], "attach event carries no worktree pin"
+
+    def test_run_level_attach_env_var_is_consumed(
+        self,
+        tmp_path: Path,
+        templates_dir: Path,
+        attachment: Path,
+        make_task,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``bernstein run --attach`` reaches the spawn path via its env var."""
+        monkeypatch.setenv("BERNSTEIN_RUN_ATTACHMENTS", str(attachment))
+        adapter = RecordingAdapter()
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)  # type: ignore[arg-type]
+
+        spawner.spawn_for_tasks([make_task(role="backend")])
+
+        ctx = adapter.captured_multimodal
+        assert ctx is not None, "--attach env var was never read by the spawn path"
+        assert len(ctx.inputs) == 1
+
+    def test_no_attachments_leaves_spawn_untouched(self, tmp_path: Path, templates_dir: Path, make_task) -> None:
+        """A run without attachments passes no context and writes no CAS/chain."""
+        adapter = RecordingAdapter()
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)  # type: ignore[arg-type]
+
+        spawner.spawn_for_tasks([make_task(role="backend")])
+
+        assert adapter.captured_multimodal is None
+        assert not (tmp_path / ".sdd" / "cas").exists()
+
+
+class TestLineagePinning:
+    """Digests are stamped so the artefact receipt can carry them."""
+
+    def test_spawn_stamps_digests_for_lineage(
+        self, tmp_path: Path, templates_dir: Path, attachment: Path, make_task
+    ) -> None:
+        """The resolved digests are recorded on the task for the lineage receipt."""
+        from bernstein.core.agents.attachment_dispatch import attachment_digests_for_tasks
+
+        adapter = RecordingAdapter()
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)  # type: ignore[arg-type]
+
+        task = make_task(role="backend")
+        task.attachments = [str(attachment)]
+        spawner.spawn_for_tasks([task])
+
+        assert attachment_digests_for_tasks([task]) == [_digest()]
+
+
+class TestWorktreePinSurvivesTheWiring:
+    """The pin the docs promise must hold against a real recorded event."""
+
+    def test_cross_worktree_resolve_is_denied(
+        self, tmp_path: Path, templates_dir: Path, attachment: Path, make_task
+    ) -> None:
+        """A worker in another worktree cannot resolve the attached bytes."""
+        from bernstein.core.agents.multimodal_attestation import resolve_attachment_for_worker
+
+        adapter = RecordingAdapter()
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)  # type: ignore[arg-type]
+
+        task = make_task(role="backend")
+        task.attachments = [str(attachment)]
+        spawner.spawn_for_tasks([task])
+
+        with pytest.raises(WorktreeAccessDenied):
+            resolve_attachment_for_worker(
+                sha256=_digest(),
+                requesting_worktree_id="some-other-worktree",
+                cas=CASStore(tmp_path / ".sdd" / "cas"),
+                audit_chain=AuditChainStore(tmp_path / ".sdd" / "audit"),
+            )
+
+
+class TestResumeResolvesThroughThePin:
+    """A resumed worker rebuilds its attachments from attested bytes."""
+
+    def test_resume_rebuilds_context_from_cas(
+        self, tmp_path: Path, templates_dir: Path, attachment: Path, make_task
+    ) -> None:
+        """Resume re-sends the attached bytes without re-reading the file."""
+        adapter = RecordingAdapter()
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)  # type: ignore[arg-type]
+
+        task = make_task(role="backend")
+        task.attachments = [str(attachment)]
+        spawner.spawn_for_tasks([task])
+
+        # The operator's file is gone by the time the crashed worker resumes;
+        # CAS is the only remaining source of the bytes the chain attests.
+        attachment.unlink()
+
+        spawner.spawn_for_resume([task], worktree_path=tmp_path, changed_files=[])
+
+        ctx = adapter.captured_multimodal
+        assert ctx is not None, "resume dropped the attachments"
+        replayed = base64.b64decode(str(ctx.inputs[0].content_base64))
+        assert replayed == PNG_BYTES
+
+    def test_resume_in_another_worktree_is_refused(
+        self, tmp_path: Path, templates_dir: Path, attachment: Path, make_task
+    ) -> None:
+        """The worktree pin is enforced on the resume read, not bypassed."""
+        adapter = RecordingAdapter()
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)  # type: ignore[arg-type]
+
+        task = make_task(role="backend")
+        task.attachments = [str(attachment)]
+        spawner.spawn_for_tasks([task])
+
+        foreign = tmp_path / "other-worktree"
+        foreign.mkdir()
+        with pytest.raises(AttachmentDispatchError, match="could not resolve attachment"):
+            spawner.spawn_for_resume([task], worktree_path=foreign, changed_files=[])
+
+
+class TestRefusalsInsteadOfSilentDrops:
+    """Every path that cannot carry attachments says so."""
+
+    def test_missing_declared_attachment_refuses(self, tmp_path: Path, templates_dir: Path, make_task) -> None:
+        """A plan-declared path that does not exist aborts the spawn."""
+        adapter = RecordingAdapter()
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)  # type: ignore[arg-type]
+
+        task = make_task(role="backend")
+        task.attachments = [str(tmp_path / "nope.png")]
+
+        with pytest.raises(AttachmentDispatchError, match="not found"):
+            spawner.spawn_for_tasks([task])
+        assert adapter.spawn_calls == 0
+
+    def test_adapter_without_the_parameter_refuses(
+        self, tmp_path: Path, templates_dir: Path, attachment: Path, make_task
+    ) -> None:
+        """An adapter whose spawn() cannot take a context never silently drops it."""
+        adapter = IncapableAdapter()
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)  # type: ignore[arg-type]
+
+        task = make_task(role="backend")
+        task.attachments = [str(attachment)]
+
+        with pytest.raises(RuntimeError, match="cannot carry attachments"):
+            spawner.spawn_for_tasks([task])
+
+    def test_container_isolation_refuses_before_writing_anything(
+        self, tmp_path: Path, templates_dir: Path, attachment: Path, make_task
+    ) -> None:
+        """Container mode refuses, and leaves no orphan blob or attach event."""
+        adapter = RecordingAdapter()
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)  # type: ignore[arg-type]
+        spawner._container_mgr = object()  # type: ignore[assignment]
+
+        task = make_task(role="backend")
+        task.attachments = [str(attachment)]
+
+        with pytest.raises(AttachmentDispatchError, match="not supported when agents run via"):
+            spawner.spawn_for_tasks([task])
+        assert not (tmp_path / ".sdd" / "cas").exists()
+        assert adapter.spawn_calls == 0


### PR DESCRIPTION
## What

Makes `--attach` actually do what `docs/operations/run.md` says it does, and corrects the one documented claim that could not ship as written.

## Why

The doc describes the `--attach` flow end to end: CAS storage at `.sdd/cas/`, a `multimodal.attach` audit-chain event, a lineage parent, and worktree pinning enforced by `WorktreeAccessDenied` / `AttachmentChainUnverified`.

None of it ran. The primitives in `core/agents/multimodal_attestation.py` had no production caller:

- `--attach` set `BERNSTEIN_RUN_ATTACHMENTS`, which nothing read.
- `Task.attachments` was parsed and serialised, then dropped.
- `multimodal_context=` was never passed anywhere outside `adapters/`, so even the documented wire format never happened. Every adapter accepted the parameter; nothing ever supplied it.

An operator following the docs got a pre-spawn capability check and nothing else: no bytes stored, no audit event, no lineage record, no pin.

## How

New `core/agents/attachment_dispatch.py` is the seam between the primitives and the spawn path, mirroring `context_attachments.py` for declared context files.

- Collects run-level `--attach` entries and plan-declared `Task.attachments` into one deterministic order, stores and attests them, and stamps the digests on the session and its tasks.
- CAS and the audit chain are rooted at the run root, not the per-session worktree. One shared chain is what makes the pin a refusal rather than a miss.
- Crash resume rebuilds the context from CAS through `resolve_attachment_for_worker` rather than re-reading files the crashed agent may have edited or deleted, so the resumed turn sends byte-identical input under the same pin and authenticated-chain requirement. This is the resolver's first production consumer.
- `Task.attachments` is no longer a dead field (#3555).

The authenticated read in `resolve_attachment_for_worker` is unchanged.

## Reviewer note: the lineage parent could not ship as written

`worker_lineage_parents` builds `multimodal-attachment://<sha256>` URIs for `persistence.lineage.LineageWriter`, whose `LineageRecord` has no `parents` field and whose writer is deprecated. The live `LineageEntry` accepts only `sha256:` parents.

Folding them into `parent_hashes` anyway would corrupt the DAG. `store._compute_tips_from_entries` treats `len(parents) >= 2` as a fork merge, so every attached linear write would be mis-projected as a merge, and ADR-009 requires parents to name entries that exist in the log.

The digests therefore ship as `attachment_digests`, an additive optional field following the `trust_class` (#2513) precedent: dropped from the canonical bytes when `None`, so **every entry recorded without attachments keeps its exact hash, HMAC and signature**. The golden signed-write tests confirm this. `worker_lineage_parents` is left in place as public API, now documented as having no live consumer.

The invariant I nearly broke is now recorded in `src/bernstein/core/lineage/AGENTS.md`.

## Refusals instead of silent drops

Container, sandbox, runtime-bridge and in-process spawns render their own command and never reach `adapter.spawn()`, so attachments would have vanished there too. They are now refused before anything is written, leaving no orphan blob or attach event. A declared path that is not a readable file aborts the spawn rather than running the agent text-only, which is the only check a plan-declared path gets (`--attach` is validated by Click).

## Verification

Tests drive the spawner rather than the primitives, which is how this gap hid: the existing integration test called the module functions directly and never spawned anything.

- `tests/unit/test_attachment_spawn_wiring.py` (new): CAS write, chain event, adapter receives the context, run-level env var consumed, resume rebuilds from CAS after the source file is deleted, cross-worktree resume refused, each refusal path, and a control asserting an unattached spawn writes nothing and passes no argument.
- 1066 passed across attachment + multimodal + integration + all `tests/unit/lineage` + all `tests/unit/tasks`; a wider run including adapters and crash recovery passed 1710.
- `ruff check` clean; `pyright` clean on every changed file; `mypy` shows no new errors against a stashed baseline.
- A full `tests/unit` sweep was still running when this PR was opened, so CI is the authority on it.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (clean on all changed files; pre-existing errors elsewhere unchanged)
- [x] Tests pass (see Verification for scope)
- [x] New code has type hints

### Documentation duty

- [ ] README section updated (N/A: no README surface for this flag)
- [x] `docs/operations/run.md` updated to match shipped behaviour
- [ ] `docs/api/` schema regenerated (N/A: no public API surface changed)
- [x] `uv run bernstein agents-md sync` run (no diff: the module map lists sub-packages, not files)
- [x] Tests cover the documented behaviour
