### PR TITLE
refactor(security): one Luhn implementation, length policy left with callers

### DIFF
--- a/src/bernstein/core/observability/log_redact.py
+++ b/src/bernstein/core/observability/log_redact.py
@@ -25,6 +25,8 @@ import re
 from collections import Counter
 from typing import Any
 
+from bernstein.core.security.luhn import luhn_check
+
 # ---------------------------------------------------------------------------
 # PII patterns - kept in sync with memory_sanitizer._PII_RULES
 # ---------------------------------------------------------------------------
@@ -51,28 +53,6 @@ _PII_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 _REDACTED = "[REDACTED]"
 
 
-def _luhn_check(digits: str) -> bool:
-    """Validate a digit string using the Luhn algorithm.
-
-    Args:
-        digits: String of digits, separators already stripped.
-
-    Returns:
-        True when the digit string passes Luhn validation.
-    """
-    if not digits or not digits.isdigit():
-        return False
-    total = 0
-    for index, char in enumerate(reversed(digits)):
-        value = int(char)
-        if index % 2 == 1:
-            value *= 2
-            if value > 9:
-                value -= 9
-        total += value
-    return total % 10 == 0
-
-
 def _redact_card(match: re.Match[str]) -> str:
     """Redact a card-shaped match only when it actually checksums as a card.
 
@@ -80,9 +60,12 @@ def _redact_card(match: re.Match[str]) -> str:
     order numbers, and ledger sequences share the shape. Redacting those
     rewrites legitimate identifiers in persisted records, which is the same
     false-positive class the credential rules below already avoid.
+
+    No length bound of its own: the ``credit_card`` pattern matches exactly
+    sixteen digits, so the shape is already fixed by the time this runs.
     """
     digits = re.sub(r"[\s\-]", "", match.group(0))
-    return _REDACTED if _luhn_check(digits) else match.group(0)
+    return _REDACTED if luhn_check(digits) else match.group(0)
 
 
 # Patterns whose match needs validating before it is treated as PII.

--- a/src/bernstein/core/security/dlp_scanner_v2.py
+++ b/src/bernstein/core/security/dlp_scanner_v2.py
@@ -34,6 +34,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 
+from bernstein.core.security.luhn import luhn_check
+
 __all__ = [
     "DLPCategory",
     "DLPMatch",
@@ -122,34 +124,6 @@ class DLPPolicy:
     custom_patterns: tuple[tuple[str, str], ...] = ()
     customer_id_prefixes: tuple[str, ...] = ("CUST", "ORG", "ACCT")
     internal_url_suffixes: tuple[str, ...] = (".internal", ".corp")
-
-
-# ---------------------------------------------------------------------------
-# Luhn validator
-# ---------------------------------------------------------------------------
-
-
-def _luhn_check(digits: str) -> bool:
-    """Validate a digit string using the Luhn algorithm.
-
-    Args:
-        digits: String of digits (spaces/dashes already stripped).
-
-    Returns:
-        True when the digit string passes Luhn validation.
-    """
-    if not digits or not digits.isdigit():
-        return False
-    total = 0
-    reverse_digits = digits[::-1]
-    for i, ch in enumerate(reverse_digits):
-        n = int(ch)
-        if i % 2 == 1:
-            n *= 2
-            if n > 9:
-                n -= 9
-        total += n
-    return total % 10 == 0
 
 
 # ---------------------------------------------------------------------------
@@ -437,9 +411,15 @@ def _collect_rules(policy: DLPPolicy) -> list[_RuleDef]:
 
 
 def _validate_credit_card(matched_raw: str) -> bool:
-    """Validate a potential credit card match using Luhn algorithm."""
+    """Validate a potential credit card match using Luhn algorithm.
+
+    The lower bound is this call site's own policy; there is deliberately no
+    upper one, so a Luhn-valid run longer than 19 digits is treated as a card
+    here and is not by ``pii_output_gate``. See
+    ``tests/unit/security/test_luhn_shared.py``, which pins that difference.
+    """
     digits_only = re.sub(r"\D", "", matched_raw)
-    return len(digits_only) >= 13 and _luhn_check(digits_only)
+    return len(digits_only) >= 13 and luhn_check(digits_only)
 
 
 def _scan_lines(

--- a/src/bernstein/core/security/luhn.py
+++ b/src/bernstein/core/security/luhn.py
@@ -1,0 +1,55 @@
+"""The Luhn checksum, in one place (issue #3820).
+
+Four call sites decide whether a digit run is a payment card, and three of
+them ran their own copy of this checksum. The copies agreed on the arithmetic
+but were spelled differently -- one walked the string reversed and doubled the
+odd indices, another walked forward and doubled ``index % 2 == len % 2`` --
+which are the same rule written two ways, so a reader comparing them had to
+derive Luhn from scratch to confirm it.
+
+What deliberately does **not** live here is the **length policy**. The bound
+legitimately differs per call site: a fixed 16-digit regex needs none, a
+labelled 13-19 digit match needs both ends. Callers keep their own bound and
+pass a stripped digit run in.
+
+Kept dependency-free (no imports at all) so the logging path can use it
+without pulling ``core/security`` machinery into every log record.
+"""
+
+from __future__ import annotations
+
+__all__ = ["luhn_check"]
+
+
+def luhn_check(digits: str) -> bool:
+    """Return True when *digits* satisfies the Luhn checksum.
+
+    Args:
+        digits: A run of decimal digits with separators already stripped.
+            Anything else -- empty, non-decimal, signed -- returns ``False``
+            rather than raising.
+
+    Returns:
+        ``True`` when the run checksums as a card number.
+
+    Note:
+        This is a checksum, not a card test. ``"0" * 16`` passes. Callers
+        must apply their own length policy, and a checksum-valid run of the
+        right length is still only card-*shaped*.
+    """
+    # ``str.isdecimal()``, not ``str.isdigit()``: isdigit() also accepts
+    # characters like superscript two, which int() then refuses with a
+    # ValueError. Both are true of exactly the same strings the callers can
+    # produce (they strip to ``\d``, which is decimals), so this costs
+    # nothing and removes a latent crash for any future caller.
+    if not digits or not digits.isdecimal():
+        return False
+    total = 0
+    for index, char in enumerate(reversed(digits)):
+        value = int(char)
+        if index % 2 == 1:
+            value *= 2
+            if value > 9:
+                value -= 9
+        total += value
+    return total % 10 == 0

--- a/src/bernstein/core/security/pii_output_gate.py
+++ b/src/bernstein/core/security/pii_output_gate.py
@@ -28,6 +28,8 @@ import re
 from dataclasses import dataclass
 from fnmatch import fnmatch
 
+from bernstein.core.security.luhn import luhn_check
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -225,20 +227,21 @@ def _has_mixed_case_and_digits(text: str) -> bool:
 
 
 def _looks_like_credit_card(match_text: str) -> bool:
-    """Return True if a candidate number passes a Luhn checksum."""
-    digits = [int(char) for char in match_text if char.isdigit()]
-    if len(digits) < 13 or len(digits) > 19:
+    """Return True if a candidate number passes a Luhn checksum.
+
+    Both length bounds are this call site's own: the rule matches a labelled
+    13-19 digit run, so it needs each end. Only the checksum is shared.
+
+    The forward walk this replaced doubled ``index % 2 == len(digits) % 2``,
+    which is the same rule as the shared helper's reverse walk doubling the
+    odd indices - forward index ``i`` is reverse index ``n-1-i``, and
+    ``n-1-i`` is odd exactly when ``i % 2 == n % 2``. Spelling it once removes
+    the need to re-derive that in order to compare the two.
+    """
+    digits = "".join(char for char in match_text if char.isdigit())
+    if not (13 <= len(digits) <= 19):
         return False
-    checksum = 0
-    parity = len(digits) % 2
-    for index, digit in enumerate(digits):
-        value = digit
-        if index % 2 == parity:
-            value *= 2
-            if value > 9:
-                value -= 9
-        checksum += value
-    return checksum % 10 == 0
+    return luhn_check(digits)
 
 
 def _is_allowlisted(line: str, allowlist_prefixes: list[str] | None = None) -> bool:

--- a/tests/unit/security/test_luhn_shared.py
+++ b/tests/unit/security/test_luhn_shared.py
@@ -41,7 +41,7 @@ LUHN_VECTORS: list[tuple[str, bool]] = [
     ("5500005555555558", False),
     ("378282246310006", False),
     ("6011111111111118", False),
-    # Shape-alikes that are not cards: trace ids, ledger sequences.
+    # Shape lookalikes that are not cards: trace ids, ledger sequences.
     ("1234567890123456", False),
     ("0000000000000001", False),
     # All zeroes checksums to 0 -- Luhn-valid, which is exactly why a

--- a/tests/unit/security/test_luhn_shared.py
+++ b/tests/unit/security/test_luhn_shared.py
@@ -1,0 +1,136 @@
+"""One card-vector table, exercised through every Luhn call site (issue #3820).
+
+The point of the table is not that Luhn is implemented correctly -- each site
+was correct for its own inputs. It is that the *length policy* lived in three
+places, so a change to "what counts as a card" had three places to be made and
+nothing noticed when only two of them moved.
+
+Where the sites legitimately differ, the difference is named here rather than
+unified:
+
+* ``log_redact`` sees only 16-digit runs (its regex fixes the length), so it
+  needs no bound of its own.
+* ``pii_output_gate`` bounds ``13 <= n <= 19``.
+* ``dlp_scanner_v2`` bounds ``n >= 13`` with **no upper bound**.
+
+That last row is a real disagreement: a 25-digit Luhn-valid run is a card to
+``dlp_scanner_v2`` and not to ``pii_output_gate``. It is pinned below rather
+than changed -- narrowing it is a policy decision, not a de-duplication.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.observability.log_redact import redact_pii
+from bernstein.core.security.dlp_scanner_v2 import _validate_credit_card
+from bernstein.core.security.luhn import luhn_check
+from bernstein.core.security.pii_output_gate import _looks_like_credit_card
+
+#: ``(digits, passes_luhn)``. Checksum truth only -- no length policy.
+LUHN_VECTORS: list[tuple[str, bool]] = [
+    # Well-known test PANs (all Luhn-valid).
+    ("4111111111111111", True),  # Visa, 16
+    ("5500005555555559", True),  # Mastercard, 16
+    ("378282246310005", True),  # Amex, 15
+    ("6011111111111117", True),  # Discover, 16
+    ("30569309025904", True),  # Diners, 14
+    ("4222222222222", True),  # Visa, 13
+    # Same numbers with the final check digit disturbed.
+    ("4111111111111112", False),
+    ("5500005555555558", False),
+    ("378282246310006", False),
+    ("6011111111111118", False),
+    # Shape-alikes that are not cards: trace ids, ledger sequences.
+    ("1234567890123456", False),
+    ("0000000000000001", False),
+    # All zeroes checksums to 0 -- Luhn-valid, which is exactly why a
+    # checksum alone is not a card test.
+    ("0000000000000000", True),
+]
+
+
+@pytest.mark.parametrize(("digits", "expected"), LUHN_VECTORS)
+def test_shared_luhn_check_matches_the_table(digits: str, expected: bool) -> None:
+    assert luhn_check(digits) is expected
+
+
+@pytest.mark.parametrize(("digits", "expected"), LUHN_VECTORS)
+def test_dlp_scanner_v2_agrees_on_13_to_19_digit_vectors(digits: str, expected: bool) -> None:
+    """``dlp_scanner_v2`` accepts >= 13 digits, so the whole table applies."""
+    assert _validate_credit_card(digits) is expected
+
+
+@pytest.mark.parametrize(("digits", "expected"), LUHN_VECTORS)
+def test_pii_output_gate_agrees_on_13_to_19_digit_vectors(digits: str, expected: bool) -> None:
+    """Every vector is 13-19 digits, inside the gate's own bounds."""
+    assert _looks_like_credit_card(digits) is expected
+
+
+@pytest.mark.parametrize(("digits", "expected"), LUHN_VECTORS)
+def test_log_redact_agrees_on_16_digit_vectors(digits: str, expected: bool) -> None:
+    """``log_redact`` only ever sees 16-digit runs, so only those apply."""
+    if len(digits) != 16:
+        pytest.skip("log_redact's regex matches 16-digit runs only")
+    redacted = redact_pii(f"card={digits}")
+    assert (digits not in redacted) is expected
+
+
+# ---------------------------------------------------------------------------
+# Separator handling: each site strips differently, and must keep doing so
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("spelling", ["4111 1111 1111 1111", "4111-1111-1111-1111"])
+def test_all_sites_see_through_separators(spelling: str) -> None:
+    assert _validate_credit_card(spelling) is True
+    assert _looks_like_credit_card(spelling) is True
+    assert "4111" not in redact_pii(f"card={spelling}")
+
+
+# ---------------------------------------------------------------------------
+# Length policy: where the sites legitimately disagree
+# ---------------------------------------------------------------------------
+
+
+def test_length_policy_disagreement_is_deliberate() -> None:
+    """A 25-digit Luhn-valid run: a card to dlp_scanner_v2, not to the gate.
+
+    Pinned, not unified. ``dlp_scanner_v2._validate_credit_card`` bounds only
+    ``>= 13``; ``pii_output_gate`` bounds ``13 <= n <= 19``. Whether the
+    scanner should gain an upper bound is a policy change with its own
+    decision to make.
+    """
+    long_run = "4" + "0" * 23 + "6"
+    assert len(long_run) == 25
+    assert luhn_check(long_run) is True
+
+    assert _validate_credit_card(long_run) is True
+    assert _looks_like_credit_card(long_run) is False
+
+
+@pytest.mark.parametrize("digits", ["", "411111111111111"[:12], "4"])
+def test_runs_below_thirteen_digits_are_not_cards_anywhere(digits: str) -> None:
+    assert _validate_credit_card(digits) is False
+    assert _looks_like_credit_card(digits) is False
+
+
+# ---------------------------------------------------------------------------
+# Non-digit input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "abcd", "4111-1111-1111-111x"])
+def test_shared_luhn_check_rejects_non_digit_input(value: str) -> None:
+    assert luhn_check(value) is False
+
+
+def test_shared_luhn_check_does_not_raise_on_non_decimal_digits() -> None:
+    """``str.isdigit()`` accepts superscripts that ``int()`` refuses.
+
+    ``"\\u00b2".isdigit()`` is True but ``int("\\u00b2")`` raises ValueError, so an
+    ``isdigit()`` guard in front of ``int()`` is a latent crash. No current
+    caller can deliver one (both strip to ``\\d``, which is decimals only), but
+    the shared helper is now reachable from anywhere, so it must not be a trap.
+    """
+    assert luhn_check("41111111111111²") is False


### PR DESCRIPTION
Closes #3820. Follow-up to #3818, which added the `log_redact` checksum that made this the third copy.

## Did the copies disagree?

**On the arithmetic, no. On the length policy, yes — and that is the bug the issue names.**

The vector table produces **identical verdicts before and after** this change at
every call site. That is the intended result: each implementation was correct
for its own inputs. What was wrong is that "what counts as a card" lived in
three places.

### The parity conventions were the same rule, written twice

`dlp_scanner_v2` and `log_redact` walked the digits reversed and doubled the
odd indices. `pii_output_gate` walked forward and doubled
`index % 2 == len(digits) % 2`. These are equivalent: forward index `i` is
reverse index `n-1-i`, and `n-1-i` is odd exactly when `i % 2 == n % 2`.

Nothing was broken by that — but it is the concrete cost the issue describes.
Two correct implementations that cannot be compared without re-deriving Luhn
are two implementations nobody will notice drifting.

### The length policy genuinely disagrees

| Call site | Bound | Source of the bound |
|---|---|---|
| `log_redact._redact_card` | none | its regex matches exactly 16 digits |
| `pii_output_gate._looks_like_credit_card` | `13 <= n <= 19` | inline |
| `dlp_scanner_v2._validate_credit_card` | `n >= 13`, **no upper bound** | inline |

A Luhn-valid 25-digit run is a card to `dlp_scanner_v2` and is not one to
`pii_output_gate`:

```python
long_run = "4" + "0" * 23 + "6"          # 25 digits, Luhn-valid
_validate_credit_card(long_run)   is True
_looks_like_credit_card(long_run) is False
```

**Pinned, not unified.** Whether the scanner should gain an upper bound is a
policy change with its own decision to make, exactly like the `dlp_scanner.py`
question the issue puts out of scope. The test names it so that the next person
to move one bound finds out that the other did not move.

## What changed

`core/security/luhn.py` exports a public `luhn_check(digits: str) -> bool`.
Length bounds stay with the callers, each now carrying a comment saying why its
bound is what it is. The three checksum sites route through it.

### Import edge, confirmed rather than assumed

`observability/log_redact.py` importing from `core/security/` is a new edge.
The module has **no imports at all**:

```
luhn module globals (non-dunder): ['annotations', 'luhn_check']
cold import of log_redact: 29.0 ms
```

No cycle (`core/security/luhn` imports nothing, so it cannot participate in
one), and nothing measurable added to the logging path.

### One deliberate hardening

The shared helper guards with `str.isdecimal()`, not `str.isdigit()`.
`"²".isdigit()` is `True` while `int("²")` raises `ValueError`, so an
`isdigit()` guard in front of `int()` is a latent crash.

**No current caller can deliver one** — `dlp_scanner_v2` strips with
`re.sub(r"\D", ...)` and `log_redact`'s regex is `\d`-only, both of which are
decimals only, and `pii_output_gate`'s matches come from a `\d`-based rule. I
am not claiming a live bug. But the helper is now reachable from anywhere, so
it should not be a trap for the next caller. Pinned by
`test_shared_luhn_check_does_not_raise_on_non_decimal_digits`.

## Proof

`tests/unit/security/test_luhn_shared.py` — one parametrised vector table
(well-known test PANs at 13/14/15/16 digits, each with its check digit
disturbed, plus shape-alikes) exercised through **every** call site:

- `luhn_check` directly
- `dlp_scanner_v2._validate_credit_card`
- `pii_output_gate._looks_like_credit_card`
- `log_redact.redact_pii` end to end (16-digit vectors only — its regex sees
  nothing else, and the table skips the rest rather than pretending otherwise)

Run against **unmodified** call sites first: `58 passed, 4 skipped`. After the
de-duplication: `58 passed, 4 skipped`. Identical, which is the claim.

The table includes `"0" * 16`, which is Luhn-valid — a reminder in the fixture
itself that this is a checksum and not a card test.

```
tests/unit/test_pii_output_gate.py, test_log_redact.py, test_dlp_scanner_v2.py,
test_debug_bundle.py, tests/unit/security/          875 passed, 4 skipped
```

```
ruff check src/bernstein/core/security/ src/bernstein/core/observability/log_redact.py   All checks passed!
ruff format                                                                               clean
mypy (the four changed files)                                                             no findings
```

Two failures in `tests/unit/test_quality_gate_regressions.py` are environmental
— the gate shells out to `python`, which is not on `PATH` in my environment
(`/bin/sh: python: command not found`). Confirmed pre-existing by stashing the
change and re-running on a clean tree: same two failures.

## Out of scope

Whether `dlp_scanner.py` should gain a checksum, as the issue specifies. It
still redacts a labelled 13-19 digit run on the strength of the label alone —
a real question, and a policy change rather than a de-duplication.
