### PR TITLE
fix(knowledge): resolve the default branch through a merge-queue ref

### DIFF
--- a/src/bernstein/core/knowledge/agents_md_generator.py
+++ b/src/bernstein/core/knowledge/agents_md_generator.py
@@ -1015,6 +1015,25 @@ def _parse_pyproject_scripts(pyproj: Path) -> dict[str, str]:
     return {str(k): str(v) for k, v in scripts.items()} if isinstance(scripts, dict) else {}
 
 
+#: A GitHub merge-queue ref: ``gh-readonly-queue/<base>/pr-<n>-<base_sha>``.
+#: The base branch may itself contain slashes, so the trailing ``pr-`` segment
+#: is what anchors the split.
+_MERGE_QUEUE_REF = re.compile(r"^gh-readonly-queue/(?P<base>.+)/pr-\d+-[0-9a-f]{7,40}$")
+
+
+def _base_branch_of_merge_queue_ref(branch: str) -> str | None:
+    """Return the base branch a merge-queue ref was built against.
+
+    A queued group is checked out as a real branch named after the ephemeral
+    ref, so the detached-HEAD guard in :func:`_git_default_branch` does not
+    fire and the ref name would otherwise be rendered into AGENTS.md as the
+    repository's default branch. Every entry in the queue would then fail the
+    mirror-drift guard, which blocks the queue rather than reporting a defect.
+    """
+    match = _MERGE_QUEUE_REF.match(branch)
+    return match.group("base") if match else None
+
+
 def _git_default_branch(repo_path: Path) -> str | None:
     """Return the default branch (``main``/``master``/...) or ``None``.
 
@@ -1033,6 +1052,10 @@ def _git_default_branch(repo_path: Path) -> str | None:
        current branch name when neither ``main`` nor ``master`` exists.
        Skipped when HEAD is detached (returns the literal ``HEAD``)
        because that would inject the PR-branch name into AGENTS.md.
+       A merge-queue ref is checked out *as a branch*, not detached, so
+       the detached-HEAD guard does not cover it; the base branch is
+       recovered from the ref's own shape instead (see
+       ``_base_branch_of_merge_queue_ref``).
     """
     try:
         result = subprocess.run(
@@ -1075,6 +1098,9 @@ def _git_default_branch(repo_path: Path) -> str | None:
         )
         if result.returncode == 0:
             branch = result.stdout.strip()
+            queue_base = _base_branch_of_merge_queue_ref(branch)
+            if queue_base:
+                return queue_base
             if branch and branch != "HEAD":
                 return branch
     except (subprocess.TimeoutExpired, OSError):

--- a/tests/unit/test_agents_md_default_branch_on_queue_ref.py
+++ b/tests/unit/test_agents_md_default_branch_on_queue_ref.py
@@ -1,0 +1,79 @@
+"""The rendered default branch must not become a merge-queue ref.
+
+GitHub checks a queued group out as a *real branch* named
+``gh-readonly-queue/<base>/pr-<n>-<base_sha>``. The detached-HEAD guard in
+``_git_default_branch`` therefore does not fire, and without the queue-ref
+case the generator renders that ephemeral name into AGENTS.md's "Git
+workflow" section. The mirror-drift guard then fails on every queued entry,
+so the queue rejects each PR in turn for a defect none of them contain.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.knowledge.agents_md_generator import (
+    _base_branch_of_merge_queue_ref,
+    _git_default_branch,
+)
+
+
+def _repo_on_branch(root: Path, branch: str) -> Path:
+    """A git repo whose only branch is ``branch`` and which has no origin.
+
+    No ``main``/``master`` ref and no ``origin/HEAD`` means resolution falls
+    through to the last-resort probe, which is the step under test.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "README.md").write_text("x\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q", "-b", branch], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=root, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=root, check=True)
+    return root
+
+
+def test_a_queue_ref_resolves_to_the_branch_it_was_queued_against(tmp_path: Path) -> None:
+    """The regression: this returned the whole ``gh-readonly-queue/...`` name."""
+    root = _repo_on_branch(
+        tmp_path / "queued",
+        "gh-readonly-queue/main/pr-3814-7c4a39fd277650c166efa1df97e4082cbdc9dee2",
+    )
+
+    assert _git_default_branch(root) == "main"
+
+
+def test_a_queue_ref_against_a_slashed_base_keeps_the_whole_base(tmp_path: Path) -> None:
+    """The base branch may contain slashes; the ``pr-`` segment anchors the split."""
+    root = _repo_on_branch(
+        tmp_path / "release",
+        "gh-readonly-queue/release/v3/pr-12-0123456789abcdef0123456789abcdef01234567",
+    )
+
+    assert _git_default_branch(root) == "release/v3"
+
+
+def test_an_ordinary_branch_is_still_returned_unchanged(tmp_path: Path) -> None:
+    """Positive control: without this, returning ``main`` always would pass above."""
+    root = _repo_on_branch(tmp_path / "ordinary", "trunk")
+
+    assert _git_default_branch(root) == "trunk"
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "gh-readonly-queue/main",
+        "gh-readonly-queue/main/pr-3814",
+        "gh-readonly-queue/main/pr-abc-7c4a39fd277650c166efa1df97e4082cbdc9dee2",
+        "feature/gh-readonly-queue/main/pr-1-7c4a39fd2",
+        "main",
+    ],
+)
+def test_a_branch_that_only_resembles_a_queue_ref_is_not_rewritten(branch: str) -> None:
+    """A partial match must not silently truncate a real branch name."""
+    assert _base_branch_of_merge_queue_ref(branch) is None


### PR DESCRIPTION
**This unblocks the merge queue.** #3814 was the first entry after the queue went active and it was ejected by `test_agents_md_mirror_guards.py` with:

```
-  branch: `gh-readonly-queue/main/pr-3814-7c4a39fd277650c166efa1df97e4082cbdc9dee2`.
+  branch: `main`.
```

The PR contains no drift — its branch is in sync, and so is its combination with main (verified locally). The generator is what moved: `_git_default_branch` falls through to `git rev-parse --abbrev-ref HEAD`, whose detached-HEAD guard does not fire on a queue ref, because GitHub checks a queued group out as a **real branch** named `gh-readonly-queue/<base>/pr-<n>-<base_sha>`. That name is then rendered into AGENTS.md's Git-workflow section and every mirror drifts. Every entry in the queue hits it, so the queue rejects each PR in turn for a defect none of them contain.

Fix: recover the base branch from the ref's own shape. The trailing `pr-<n>-<sha>` segment anchors the split, so a base containing slashes (`release/v3`) survives intact.

Behavioural before/after on a repo checked out on a queue ref:

```
BEFORE FIX -> gh-readonly-queue/main/pr-3814-7c4a39fd277650c166efa1df97e4082cbdc9dee2
AFTER FIX  -> main
```

Tests: a queue ref resolves to its base; a slashed base survives; an ordinary branch is returned unchanged (positive control — without it, hardcoding `main` would pass); and five near-miss shapes assert a partial match never truncates a real branch name. 54 passed across the three generator test files.

This PR is self-healing through the queue: on its own `merge_group` ref the fixed generator resolves `main`, so the guard passes and the entry merges.

Refs #2966