### PR TITLE
fix: fence evolve and listen first-run paths

### DIFF
--- a/docs/operations/voice-control.md
+++ b/docs/operations/voice-control.md
@@ -1,5 +1,7 @@
 # Voice control
 
+> **Preview:** `bernstein listen` does not start from a base Bernstein installation. Without the optional `voice` dependencies it exits with the `pip install 'bernstein[voice]'` hint. After installing the extra, voice operation also requires working microphone/audio support, and the selected Whisper model is downloaded on first use.
+
 `bernstein listen` is an experimental voice front-end: capture audio
 from your microphone, transcribe it locally with `faster-whisper`,
 match the result against a small grammar plus a user-defined alias

--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -247,7 +247,7 @@ test, and a row naming a command the CLI no longer registers fails it too.
 | `bernstein demo` | Full | 2 | Zero-config demo |
 | [`bernstein demo --flask-todo`](../getting-started/quickstart-demo.md) | Full | 2 | Flask TODO demo (3 tasks). `bernstein quickstart` is a deprecated alias, removed in 4.0.0. |
 | `bernstein agents ...` | Full | 3 | Catalog management |
-| `bernstein evolve ...` | Full | 2 | Self-improvement |
+| `bernstein evolve ...` | Full | 2 | **Preview.** A clean directory exits before the evolution loop starts because `.sdd/` is missing; initialise a Bernstein workspace first. |
 | `bernstein ci fix` | Full | 3 | CI autofix |
 | `bernstein github setup` | Full | 3 | GitHub App setup |
 | [`bernstein worker`](../operations/cluster-mode.md) | Full | 2 | Join cluster as worker |
@@ -270,7 +270,7 @@ test, and a row naming a command the CLI no longer registers fails it too.
 | [`bernstein gateway`](../operations/mcp-gateway.md) | Full | 3 | MCP gateway proxy |
 | [`bernstein workflow`](../operations/workflow-manifests.md) | Full | 3 | Workflow DSL |
 | [`bernstein watch`](../operations/watch.md) | Full | 3 | Directory file watcher |
-| [`bernstein listen`](../operations/voice-control.md) | Full | 2 | Voice commands (experimental). Needs the optional `voice` extra (`pip install 'bernstein[voice]'`); without it the command exits with the install hint rather than starting a session |
+| [`bernstein listen`](../operations/voice-control.md) | Full | 2 | **Preview.** Voice commands are experimental. A base install exits with the `pip install 'bernstein[voice]'` hint; a usable first run also requires microphone/audio support and downloads the selected Whisper model on first use. |
 | [`bernstein completions`](../operations/shell-completions.md) | Full | 3 | Shell completion scripts |
 | [`bernstein self`](../operations/updates.md) | Full | 3 | Provenance-verified update lifecycle: signed feed, chain-anchored advisory, pre-install wheel verification, pin, receipted rollback |
 | [`bernstein self-update`](../operations/self-update.md) | Full | 3 | Compatibility alias for `bernstein self` |

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -704,6 +704,8 @@ See [`operations/cluster-mode.md`](../operations/cluster-mode.md) for the full s
 
 #### `bernstein evolve`
 
+> **Preview:** `bernstein evolve run` is not a zero-workspace first-run path. In a clean directory it exits before starting the evolution loop because `.sdd/` is missing. Initialise a Bernstein workspace first, then run the command from that workspace.
+
 Group: self-evolution proposals and their review lifecycle.
 
 | Subcommand | Purpose |

--- a/src/bernstein/cli/commands/evolve_cmd.py
+++ b/src/bernstein/cli/commands/evolve_cmd.py
@@ -59,6 +59,34 @@ def evolve() -> None:
     """
 
 
+def _load_evolve_config_from_seed(
+    root: Path,
+    github_sync: bool,
+    github_repo: str | None,
+) -> tuple[bool, str | None]:
+    """Read evolve config from bernstein.yaml if CLI flags were not set."""
+    for seed_name in ("bernstein.yaml", "bernstein.yml"):
+        seed_path = root / seed_name
+        if not seed_path.exists():
+            continue
+        with suppress(Exception):
+            import yaml as _yaml
+
+            raw = _yaml.safe_load(seed_path.read_text(encoding="utf-8"))
+            if not isinstance(raw, dict):
+                break
+            evolve_cfg = cast("dict[str, Any]", raw).get("evolve", {})
+            if not isinstance(evolve_cfg, dict):
+                break
+            evolve_dict = cast("dict[str, Any]", evolve_cfg)
+            if not github_sync and evolve_dict.get("github_sync"):
+                github_sync = True
+            if github_repo is None and evolve_dict.get("github_repo"):
+                github_repo = str(evolve_dict["github_repo"])
+        break
+    return github_sync, github_repo
+
+
 @evolve.command("run")
 @click.option(
     "--window",
@@ -97,34 +125,6 @@ def evolve() -> None:
     default=None,
     help="GitHub repo slug (owner/repo). Inferred from git remote if omitted.",
 )
-def _load_evolve_config_from_seed(
-    root: Path,
-    github_sync: bool,
-    github_repo: str | None,
-) -> tuple[bool, str | None]:
-    """Read evolve config from bernstein.yaml if CLI flags were not set."""
-    for seed_name in ("bernstein.yaml", "bernstein.yml"):
-        seed_path = root / seed_name
-        if not seed_path.exists():
-            continue
-        with suppress(Exception):
-            import yaml as _yaml
-
-            raw = _yaml.safe_load(seed_path.read_text(encoding="utf-8"))
-            if not isinstance(raw, dict):
-                break
-            evolve_cfg = cast("dict[str, Any]", raw).get("evolve", {})
-            if not isinstance(evolve_cfg, dict):
-                break
-            evolve_dict = cast("dict[str, Any]", evolve_cfg)
-            if not github_sync and evolve_dict.get("github_sync"):
-                github_sync = True
-            if github_repo is None and evolve_dict.get("github_repo"):
-                github_repo = str(evolve_dict["github_repo"])
-        break
-    return github_sync, github_repo
-
-
 def evolve_run(
     window: str,
     max_proposals: int,

--- a/tests/unit/test_feature_matrix_drift.py
+++ b/tests/unit/test_feature_matrix_drift.py
@@ -289,3 +289,47 @@ def test_named_verification_surfaces_stay_indexed(command: str) -> None:
     only reporting that some command fell out of the matrix.
     """
     assert command in documented_commands(), f"`bernstein {command}` is not named by any matrix row"
+
+
+def _matrix_row_for(command: str) -> str:
+    """Return the feature-matrix row that documents a command."""
+    for line in _MATRIX.read_text(encoding="utf-8").splitlines():
+        if line.lstrip().startswith("|") and command in line:
+            return line
+    raise AssertionError(f"No feature-matrix row found for {command!r}")
+
+
+@pytest.mark.parametrize(
+    ("command", "entry_page", "entry_marker", "blocker"),
+    [
+        (
+            "bernstein evolve",
+            _REPO_ROOT / "docs" / "reference" / "cli-reference.md",
+            "> **Preview:** `bernstein evolve run`",
+            ".sdd/",
+        ),
+        (
+            "bernstein listen",
+            _REPO_ROOT / "docs" / "operations" / "voice-control.md",
+            "> **Preview:** `bernstein listen`",
+            "bernstein[voice]",
+        ),
+    ],
+)
+def test_preview_fences_stay_visible(
+    command: str,
+    entry_page: Path,
+    entry_marker: str,
+    blocker: str,
+) -> None:
+    """Fenced maturity-2 commands keep their Preview marker and blocker."""
+    row = _matrix_row_for(command)
+
+    assert "| 2 |" in row
+    assert "**Preview.**" in row
+    assert blocker in row
+
+    entry_text = entry_page.read_text(encoding="utf-8")
+
+    assert entry_marker in entry_text
+    assert blocker in entry_text


### PR DESCRIPTION
## What

Fence the first-run paths for `bernstein evolve` and `bernstein listen`, fix the misplaced Click decorators on `evolve run`, and add regression coverage for the documented Preview fences.

## Why

Closes #3827.

Both commands are currently maturity 2 and do not provide a clean zero-requirement first-run path.

During clean first-run verification:

* `bernstein evolve run` initially failed with a `TypeError` because the Click decorators for the `run` command were attached to `_load_evolve_config_from_seed()` instead of `evolve_run()`. After correcting the command registration, a clean directory exits with:
  `.sdd directory not found. Run bernstein first to initialise the workspace.`
* `bernstein listen` exits on a base installation with:
  `Voice dependencies are not installed.`
  `Install the voice extra with: pip install 'bernstein[voice]'`

Both paths therefore remain at maturity 2 and are now explicitly documented as Preview/fenced paths with their concrete first-run requirements.

## How

* Move `_load_evolve_config_from_seed()` above the `evolve run` Click decorators so the decorators correctly apply to `evolve_run()`.
* Add an explicit Preview fence for `bernstein evolve` in `FEATURE_MATRIX.md` and the CLI reference.
* Add an explicit Preview fence for `bernstein listen` in `FEATURE_MATRIX.md` and the voice-control documentation.
* Add regression coverage in `test_feature_matrix_drift.py` to ensure both Preview markers and their concrete blockers remain documented.
* Verify the targeted feature-matrix regression tests successfully.

## Checklist

* [x] `uv run ruff check src/` passes
* [ ] `uv run pyright src/` passes
* [ ] `uv run python scripts/run_tests.py -x` passes
* [x] New code has type hints

### Documentation duty (every PR that touches a feature)

* [x] User-visible README section updated (N/A — no README change required for these existing fenced commands)
* [x] `docs/operations/<area>.md` updated (`docs/operations/voice-control.md`)
* [x] `docs/api/` schema regenerated if a public surface changed (N/A — no API schema change)
* [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (N/A — no new module was added)
* [x] Tests cover the documented behaviour

### Test notes

Targeted regression coverage passes:

```text
uv run pytest tests/unit/test_feature_matrix_drift.py -x -q

13 passed, 1 warning
```

The full isolated test runner was also attempted with:

```text
uv run python scripts/run_tests.py -x
```

It stopped on the unrelated Windows/platform-specific test:

```text
tests/unit/adapters/test_openai_agents_builtins.py::TestRunCommandNoShell::test_metacharacter_arg_passed_literally
```

`uv run pyright src/` was also attempted locally, but the repository reports pre-existing project-wide type/import resolution errors in this environment.

A targeted Pyright run against `src/bernstein/cli/commands/evolve_cmd.py` reports the pre-existing unresolved `bernstein.core.github` imports already present in that file. This PR does not modify those imports.
