### PR TITLE
feat(config): gate the reviewer auto-execute path through the same admission policy

### DIFF
--- a/src/bernstein/core/config/upgrade_executor.py
+++ b/src/bernstein/core/config/upgrade_executor.py
@@ -19,6 +19,8 @@ import shutil
 import time
 import uuid
 from dataclasses import dataclass, field
+
+from bernstein.evolution.admission import AdmissionPolicy
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -91,6 +93,24 @@ class UpgradeTransaction:
 
     # Changes to apply
     file_changes: list[FileChange] = field(default_factory=list)
+
+    @property
+    def category(self) -> UpgradeType:
+        """The admission gate's category for this lineage.
+
+        Named `upgrade_type` here and `category` on `UpgradeProposal`. The
+        alias is explicit rather than letting the gate guess between attribute
+        names, which would silently key on the wrong field the day a third
+        lineage appears.
+        """
+        return self.upgrade_type
+
+    #: Agent that produced this upgrade. The admission gate measures the
+    #: proposer; the reviewer that approves it is a different actor.
+    produced_by: str = ""
+    #: What caused this upgrade to be proposed. Constant for this path, but
+    #: named so the decision key matches the evolution-loop key shape.
+    triggered_by: str = "reviewer_approval"
 
     # Review results
     reviewer_feedback: str = ""
@@ -263,10 +283,14 @@ class UpgradeExecutor:
         workdir: Path | None = None,
         reviewer: UpgradeReviewer | None = None,
         auto_git: bool = True,
+        admission: AdmissionPolicy | None = None,
     ) -> None:
         self._workdir = workdir or Path.cwd()
         self._reviewer = reviewer or UpgradeReviewer(workdir=self._workdir)
         self._auto_git = auto_git
+        # The same service the FileUpgradeExecutor path uses, not a second
+        # gate with its own semantics.
+        self._admission = admission if admission is not None else AdmissionPolicy()
         self._transactions: dict[str, UpgradeTransaction] = {}
         self._backup_dir = self._workdir / ".sdd" / "upgrades" / "backups"
         self._backup_dir.mkdir(parents=True, exist_ok=True)
@@ -322,8 +346,32 @@ class UpgradeExecutor:
         if result.verdict == "approve":
             transaction.status = UpgradeStatus.REVIEW_APPROVED
             logger.info("Upgrade %s approved by reviewer", transaction.id)
-            # Auto-execute if approved
-            self._execute_upgrade(transaction)
+            # Reviewer approval is not admission. Without this the path
+            # auto-executes on a reviewer verdict alone, which is the bypass
+            # the gate exists to close: an approved upgrade from a producer
+            # with a poor measured history would still apply.
+            decision = self._admission.evaluate(transaction)
+            if not decision.admitted:
+                transaction.status = UpgradeStatus.REVIEW_REJECTED
+                transaction.error_message = (
+                    f"Refused by admission policy: {decision.reason}"
+                )
+                logger.warning(
+                    "Upgrade %s refused by admission policy: %s",
+                    transaction.id,
+                    decision.reason,
+                )
+                return
+            applied = True
+            try:
+                self._execute_upgrade(transaction)
+            except Exception:
+                applied = False
+                raise
+            finally:
+                # Recorded against the key admission used, including the
+                # failure path.
+                self._admission.record_outcome(decision, applied)
         elif result.verdict == "reject":
             transaction.status = UpgradeStatus.REVIEW_REJECTED
             transaction.error_message = result.reasoning

--- a/src/bernstein/core/config/upgrade_executor.py
+++ b/src/bernstein/core/config/upgrade_executor.py
@@ -19,8 +19,6 @@ import shutil
 import time
 import uuid
 from dataclasses import dataclass, field
-
-from bernstein.evolution.admission import AdmissionPolicy
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -40,6 +38,7 @@ from bernstein.core.models import (
     Task,
     TaskType,
 )
+from bernstein.evolution.admission import AdmissionPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -353,9 +352,7 @@ class UpgradeExecutor:
             decision = self._admission.evaluate(transaction)
             if not decision.admitted:
                 transaction.status = UpgradeStatus.REVIEW_REJECTED
-                transaction.error_message = (
-                    f"Refused by admission policy: {decision.reason}"
-                )
+                transaction.error_message = f"Refused by admission policy: {decision.reason}"
                 logger.warning(
                     "Upgrade %s refused by admission policy: %s",
                     transaction.id,

--- a/src/bernstein/evolution/admission.py
+++ b/src/bernstein/evolution/admission.py
@@ -116,14 +116,14 @@ class AdmissionDecision:
         }
 
 
-def producer_identity(proposal: "Admissible | UpgradeProposal") -> str:
+def producer_identity(proposal: Admissible | UpgradeProposal) -> str:
     """The agent that produced this proposal, not the one that applies it."""
     produced_by = getattr(proposal, "produced_by", "") or ""
     produced_by = produced_by.strip()
     return produced_by or UNATTRIBUTED_PRODUCER
 
 
-def decision_key(proposal: "Admissible | UpgradeProposal") -> str:
+def decision_key(proposal: Admissible | UpgradeProposal) -> str:
     """``category:<category>|trigger:<triggered_by>``.
 
     Both halves are read through ``getattr(..., "value", ...)`` so the key is
@@ -214,7 +214,7 @@ class AdmissionPolicy:
     def min_confidence(self) -> float:
         return self._min_confidence
 
-    def evaluate(self, proposal: "Admissible | UpgradeProposal") -> AdmissionDecision:
+    def evaluate(self, proposal: Admissible | UpgradeProposal) -> AdmissionDecision:
         """Decide whether this proposal may be applied."""
         agent_type = producer_identity(proposal)
         key = decision_key(proposal)

--- a/src/bernstein/evolution/admission.py
+++ b/src/bernstein/evolution/admission.py
@@ -29,7 +29,7 @@ import logging
 import os
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from bernstein.core.quality.empirical_confidence import (
     Confidence,
@@ -52,6 +52,21 @@ DEFAULT_MIN_CONFIDENCE: float = 0.5
 #: any real agent type so unattributed proposals accumulate their own history
 #: instead of silently borrowing someone else's.
 UNATTRIBUTED_PRODUCER = "unattributed"
+
+
+@runtime_checkable
+class Admissible(Protocol):
+    """The three things the gate needs, wherever the upgrade came from.
+
+    Deliberately structural rather than a base class: ``UpgradeProposal`` and
+    ``UpgradeTransaction`` are separate lineages that reach the same executor
+    families, and a shared parent would couple them for no reason. The gate
+    needs a category, a trigger and a producer, and nothing else.
+    """
+
+    category: object
+    triggered_by: object
+    produced_by: str
 
 
 class ColdStartMode(StrEnum):
@@ -101,14 +116,14 @@ class AdmissionDecision:
         }
 
 
-def producer_identity(proposal: UpgradeProposal) -> str:
+def producer_identity(proposal: "Admissible | UpgradeProposal") -> str:
     """The agent that produced this proposal, not the one that applies it."""
     produced_by = getattr(proposal, "produced_by", "") or ""
     produced_by = produced_by.strip()
     return produced_by or UNATTRIBUTED_PRODUCER
 
 
-def decision_key(proposal: UpgradeProposal) -> str:
+def decision_key(proposal: "Admissible | UpgradeProposal") -> str:
     """``category:<category>|trigger:<triggered_by>``.
 
     Both halves are read through ``getattr(..., "value", ...)`` so the key is
@@ -199,7 +214,7 @@ class AdmissionPolicy:
     def min_confidence(self) -> float:
         return self._min_confidence
 
-    def evaluate(self, proposal: UpgradeProposal) -> AdmissionDecision:
+    def evaluate(self, proposal: "Admissible | UpgradeProposal") -> AdmissionDecision:
         """Decide whether this proposal may be applied."""
         agent_type = producer_identity(proposal)
         key = decision_key(proposal)
@@ -273,6 +288,7 @@ class AdmissionPolicy:
 __all__ = [
     "DEFAULT_MIN_CONFIDENCE",
     "UNATTRIBUTED_PRODUCER",
+    "Admissible",
     "AdmissionDecision",
     "AdmissionMode",
     "AdmissionPolicy",

--- a/tests/unit/test_evolution_upgrade_executor_admission.py
+++ b/tests/unit/test_evolution_upgrade_executor_admission.py
@@ -1,0 +1,120 @@
+"""Reviewer approval is not admission.
+
+Without a gate here, an approved upgrade auto-executes on the reviewer verdict
+alone -- the bypass #3701 exists to close. This path reaches the same admission
+service the FileUpgradeExecutor path uses, not a second gate with its own
+semantics.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.config.upgrade_executor import (
+    UpgradeExecutor,
+    UpgradeStatus,
+    UpgradeTransaction,
+    UpgradeType,
+)
+from bernstein.core.quality.empirical_confidence import ConfidenceQuery
+from bernstein.evolution.admission import (
+    AdmissionMode,
+    AdmissionPolicy,
+    ColdStartMode,
+    decision_key,
+    producer_identity,
+)
+
+
+@pytest.fixture()
+def query(tmp_path) -> ConfidenceQuery:
+    return ConfidenceQuery(db_path=tmp_path / "confidence.db", min_samples=5)
+
+
+def _transaction(produced_by: str = "manager-agent") -> UpgradeTransaction:
+    return UpgradeTransaction(
+        id="txn-1",
+        upgrade_type=UpgradeType.CONFIG_ADJUSTMENT,
+        title="Tune a setting",
+        description="desc",
+        produced_by=produced_by,
+    )
+
+
+def test_transaction_satisfies_the_admission_protocol() -> None:
+    """The gate takes a category, a trigger and a producer. A transaction and a
+    proposal are separate lineages that both supply those."""
+    transaction = _transaction()
+    assert producer_identity(transaction) == "manager-agent"
+    key = decision_key(transaction)
+    assert key.startswith("category:")
+    assert "|trigger:reviewer_approval" in key
+
+
+def test_the_trigger_distinguishes_this_path_from_the_loop() -> None:
+    """Both executor families share one service, but their histories must not
+    merge -- a producer reliable through the evolution loop has said nothing
+    about its behaviour under reviewer auto-execute."""
+    assert "trigger:reviewer_approval" in decision_key(_transaction())
+
+
+def test_unattributed_transactions_get_their_own_history() -> None:
+    assert producer_identity(_transaction(produced_by="")) == "unattributed"
+
+
+def test_executor_defaults_to_the_shared_service(tmp_path) -> None:
+    executor = UpgradeExecutor(workdir=tmp_path, auto_git=False)
+    assert executor._admission is not None
+    assert executor._admission.mode is AdmissionMode.OBSERVE
+
+
+def test_a_measured_bad_producer_is_refused(tmp_path, query) -> None:
+    transaction = _transaction()
+    key = decision_key(transaction)
+    for outcome in (True, False, False, False, False):
+        query.record("manager-agent", key, outcome)
+
+    policy = AdmissionPolicy(query=query, mode=AdmissionMode.ENFORCE)
+    decision = policy.evaluate(transaction)
+
+    assert decision.admitted is False
+    assert decision.confidence.samples == 5
+
+
+def test_observe_mode_lets_history_accumulate(tmp_path, query) -> None:
+    """The same bootstrap argument as the loop path: enforcing on a cold
+    database deadlocks, because nothing applies and so nothing is recorded."""
+    transaction = _transaction()
+    policy = AdmissionPolicy(query=query)
+
+    for _ in range(5):
+        policy.record_outcome(policy.evaluate(transaction), True)
+
+    enforcing = AdmissionPolicy(query=query, mode=AdmissionMode.ENFORCE)
+    assert enforcing.evaluate(transaction).admitted is True
+
+
+def test_refusal_marks_the_transaction_rejected(tmp_path, query) -> None:
+    """A refused upgrade is not silently dropped: the transaction carries why."""
+    transaction = _transaction()
+    key = decision_key(transaction)
+    for _ in range(5):
+        query.record("manager-agent", key, False)
+
+    policy = AdmissionPolicy(query=query, mode=AdmissionMode.ENFORCE)
+    decision = policy.evaluate(transaction)
+    assert decision.admitted is False
+
+    # Mirror what _review_upgrade does on refusal.
+    transaction.status = UpgradeStatus.REVIEW_REJECTED
+    transaction.error_message = f"Refused by admission policy: {decision.reason}"
+
+    assert transaction.status is UpgradeStatus.REVIEW_REJECTED
+    assert "admission policy" in transaction.error_message
+
+
+def test_cold_start_config_typo_fails_closed(query, monkeypatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_ADMISSION_COLD_START", "fail-open")
+    policy = AdmissionPolicy(query=query, mode=AdmissionMode.ENFORCE)
+    assert policy.cold_start is ColdStartMode.FAIL_CLOSED
+    assert policy.evaluate(_transaction()).admitted is False


### PR DESCRIPTION
PR 2 of 2 for #3701, stacked on #3840. Closes the auto-execute bypass.

`_review_upgrade` executed on a reviewer verdict alone:

```python
if result.verdict == "approve":
    transaction.status = UpgradeStatus.REVIEW_APPROVED
    self._execute_upgrade(transaction)   # nothing consulted history
```

So an approved upgrade from a producer with a poor measured history still applied. As you put it on the issue, that path being ungated is the exact bypass this exists to close.

## One admission service, not a second gate

`AdmissionPolicy.evaluate` now takes a structural protocol — `category`, `triggered_by`, `produced_by` — rather than `UpgradeProposal` specifically.

`UpgradeProposal` and `UpgradeTransaction` are separate lineages that reach the same executor families. A shared base class would couple them for no reason, and copying the gate would give this path its own drifting semantics. The protocol is the smallest thing that lets both through one service.

## Histories stay separate

`UpgradeTransaction` gains `produced_by` and a `triggered_by` of `reviewer_approval`, so the decision key is `category:<upgrade_type>|trigger:reviewer_approval`.

That matters: a producer reliable through the evolution loop has said nothing about its behaviour under reviewer auto-execute. Merging those histories would let one vouch for the other.

`category` is an explicit property aliasing `upgrade_type` rather than teaching the gate to guess between attribute names — a guess would silently key on the wrong field the day a third lineage appears.

## Behaviour on refusal

Marked `REVIEW_REJECTED` with the reason on the transaction, not dropped silently. The outcome is recorded against the admitting key on both the success and failure paths, so a producer that keeps breaking things can lower its own score.

Default is `observe`, same as #3840 — merging changes nothing until you turn enforcement on.

## Verification

```
tests/evolution                              28
tests/unit/test_evolution*.py
tests/unit/test_upgrade_executor.py
tests/unit/test_manager.py
tests/unit/orchestration/test_manager_upgrades.py

322 passed
```

Depends on #3840 for `bernstein.evolution.admission`.

## Why trigger-keyed, not just path-gated

Per review (#3701): the property most likely to be missed later is that this closes *trust transfer*, not just the bypass path. The gate keys on `decision_key = category:<category>|trigger:<triggered_by>` (`admission.py:126`) and confidence is looked up as `query.get(agent_type, key)`, so a producer's earned confidence is scoped to the trigger that produced it. A producer that built confidence through the evolution loop arrives at `trigger:reviewer_approval` with no history and falls to the cold-start policy — it cannot inherit trust earned under different conditions. Gating the reviewer route while letting it inherit evolution-loop confidence would have re-opened the same hole one level down: nominally gated, but always admits because the producer looks reliable on evidence gathered elsewhere.
