### PR TITLE
fix(routes,replay): contain the run id in the diff path, not just the task id

### DIFF
--- a/src/bernstein/core/replay/review_board.py
+++ b/src/bernstein/core/replay/review_board.py
@@ -65,6 +65,10 @@ from bernstein.core.replay.journal import (
     run_journal_path,
     verify_journal,
 )
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    contained_path,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -454,17 +458,27 @@ def diff_summary(diff_text: str) -> dict[str, Any]:
 def _contained_diff_path(sdd_dir: Path, run_id: str, task_id: str) -> Path | None:
     """Resolve ``runs/<run_id>/review/diffs/<task_id>.diff`` inside the run.
 
-    Returns ``None`` when the resolved path escapes the per-run diffs
-    directory (defence in depth against a crafted ``task_id`` / ``run_id``;
-    the route also slug-validates both before calling in).
+    Returns ``None`` when the resolved path escapes the runs root (defence in
+    depth against a crafted ``task_id`` / ``run_id``; the route also
+    slug-validates both before calling in).
+
+    Both identifiers are segments of the *candidate*, and the runs root is the
+    base. That ordering is what makes the promise above true: interpolating
+    ``run_id`` into the base instead let it relocate the very directory the
+    containment check then compared against, so a crafted ``run_id`` could not
+    be refused by it. Keeping ``review/diffs`` in the candidate likewise means
+    a symlinked ``diffs/`` is refused rather than followed.
     """
-    diffs_root = (sdd_dir / "runs" / run_id / REVIEW_DIFF_SUBDIR).resolve()
-    candidate = (diffs_root / f"{task_id}.diff").resolve()
-    if candidate != diffs_root and not candidate.is_relative_to(diffs_root):
+    try:
+        return contained_path(
+            sdd_dir / "runs",
+            run_id,
+            *REVIEW_DIFF_SUBDIR.split("/"),
+            f"{task_id}.diff",
+            label="run/task id",
+        )
+    except PathContainmentError:
         return None
-    if candidate.parent != diffs_root:
-        return None
-    return candidate
 
 
 def store_task_diff(sdd_dir: Path, run_id: str, task_id: str, diff_text: str) -> dict[str, Any] | None:

--- a/src/bernstein/core/routes/approvals.py
+++ b/src/bernstein/core/routes/approvals.py
@@ -34,6 +34,10 @@ from bernstein.core.approval.models import (
 from bernstein.core.approval.models import PendingApproval as QueuedApproval
 from bernstein.core.approval.queue import get_default_queue, promote_to_always_allow
 from bernstein.core.sanitize import sanitize_log
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    contained_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -102,10 +106,12 @@ def _safe_child(base: Path, filename: str) -> Path:
 
     Raises HTTPException(400) if the resolved path escapes the directory.
     """
-    resolved = (base / filename).resolve()
-    if not resolved.is_relative_to(base.resolve()):
-        raise HTTPException(status_code=400, detail="Invalid task_id")
-    return resolved
+    try:
+        return contained_path(base, filename, label="task_id")
+    except PathContainmentError as exc:
+        # The API's own wording is kept so the response shape is unchanged;
+        # the barrier's message omits the base, and so must this one.
+        raise HTTPException(status_code=400, detail="Invalid task_id") from exc
 
 
 def _load_pending(filepath: Path) -> PendingApproval | None:

--- a/src/bernstein/core/routes/review_board.py
+++ b/src/bernstein/core/routes/review_board.py
@@ -61,6 +61,10 @@ from bernstein.core.replay.review_board import (
     read_task_diff,
     record_review_decision,
 )
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    contained_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -118,12 +122,19 @@ def _validate_task_id(task_id: str) -> str:
 
 
 def _contained_run_dir(sdd_dir: Path, run_id: str) -> Path:
-    """Resolve ``runs/<run_id>`` and verify it stays inside the runs root."""
-    runs_root = (sdd_dir / "runs").resolve()
-    resolved = (runs_root / run_id).resolve()
-    if resolved != runs_root and not resolved.is_relative_to(runs_root):
-        raise HTTPException(status_code=400, detail="invalid run id")
-    return resolved
+    """Resolve ``runs/<run_id>`` and verify it stays inside the runs root.
+
+    The barrier requires a strict descendant, so an id that resolves *to* the
+    runs root (``.``) is refused rather than returned. ``_RUN_ID_RE`` admits
+    both ``.`` and ``..``, so this is the check that separates them.
+    """
+    try:
+        return contained_path(sdd_dir / "runs", run_id, label="run id")
+    except PathContainmentError as exc:
+        # The barrier's message names the identifier and deliberately omits
+        # the base directory, but the API's own wording is kept so the
+        # response shape does not change.
+        raise HTTPException(status_code=400, detail="invalid run id") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/server/hooks_receiver.py
+++ b/src/bernstein/core/server/hooks_receiver.py
@@ -43,6 +43,11 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    contained_path,
+)
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -117,18 +122,16 @@ def _safe_child(base: Path, session_id: str, *, suffix: str = "") -> Path:
         InvalidSessionIdError: If the resolved child escapes ``base``.
     """
     validate_session_id(session_id)
-    candidate = base / f"{session_id}{suffix}"
     try:
-        resolved_base = base.resolve()
-        # ``strict=False`` so we can resolve a file that does not yet exist.
-        resolved_candidate = candidate.resolve(strict=False)
-    except (OSError, RuntimeError) as exc:  # pragma: no cover - defensive
-        raise InvalidSessionIdError(f"could not resolve path: {exc}") from exc
-    if not resolved_candidate.is_relative_to(resolved_base):
+        return contained_path(base, f"{session_id}{suffix}", label="session id")
+    except PathContainmentError as exc:
+        # The barrier's message names the identifier and omits the base, which
+        # is the property this error already had and must keep.
         raise InvalidSessionIdError(
             "resolved path escapes the hook base directory",
-        )
-    return resolved_candidate
+        ) from exc
+    except (OSError, RuntimeError) as exc:  # pragma: no cover - defensive
+        raise InvalidSessionIdError(f"could not resolve path: {exc}") from exc
 
 
 class HookEventType(Enum):

--- a/tests/unit/test_routes_replay_path_containment.py
+++ b/tests/unit/test_routes_replay_path_containment.py
@@ -1,0 +1,178 @@
+"""Containment tests for the four route and replay path checks (issue #3822).
+
+One escape test per converted site, each paired with a positive control.
+
+The two ``review_board`` modules implement *different* surfaces -- a run
+directory in ``routes``, a per-run diff file in ``replay`` -- and they had
+drifted in what they proved:
+
+* ``routes._contained_run_dir`` short-circuited on ``resolved != runs_root``,
+  so an id resolving *to* the runs root itself was accepted.
+* ``replay._contained_diff_path`` contained the ``task_id`` only. Its
+  docstring promised defence in depth against a crafted ``run_id`` as well,
+  but the ``run_id`` was interpolated into the base it then checked against,
+  so it could not refuse one.
+
+A refusal on a request path must name the rejected identifier and never the
+absolute layout; the tests assert that property directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from bernstein.core.replay.review_board import REVIEW_DIFF_SUBDIR, _contained_diff_path
+from bernstein.core.routes.approvals import _safe_child as approvals_safe_child
+from bernstein.core.routes.review_board import _contained_run_dir
+from bernstein.core.server.hooks_receiver import InvalidSessionIdError
+from bernstein.core.server.hooks_receiver import _safe_child as hooks_safe_child
+
+#: Ids that resolve outside, or exactly onto, the base they are joined under.
+#: Each is accepted by the callers' own slug patterns.
+ESCAPING_IDS = ["..", "."]
+
+
+# ---------------------------------------------------------------------------
+# routes/review_board.py - _contained_run_dir
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("run_id", ESCAPING_IDS)
+def test_contained_run_dir_refuses_non_descendant_run_id(tmp_path: Path, run_id: str) -> None:
+    """``.`` resolved to the runs root itself and was let through."""
+    sdd_dir = tmp_path / ".sdd"
+    (sdd_dir / "runs").mkdir(parents=True)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _contained_run_dir(sdd_dir, run_id)
+    assert exc_info.value.status_code == 400
+
+
+def test_contained_run_dir_accepts_an_ordinary_run_id(tmp_path: Path) -> None:
+    """Positive control: a real run directory still resolves."""
+    sdd_dir = tmp_path / ".sdd"
+    run_dir = sdd_dir / "runs" / "run-123"
+    run_dir.mkdir(parents=True)
+
+    assert _contained_run_dir(sdd_dir, "run-123") == run_dir.resolve()
+
+
+def test_contained_run_dir_refusal_does_not_leak_the_base(tmp_path: Path) -> None:
+    """The 400 detail must not carry the absolute layout."""
+    sdd_dir = tmp_path / ".sdd"
+    (sdd_dir / "runs").mkdir(parents=True)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _contained_run_dir(sdd_dir, "..")
+    assert str(tmp_path) not in str(exc_info.value.detail)
+
+
+# ---------------------------------------------------------------------------
+# replay/review_board.py - _contained_diff_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("run_id", ESCAPING_IDS)
+def test_contained_diff_path_refuses_escaping_run_id(tmp_path: Path, run_id: str) -> None:
+    """A crafted run_id must not move the diffs root out of the runs root.
+
+    Before this change the run_id was interpolated into the base, so
+    ``run_id=".."`` yielded ``.sdd/review/diffs/<task>.diff`` -- outside
+    ``.sdd/runs/`` entirely -- and the containment check still passed, because
+    it compared the candidate against that relocated base.
+    """
+    sdd_dir = tmp_path / ".sdd"
+    (sdd_dir / "runs").mkdir(parents=True)
+
+    assert _contained_diff_path(sdd_dir, run_id, "task-1") is None
+
+
+def test_contained_diff_path_refuses_escaping_task_id(tmp_path: Path) -> None:
+    """The pre-existing task_id refusal survives the conversion."""
+    sdd_dir = tmp_path / ".sdd"
+    (sdd_dir / "runs").mkdir(parents=True)
+
+    assert _contained_diff_path(sdd_dir, "run-123", "../../escape") is None
+
+
+def test_contained_diff_path_accepts_an_ordinary_pair(tmp_path: Path) -> None:
+    """Positive control: an ordinary run/task pair still resolves in place."""
+    sdd_dir = tmp_path / ".sdd"
+    diffs_root = sdd_dir / "runs" / "run-123" / REVIEW_DIFF_SUBDIR
+    diffs_root.mkdir(parents=True)
+
+    path = _contained_diff_path(sdd_dir, "run-123", "task-1")
+
+    assert path is not None
+    assert path == (diffs_root / "task-1.diff").resolve()
+    assert path.parent == diffs_root.resolve()
+
+
+def test_contained_diff_path_refuses_symlinked_diffs_dir(tmp_path: Path) -> None:
+    """A symlinked diffs directory cannot relocate the write out of the run."""
+    sdd_dir = tmp_path / ".sdd"
+    review = sdd_dir / "runs" / "run-123" / "review"
+    review.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (review / "diffs").symlink_to(outside, target_is_directory=True)
+
+    assert _contained_diff_path(sdd_dir, "run-123", "task-1") is None
+
+
+# ---------------------------------------------------------------------------
+# routes/approvals.py - _safe_child
+# ---------------------------------------------------------------------------
+
+
+def test_approvals_safe_child_refuses_symlinked_child(tmp_path: Path) -> None:
+    """A symlinked entry in the approvals directory cannot capture the path."""
+    base = tmp_path / "pending"
+    base.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim.json").write_text("{}", encoding="utf-8")
+    (base / "task-1.json").symlink_to(outside / "victim.json")
+
+    with pytest.raises(HTTPException) as exc_info:
+        approvals_safe_child(base, "task-1.json")
+    assert exc_info.value.status_code == 400
+    assert str(tmp_path) not in str(exc_info.value.detail)
+
+
+def test_approvals_safe_child_accepts_an_ordinary_filename(tmp_path: Path) -> None:
+    """Positive control: an ordinary filename still resolves under the base."""
+    base = tmp_path / "pending"
+    base.mkdir()
+
+    assert approvals_safe_child(base, "task-1.json") == (base / "task-1.json").resolve()
+
+
+# ---------------------------------------------------------------------------
+# server/hooks_receiver.py - _safe_child
+# ---------------------------------------------------------------------------
+
+
+def test_hooks_safe_child_refuses_symlinked_sidecar(tmp_path: Path) -> None:
+    """A symlinked sidecar cannot redirect hook writes out of the hooks dir."""
+    base = tmp_path / "hooks"
+    base.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim.jsonl").write_text("", encoding="utf-8")
+    (base / "sess-1.jsonl").symlink_to(outside / "victim.jsonl")
+
+    with pytest.raises(InvalidSessionIdError) as exc_info:
+        hooks_safe_child(base, "sess-1", suffix=".jsonl")
+    assert str(tmp_path) not in str(exc_info.value)
+
+
+def test_hooks_safe_child_accepts_an_ordinary_session_id(tmp_path: Path) -> None:
+    """Positive control: an ordinary session id still resolves."""
+    base = tmp_path / "hooks"
+    base.mkdir()
+
+    assert hooks_safe_child(base, "sess-1", suffix=".jsonl") == (base / "sess-1.jsonl").resolve()


### PR DESCRIPTION
Closes #3822. Slice 3 of 4 of #3802. (Slice 1: #3855. Slice 2: #3857.)

## Were the two `review_board` modules doing the same thing?

**No — they are different surfaces, and the acceptance criteria ask for that
difference to be described rather than silently unified.**

| | `routes/review_board._contained_run_dir` | `replay/review_board._contained_diff_path` |
|---|---|---|
| resolves | `runs/<run_id>` (a directory) | `runs/<run_id>/review/diffs/<task_id>.diff` (a file) |
| refuses by | `HTTPException(400)` | returning `None` |
| escape hatch | `resolved != runs_root` short-circuit | `candidate != diffs_root`, then `parent != diffs_root` |

They are **not** two copies of one check that drifted. They are two different
containment decisions that were each written by hand, and each got a different
part wrong. This slice unifies the containment decision only; the two modules
remain separate surfaces with their own return contracts.

## Two of the four did not prove what they claimed

### `replay/_contained_diff_path` could not refuse a crafted `run_id`

Its docstring promises defence in depth against a crafted `task_id` **and**
`run_id`. It delivered it for the task id only:

```python
diffs_root = (sdd_dir / "runs" / run_id / REVIEW_DIFF_SUBDIR).resolve()   # run_id is in the BASE
candidate  = (diffs_root / f"{task_id}.diff").resolve()
if candidate != diffs_root and not candidate.is_relative_to(diffs_root):  # ...compared against that base
```

The `run_id` was interpolated into the base that the check then compared
against, so it **relocated the base along with the candidate**. Probed against
unmodified `main`:

```
run_id='..'      -> .../.sdd/review/diffs/task1.diff     inside runs root: False
run_id='.'       -> .../.sdd/runs/review/diffs/task1.diff
run_id='ok-run'  -> .../.sdd/runs/ok-run/review/diffs/task1.diff
```

`run_id=".."` lands outside `.sdd/runs/` entirely and the containment check
still passes. A symlinked `diffs/` directory escaped by the same mechanism.

This is the same lesson as slice 1, from the opposite direction: there, a
component in the base was *resolved* and admitted an escape; here, a component
in the base was *attacker-influenced* and moved the goalposts. Anything not
trusted belongs in the candidate.

**Reachability, stated honestly.** Not a live traversal. The HTTP route calls
`_contained_run_dir` first, which rejects `..`, and the other caller
(`task_lifecycle.py:3151`) passes an orchestrator-generated run id. This is a
defence-in-depth layer that did not defend — which is exactly the failure mode
a hand-rolled copy of a shared invariant produces, and why it belongs in this
slice.

### `routes/_contained_run_dir` accepted the runs root itself

```python
if resolved != runs_root and not resolved.is_relative_to(runs_root):
```

The left conjunct short-circuits, so an id resolving *to* `runs_root` was
returned rather than refused. `_RUN_ID_RE` is `^[A-Za-z0-9_.\-]{1,128}$`, which
admits both `.` and `..` — separating them was precisely this check's job. It
caught `..` and let `.` through.

`contained_path` requires a strict descendant, which closes it.

## `approvals.py` and `hooks_receiver.py`

Both were already correct; the conversion is a de-duplication, and their
existing escape tests keep passing unchanged. Both gain the length bounds and
the both-separators string check for free.

## Decisions the issue left open

**400 vs 404: kept at 400, applied consistently.** Both routes already return
400 and the surrounding validators (`_validate_run_id`, `_validate_task_id`,
`_INVALID_TASK_ID_MSG`) return 400 for a malformed id. Moving to 404 would make
a malformed id and a well-formed unknown id indistinguishable — and would be an
API change for existing clients, which is not this issue's remit. The
information-leak argument for 404 does not apply here: these bases (`.sdd/runs`,
the approvals directory) always exist, so the status code reveals nothing about
the layout.

**Refusal types unchanged.** Each site catches `PathContainmentError` and
re-raises its own existing exception with its existing message, so no
`PathContainmentError` reaches an operator and no response body changes.
`from exc` keeps the origin in the traceback.

## The no-leak property is asserted, not assumed

`contained_path` deliberately omits the base from its message. Rather than rely
on that, three tests assert the base is absent from what the caller actually
surfaces:

```python
assert str(tmp_path) not in str(exc_info.value.detail)
```

## Proof

`tests/unit/test_routes_replay_path_containment.py` — one escape test per
converted site, each with a positive control. Against unmodified code:

```
4 failed, 9 passed
FAILED test_contained_run_dir_refuses_non_descendant_run_id[.]
FAILED test_contained_diff_path_refuses_escaping_run_id[..]
FAILED test_contained_diff_path_refuses_escaping_run_id[.]
FAILED test_contained_diff_path_refuses_symlinked_diffs_dir
```

The 9 that already passed are the positive controls and the refusals that were
already correct — evidence this adds refusals rather than replacing working
ones.

After: **13 passed**, and across every suite touching the four modules
(review board route/projection/live-cycle, approvals, approval gates/queue/hook/CLI,
hooks receiver, hooks path traversal, task suspension, dual approval, voting,
run progress, intent capsule, `tests/unit/routes/`, `tests/unit/test_path_containment.py`):

```
624 passed
```

```
ruff check src/bernstein/core/{routes,replay}/ src/bernstein/core/server/hooks_receiver.py   All checks passed!
ruff format                                                                                  clean
mypy (the four changed files)                                                                no findings
```

`mypy` does report pre-existing errors in `server_models.py` and
`server_app.py`; those files are untouched here and the errors reproduce on a
clean tree.

## Out of scope

The remaining orchestration sites (slice 4). No route signature changes, and
the two `review_board` modules are not merged — this slice only reports that
they differ, and how.
