### PR TITLE
fix(routes): scope budget forecast to the caller's tenant

### DIFF
--- a/src/bernstein/core/routes/quality.py
+++ b/src/bernstein/core/routes/quality.py
@@ -375,12 +375,16 @@ def get_quality_metrics(request: Request) -> JSONResponse:
 @router.get("/quality/budget-forecast")
 def get_budget_forecast(request: Request) -> JSONResponse:
     """Return projected spend for the active planned backlog."""
+    # Imported inside the handler to match team_dashboard.py and avoid a
+    # circular import between the route modules.
+    from bernstein.core.routes.task_crud import _resolve_request_tenant_scope
+
     sdd_dir = _get_sdd_dir(request)
     store = _get_store(request)
     metrics_dir = sdd_dir / "metrics"
     payload = (
         forecast_planned_backlog(
-            store.list_tasks(),
+            store.list_tasks(tenant_id=_resolve_request_tenant_scope(request)),
             metrics_dir=metrics_dir if metrics_dir.exists() else None,
             current_spend_usd=_read_current_spend(metrics_dir),
             budget_usd=_load_budget_from_seed(sdd_dir),

--- a/tests/unit/test_tenant_scoped_readers.py
+++ b/tests/unit/test_tenant_scoped_readers.py
@@ -1,0 +1,73 @@
+"""Tenant scoping for readers that used to list the whole task table.
+
+Each call site gets the same pair: a caller scoped to tenant A must see a figure
+that does not move when tenant B's tasks change, plus a positive control proving
+A's own tasks still count (so the scoping cannot pass by returning nothing).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from bernstein.core.server import create_app
+from bernstein.core.server.server_models import TaskCreate
+
+
+def _write_seed(tmp_path: Path) -> None:
+    (tmp_path / "bernstein.yaml").write_text(
+        'goal: "Ship multi-tenant platform"\n'
+        "tenants:\n"
+        "  - id: team-a\n"
+        "    budget: 100\n"
+        "  - id: team-b\n"
+        "    budget: 250\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def app(tmp_path: Path) -> FastAPI:
+    _write_seed(tmp_path)
+    application = create_app(jsonl_path=tmp_path / ".sdd" / "runtime" / "tasks.jsonl")
+    application.state.reload_seed_config()
+    return application
+
+
+@pytest_asyncio.fixture()
+async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+        yield async_client
+
+
+async def _create(app: FastAPI, title: str, tenant_id: str, **extra: object) -> None:
+    await app.state.store.create(TaskCreate(title=title, description="scoping fixture", tenant_id=tenant_id, **extra))
+
+
+class TestBudgetForecastTenantScope:
+    @pytest.mark.asyncio
+    async def test_forecast_ignores_another_tenants_tasks(self, app: FastAPI, client: AsyncClient) -> None:
+        baseline = (await client.get("/quality/budget-forecast", headers={"X-Tenant-Id": "team-a"})).json()
+
+        await _create(app, "team-b work", "team-b")
+
+        after = await client.get("/quality/budget-forecast", headers={"X-Tenant-Id": "team-a"})
+        assert after.status_code == 200
+        assert after.json()["task_count"] == baseline["task_count"]
+
+    @pytest.mark.asyncio
+    async def test_forecast_still_counts_own_tasks(self, app: FastAPI, client: AsyncClient) -> None:
+        baseline = (await client.get("/quality/budget-forecast", headers={"X-Tenant-Id": "team-a"})).json()[
+            "task_count"
+        ]
+
+        await _create(app, "team-a work", "team-a")
+
+        after = await client.get("/quality/budget-forecast", headers={"X-Tenant-Id": "team-a"})
+        assert after.json()["task_count"] == baseline + 1


### PR DESCRIPTION
Refs #3801 — one of the four call sites, deliberately not the whole issue. See the note at the end.

## Problem

`get_budget_forecast` called `store.list_tasks()` with no tenant scope, so the spend projection every tenant saw was computed across every tenant's backlog. `list_tasks` already accepts `tenant_id` and the request already carries a resolvable scope; the reader just wasn't using either.

## Fix

Resolve the scope with `_resolve_request_tenant_scope`, the same helper `team_dashboard.py` and `status_events.py` use. The import is function-local to match `team_dashboard.py`, which does the same to avoid a circular import between route modules.

## Tests

Two cases in a new `tests/unit/test_tenant_scoped_readers.py`, following the shape the issue asks for:

- `test_forecast_ignores_another_tenants_tasks` — team-a's `task_count` does not move when a team-b task is created.
- `test_forecast_still_counts_own_tasks` — the positive control, so the scoping can't pass by simply returning nothing.

Both fail on `main` and pass here. `tests/unit/test_multi_tenant.py`, `tests/unit/test_multi_repo.py` and the new file run green together (22 passed). `ruff check` and `ruff format` clean.

## Why this is one site and not four

The issue lists four. I'm sending the one I can demonstrate, rather than four I can't:

- **`workspace.py` `workspace_merge_order`** — I made this change and backed it out. `merge_order` returns the configured repo set regardless of tasks, so scoping affects the cross-repo *dependency edges* that determine ordering, not which repos appear. A test that actually pins that behaviour needs cross-tenant dependency edges, and I'd rather that landed with a test that proves it than as a plausible-looking one-liner.
- **`webhooks.py` `_count_ci_fix_attempts`** — real and worth fixing (one tenant's retries do consume another's cap), but it's a webhook handler with no request principal, so where the tenant comes from is a design decision that's yours to make. Also worth noting the issue's location drifted: it's `core/routes/webhooks.py`, not `github_app/webhooks.py`, and there's one call site rather than two — there's no separate GitLab path in the current code.
- **`status_lifecycle.py` `health_check`** — the issue itself flags the open question about the unauthenticated liveness probe. Not mine to decide.

Happy to take any of the three in follow-ups once you've called the design questions.