### PR TITLE
fix(ci): gate the RPM smokes on the simple index, not the JSON API (#3815)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -459,15 +459,12 @@ jobs:
           # the index can lag the publish by a short window. Distinguish
           # "not yet visible" from "the RPM is broken" by waiting here, with
           # a bounded budget, before the smoke starts.
-          for _ in $(seq 1 30); do
-            if curl -fsS "https://pypi.org/pypi/bernstein/${VERSION}/json" >/dev/null 2>&1; then
-              echo "bernstein ${VERSION} is visible on PyPI"
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "::error::bernstein ${VERSION} never appeared on PyPI within the wait budget"
-          exit 1
+          #
+          # The wait polls the simple index rather than the JSON API: they are
+          # separate caches with separate propagation, and `pip` resolves
+          # against the index. Polling the JSON API let a green wait be
+          # followed by `No matching distribution found` (#3815).
+          python3 scripts/wait_for_pypi_visibility.py "${VERSION}"
       - name: Build the RPM, install it, run it offline
         env:
           SMOKE_IMAGE: ${{ matrix.image }}

--- a/scripts/wait_for_pypi_visibility.py
+++ b/scripts/wait_for_pypi_visibility.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Wait until a release is resolvable from the index ``pip`` actually reads.
+
+Why this exists
+---------------
+The RPM install smokes build a spec whose ``%install`` runs
+``pip install bernstein==VERSION``. PyPI can lag a publish by a short
+window, so the workflow waits first, to keep "not yet visible" from being
+reported as "the RPM is broken".
+
+That wait used to poll ``https://pypi.org/pypi/bernstein/<version>/json``.
+The JSON API and the simple index are separate surfaces with separate
+caches and separate propagation, and ``pip`` resolves against the simple
+index. A green wait therefore proved nothing about the step that followed
+it: on the v3.15.1 publish the wait passed and two of four chroots then
+failed with ``No matching distribution found for bernstein==3.15.1``
+(#3815).
+
+So the poll asks the resolver surface, and asks it the precise question
+the next step will ask: not "does the project page mention this version"
+but "is there a distribution file for exactly this version". A project
+page that lists the version in some other form is not enough, because it
+is not enough for ``pip`` either.
+
+A timeout stays fatal. An index that has not converged within the budget
+is worth a human look, and the exit message says which of the two cases
+it is so the run summary stays readable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import TextIO
+
+DEFAULT_INDEX_URL = "https://pypi.org/simple/bernstein/"
+DEFAULT_ATTEMPTS = 30
+DEFAULT_DELAY_SECONDS = 10.0
+DEFAULT_PROJECT = "bernstein"
+
+
+def _normalize(version: str) -> str:
+    """Normalize a version the way a distribution filename spells it.
+
+    ``-`` is the field separator in a wheel filename, so packaging tools
+    escape any ``-`` inside the version itself to ``_`` (PEP 427). Compare
+    against that spelling rather than the tag's.
+    """
+    return version.strip().lower().replace("-", "_")
+
+
+def _distribution_filenames(project: str, version: str) -> tuple[re.Pattern[str], ...]:
+    """The filename shapes that prove ``project==version`` is installable."""
+    name = re.escape(project)
+    ver = re.escape(_normalize(version))
+    return (
+        # Wheel: name-version-pytag-abitag-platformtag.whl
+        re.compile(rf"\b{name}-{ver}-[^/\"']*\.whl\b", re.IGNORECASE),
+        # Source distribution: name-version.tar.gz
+        re.compile(rf"\b{name}-{ver}\.tar\.gz\b", re.IGNORECASE),
+    )
+
+
+def index_has_version(body: str, project: str, version: str) -> bool:
+    """True when the simple-index body offers a file for exactly ``version``.
+
+    Matching on the distribution filename is what makes this stricter than
+    the JSON API check it replaced: the project page mentioning the version
+    anywhere in prose or in a neighbouring version's filename does not
+    satisfy it.
+    """
+    return any(pattern.search(body) for pattern in _distribution_filenames(project, version))
+
+
+def _fetch(url: str, timeout: float) -> str | None:
+    """Return the index body, or ``None`` when it could not be read."""
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "text/html", "User-Agent": "bernstein-release-gate"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+
+def wait_for_visibility(
+    version: str,
+    *,
+    index_url: str = DEFAULT_INDEX_URL,
+    project: str = DEFAULT_PROJECT,
+    attempts: int = DEFAULT_ATTEMPTS,
+    delay: float = DEFAULT_DELAY_SECONDS,
+    sleep: Callable[[float], object] = time.sleep,
+    stream: TextIO = sys.stderr,
+) -> int:
+    """Poll ``index_url`` until ``version`` is resolvable. Return an exit code."""
+    reachable = False
+    for attempt in range(1, attempts + 1):
+        body = _fetch(index_url, timeout=30.0)
+        if body is not None:
+            reachable = True
+            if index_has_version(body, project, version):
+                print(f"{project} {version} is resolvable from {index_url}", file=stream)
+                return 0
+        if attempt < attempts:
+            sleep(delay)
+
+    if reachable:
+        print(
+            f"::error::{project} {version} never became resolvable from {index_url} "
+            f"within the wait budget ({attempts} attempts). The index was reachable "
+            f"but never offered a distribution for this version: the index has not "
+            f"converged. This is not evidence that the build is broken.",
+            file=stream,
+        )
+    else:
+        print(
+            f"::error::{index_url} could not be read on any of {attempts} attempts, "
+            f"so visibility of {project} {version} was never established. Treat this "
+            f"as an index or network fault, not as a broken build.",
+            file=stream,
+        )
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="Release version to wait for, without a leading 'v'.")
+    parser.add_argument("--index-url", default=DEFAULT_INDEX_URL, help="Simple-index URL for the project.")
+    parser.add_argument("--project", default=DEFAULT_PROJECT, help="Project name as it appears in filenames.")
+    parser.add_argument("--attempts", type=int, default=DEFAULT_ATTEMPTS, help="Number of polls before giving up.")
+    parser.add_argument("--delay", type=float, default=DEFAULT_DELAY_SECONDS, help="Seconds between polls.")
+    args = parser.parse_args(argv)
+
+    return wait_for_visibility(
+        args.version,
+        index_url=args.index_url,
+        project=args.project,
+        attempts=args.attempts,
+        delay=args.delay,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_wait_for_pypi_visibility.py
+++ b/tests/unit/test_wait_for_pypi_visibility.py
@@ -1,0 +1,128 @@
+"""The PyPI visibility gate polls the resolver surface (issue #3815).
+
+The defect these cover: the gate used to poll the JSON metadata API while
+the step it guards resolves against the simple index. The two are separate
+caches, so the gate could pass on a version ``pip`` could not yet install.
+
+The central case is ``test_version_absent_from_index_is_not_visible`` —
+a version the project page knows about but offers no distribution for is
+exactly the input the old check passed and the RPM build then failed on.
+Each negative is paired with a positive control, so an over-strict gate
+that refuses everything cannot satisfy the suite on its own.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "wait_for_pypi_visibility.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("wait_for_pypi_visibility", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load()
+
+
+def _index(*filenames: str) -> str:
+    """A PEP 503 simple-index page offering ``filenames``."""
+    links = "\n".join(f'<a href="/packages/{name}#sha256=deadbeef">{name}</a><br/>' for name in filenames)
+    return f"<!DOCTYPE html><html><head><title>Links for bernstein</title></head><body>{links}</body></html>"
+
+
+class TestIndexHasVersion:
+    """The resolvability predicate itself."""
+
+    def test_wheel_for_the_exact_version_is_visible(self) -> None:
+        body = _index("bernstein-3.15.1-py3-none-any.whl")
+        assert gate.index_has_version(body, "bernstein", "3.15.1") is True
+
+    def test_sdist_for_the_exact_version_is_visible(self) -> None:
+        body = _index("bernstein-3.15.1.tar.gz")
+        assert gate.index_has_version(body, "bernstein", "3.15.1") is True
+
+    def test_version_absent_from_index_is_not_visible(self) -> None:
+        """The v3.15.1 failure: neighbouring versions present, this one absent.
+
+        The JSON API knew about 3.15.1 while the simple index still served
+        only 3.15.0, and the old gate passed on precisely this state.
+        """
+        body = _index("bernstein-3.14.159-py3-none-any.whl", "bernstein-3.15.0-py3-none-any.whl")
+        assert gate.index_has_version(body, "bernstein", "3.15.1") is False
+
+    def test_a_mention_without_a_distribution_is_not_visible(self) -> None:
+        """ "Resolvable" means a file exists, not that the page says the number."""
+        body = "<html><body>Links for bernstein — latest is 3.15.1</body></html>"
+        assert gate.index_has_version(body, "bernstein", "3.15.1") is False
+
+    def test_a_longer_version_does_not_satisfy_a_prefix(self) -> None:
+        """3.15.10 must not be read as proof that 3.15.1 is there."""
+        body = _index("bernstein-3.15.10-py3-none-any.whl")
+        assert gate.index_has_version(body, "bernstein", "3.15.1") is False
+
+
+class TestWaitForVisibility:
+    """The polling loop and the exit codes the workflow reads."""
+
+    def test_returns_zero_once_the_version_is_resolvable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gate, "_fetch", lambda url, timeout: _index("bernstein-3.15.1-py3-none-any.whl"))
+
+        exit_code = gate.wait_for_visibility("3.15.1", attempts=3, delay=0, sleep=lambda _: None, stream=sys.stdout)
+
+        assert exit_code == 0
+
+    def test_returns_nonzero_when_the_index_never_offers_the_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The failing-first assertion from #3815: stub index omits the version."""
+        monkeypatch.setattr(gate, "_fetch", lambda url, timeout: _index("bernstein-3.15.0-py3-none-any.whl"))
+
+        exit_code = gate.wait_for_visibility("3.15.1", attempts=3, delay=0, sleep=lambda _: None, stream=sys.stdout)
+
+        assert exit_code == 1
+
+    def test_timeout_message_names_a_stalled_index_not_a_broken_build(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(gate, "_fetch", lambda url, timeout: _index("bernstein-3.15.0-py3-none-any.whl"))
+
+        gate.wait_for_visibility("3.15.1", attempts=2, delay=0, sleep=lambda _: None, stream=sys.stdout)
+
+        message = capsys.readouterr().out
+        assert "not evidence that the build is broken" in message
+        assert "has not" in message and "converged" in message
+
+    def test_unreadable_index_is_reported_as_a_fault_not_a_missing_release(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An index that never answers is a different diagnosis from one that lags."""
+        monkeypatch.setattr(gate, "_fetch", lambda url, timeout: None)
+
+        exit_code = gate.wait_for_visibility("3.15.1", attempts=2, delay=0, sleep=lambda _: None, stream=sys.stdout)
+
+        assert exit_code == 1
+        assert "index or network fault" in capsys.readouterr().out
+
+    def test_polls_again_after_a_miss(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A release that lands mid-wait is picked up rather than failed."""
+        bodies = [
+            _index("bernstein-3.15.0-py3-none-any.whl"),
+            _index("bernstein-3.15.0-py3-none-any.whl"),
+            _index("bernstein-3.15.1-py3-none-any.whl"),
+        ]
+        monkeypatch.setattr(gate, "_fetch", lambda url, timeout: bodies.pop(0))
+        slept: list[float] = []
+
+        exit_code = gate.wait_for_visibility("3.15.1", attempts=5, delay=10, sleep=slept.append, stream=sys.stdout)
+
+        assert exit_code == 0
+        assert slept == [10, 10], "should sleep between polls, and stop as soon as it resolves"


### PR DESCRIPTION
Closes #3815.

The wait polled the metadata API; the step it guards resolves against the simple index. Now it polls the index, and asks it the same question `pip` will ask.

## The fix

`.github/workflows/publish.yml` no longer curls `pypi.org/pypi/bernstein/<version>/json`. The loop moves into `scripts/wait_for_pypi_visibility.py` — following the `scripts/publish_required_check.py` precedent — because the proof the issue asks for is "point the wait at a stub index that omits the version and assert it fails", and inline YAML cannot be given a stub index.

Resolvability is defined as **a distribution file for exactly this version**, matched on the filename:

- `bernstein-3.15.1-*.whl` or `bernstein-3.15.1.tar.gz` → resolvable
- the page merely naming `3.15.1` in prose → **not** resolvable
- `bernstein-3.15.10-*.whl` → **not** proof that `3.15.1` is there

That last one is why this matches filenames rather than substrings: a prefix match would have reintroduced the same class of false green.

Per the decision the issue leaves open: **the timeout stays fatal.** An index that has not converged in five minutes is worth a human look, and making it non-fatal would erase the very distinction the step exists to draw. What changed is the message, which now separates the two diagnoses and says explicitly that neither is evidence of a broken build:

- index reachable, version never offered → `the index has not converged. This is not evidence that the build is broken.`
- index never readable at all → `Treat this as an index or network fault, not as a broken build.`

The retry budget (30 × 10s) and the fatal exit are otherwise unchanged, per the stated non-goals. No Copr logic and no spec-file changes.

## Verification

`tests/unit/test_wait_for_pypi_visibility.py` — **10 passed**. The failing-first case is `test_version_absent_from_index_is_not_visible`: an index serving `3.14.159` and `3.15.0` but not `3.15.1`, which is the exact state the v3.15.1 publish was in and which the old check passed. Every negative is paired with a positive control, so a gate that simply refused everything could not satisfy the suite.

Also smoked against the live index:

```
$ python scripts/wait_for_pypi_visibility.py 3.15.0 --attempts 1 --delay 0
bernstein 3.15.0 is resolvable from https://pypi.org/simple/bernstein/   # exit 0

$ python scripts/wait_for_pypi_visibility.py 99.99.99 --attempts 1 --delay 0
::error::bernstein 99.99.99 never became resolvable ... has not converged.  # exit 1
```

`ruff check` and `ruff format --check` are clean on both new files, and `publish.yml` still parses. I could not run `actionlint` locally (not installed in this environment) — worth a glance on CI.

## Note

I went with the filename check rather than the heavier `pip download --no-deps` probe the issue floats as the more honest option. It needs no network install, no pip invocation, and no cleanup, and it is testable offline against a stub index — but it does assert against the index's rendering rather than by driving the resolver itself. If you would rather the gate exercise the real resolver, say so and I will swap the predicate; the surrounding loop, messages, and tests stay as they are.
