### PR TITLE
chore(ci): ratchet coverage baseline up to 83.63%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
   "diff_coverage_floor_percent": 85,
-  "head_sha": "f40bee4b4162e85e585b3a41f9572c380ee6060c",
+  "head_sha": "6db1c876334406a25ff4e4fd5514184f6fc7ccab",
   "line_rate": 0.8363,
-  "run_id": "31823225708",
+  "run_id": "31829419690",
   "total_coverage_percent": 83.63,
-  "updated_at": "2026-08-14T18:00:48+00:00"
+  "updated_at": "2026-08-14T19:21:24+00:00"
 }


### PR DESCRIPTION
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **83.63%**.

Measured on `6db1c876334406a25ff4e4fd5514184f6fc7ccab` from the
`coverage-report` artifact of CI run
[31829419690](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/31829419690).
Those, and the raw Cobertura `line-rate` the percentage was
rounded from, are recorded in the baseline, so the number in the
diff can be re-derived from the file itself:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.