### PR TITLE
fix(skills): route the three core/skills path checks through the containment helper

### DIFF
--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -48,6 +48,10 @@ from typing import Any, TypedDict, cast
 import yaml
 from pydantic import ValidationError
 
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    contained_subpath,
+)
 from bernstein.core.skills.lint import LintSeverity, lint_skill
 from bernstein.core.skills.manifest import SkillManifest
 from bernstein.core.skills.sanitizer import strip_invisible_tags
@@ -323,24 +327,27 @@ def _referenced_files(skill_dir: Path, frontmatter: dict[str, Any]) -> list[Path
         values = frontmatter.get(bucket, [])
         if not isinstance(values, list):
             continue
-        bucket_root = (skill_dir / bucket).resolve()
         for entry in cast("list[object]", values):
             if not isinstance(entry, str):
                 continue
-            entry_path = Path(entry)
-            if entry_path.is_absolute() or ".." in entry_path.parts:
-                # Reject traversal / absolute paths: the digest must not
-                # depend on files outside the skill directory.
-                continue
+            # The bucket is part of the *candidate*, not the base, so a
+            # bucket that is itself a symlink out of the skill tree is
+            # refused rather than followed. Anchoring to a resolved bucket
+            # root admitted that escape and then tripped the sort key below
+            # with an uncaught ValueError. This matches what lint already
+            # reports as ``unsafe-reference-path``.
             try:
-                candidate = (bucket_root / entry_path).resolve()
-            except OSError:
-                continue
-            if not candidate.is_relative_to(bucket_root):
+                candidate = contained_subpath(skill_root, f"{bucket}/{entry}", label=f"{bucket} entry")
+            except (PathContainmentError, OSError):
+                # Best-effort by contract: the digest simply does not cover
+                # an entry it cannot prove is inside the skill directory.
+                # Lint is what surfaces these to the author.
                 continue
             if candidate.is_file():
                 out.append(candidate)
-    out.sort(key=lambda p: str(p.resolve().relative_to(skill_root)))
+    # Every path is a proven descendant of skill_root, so the relative key
+    # cannot raise.
+    out.sort(key=lambda p: str(p.relative_to(skill_root)))
     return out
 
 

--- a/src/bernstein/core/skills/lint.py
+++ b/src/bernstein/core/skills/lint.py
@@ -32,14 +32,20 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from enum import StrEnum
-from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import yaml
 from pydantic import ValidationError
 
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    contained_subpath,
+)
 from bernstein.core.skills.manifest import SkillManifest
 from bernstein.core.skills.sanitizer import strip_invisible_tags
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 #: Body cap: 5 KB before we warn. The RFC sets this as a soft cap so a
 #: future skill that needs more context can still ship.
@@ -381,36 +387,22 @@ def lint_skill(skill_dir: Path, *, skill_name: str | None = None) -> list[LintFi
 
     # Anchor containment to the resolved skill root so a symlinked
     # bucket (``references -> /tmp/elsewhere``) cannot smuggle host
-    # files past the lint. The bucket directories themselves are not
-    # resolved; we build candidates from the unresolved path and check
-    # them against the resolved skill root.
+    # files past the lint. The bucket name is passed as part of the
+    # *candidate* rather than folded into the base, because the barrier
+    # resolves its base: making ``<skill>/references`` the base would
+    # follow that symlink and re-admit exactly the escape this refuses.
     skill_root = skill_dir.resolve()
     for bucket in _VALID_BUCKETS:
-        bucket_root = skill_root / bucket
         for filename in getattr(manifest, bucket):
-            rel = Path(filename)
-            if rel.is_absolute() or ".." in rel.parts:
+            try:
+                candidate = contained_subpath(skill_root, f"{bucket}/{filename}", label=f"{bucket} path")
+            except PathContainmentError as exc:
                 findings.append(
                     LintFinding(
                         skill_name=name,
                         severity=LintSeverity.ERROR,
                         code="unsafe-reference-path",
-                        message=(
-                            f"manifest declares unsafe {bucket} path {filename!r}; "
-                            "absolute paths and parent traversal are not allowed"
-                        ),
-                        path=skill_md,
-                    )
-                )
-                continue
-            candidate = (skill_dir / bucket / rel).resolve()
-            if not candidate.is_relative_to(bucket_root):
-                findings.append(
-                    LintFinding(
-                        skill_name=name,
-                        severity=LintSeverity.ERROR,
-                        code="unsafe-reference-path",
-                        message=(f"manifest {bucket} path {filename!r} escapes the {bucket}/ root"),
+                        message=f"manifest declares unsafe {bucket} path {filename!r}: {exc}",
                         path=skill_md,
                     )
                 )

--- a/src/bernstein/core/skills/packaging.py
+++ b/src/bernstein/core/skills/packaging.py
@@ -35,6 +35,11 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    PathTooLongError,
+    contained_subpath,
+)
 from bernstein.core.skills.provenance import (
     InstallReceipt,
     InstallVerifyResult,
@@ -240,9 +245,15 @@ def _copy_tree(source: Path, dest: Path) -> None:
     dest_resolved = dest.resolve()
     for src_file in _iter_regular_files(source):
         rel = src_file.relative_to(source)
-        target = (dest_resolved / rel).resolve()
-        if not target.is_relative_to(dest_resolved):
-            raise PackagedInstallError(f"install path escapes destination: {rel.as_posix()}")
+        try:
+            target = contained_subpath(dest_resolved, rel.as_posix(), label="install path")
+        except PathTooLongError as exc:
+            # A capacity failure, not an escape. Reported separately so an
+            # over-long name is never described to the operator as an attack;
+            # previously it surfaced as OSError(ENAMETOOLONG) from copyfile.
+            raise PackagedInstallError(f"install path is too long for this filesystem: {rel.as_posix()}") from exc
+        except PathContainmentError as exc:
+            raise PackagedInstallError(f"install path escapes destination: {rel.as_posix()}") from exc
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(src_file, target)
 

--- a/tests/unit/skills/test_path_containment_sites.py
+++ b/tests/unit/skills/test_path_containment_sites.py
@@ -1,0 +1,187 @@
+"""Containment tests for the three ``core/skills`` path checks (issue #3824).
+
+Each converted site gets an escape test paired with a positive control, so an
+unconditional refusal cannot satisfy the suite. The escape vector is the one a
+hand-rolled ``resolve()`` + ``is_relative_to()`` comparison is most likely to
+miss: a *bucket directory that is itself a symlink* out of the skill tree.
+
+The three sites did not agree on that vector before this change:
+
+* ``lint.py`` refused it (it anchored containment to the unresolved bucket
+  under the resolved skill root).
+* ``lifecycle.py`` accepted it (it anchored to the *resolved* bucket, so the
+  symlink was followed) and then raised an uncaught ``ValueError`` from its
+  sort key, crashing ``compute_skill_digest``.
+* ``packaging.py`` refused it (its base is the destination root, and the
+  symlink sits in the candidate portion).
+
+``lifecycle.py`` now matches ``lint.py``.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.skills.lifecycle import compute_skill_digest
+from bernstein.core.skills.lint import LintSeverity, lint_skill
+from bernstein.core.skills.packaging import PackagedInstallError, _copy_tree
+
+
+def _author(skill_dir: Path, name: str, *, references: list[str] | None = None) -> Path:
+    """Write a minimal well-formed SKILL.md, optionally declaring references."""
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    front = [
+        "---",
+        f"name: {name}",
+        "description: A skill used by the path containment tests for this bucket.",
+    ]
+    if references:
+        front.append("references:")
+        front += [f"  - {entry}" for entry in references]
+    front.append("---")
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(front)
+        + textwrap.dedent(f"""
+
+            # {name}
+
+            Body text.
+            """),
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+# --------------------------------------------------------------------------
+# lifecycle.py - _referenced_files, reached through compute_skill_digest
+# --------------------------------------------------------------------------
+
+
+def test_digest_skips_reference_behind_symlinked_bucket(tmp_path: Path) -> None:
+    """A symlinked ``references/`` must not pull host bytes into the digest.
+
+    Before this change the resolved bucket root made the escape *pass*
+    containment, and the file then failed the ``relative_to(skill_root)`` sort
+    key with an uncaught ``ValueError``.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.md").write_text("host secret\n", encoding="utf-8")
+
+    skill = _author(tmp_path / "skills" / "escaping", "escaping", references=["secret.md"])
+    (skill / "references").symlink_to(outside, target_is_directory=True)
+
+    # Does not raise, and the out-of-tree bytes do not participate.
+    escaped = compute_skill_digest(skill)
+
+    (outside / "secret.md").write_text("host secret, mutated\n", encoding="utf-8")
+    assert compute_skill_digest(skill).digest == escaped.digest
+
+
+def test_digest_includes_reference_under_real_bucket(tmp_path: Path) -> None:
+    """Positive control: an ordinary in-tree reference still counts."""
+    skill = _author(tmp_path / "skills" / "ordinary", "ordinary", references=["ref.md"])
+    refs = skill / "references"
+    refs.mkdir()
+    (refs / "ref.md").write_text("ref body\n", encoding="utf-8")
+
+    before = compute_skill_digest(skill)
+    (refs / "ref.md").write_text("ref body, mutated\n", encoding="utf-8")
+    assert compute_skill_digest(skill).digest != before.digest
+
+
+@pytest.mark.parametrize("entry", ["..\\..\\escape.md", "", "."])
+def test_digest_ignores_unusable_reference_entries(tmp_path: Path, entry: str) -> None:
+    """Entries that name no path below the bucket are skipped, not crashed on.
+
+    ``..\\..\\escape.md`` is the interesting one: ``Path(entry).parts`` keeps it
+    as a single component on POSIX, so the previous ``".." in parts`` guard let
+    it through. It is a parent reference wherever it is read.
+    """
+    skill = _author(tmp_path / "skills" / "odd", "odd", references=[entry])
+    (skill / "references").mkdir()
+
+    assert compute_skill_digest(skill).digest  # no exception
+
+
+# --------------------------------------------------------------------------
+# lint.py - reference bucket checks
+# --------------------------------------------------------------------------
+
+
+def test_lint_rejects_reference_behind_symlinked_bucket(tmp_path: Path) -> None:
+    """The pre-existing refusal survives the conversion unchanged."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.md").write_text("host secret\n", encoding="utf-8")
+
+    skill = _author(tmp_path / "skills" / "linted", "linted", references=["secret.md"])
+    (skill / "references").symlink_to(outside, target_is_directory=True)
+
+    findings = lint_skill(skill)
+    assert any(f.code == "unsafe-reference-path" and f.severity is LintSeverity.ERROR for f in findings)
+
+
+def test_lint_accepts_reference_under_real_bucket(tmp_path: Path) -> None:
+    """Positive control: a real file under a real bucket lints clean."""
+    skill = _author(tmp_path / "skills" / "clean", "clean", references=["ref.md"])
+    refs = skill / "references"
+    refs.mkdir()
+    (refs / "ref.md").write_text("ref body\n", encoding="utf-8")
+
+    codes = {f.code for f in lint_skill(skill)}
+    assert "unsafe-reference-path" not in codes
+    assert "missing-reference" not in codes
+
+
+def test_lint_rejects_backslash_traversal_reference(tmp_path: Path) -> None:
+    """A backslash parent reference is refused on POSIX too.
+
+    The previous ``".." in Path(filename).parts`` guard did not see it, because
+    POSIX does not split on backslash; the shared validator splits on both.
+    """
+    skill = _author(tmp_path / "skills" / "winpath", "winpath", references=["..\\..\\escape.md"])
+    (skill / "references").mkdir()
+
+    findings = lint_skill(skill)
+    assert any(f.code == "unsafe-reference-path" and f.severity is LintSeverity.ERROR for f in findings)
+
+
+# --------------------------------------------------------------------------
+# packaging.py - _copy_tree
+# --------------------------------------------------------------------------
+
+
+def test_copy_tree_refuses_symlinked_destination_subdir(tmp_path: Path) -> None:
+    """A symlinked directory inside the destination cannot capture the write."""
+    source = tmp_path / "source"
+    (source / "nested").mkdir(parents=True)
+    (source / "nested" / "payload.txt").write_text("payload\n", encoding="utf-8")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    (dest / "nested").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(PackagedInstallError, match="escapes destination"):
+        _copy_tree(source, dest)
+    assert not (outside / "payload.txt").exists()
+
+
+def test_copy_tree_copies_ordinary_nested_files(tmp_path: Path) -> None:
+    """Positive control: an ordinary nested tree still copies through."""
+    source = tmp_path / "source"
+    (source / "nested").mkdir(parents=True)
+    (source / "nested" / "payload.txt").write_text("payload\n", encoding="utf-8")
+    (source / "top.txt").write_text("top\n", encoding="utf-8")
+
+    dest = tmp_path / "dest"
+    _copy_tree(source, dest)
+
+    assert (dest / "nested" / "payload.txt").read_text(encoding="utf-8") == "payload\n"
+    assert (dest / "top.txt").read_text(encoding="utf-8") == "top\n"


### PR DESCRIPTION
Closes #3824. Slice 1 of 4 of #3802.

## Did the helper's semantics differ from the local checks?

**Yes, in both directions — and the three sites disagreed with each other.** This is the answer slices 2–4 depend on, so it is stated up front.

The vector that separates them is a **bucket directory that is itself a symlink** out of the skill tree (`references -> /tmp/elsewhere`):

| Site | Before | Why |
|---|---|---|
| `lint.py` | **refused** | anchored to the *unresolved* bucket under the resolved skill root |
| `lifecycle.py` | **followed it, then crashed** | anchored to the *resolved* bucket, so the symlink was followed |
| `packaging.py` | **refused** | its base is the destination root; the symlink sits in the candidate portion |

### The load-bearing detail for the later slices

`contained_subpath` **resolves its base**. So the obvious conversion —
`contained_subpath(skill_dir / bucket, entry)` — would have *re-admitted* the
escape at `lint.py` and quietly weakened a correct check.

Passing the bucket as part of the **candidate** instead keeps it inside the
resolved-candidate half of the comparison, which preserves lint's strictness:

```python
contained_subpath(skill_root, f"{bucket}/{entry}", label=f"{bucket} entry")
```

That call shape is the finding. Anywhere a later slice has a base whose own
last component is attacker-influenced or symlinkable, the component belongs in
the candidate, not the base.

## The bug this surfaced

`lifecycle._referenced_files` resolved `bucket_root`, so a symlinked
`references/` passed containment and the out-of-tree file was collected. The
function then sorted with:

```python
out.sort(key=lambda p: str(p.resolve().relative_to(skill_root)))
```

`relative_to` raises `ValueError` for a path outside `skill_root`, so
`compute_skill_digest` **crashed with an uncaught `ValueError`** on any skill
whose bucket is a symlink — against a docstring that promises missing files are
"silently skipped". Reproduced before the change:

```
ValueError: '/tmp/.../outside/secret.md' is not in the subpath of '/tmp/.../skills/escaping'
```

Both halves are fixed by the conversion: the entry is refused, so nothing
out-of-tree reaches the sort key.

## Behaviour changes, and the tests that pin them

1. **`lifecycle.py`: an entry behind a symlinked bucket is skipped instead of
   crashing the digest.** This makes lifecycle agree with lint, which already
   reports that entry as `unsafe-reference-path`. Pinned by
   `test_digest_skips_reference_behind_symlinked_bucket`, which also asserts
   the digest does not move when the out-of-tree bytes are mutated — a skip
   that still hashed the file would fail.

2. **The string half tightens at all three sites.** `..\..\escape.md` passed
   the previous `".." in Path(entry).parts` guard, because POSIX does not split
   on backslash — `Path("..\\..\\escape.md").parts` is a *single* component.
   `validate_relative_path` splits on both separators, so it is refused on
   POSIX too. Not a live escape on POSIX (the join treats it as a literal
   filename), but it is a parent reference wherever it is read, and it was
   silently accepted into a manifest. Pinned by
   `test_lint_rejects_backslash_traversal_reference`.

3. **Per-component and total path length are now bounded** at all three sites.
   In `packaging.py` a `PathTooLongError` is translated to its own
   `PackagedInstallError` message rather than the escape message, so an
   over-long name is never reported to the operator as an attack. Previously it
   surfaced as `OSError(ENAMETOOLONG)` from `copyfile`, outside the error type
   the caller guards on.

`lint.py`'s two `unsafe-reference-path` branches collapse into one; the code
and severity are unchanged and the message now carries the barrier's reason.
No test asserted on the old message text.

## Proof

`tests/unit/skills/test_path_containment_sites.py` — one escape test per
converted site, each paired with a positive control, so an unconditional
refusal cannot satisfy the suite. Written against unmodified code first:

```
2 failed, 8 passed
FAILED test_digest_skips_reference_behind_symlinked_bucket   <- the crash
FAILED test_lint_rejects_backslash_traversal_reference       <- the string gap
```

The 8 that already passed are the positive controls and the two sites that
were already correct — that is the evidence this is a de-duplication at
`lint.py` and `packaging.py`, and a fix at `lifecycle.py`.

After the change:

```
tests/unit/skills/                 331 passed
tests/unit/core/skills/            138 passed
tests/unit/test_path_containment.py + tests/unit/security/   745 passed
```

```
ruff check src/bernstein/core/skills/     All checks passed!
ruff format                                clean
mypy src/bernstein/core/skills/{lifecycle,lint,packaging}.py   no findings
```

`tests/unit/security/vault/` is excluded from the run above: it fails to
collect in my environment on `ModuleNotFoundError: respx`, which is unrelated
to this change and reproduces on a clean tree.

## No import cycle

`core/skills/` → `core/security/path_containment` is a new edge. It is a leaf
module importing only `os`, `re`, and `pathlib`, and `core/security/` does not
import `core/skills/`. Confirmed rather than assumed — the full suites above
import all three modules and collect cleanly.

## Out of scope

The other thirteen sites (slices 2–4). No change to what any skill does, and
`core/orchestration/worker.py` is untouched.
