### PR TITLE
fix(adapters): contain the receipt temp path, not just the sealed name

### DIFF
--- a/src/bernstein/adapters/admission.py
+++ b/src/bernstein/adapters/admission.py
@@ -52,6 +52,12 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    PathTooLongError,
+    contained_path,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
 
@@ -937,12 +943,19 @@ def write_admission_receipt(base_dir: Path, receipt: dict[str, Any]) -> Path:
         raise ValueError(f"invalid adapter name for receipt filename: {adapter!r}")
     sha = receipt_sha256(receipt)
     base_dir.mkdir(parents=True, exist_ok=True)
-    resolved_base = base_dir.resolve()
-    candidate = (resolved_base / f"{adapter}-{sha[:16]}.json").resolve()
-    if not candidate.is_relative_to(resolved_base):
-        raise ValueError("receipt path escapes the receipts directory")
+    stem = f"{adapter}-{sha[:16]}"
+    try:
+        candidate = contained_path(base_dir, f"{stem}.json", label="receipt path")
+        # The temporary sibling is opened *before* the rename, so it needs the
+        # same proof as the final name. A pre-placed symlink at the .tmp path
+        # otherwise captures the write and lands the receipt body outside the
+        # receipts directory, then the rename seals the link into place.
+        tmp = contained_path(base_dir, f"{stem}.json.tmp", label="receipt temp path")
+    except PathTooLongError as exc:
+        raise ValueError(f"receipt filename is too long for this filesystem: {stem}.json") from exc
+    except PathContainmentError as exc:
+        raise ValueError("receipt path escapes the receipts directory") from exc
     doc = {"receipt": receipt, "receipt_sha256": sha}
-    tmp = candidate.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(doc, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     tmp.replace(candidate)
     return candidate

--- a/src/bernstein/adapters/canary.py
+++ b/src/bernstein/adapters/canary.py
@@ -41,6 +41,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    PathTooLongError,
+    contained_path,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -509,12 +515,19 @@ def write_canary_receipt(base_dir: Path, receipt: dict[str, Any]) -> Path:
         raise ValueError(f"invalid adapter name for receipt filename: {adapter!r}")
     sha = receipt_sha256(receipt)
     base_dir.mkdir(parents=True, exist_ok=True)
-    resolved_base = base_dir.resolve()
-    candidate = (resolved_base / f"{adapter}-{sha[:16]}.json").resolve()
-    if not candidate.is_relative_to(resolved_base):
-        raise ValueError("receipt path escapes the receipts directory")
+    stem = f"{adapter}-{sha[:16]}"
+    try:
+        candidate = contained_path(base_dir, f"{stem}.json", label="receipt path")
+        # The temporary sibling is opened *before* the rename, so it needs the
+        # same proof as the final name. A pre-placed symlink at the .tmp path
+        # otherwise captures the write and lands the receipt body outside the
+        # receipts directory, then the rename seals the link into place.
+        tmp = contained_path(base_dir, f"{stem}.json.tmp", label="receipt temp path")
+    except PathTooLongError as exc:
+        raise ValueError(f"receipt filename is too long for this filesystem: {stem}.json") from exc
+    except PathContainmentError as exc:
+        raise ValueError("receipt path escapes the receipts directory") from exc
     doc = {"receipt": receipt, "receipt_sha256": sha}
-    tmp = candidate.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(doc, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     tmp.replace(candidate)
     return candidate

--- a/src/bernstein/adapters/security_floor.py
+++ b/src/bernstein/adapters/security_floor.py
@@ -37,6 +37,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from bernstein.adapters.advisories import ADAPTER_MIN_SAFE_VERSIONS, AdapterAdvisory
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    PathTooLongError,
+    contained_path,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -442,12 +447,19 @@ def write_preflight_receipt(base_dir: Path, receipt: dict[str, Any]) -> Path:
         raise ValueError(f"invalid adapter name for receipt filename: {adapter!r}")
     sha = receipt_sha256(receipt)
     base_dir.mkdir(parents=True, exist_ok=True)
-    resolved_base = base_dir.resolve()
-    candidate = (resolved_base / f"{adapter}-{sha[:16]}.json").resolve()
-    if not candidate.is_relative_to(resolved_base):
-        raise ValueError("receipt path escapes the receipts directory")
+    stem = f"{adapter}-{sha[:16]}"
+    try:
+        candidate = contained_path(base_dir, f"{stem}.json", label="receipt path")
+        # The temporary sibling is opened *before* the rename, so it needs the
+        # same proof as the final name. A pre-placed symlink at the .tmp path
+        # otherwise captures the write and lands the receipt body outside the
+        # receipts directory, then the rename seals the link into place.
+        tmp = contained_path(base_dir, f"{stem}.json.tmp", label="receipt temp path")
+    except PathTooLongError as exc:
+        raise ValueError(f"receipt filename is too long for this filesystem: {stem}.json") from exc
+    except PathContainmentError as exc:
+        raise ValueError("receipt path escapes the receipts directory") from exc
     doc = {"receipt": receipt, "receipt_sha256": sha}
-    tmp = candidate.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(doc, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     tmp.replace(candidate)
     return candidate

--- a/tests/unit/adapters/test_receipt_path_containment.py
+++ b/tests/unit/adapters/test_receipt_path_containment.py
@@ -1,0 +1,127 @@
+"""Containment tests for the three adapter receipt-write sites (issue #3821).
+
+All three sites (`security_floor`, `canary`, `admission`) sealed a receipt by
+writing a ``.json.tmp`` sibling and renaming it over the content-addressed
+name. The containment check covered the *final* name only, so the temporary
+path -- the one actually opened first -- was never proven to be inside the
+receipts directory.
+
+Each site gets an escape test paired with a positive control, so an
+unconditional refusal cannot satisfy the suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Protocol
+
+import pytest
+
+from bernstein.adapters.admission import write_admission_receipt
+from bernstein.adapters.canary import write_canary_receipt
+from bernstein.adapters.security_floor import receipt_sha256, write_preflight_receipt
+
+
+class _ReceiptWriter(Protocol):
+    def __call__(self, base_dir: Path, receipt: dict[str, Any]) -> Path: ...
+
+
+#: The three converted sites. Byte-identical code before this change.
+WRITERS: list[tuple[str, _ReceiptWriter]] = [
+    ("security_floor", write_preflight_receipt),
+    ("canary", write_canary_receipt),
+    ("admission", write_admission_receipt),
+]
+
+
+def _receipt(adapter: str = "claude") -> dict[str, Any]:
+    return {"adapter": adapter, "kind": "spawn_preflight", "verdict": "admit"}
+
+
+def _content_addressed_stem(receipt: dict[str, Any]) -> str:
+    """Return the ``<adapter>-<sha16>`` stem the writers derive."""
+    return f"{receipt['adapter']}-{receipt_sha256(receipt)[:16]}"
+
+
+@pytest.mark.parametrize(("site", "write"), WRITERS, ids=[name for name, _ in WRITERS])
+def test_receipt_write_refuses_symlinked_temp_path(site: str, write: _ReceiptWriter, tmp_path: Path) -> None:
+    """A pre-placed ``.json.tmp`` symlink must not capture the receipt write.
+
+    Before this change the write followed the link and overwrote a file
+    outside the receipts directory, then renamed the link into place -- so the
+    "sealed" receipt was a symlink and an arbitrary host file held the receipt
+    body.
+    """
+    base = tmp_path / "receipts"
+    base.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.txt"
+    victim.write_text("ORIGINAL\n", encoding="utf-8")
+
+    receipt = _receipt()
+    (base / f"{_content_addressed_stem(receipt)}.json.tmp").symlink_to(victim)
+
+    with pytest.raises(ValueError, match="escapes the receipts directory"):
+        write(base, receipt)
+
+    assert victim.read_text(encoding="utf-8") == "ORIGINAL\n"
+
+
+@pytest.mark.parametrize(("site", "write"), WRITERS, ids=[name for name, _ in WRITERS])
+def test_receipt_write_refuses_symlinked_final_path(site: str, write: _ReceiptWriter, tmp_path: Path) -> None:
+    """The pre-existing refusal on the final name survives the conversion."""
+    base = tmp_path / "receipts"
+    base.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.json"
+    victim.write_text("ORIGINAL\n", encoding="utf-8")
+
+    receipt = _receipt()
+    (base / f"{_content_addressed_stem(receipt)}.json").symlink_to(victim)
+
+    with pytest.raises(ValueError, match="escapes the receipts directory"):
+        write(base, receipt)
+
+    assert victim.read_text(encoding="utf-8") == "ORIGINAL\n"
+
+
+@pytest.mark.parametrize(("site", "write"), WRITERS, ids=[name for name, _ in WRITERS])
+def test_receipt_write_seals_an_ordinary_receipt(site: str, write: _ReceiptWriter, tmp_path: Path) -> None:
+    """Positive control: an ordinary write still lands under the base."""
+    base = tmp_path / "receipts"
+    receipt = _receipt()
+
+    path = write(base, receipt)
+
+    assert path.is_file()
+    assert not path.is_symlink()
+    assert path.parent.resolve() == base.resolve()
+    # The temporary sibling is cleaned up by the rename.
+    assert not (base / f"{_content_addressed_stem(receipt)}.json.tmp").exists()
+
+
+@pytest.mark.parametrize(("site", "write"), WRITERS, ids=[name for name, _ in WRITERS])
+def test_receipt_write_still_refuses_a_hostile_adapter_name(site: str, write: _ReceiptWriter, tmp_path: Path) -> None:
+    """Positive control for the allow-pattern: traversal never reaches the join."""
+    base = tmp_path / "receipts"
+    base.mkdir()
+
+    with pytest.raises(ValueError, match="invalid adapter name"):
+        write(base, _receipt(adapter="../../etc/passwd"))
+
+
+@pytest.mark.parametrize(("site", "write"), WRITERS, ids=[name for name, _ in WRITERS])
+def test_receipt_write_refuses_an_over_long_adapter_name(site: str, write: _ReceiptWriter, tmp_path: Path) -> None:
+    """An adapter name too long to name a file is a ValueError, not an OSError.
+
+    The allow-pattern bounds the alphabet but not the length, so a long name
+    previously reached ``open()`` and raised ``OSError(ENAMETOOLONG)`` --
+    outside the ``ValueError`` the callers guard on.
+    """
+    base = tmp_path / "receipts"
+    base.mkdir()
+
+    with pytest.raises(ValueError):
+        write(base, _receipt(adapter="a" * 300))


### PR DESCRIPTION
Closes #3821. Slice 2 of 4 of #3802.

Slice 1 is #3855; this branch is cut from `main` and does not depend on its
code, only on its finding. That finding — **`contained_subpath`/`contained_path`
resolve their base, so an attacker-influenced or symlinkable component belongs
in the *candidate*, not the base** — is what the three sites here needed.

## The escape test found a live one

All three sites sealed a receipt the same way:

```python
candidate = (resolved_base / f"{adapter}-{sha[:16]}.json").resolve()
if not candidate.is_relative_to(resolved_base):
    raise ValueError("receipt path escapes the receipts directory")
...
tmp = candidate.with_suffix(".json.tmp")
tmp.write_text(...)      # <- first write, never containment-checked
tmp.replace(candidate)
```

The check covers the **final** name. The **temporary** path is the one opened
first, and nothing proved it was inside the receipts directory.

Pre-placing a symlink at `<receipts>/<adapter>-<sha16>.json.tmp` captures the
write. Reproduced against unmodified `main`:

```
write_preflight_receipt returned: .../receipts/claude-3119cff538538321.json
victim content now: '{\n  "receipt": {\n    "adapter": "claude", ...'
receipt landed inside base: True | is symlink: True
```

The receipt body landed on the link target outside the receipts directory, and
the rename then sealed **the link itself** into place — so the "sealed"
receipt is a symlink, and later verification reads through it.

### Reachability, stated honestly

The adapter component is allow-patterned (`^[a-z0-9][a-z0-9_-]*$`), so the
name is not attacker-chosen. The filename is content-addressed, so the
attacker must predict `sha[:16]` — derivable, since the receipt body is a
deterministic projection of the adapter and its verdict. What is required is
the ability to **create a file in the receipts directory**.

So this is not a remote primitive. It is a containment barrier that does not
hold where it claims to: an actor with write access to one directory gets a
write to anywhere they can point a link, on the spawn-preflight path. That is
precisely the property `path_containment` exists to guarantee, which is why it
belongs in this slice rather than in a separate report.

## What changed

Both paths now come from `contained_path`, so each is proven to be a strict
descendant of the receipts directory *after* symlink resolution:

```python
stem = f"{adapter}-{sha[:16]}"
try:
    candidate = contained_path(base_dir, f"{stem}.json", label="receipt path")
    tmp = contained_path(base_dir, f"{stem}.json.tmp", label="receipt temp path")
except PathTooLongError as exc:
    raise ValueError(f"receipt filename is too long for this filesystem: {stem}.json") from exc
except PathContainmentError as exc:
    raise ValueError("receipt path escapes the receipts directory") from exc
```

### Decision: catch and re-raise, not propagate

The issue leaves this open. I catch `PathContainmentError` and re-raise the
**existing** `ValueError` with its existing message, because:

- `security_floor.enforce_spawn_floor` already guards the write with
  `except (OSError, ValueError)` and downgrades it to a warning. A
  `PathContainmentError` would technically be caught (it subclasses
  `ValueError`), but the operator-facing string would change from a stable
  message to the barrier's internal phrasing.
- The barrier's message deliberately omits the base directory. Re-raising the
  site's own message keeps that property without depending on it.

`from exc` preserves the original in the traceback, so the failure stays
honest about where it came from.

### `PathTooLongError` is separated

The allow-pattern bounds the adapter *alphabet* but not its *length*. A
300-character adapter name previously reached `open()` and raised
`OSError(ENAMETOOLONG)` — outside the `ValueError` the callers guard on, so it
crashed rather than being logged. It is now a `ValueError`, and with its own
message: an over-long name is a capacity failure and must not be reported to
the operator as an escape attempt.

## Proof

`tests/unit/adapters/test_receipt_path_containment.py` — five tests
parametrised across all three sites (15 cases). Against unmodified code:

```
6 failed, 9 passed
FAILED test_receipt_write_refuses_symlinked_temp_path[security_floor|canary|admission]
FAILED test_receipt_write_refuses_an_over_long_adapter_name[security_floor|canary|admission]
```

The 9 that already passed are the positive controls and the final-name
refusal, which was already correct — that is the evidence this change adds a
refusal rather than replacing a working one.

Each escape test asserts the victim file is **byte-unchanged**, so a refusal
that still wrote before failing would not pass. Positive controls: an ordinary
receipt still seals and is not a symlink; a hostile adapter name is still
refused by the allow-pattern before the join.

After:

```
tests/unit/adapters/                                              646 passed
11 further files touching these modules (spawner, admission,
canary, security floor, floor refresh, doctor, packaging)         338 passed
```

```
ruff check src/bernstein/adapters/    All checks passed!
ruff format                            clean
mypy src/bernstein/adapters/{security_floor,canary,admission}.py   no findings
```

Some unrelated suites cannot be collected in my environment
(`ModuleNotFoundError: respx`, and similar for the sandbox/tracker adapters);
those reproduce on a clean tree and are untouched by this change.

## Out of scope

The other thirteen sites. No change to admission receipt fields, and no change
to what the security floor admits beyond the containment decision itself.

One thing found while here and **deliberately not changed**: `canary.py:701`
and `canary.py:949` use the same write-tmp-then-rename shape
(`path.with_suffix(path.suffix + ".tmp")`) for the last-green artifacts. Those
are not receipt paths and not among this slice's three sites, so they are left
alone — but they are the same pattern and may be worth their own look.
