### PR TITLE
fix(adapters): relay explicit_max_turns through CachingAdapter (#3738)

### DIFF
--- a/src/bernstein/adapters/caching_adapter.py
+++ b/src/bernstein/adapters/caching_adapter.py
@@ -112,6 +112,7 @@ class CachingAdapter(CLIAdapter):
         multimodal_context: Any | None = None,
         task_id: str = "",
         task_title: str = "",
+        explicit_max_turns: int | None = None,
     ) -> SpawnResult:
         """Spawn agent with caching: process prompt, check response cache, then delegate.
 
@@ -194,13 +195,30 @@ class CachingAdapter(CLIAdapter):
         # signature gate the spawner applies. Production always wraps the
         # adapter in this class, so without the relay the spawner would gate
         # on the wrapper's signature and the identity would never reach an
-        # inner adapter that wants it.
+        # inner adapter that wants it. explicit_max_turns hits the same wall:
+        # the spawner forwards it gated on *this* wrapper's signature, so a
+        # missing parameter here makes the operator's per-task turn cap
+        # silently vanish on every cached spawn while the fallback warning
+        # blames the inner adapter, which actually supports it.
         _identity_kwargs: dict[str, Any] = {}
         _inner_params = inspect.signature(self._inner.spawn).parameters
         if task_id and "task_id" in _inner_params:
             _identity_kwargs["task_id"] = task_id
         if task_title and "task_title" in _inner_params:
             _identity_kwargs["task_title"] = task_title
+        if explicit_max_turns is not None:
+            if "explicit_max_turns" in _inner_params:
+                _identity_kwargs["explicit_max_turns"] = explicit_max_turns
+            else:
+                # Inner adapter cannot carry the cap; drop it quietly at
+                # debug level. The spawner's warning can no longer fire here
+                # (its gate now sees the wrapper's accepting signature), so
+                # this is the only trace that the cap was not applied.
+                logger.debug(
+                    "CachingAdapter: inner adapter %s spawn() does not accept explicit_max_turns; dropping cap %d",
+                    self._inner.name(),
+                    explicit_max_turns,
+                )
         return self._inner.spawn(
             prompt=prompt,
             workdir=workdir,

--- a/tests/unit/test_spawner_task_identity.py
+++ b/tests/unit/test_spawner_task_identity.py
@@ -22,6 +22,7 @@ from bernstein.adapters.plugin_sdk import (
     AdapterPluginInfo,
     PluginAdapter,
 )
+from tests.factories import make_task as make_task_factory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -34,6 +35,7 @@ class _IdentityAwareAdapter(PluginAdapter):
         super().__init__()
         self.seen_task_id: str | None = None
         self.seen_task_title: str | None = None
+        self.seen_explicit_max_turns: int | None = None
 
     def plugin_info(self) -> AdapterPluginInfo:
         return AdapterPluginInfo(
@@ -63,9 +65,11 @@ class _IdentityAwareAdapter(PluginAdapter):
         multimodal_context: Any | None = None,
         task_id: str = "",
         task_title: str = "",
+        explicit_max_turns: int | None = None,
     ) -> SpawnResult:
         self.seen_task_id = task_id
         self.seen_task_title = task_title
+        self.seen_explicit_max_turns = explicit_max_turns
         return SpawnResult(pid=4242, log_path=workdir / "stub.log")
 
     def name(self) -> str:
@@ -161,3 +165,38 @@ class TestTaskIdentitySpawnPath:
         spawner.spawn_for_tasks([make_task()])
 
         assert adapter.spawn_calls == 1
+
+
+class TestExplicitMaxTurnsSpawnPath:
+    def test_explicit_max_turns_reaches_capable_adapter(self, tmp_path: Path, make_task) -> None:
+        """spawn() must receive the task's max_turns, not None.
+
+        Fails before the spawner forwards max_turns: the adapter records
+        None and every per-task turn budget degrades to the auto-computed
+        fallback.
+        """
+        adapter = _IdentityAwareAdapter()
+        spawner = _make_spawner(adapter, tmp_path)
+
+        spawner.spawn_for_tasks([make_task_factory(max_turns=7)])
+
+        assert adapter.seen_explicit_max_turns == 7
+
+    def test_explicit_max_turns_survives_caching_wrapper(self, tmp_path: Path, make_task) -> None:
+        """Production wraps every adapter in CachingAdapter; the turn cap
+        must be relayed through the wrapper to the inner adapter."""
+        adapter = _IdentityAwareAdapter()
+        spawner = _make_spawner(adapter, tmp_path, enable_caching=True)
+
+        spawner.spawn_for_tasks([make_task_factory(max_turns=7)])
+
+        assert adapter.seen_explicit_max_turns == 7
+
+    def test_explicit_max_turns_absent_stays_none(self, tmp_path: Path, make_task) -> None:
+        """Tasks without max_turns must not fabricate a cap."""
+        adapter = _IdentityAwareAdapter()
+        spawner = _make_spawner(adapter, tmp_path, enable_caching=True)
+
+        spawner.spawn_for_tasks([make_task_factory()])
+
+        assert adapter.seen_explicit_max_turns is None


### PR DESCRIPTION
Closes #3738.

## Problem

`AgentSpawner` threads a task's `max_turns` to the adapter as `explicit_max_turns`, gated on the adapter's `spawn()` signature (`_extra_spawn_kwargs` in `spawner_core.py`). Production constructs the spawner with `enable_caching=True`, which wraps every adapter in `CachingAdapter` — and `CachingAdapter.spawn()` did not accept `explicit_max_turns`, so the signature gate always failed behind the wrapper:

- the operator's per-task turn cap was silently ignored on every cached spawn
- the fallback warning fired on every spawn, pointing at the wrong culprit — the inner adapter supports it, the wrapper hides it

## What changes

`CachingAdapter.spawn()` now accepts `explicit_max_turns: int | None = None` and relays it to the inner adapter under the same inner-signature gate as the `task_id`/`task_title` identity relay next to it (per the issue's "same gate shape" instruction). Adapters without support keep current behaviour: the cap is dropped, no crash.

## Decision (left to the implementer by the issue)

The wrapper emits its own **debug-level** log when it drops the parameter for an unsupporting inner adapter. Rationale: after this fix the spawner's warning can no longer fire (its signature gate now sees the wrapper's accepting signature), so without a wrapper-side trace the operator would have *no* indication at all that the cap was silently not applied. Debug level keeps normal runs quiet while leaving an audit trail for troubleshooting.

## Verification

```
uv run pytest tests/unit/test_spawner_task_identity.py tests/unit/test_caching_adapter.py
# 18 passed (7 identity incl. 3 new max_turns tests + 11 caching adapter)

uv run pytest tests/unit/test_spawner.py
# 118 passed (regression)

uv run ruff check src/bernstein/adapters/caching_adapter.py tests/unit/test_spawner_task_identity.py
# All checks passed
```

2 files / +58 -1 (within the 3-file target). mypy on the changed module reports only the pre-existing `kill` override baseline (unchanged from main).

Co-authored-by: AI coding agent <noreply@hermes>