### PR TITLE
fix(observability): Luhn-validate card matches before redacting

### DIFF
--- a/src/bernstein/core/observability/log_redact.py
+++ b/src/bernstein/core/observability/log_redact.py
@@ -50,6 +50,44 @@ _PII_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 
 _REDACTED = "[REDACTED]"
 
+
+def _luhn_check(digits: str) -> bool:
+    """Validate a digit string using the Luhn algorithm.
+
+    Args:
+        digits: String of digits, separators already stripped.
+
+    Returns:
+        True when the digit string passes Luhn validation.
+    """
+    if not digits or not digits.isdigit():
+        return False
+    total = 0
+    for index, char in enumerate(reversed(digits)):
+        value = int(char)
+        if index % 2 == 1:
+            value *= 2
+            if value > 9:
+                value -= 9
+        total += value
+    return total % 10 == 0
+
+
+def _redact_card(match: re.Match[str]) -> str:
+    """Redact a card-shaped match only when it actually checksums as a card.
+
+    Sixteen consecutive digits on their own are not a card number: trace ids,
+    order numbers, and ledger sequences share the shape. Redacting those
+    rewrites legitimate identifiers in persisted records, which is the same
+    false-positive class the credential rules below already avoid.
+    """
+    digits = re.sub(r"[\s\-]", "", match.group(0))
+    return _REDACTED if _luhn_check(digits) else match.group(0)
+
+
+# Patterns whose match needs validating before it is treated as PII.
+_PII_VALIDATORS = {"credit_card": _redact_card}
+
 # Credential matches deliberately require either a known prefix/header/block or
 # a sensitive field name.  Entropy alone is not a signal: content hashes,
 # UUIDs, and base64 payloads are legitimate trace data and must remain stable.
@@ -86,8 +124,9 @@ def redact_pii(text: str) -> str:
         Sanitised copy with PII spans replaced.
     """
     result = text
-    for _label, pattern in _PII_PATTERNS:
-        result = pattern.sub(_REDACTED, result)
+    for label, pattern in _PII_PATTERNS:
+        validator = _PII_VALIDATORS.get(label)
+        result = pattern.sub(validator, result) if validator else pattern.sub(_REDACTED, result)
     return result
 
 

--- a/tests/unit/test_log_redact.py
+++ b/tests/unit/test_log_redact.py
@@ -71,6 +71,20 @@ class TestRedactCreditCard:
     def test_no_cc(self) -> None:
         assert redact_pii("id 12345") == "id 12345"
 
+    def test_sixteen_digit_identifier_that_fails_luhn_survives(self) -> None:
+        # A trace id drawn from uuid4().hex[:16] that happened to be all
+        # digits. It is not a card number -- no card validator would accept it
+        # -- and rewriting it loses the record's own identity on disk.
+        assert redact_pii("trace 2018678836144587") == "trace 2018678836144587"
+
+    def test_luhn_valid_cards_are_still_redacted(self) -> None:
+        # Spot-check a second issuer prefix so the Luhn gate is not passing
+        # purely because of the repeated-digit test Visa above.
+        assert redact_pii("card 5500005555555559") == "card [REDACTED]"
+
+    def test_sequential_digits_are_not_treated_as_a_card(self) -> None:
+        assert redact_pii("order 1234567890123456") == "order 1234567890123456"
+
 
 class TestRedactMultiple:
     def test_mixed_pii(self) -> None:


### PR DESCRIPTION
Fixes #3810

## Problem

`log_redact.py` matched a card number as sixteen consecutive digits and nothing else:

```python
("credit_card", re.compile(r"\b(?:\d{4}[\s\-]?){3}\d{4}\b")),
```

With no checksum, every sixteen-digit identifier in trace data was replaced with `[REDACTED]` on write. `TraceStore.write` runs the payload through `redact_sensitive_text`, so the rewrite landed in the persisted record — including the record's own `trace_id`, which `new_trace` builds from `uuid.uuid4().hex[:16]`.

The same file already states the intent this violates:

> Entropy alone is not a signal: content hashes, UUIDs, and base64 payloads are legitimate trace data and must remain stable.

## Fix

Card-shaped matches are now Luhn-checked before being redacted. This mirrors `dlp_scanner_v2`, which already Luhn-validates the same data class (`_luhn_check`, `_validate_credit_card`) precisely to hold down false positives — the two modules now agree on what counts as a card.

The dispatch is a small `_PII_VALIDATORS` map rather than a special case inside the loop, so any future pattern needing post-match validation has a place to go.

## Behaviour

| input | before | after |
|---|---|---|
| `card 4111111111111111` | redacted | redacted |
| `card 5500 0055 5555 5559` | redacted | redacted |
| `card 4111-1111-1111-1111` | redacted | redacted |
| `trace 2018678836144587` | **redacted** | preserved |
| `order 1234567890123456` | **redacted** | preserved |

Real cards still redact in every separator form the pattern accepts; identifiers that no card validator would accept survive.

## Tests

Three cases added to `TestRedactCreditCard`. The two negative ones fail on `main`:

```
AssertionError: assert 'order [REDACTED]' == 'order 1234567890123456'
```

Verified locally: `tests/unit/test_log_redact.py` 30 passed, `tests/unit/test_traces.py` 41 passed, and all 1264 tests across every test file referencing redaction pass. `ruff check` and `ruff format --check` are clean.

## Deliberately not in this PR

`core/memory/cross_task_kb.py` carries the same pattern (line 170) and the same false positive. Its comment says it duplicates the subset on purpose so the module does not depend on the observability stack, so syncing it is a separate judgement call about where a shared Luhn helper should live — happy to follow up if you'd like it in the same change.