### PR TITLE
docs(release-notes): match the v3.15.1 page to the published release

### DIFF
--- a/docs/release-notes/v3.15.1.md
+++ b/docs/release-notes/v3.15.1.md
@@ -1,150 +1,41 @@
 # v3.15.1
 
-A patch release, and the first one this project has cut on a theme rather than
-on a count. v3.15.0 closed the trust boundary where it was leaking; this one
-walks the same boundary looking for the places the fix did not reach — the
-credential that authenticates and is then asked nothing further, the reader
-that narrows its answer for one caller and not the next, the surface that was
-hardened in REST and left as it was in gRPC.
+v3.15.0 closed a trust boundary. This release went back to see how far that fix
+reached. Not far enough.
 
-Eleven changes, eight of them the same sentence in different subsystems: derive
-what you are allowed to see from what you proved, and check it at the place
-that reads, not at the place that asks.
+## Tenant scoping
 
-Two of the eleven were not on the list when this release was cut. They were
-found by reviewing the other nine, which is the argument for reviewing them.
+#3799 narrowed the task routes and listed a second set of readers it
+deliberately left alone. That set got asked directly: a server with two tenants,
+all five kinds of credential. Twelve of thirteen handed over another tenant's
+task ids and titles. The thirteenth never touches the task table, so it is
+closed with evidence instead of a patch.
 
-## Security
+The twelve now derive their tenant from authenticated state (#3808). So does the
+budget forecast, where one tenant's spending moved another tenant's exhaustion
+date. Found and fixed by @BinarySpecter (#3809).
 
-- **Every credential kind now clears the same route gate (#3797).** An agent
-  identity authenticated and then proceeded without the per-route permission
-  check the other principal paths apply, so a task-scoped token reached log
-  and stream reads and session-kill routes it held no permission for. The
-  middleware now resolves the required permission for every authenticated
-  request and refuses when the credential does not hold it. The fleet-wide
-  cluster secret is bound the same way in the same change — review of the
-  first patch found it carrying the identical shape, and shipping half of
-  this would have been worse than shipping none of it.
-- **Task reads and mutations narrow to the caller's tenant (#3799).** The
-  export, the GraphQL collection resolver, the batch mutator and the task
-  detail and diff routes each resolved rows without passing through the
-  scoped single-task path, so a valid credential could read and mutate
-  another tenant's tasks. Each now applies the effective tenant derived from
-  authenticated state, with a cross-tenant refusal test per surface and a
-  positive control per surface — a leak assertion that an empty response
-  would satisfy is not an assertion.
-- **The dashboard, observability and export readers narrow the same way
-  (#3808).** The change above closed the task routes and named a second set
-  of readers it deliberately left, on the grounds that folding them in would
-  have made it unreviewable. That was the right call about review and a bad
-  place to stop. Those readers were then checked one at a time against a
-  running two-tenant server rather than by reading the code, and twelve of
-  the thirteen handed an authenticated caller another tenant's task ids and
-  titles: `/status` and its duration predictions, `/recap`,
-  `/dashboard/data`, the team dashboard, the dependency graph, the agent and
-  token-breakdown views, `/agents` and its comparison, `/export/agents`,
-  `/badge.json`, and the GraphQL status summary. The thirteenth — the
-  `/events` stream — turned out to subscribe to the event bus and never
-  touch the task table, so it is closed with that evidence and no change to
-  it. Each of the twelve now derives its tenant from authenticated state.
-  `status_summary()` gains a tenant argument rather than the surface quietly
-  ceasing to be a per-tenant figure, and runtime records that carry no
-  tenant of their own — agent sessions, token sidecars — derive one from the
-  task they name; an id that resolves to nothing is kept rather than
-  dropped, because dropping it would be an existence check wearing a scope
-  check's clothes.
-- **The budget forecast is scoped to the caller's tenant (#3809).**
-  `/metrics/predictions` built its spend series from every tenant's cost
-  points, so one tenant's spend moved another's exhaustion forecast. It is
-  now narrowed the way the rest of the cost surface is. A cost point written
-  before per-tenant attribution existed reads as the default tenant's spend,
-  which is not a second policy sitting next to #3702's but agreement with
-  the writer: the metric collector already resolves an absent tenant label
-  to the default when it picks the file to write to. Reported and fixed by
-  @BinarySpecter.
-- **The gRPC cluster surface is hardened to the REST surface's level
-  (#3537).** Mutating handlers require the scopes their REST equivalents
-  require; `RegisterNodeResponse.auth_token` is populated with a node JWT
-  carrying `node:register` and `node:heartbeat` and never `node:admin`;
-  re-registration resolves an existing node by identity instead of adding a
-  row, so a restarting worker stops inflating cluster capacity. Verified
-  against main first: three registrations of one worker produced three
-  entries and a capacity of 12 where 4 was correct. The surface is latent —
-  nothing in `src/` starts the server — which is exactly why it was worth
-  closing before it is not.
-- **Attachment worktree access rests only on authenticated rows (#3567).**
-  The access decision read `multimodal.attach` events through the
-  unverified query path, so a forged row could name another worktree as an
-  owner. It now reads through the verified scan with a kept cursor.
-  Reviewing that fix turned up a defect in the cursor primitive itself: a
-  failed scan mutated the caller's cursor before the verdict existed, so a
-  store that detected tampering once went quiet about it afterwards. The
-  scan now walks a working copy and the caller's cursor advances only on a
-  verdict it accepted. Two other subsystems — signal actions and native
-  tool-call evidence — carried the same latent bug and are fixed by the same
-  change. Stated plainly: the attachment surface has no production caller
-  yet, so this makes it safe to wire rather than closing a live hole.
-- **Tenant directory derivation goes through the shared containment barrier
-  (#3693).** `tenant_paths` and `tenant_metrics_dir` asserted containment
-  with their own local check instead of `path_containment.contained_path`.
-  One invariant with two implementations is one invariant waiting to drift.
-  Sixteen further call sites still hold their own copy; #3802 tracks them.
+## Credentials
 
-## Behaviour changes (read before upgrading)
+An agent token authenticated, and then nothing else was asked of it (#3797). It
+reached log reads, stream reads and session-kill routes it held no permission
+for. Review of that patch found the cluster secret doing the same. Both closed
+in one change. Same shape in gRPC (#3537), attachment access (#3567) and tenant
+directories (#3693).
 
-- **`auth_type="oauth"` on a remote MCP server now fails at construction
-  (#3463).** It was documented as supported, implemented nowhere, and fell
-  through to refusing every request — a server that looked configured and
-  answered nothing. There is no issuer or audience binding in that code
-  path, so accepting a token would have been worse than refusing one. The
-  value is removed from the documented and accepted set, and an unknown
-  `auth_type` raises `RemoteMCPConfigError` at construction rather than
-  denying silently at serve time. A config carrying `"oauth"` must move to
-  `"bearer"` or `"none"`.
-- **Cost-history rows with no tenant attribution are excluded from every
-  tenant-scoped query (#3702).** `DailyCostSnapshot` gains a tenant field so
-  the 30- and 90-day trend behind `/costs/alerts` can be narrowed at all.
-  Every row written before this release loads with no attribution, and
-  absence is treated as a sentinel rather than as the default tenant:
-  crediting unverified spend to one tenant is a worse answer than omitting
-  it. A single-tenant install sees its trend start from rows written after
-  the upgrade. `upsert_daily_snapshot` also matches on date *and* tenant,
-  where a same-day upsert could previously clobber another tenant's row.
-- **Disclosure defaults match the published policy (#3694).** The module
-  encoded a programme the project no longer runs: a 48-hour response SLA, a
-  four-tier recognition ladder including a hall of fame whose page was
-  removed in #3689, and fix-deadline arithmetic. `SECURITY.md` states a
-  90-day first-response window, no fix deadline, and one uniform credit
-  path; the defaults now say the same thing. Anything reading
-  `response_sla_hours`, the recognition tiers, or the fix-deadline keys in
-  the compliance and timeline outputs will see the new shape.
+## Behaviour changes
 
-## Release engineering
+- `auth_type="oauth"` fails at construction (#3463). Documented, implemented
+  nowhere, refused every request. Move to `"bearer"` or `"none"`.
+- Cost rows with no tenant are excluded from tenant-scoped queries (#3702).
+- Disclosure defaults match the published policy (#3694).
+- Rawhide no longer holds the RPM channel red while every released chroot ships
+  (#3791).
 
-- **A rawhide build no longer holds the RPM channel (#3791).** The v3.15.0
-  publish went red while every released chroot published: fedora 43 and 44
-  and epel 9 and 10 all shipped, and only rawhide failed, on a dependency
-  with no wheel for its interpreter falling back to a source build with no
-  `g++` present. Copr reports one state per build and that state is failed
-  when any single chroot is, which contradicted the workflow's own stated
-  intent. The watcher now decides a failed build on its gating chroots and
-  the spec carries a C++ toolchain, so rawhide builds instead of merely
-  stopping short of blocking. Tolerating rawhide did not widen into
-  tolerating a bad build: a failure on a released chroot, a build that
-  published nothing, and an unreadable chroot list all still fail.
+## Upgrading
 
-Upgrade in place. Things worth checking first: any remote MCP server
-configured with `auth_type="oauth"` (it now raises at construction, #3463),
-anything reading the cost-history trend on a multi-tenant install (untagged
-historical rows are excluded, #3702), anything reading disclosure SLA or
-recognition fields (#3694), any client holding an agent identity or the
-cluster secret that reached a route it had no permission for (it now gets a
-403, #3797), and any caller that relied on a task read answering across
-tenants (#3799).
+Upgrade in place. On a multi-tenant install the operator views now answer for one
+tenant: dashboards, recap, observability, exports, `/badge.json`, the budget
+forecast. A fleet-wide number will drop. Single-tenant sees no change.
 
-The one to check properly on a multi-tenant install is the operator view.
-Dashboards, the recap, the dependency graph, the agent and token views,
-`/export/agents`, `/badge.json` and the budget forecast now answer for one
-tenant rather than for the install (#3808, #3809). If you were reading any of
-those as a whole-fleet figure, the number will drop, and it was never the
-number you thought it was. A single-tenant install sees no change.
+Two security advisories are published alongside this release.


### PR DESCRIPTION
`docs/release-notes/v3.15.1.md` and the published release page carry different text. The bump commit merged a longer draft than the one that went out on the tag, so a reader following the docs site and a reader following the release page get different notes for the same version.

Replaces the file with the published text.

Nothing that affects an upgrade decision is dropped: `auth_type="oauth"` failing at construction, the untagged cost rows, the disclosure defaults, and the operator-view warning for multi-tenant installs are all still named, with their issue references.

Verified: the file now matches https://github.com/sipyourdrink-ltd/bernstein/releases/tag/v3.15.1 above the auto-generated changelog.