### PR TITLE
fix(ci): pin the aider canary install to an interpreter the CLI runs under

### DIFF
--- a/.github/workflows/adapter-conformance-canary.yml
+++ b/.github/workflows/adapter-conformance-canary.yml
@@ -117,8 +117,16 @@ jobs:
                   # pip / uv / pipx all resolve to the same PyPI distribution;
                   # `uv tool install` is the one runner-side installer that
                   # puts the console script on PATH for every one of them.
-                  print(f"::group::uv tool install {spec}")
-                  rc = subprocess.run(["uv", "tool", "install", spec], check=False).returncode
+                  # An `install.python` pin in the contract selects the
+                  # interpreter: an unpinned install can resolve to a
+                  # runtime the CLI crashes under, which probes as a
+                  # chronic skip rather than an install failure (#3719).
+                  cmd = ["uv", "tool", "install", spec]
+                  pin = install.get("python", "")
+                  if pin:
+                      cmd[3:3] = ["--python", str(pin)]
+                  print(f"::group::{' '.join(cmd)}")
+                  rc = subprocess.run(cmd, check=False).returncode
                   print(f"::endgroup::")
                   if rc != 0:
                       print(f"::warning::install failed for {target.adapter} ({spec}); will probe as skip")

--- a/.github/workflows/adapter-contract-drift.yml
+++ b/.github/workflows/adapter-contract-drift.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           # aider-chat does not yet support Python 3.14; pin the aider
           # matrix row to 3.13 until upstream lands 3.14 compatibility.
-          python-version: ${{ matrix.adapter == 'aider' && '3.13' || '3.14' }}
+          python-version: ${{ matrix.adapter == 'aider' && '3.12' || '3.14' }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/tests/contract/contracts/aider.yaml
+++ b/tests/contract/contracts/aider.yaml
@@ -6,6 +6,10 @@ binary: aider
 install:
   method: pipx
   spec: "aider-chat"
+  # Interpreter the console script must run under. aider 0.86.x crashes at
+  # import on 3.13+, so an unpinned install yields a binary whose --help
+  # is a traceback and the canary records a chronic skip (#3719).
+  python: "3.12"
 auth:
   required_for_help: false
   required_for_models: false


### PR DESCRIPTION
The nightly conformance canary has recorded aider as a degraded skip for three consecutive runs (#3719). The probe transcript shows why: the unpinned `uv tool install aider-chat` resolves to a runtime aider crashes under at import, so `--version` yields the first dotted token of a traceback (`3.13`) and `--help` advertises none of the six required flags — an inconclusive probe, not drift.

Reproduced with ephemeral installs: unpinned fails building `scipy` for the resolved interpreter; `--python 3.12` prints `aider 0.86.2` and a full help.

Three changes, one concern:

- `tests/contract/contracts/aider.yaml` gains `install.python: "3.12"` — the contract stays the single pinning surface.
- The canary install step honours `install.python` for the `pipx`/`pip`/`uv` methods (`uv tool install --python <pin>`), commented with why an unpinned install probes as a chronic skip rather than an install failure.
- The drift workflow's aider matrix cell moves from 3.13 to 3.12 — the existing pin predates the breakage.

`ci-topology.md` regenerated with no delta (step internals are not part of the report). Contract-schema and wheel-data tests pass locally (36 passed).

Fixes #3719