### PR TITLE
fix(observability): stop a late prometheus_client import from replacing the stub registry

### DIFF
--- a/docs/operations/CONFIG.md
+++ b/docs/operations/CONFIG.md
@@ -344,6 +344,13 @@ bernstein doctor
 
 Treat telemetry as configurable: enabled only when endpoint/settings are provided.
 
+On Windows, `prometheus_client` is imported with a timeout because it can hang
+there; if it does not finish in time, metrics are disabled for that process and
+`/metrics` returns an empty body. `BERNSTEIN_PROMETHEUS_IMPORT_TIMEOUT` sets that
+budget in seconds (default `3.0`). Raise it on a machine slow enough that metrics
+disable themselves on every start. It has no effect on other platforms, where the
+import is not timed.
+
 ---
 
 ## Notifications

--- a/src/bernstein/core/observability/prometheus.py
+++ b/src/bernstein/core/observability/prometheus.py
@@ -16,6 +16,7 @@ Usage::
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from typing import Any, cast
 
@@ -23,6 +24,12 @@ logger = logging.getLogger(__name__)
 
 # prometheus_client can hang on Windows during import due to multiprocessing issues.
 # Make it optional with stub fallbacks for Windows compatibility.
+
+# How long the Windows import gets before this module gives up on it. Raising it
+# is the fix for a machine slow enough that metrics disable themselves on every
+# start; the default is what CI runners have always used.
+_IMPORT_TIMEOUT_SECONDS = float(os.environ.get("BERNSTEIN_PROMETHEUS_IMPORT_TIMEOUT", "3.0"))
+
 _PROMETHEUS_AVAILABLE = False
 try:
     # Set a short import timeout using threading on Windows
@@ -31,31 +38,59 @@ try:
 
         _import_done = threading.Event()
         _import_error: Exception | None = None
+        # The worker publishes here and never touches this module's public names.
+        # An import that lands after the timeout finds nobody reading the box: by
+        # then the stubs below are defined and ``registry`` is built from them, and
+        # rebinding ``Counter`` to the real class at that point would hand a real
+        # metric constructor a stub registry to register itself into.
+        _import_result: dict[str, Any] = {}
 
         def _try_import() -> None:
-            global _PROMETHEUS_AVAILABLE, _import_error
+            global _import_error
             try:
-                global CollectorRegistry, Counter, Gauge, Histogram, generate_latest
                 from prometheus_client import (
-                    CollectorRegistry,
-                    Counter,
-                    Gauge,
-                    Histogram,
-                    generate_latest,
+                    CollectorRegistry as _RealCollectorRegistry,
                 )
-
-                _PROMETHEUS_AVAILABLE = True
+                from prometheus_client import (
+                    Counter as _RealCounter,
+                )
+                from prometheus_client import (
+                    Gauge as _RealGauge,
+                )
+                from prometheus_client import (
+                    Histogram as _RealHistogram,
+                )
+                from prometheus_client import (
+                    generate_latest as _real_generate_latest,
+                )
             except Exception as e:
                 _import_error = e
+            else:
+                _import_result.update(
+                    CollectorRegistry=_RealCollectorRegistry,
+                    Counter=_RealCounter,
+                    Gauge=_RealGauge,
+                    Histogram=_RealHistogram,
+                    generate_latest=_real_generate_latest,
+                )
             finally:
                 _import_done.set()
 
         t = threading.Thread(target=_try_import, daemon=True)
         t.start()
-        if not _import_done.wait(timeout=3.0):
+        if not _import_done.wait(timeout=_IMPORT_TIMEOUT_SECONDS):
             logger.warning("prometheus_client import timed out on Windows - metrics disabled")
         elif _import_error:
             logger.warning("prometheus_client import failed: %s - metrics disabled", _import_error)
+        else:
+            # ``wait`` returned True, so the worker's dict writes happened before
+            # the event was set and are visible here.
+            CollectorRegistry = _import_result["CollectorRegistry"]
+            Counter = _import_result["Counter"]
+            Gauge = _import_result["Gauge"]
+            Histogram = _import_result["Histogram"]
+            generate_latest = _import_result["generate_latest"]
+            _PROMETHEUS_AVAILABLE = True
     else:
         from prometheus_client import (
             CollectorRegistry,
@@ -69,40 +104,64 @@ try:
 except ImportError as e:
     logger.warning("prometheus_client not available: %s - metrics disabled", e)
 
-# Stub classes for when prometheus is unavailable
+# Stubs for when prometheus is unavailable. Defined unconditionally so they can
+# be inspected and tested on a machine where the real client imports fine; only
+# the binding below is conditional.
+
+
+class _StubCollectorRegistry:
+    """No-op collector registry when prometheus_client is unavailable.
+
+    It answers every call made on ``registry`` anywhere in this module, and the
+    ``register`` that a real metric constructor performs on the registry it is
+    handed. A stub that raises on those turns "metrics are disabled" into an
+    import-time ``AttributeError``, which is worse than having no metrics and
+    reads in CI as a broken conftest rather than as a fallback.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass  # Stub: prometheus_client not installed
+
+    def register(self, *args: Any, **kwargs: Any) -> None:
+        pass  # Stub: nothing to collect from
+
+    def unregister(self, *args: Any, **kwargs: Any) -> None:
+        pass  # Stub: nothing was registered
+
+    def collect(self, *args: Any, **kwargs: Any) -> tuple[Any, ...]:
+        return ()
+
+
+class _StubMetric:
+    """No-op metric stub when prometheus_client is unavailable."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass  # Stub: no-op metric
+
+    def labels(self, *args: Any, **kwargs: Any) -> _StubMetric:
+        return self
+
+    def inc(self, *args: Any, **kwargs: Any) -> None:
+        pass  # Stub: no-op increment
+
+    def dec(self, *args: Any, **kwargs: Any) -> None:
+        pass  # Stub: no-op decrement
+
+    def set(self, *args: Any, **kwargs: Any) -> None:
+        pass  # Stub: no-op set
+
+    def observe(self, *args: Any, **kwargs: Any) -> None:
+        pass  # Stub: no-op observe
+
+
+def _stub_generate_latest(*args: Any, **kwargs: Any) -> bytes:
+    return b""
+
+
 if not _PROMETHEUS_AVAILABLE:
-
-    class CollectorRegistry:  # type: ignore[no-redef]
-        """No-op collector registry when prometheus_client is unavailable."""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            pass  # Stub: prometheus_client not installed
-
-    class _StubMetric:
-        """No-op metric stub when prometheus_client is unavailable."""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            pass  # Stub: no-op metric
-
-        def labels(self, *args: Any, **kwargs: Any) -> _StubMetric:
-            return self
-
-        def inc(self, *args: Any, **kwargs: Any) -> None:
-            pass  # Stub: no-op increment
-
-        def dec(self, *args: Any, **kwargs: Any) -> None:
-            pass  # Stub: no-op decrement
-
-        def set(self, *args: Any, **kwargs: Any) -> None:
-            pass  # Stub: no-op set
-
-        def observe(self, *args: Any, **kwargs: Any) -> None:
-            pass  # Stub: no-op observe
-
+    CollectorRegistry = _StubCollectorRegistry  # type: ignore[misc,assignment]
     Counter = Gauge = Histogram = _StubMetric  # type: ignore[misc,assignment]
-
-    def generate_latest(*args: Any, **kwargs: Any) -> bytes:
-        return b""
+    generate_latest = _stub_generate_latest  # type: ignore[assignment]
 
 
 __all__ = [

--- a/tests/unit/observability/test_prometheus_import_fallback.py
+++ b/tests/unit/observability/test_prometheus_import_fallback.py
@@ -1,0 +1,172 @@
+"""The Windows import fallback in ``observability.prometheus`` must not race.
+
+The module imports ``prometheus_client`` on a daemon thread with a timeout, so
+three things can happen and all three have to leave the module in one coherent
+state: the import lands in time, it fails, or it lands *after* the module has
+already given up and built its stubs. The third one broke `main`: the late
+import used to rebind ``Counter`` to the real class while ``registry`` was
+already a stub instance, and the real ``Counter.__init__`` calls
+``registry.register(self)``.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import inspect
+import re
+import sys
+import time
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+MODULE = "bernstein.core.observability.prometheus"
+
+# Well under any real import, so a "slow" import in these tests is still fast.
+_TIMEOUT = "0.05"
+_SLOWER_THAN_TIMEOUT = 0.35
+
+
+def _reimport(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    platform: str,
+    import_delay: float = 0.0,
+) -> ModuleType:
+    """Import the module fresh under a chosen platform and import speed.
+
+    ``sys.platform`` and ``__import__`` are restored before this returns rather
+    than at test teardown. Leaving them patched for the rest of the test lets
+    another fixture's teardown import a third-party module under a platform the
+    process never started on, which fails in a place that has nothing to do with
+    what is being tested.
+    """
+    real_import = builtins.__import__
+    real_platform = sys.platform
+
+    def maybe_slow_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "prometheus_client" and import_delay:
+            time.sleep(import_delay)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setenv("BERNSTEIN_PROMETHEUS_IMPORT_TIMEOUT", _TIMEOUT)
+    sys.modules.pop(MODULE, None)
+    sys.platform = platform  # type: ignore[misc]
+    builtins.__import__ = maybe_slow_import  # type: ignore[assignment]
+    try:
+        return importlib.import_module(MODULE)
+    finally:
+        builtins.__import__ = real_import  # type: ignore[assignment]
+        sys.platform = real_platform  # type: ignore[misc]
+
+
+@pytest.fixture(autouse=True)
+def _restore_module() -> Any:
+    """Put the original module object back for everything else in the process.
+
+    Restoring the object rather than re-importing it matters: a re-import here
+    would run while this test's platform patch may still be in effect, and
+    third-party modules that branch on ``sys.platform`` at import time refuse to
+    load under a platform they were not started on.
+    """
+    original = sys.modules.get(MODULE)
+    yield
+    if original is not None:
+        sys.modules[MODULE] = original
+    else:
+        sys.modules.pop(MODULE, None)
+
+
+def test_module_imports_when_the_windows_import_overruns_its_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The regression: this raised AttributeError at module scope.
+
+    The stub registry was constructed, the late import rebound ``Counter`` to
+    the real class, and constructing it called ``register`` on a stub that had
+    no such method.
+    """
+    module = _reimport(monkeypatch, platform="win32", import_delay=_SLOWER_THAN_TIMEOUT)
+
+    assert module._PROMETHEUS_AVAILABLE is False
+    # Give the daemon thread more than enough time to finish and try to interfere.
+    time.sleep(_SLOWER_THAN_TIMEOUT)
+    assert module._PROMETHEUS_AVAILABLE is False
+
+
+def test_a_late_windows_import_does_not_replace_the_stub_metric_classes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An import that lands after the timeout must be discarded, not adopted.
+
+    A process that has already handed out stub metric objects cannot make them
+    real retroactively, so a half-adopted result is worse than none.
+    """
+    module = _reimport(monkeypatch, platform="win32", import_delay=_SLOWER_THAN_TIMEOUT)
+    counter_at_import = module.Counter
+
+    time.sleep(_SLOWER_THAN_TIMEOUT)
+
+    assert module.Counter is counter_at_import
+    assert module.Counter.__module__ == MODULE, "a real prometheus class was adopted late"
+    assert type(module.registry).__module__ == MODULE
+
+
+def test_stub_metrics_still_record_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disabling metrics must disable them, not break the caller."""
+    module = _reimport(monkeypatch, platform="win32", import_delay=_SLOWER_THAN_TIMEOUT)
+
+    module.tasks_total.labels(status="done", role="backend").inc()
+    assert module.generate_latest(module.registry) == b""
+
+
+def test_stub_registry_answers_every_call_this_module_makes_on_registry() -> None:
+    """Enumerated from the source, so a new ``registry.<x>`` call is caught here.
+
+    Hand-listing the methods would pass forever after someone adds a call the
+    stub does not implement, which is exactly how the ``register`` gap shipped.
+    """
+    module = importlib.import_module(MODULE)
+    source = inspect.getsource(module)
+
+    called = set(re.findall(r"\bregistry\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\(", source))
+    # Every real metric constructor registers itself into the registry it is given.
+    called.add("register")
+
+    stub_registry = module._StubCollectorRegistry()
+    missing = sorted(name for name in called if not hasattr(stub_registry, name))
+    assert not missing, f"stub registry is missing {missing}"
+
+
+def test_a_windows_import_that_beats_the_timeout_is_adopted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Positive control: without this, always-stub would satisfy every test above."""
+    pytest.importorskip("prometheus_client")
+    module = _reimport(monkeypatch, platform="win32")
+
+    assert module._PROMETHEUS_AVAILABLE is True
+    assert module.Counter.__module__.startswith("prometheus_client")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="this is the non-Windows path")
+def test_a_slow_import_off_windows_is_still_adopted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Positive control: the ordinary path has no timeout, so slow is fine.
+
+    The host's own platform is used rather than a fabricated one, because
+    third-party modules imported along the way branch on ``sys.platform`` when
+    they load and refuse a platform the process did not start on.
+    """
+    pytest.importorskip("prometheus_client")
+    module = _reimport(monkeypatch, platform=sys.platform, import_delay=_SLOWER_THAN_TIMEOUT)
+
+    assert module._PROMETHEUS_AVAILABLE is True
+    assert module.Counter.__module__.startswith("prometheus_client")


### PR DESCRIPTION
Closes #3817. Fixes the red `Adapter conformance + e2e (windows)` job on `main`.

## What broke

On Windows `prometheus.py` imports `prometheus_client` on a daemon thread with a 3-second timeout. When the wait expired, the module defined its stubs and built `registry` from the stub class — but the thread stayed alive and rebound the globals it had declared at `:38`. `Counter` became the real prometheus class while `registry` was still a stub instance, and the real `Counter.__init__` calls `registry.register(self)` on whatever registry it is handed:

```
ImportError while loading conftest 'D:\a\bernstein\bernstein\tests\conftest.py'.
E   AttributeError: 'CollectorRegistry' object has no attribute 'register'
```

The same job passed on `6db1c8763` and `38f8929c8` and failed on `74594eb49`, whose entire diff is one data file (`.coverage-baseline.json`). Nothing in that diff reaches this code — the outcome depended on whether the import beat 3 seconds on that runner.

## What changed

- The import worker publishes into a private dict and never touches the module's public names. The main thread adopts the result only when `wait()` returned true, so a late arrival is discarded rather than half-adopted. A process that has already handed out stub metric objects cannot make them real retroactively.
- The stub registry answers `register`, `unregister` and `collect`. `registry.collect()` is called at `:650` and `register` by every real metric constructor; a stub that raises on those converts "metrics disabled" into an import-time crash.
- Stubs are defined unconditionally and only bound conditionally, so they are inspectable where the real client imports fine.
- The timeout reads `BERNSTEIN_PROMETHEUS_IMPORT_TIMEOUT` (default `3.0`), documented in `docs/operations/CONFIG.md`. A machine slow enough to disable its own metrics every start now has a knob instead of a silent downgrade.

## Proof

Verified failing first against the unfixed module — 4 failed, 2 passed:

| Test | Protects |
|---|---|
| `test_module_imports_when_the_windows_import_overruns_its_timeout` | the regression itself |
| `test_a_late_windows_import_does_not_replace_the_stub_metric_classes` | the late result is discarded |
| `test_stub_metrics_still_record_without_raising` | disabling metrics disables them, not the caller |
| `test_stub_registry_answers_every_call_this_module_makes_on_registry` | enumerated from source, not hand-listed |
| `test_a_windows_import_that_beats_the_timeout_is_adopted` | positive control |
| `test_a_slow_import_off_windows_is_still_adopted` | positive control |

The two positive controls pass before and after, which is their job: without them an always-stub module would satisfy every other assertion.

The enumeration test reads `registry.<x>` calls out of the module source. Hand-listing the methods is how the `register` gap shipped in the first place.

Local: `tests/unit/observability/` 126 passed, ruff clean, mypy clean.