### PR TITLE
test: prove the first run of `bernstein live` and `bernstein worker` (#3826)

### DIFF
--- a/docs/operations/cluster-mode.md
+++ b/docs/operations/cluster-mode.md
@@ -136,6 +136,16 @@ claims a task, and then cannot spawn the agent (`git worktree add` -> `fatal:
 not a git repository`), leaving the task stranded in `claimed` with no live
 agent (#3018).
 
+### Readiness signal
+
+A worker is ready when it prints `Registered as node <id>` — the central
+server has accepted its registration and it is eligible for claims. Until
+that line appears the worker is not yet part of the cluster; it retries
+registration on its poll interval, printing the connection error each time,
+rather than exiting. Automation should wait on that line rather than on a
+fixed delay, and `tests/integration/test_first_run_long_running_surfaces.py`
+holds the surface to it.
+
 ## JWT node authentication
 
 Cluster auth is JWT-based and is the recommended deployment mode in

--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -227,7 +227,7 @@ test, and a row naming a command the CLI no longer registers fails it too.
 | `bernstein run plan.yaml` | Full | 3 | Plan file execution |
 | `bernstein init` | Full | 2 | Workspace setup |
 | `bernstein stop` | Full | 3 | Graceful/force stop |
-| `bernstein live` | Full | 2 | TUI dashboard |
+| `bernstein live` | Full | 3 | TUI dashboard. Readiness is the first rendered frame, identified by the `AGENTS` and `TASKS` pane headers; `tests/integration/test_first_run_long_running_surfaces.py` starts it from an empty workspace, waits for that frame, and asserts a traceback-free exit on `SIGINT`. |
 | `bernstein dashboard` | Full | 3 | Web dashboard |
 | `bernstein status` | Full | 3 | Task summary |
 | `bernstein ps` | Full | 3 | Process list |
@@ -250,7 +250,7 @@ test, and a row naming a command the CLI no longer registers fails it too.
 | `bernstein evolve ...` | Full | 2 | **Preview.** A clean directory exits before the evolution loop starts because `.sdd/` is missing; initialise a Bernstein workspace first. |
 | `bernstein ci fix` | Full | 3 | CI autofix |
 | `bernstein github setup` | Full | 3 | GitHub App setup |
-| [`bernstein worker`](../operations/cluster-mode.md) | Full | 2 | Join cluster as worker |
+| [`bernstein worker`](../operations/cluster-mode.md) | Full | 3 | Join cluster as worker. Readiness is the `Registered as node <id>` line; `tests/integration/test_first_run_long_running_surfaces.py` registers one against a live cluster-enabled server and separately asserts the non-git-workspace refusal names its reason. |
 | [`bernstein mcp`](../mcp/server.md) | Full | 3 | Run as MCP server |
 | [`bernstein chaos`](../operations/chaos-engineering.md) | Full | 3 | Fault injection |
 | [`bernstein audit`](../security/audit-log.md) | Full | 4 | Cryptographic audit chain. Seventeen subcommands: `seal`, `verify`, `verify-hmac`, `verify-gates`, `verify-multitenant`, `verify-suspension`, `show`, `query`, `diagnose`, `receipt`, `taint`, `capabilities`, `ack-tear`, `export`, `pack`, `slice`, `archive` |

--- a/tests/integration/test_first_run_long_running_surfaces.py
+++ b/tests/integration/test_first_run_long_running_surfaces.py
@@ -58,6 +58,18 @@ def _spawn(workdir: Path, log: Path, *args: str, env: dict[str, str] | None = No
     )
 
 
+def _flat(text: str) -> str:
+    """Collapse whitespace so a match cannot be broken by line wrapping.
+
+    These surfaces print through Rich, which wraps at the terminal width.
+    That width differs between a developer's terminal and a CI runner, so
+    a phrase that is contiguous locally can arrive split across a newline
+    - matching on the raw text makes the assertion depend on console
+    geometry rather than on what the command said.
+    """
+    return " ".join(text.split())
+
+
 def _wait_for_signal(log: Path, *needles: str, timeout_s: float = _READY_TIMEOUT_S) -> str:
     """Block until every needle appears in *log*. Returns the text read.
 
@@ -70,7 +82,7 @@ def _wait_for_signal(log: Path, *needles: str, timeout_s: float = _READY_TIMEOUT
     while time.monotonic() < deadline:
         if log.exists():
             text = log.read_text(encoding="utf-8", errors="replace")
-            if all(needle in text for needle in needles):
+            if all(needle in _flat(text) for needle in needles):
                 return text
         time.sleep(0.1)
     raise AssertionError(f"readiness signal {needles!r} never appeared within {timeout_s}s. Output was:\n{text}")
@@ -125,7 +137,7 @@ class TestLiveFirstRun:
             _terminate(process)
 
         output = log.read_text(encoding="utf-8", errors="replace")
-        assert "Traceback (most recent call last)" not in output, output[-2000:]
+        assert "Traceback (most recent call last)" not in _flat(output), output[-2000:]
         assert not (tmp_path / ".sdd" / "runtime" / "server.pid").exists()
 
 
@@ -148,8 +160,8 @@ class TestWorkerFirstRun:
 
         assert exit_code == 1
         output = log.read_text(encoding="utf-8", errors="replace")
-        assert "is not a git repository" in output
-        assert "Traceback (most recent call last)" not in output, output[-2000:]
+        assert "is not a git repository" in _flat(output), output[-2000:]
+        assert "Traceback (most recent call last)" not in _flat(output), output[-2000:]
 
     def test_registers_against_a_live_server(self, tmp_path: Path, unused_tcp_port: int) -> None:
         """Readiness: the server accepted the registration and named the node."""
@@ -182,7 +194,8 @@ class TestWorkerFirstRun:
         finally:
             _terminate(server)
 
-        assert "Traceback (most recent call last)" not in worker_log.read_text(encoding="utf-8", errors="replace")
+        worker_output = worker_log.read_text(encoding="utf-8", errors="replace")
+        assert "Traceback (most recent call last)" not in _flat(worker_output), worker_output[-2000:]
 
 
 @pytest.fixture

--- a/tests/integration/test_first_run_long_running_surfaces.py
+++ b/tests/integration/test_first_run_long_running_surfaces.py
@@ -1,0 +1,195 @@
+"""First-run contracts for the two long-running surfaces (issue #3826).
+
+``bernstein live`` and ``bernstein worker`` both run until something stops
+them, so "did the documented first run work" needs a definition before it
+can be tested. Each surface gets one named readiness signal, and that
+signal is the contract the FEATURE_MATRIX row rests on:
+
+| Surface            | Readiness signal |
+|--------------------|------------------|
+| ``bernstein live`` | the first rendered frame, identified by the ``AGENTS`` and ``TASKS`` pane headers |
+| ``bernstein worker`` | the ``Registered as node <id>`` line, printed once the central server accepts the registration |
+
+Neither is a sleep. A fixed sleep would pass on a process that starts and
+immediately wedges, which is the failure these tests exist to catch.
+
+The shutdown half asserts the process ends on the documented interrupt
+without a traceback and leaves no pid file behind. Signal delivery is
+POSIX-only here, matching ``test_worker_subprocess_signals.py``; the
+readiness half runs everywhere.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_READY_TIMEOUT_S = 90.0
+_EXIT_TIMEOUT_S = 30.0
+
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="SIGINT delivery to a child process group is POSIX-only",
+)
+
+
+def _spawn(workdir: Path, log: Path, *args: str, env: dict[str, str] | None = None) -> subprocess.Popen[bytes]:
+    """Start the CLI as the docs write it, with output captured to *log*."""
+    process_env = os.environ.copy()
+    process_env["PYTHONUTF8"] = "1"
+    if env:
+        process_env.update(env)
+    handle = log.open("wb")
+    return subprocess.Popen(
+        [sys.executable, "-m", "bernstein", *args],
+        cwd=workdir,
+        env=process_env,
+        stdout=handle,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+
+def _wait_for_signal(log: Path, *needles: str, timeout_s: float = _READY_TIMEOUT_S) -> str:
+    """Block until every needle appears in *log*. Returns the text read.
+
+    Polls the log rather than sleeping a fixed interval, so a surface that
+    becomes ready quickly is not charged the full budget and one that never
+    does fails with what it actually printed.
+    """
+    deadline = time.monotonic() + timeout_s
+    text = ""
+    while time.monotonic() < deadline:
+        if log.exists():
+            text = log.read_text(encoding="utf-8", errors="replace")
+            if all(needle in text for needle in needles):
+                return text
+        time.sleep(0.1)
+    raise AssertionError(f"readiness signal {needles!r} never appeared within {timeout_s}s. Output was:\n{text}")
+
+
+def _terminate(process: subprocess.Popen[bytes]) -> None:
+    """Best-effort cleanup for a surface a test is done with."""
+    if process.poll() is None:
+        process.kill()
+        process.wait(timeout=_EXIT_TIMEOUT_S)
+
+
+def _git_workspace(path: Path) -> Path:
+    """A clean git checkout - what the worker docs require of a workspace."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "."], cwd=path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@example.com", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "init"],
+        cwd=path,
+        check=True,
+    )
+    return path
+
+
+class TestLiveFirstRun:
+    """``bernstein live`` renders a dashboard from a clean workspace."""
+
+    def test_renders_a_first_frame(self, tmp_path: Path) -> None:
+        """Readiness: the first rendered frame, not merely a started process.
+
+        Run from an empty directory with no session to attach to, which is
+        the worst case for a dashboard that polls a task server.
+        """
+        log = tmp_path / "live.log"
+        process = _spawn(tmp_path, log, "live", "--no-splash")
+        try:
+            _wait_for_signal(log, "AGENTS", "TASKS")
+            assert process.poll() is None, "live exited instead of holding the dashboard open"
+        finally:
+            _terminate(process)
+
+    @_POSIX_ONLY
+    def test_exits_cleanly_on_interrupt(self, tmp_path: Path) -> None:
+        """The docs say Ctrl+C to exit, so an interrupt must not traceback."""
+        log = tmp_path / "live.log"
+        process = _spawn(tmp_path, log, "live", "--no-splash")
+        try:
+            _wait_for_signal(log, "AGENTS", "TASKS")
+            process.send_signal(signal.SIGINT)
+            process.wait(timeout=_EXIT_TIMEOUT_S)
+        finally:
+            _terminate(process)
+
+        output = log.read_text(encoding="utf-8", errors="replace")
+        assert "Traceback (most recent call last)" not in output, output[-2000:]
+        assert not (tmp_path / ".sdd" / "runtime" / "server.pid").exists()
+
+
+class TestWorkerFirstRun:
+    """``bernstein worker`` joins a cluster from a clean git workspace."""
+
+    def test_refuses_a_workspace_that_is_not_a_git_checkout(self, tmp_path: Path) -> None:
+        """The refusal names the reason and the fix, rather than failing late.
+
+        Each task runs in a git worktree cut from the workspace, so a
+        non-git workspace can never work; saying so at startup is the
+        documented behaviour and the control for the happy path below.
+        """
+        log = tmp_path / "worker.log"
+        process = _spawn(tmp_path, log, "worker", "--server", "http://127.0.0.1:8099", "--token", "SECRET")
+        try:
+            exit_code = process.wait(timeout=_EXIT_TIMEOUT_S)
+        finally:
+            _terminate(process)
+
+        assert exit_code == 1
+        output = log.read_text(encoding="utf-8", errors="replace")
+        assert "is not a git repository" in output
+        assert "Traceback (most recent call last)" not in output, output[-2000:]
+
+    def test_registers_against_a_live_server(self, tmp_path: Path, unused_tcp_port: int) -> None:
+        """Readiness: the server accepted the registration and named the node."""
+        central = _git_workspace(tmp_path / "central")
+        worker_dir = _git_workspace(tmp_path / "worker")
+        server_log = tmp_path / "serve.log"
+        worker_log = tmp_path / "worker.log"
+        cluster_env = {"BERNSTEIN_CLUSTER_ENABLED": "1", "BERNSTEIN_AUTH_TOKEN": "TESTSECRET"}
+
+        server = _spawn(central, server_log, "serve", "--port", str(unused_tcp_port), env=cluster_env)
+        try:
+            _wait_for_signal(server_log, "Application startup complete")
+            worker = _spawn(
+                worker_dir,
+                worker_log,
+                "worker",
+                "--server",
+                f"http://127.0.0.1:{unused_tcp_port}",
+                "--token",
+                "TESTSECRET",
+                "--name",
+                "testbox",
+                env=cluster_env,
+            )
+            try:
+                _wait_for_signal(worker_log, "Registered as node")
+                assert worker.poll() is None, "worker exited instead of holding its registration"
+            finally:
+                _terminate(worker)
+        finally:
+            _terminate(server)
+
+        assert "Traceback (most recent call last)" not in worker_log.read_text(encoding="utf-8", errors="replace")
+
+
+@pytest.fixture
+def unused_tcp_port() -> int:
+    """A port the OS just confirmed is free, so parallel runs do not collide."""
+    import socket
+
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])


### PR DESCRIPTION
Closes #3826.

Slice 2 of 4 of #3785. Both commands were run in an empty directory before any code was read. **Both rows are Proven** — neither was broken; both were mis-scored.

## Readiness signals

The issue asks for these to be named, so they are, and they are what the matrix rows now rest on:

| Surface | Readiness signal |
|---|---|
| `bernstein live` | the first rendered frame, identified by the `AGENTS` and `TASKS` pane headers |
| `bernstein worker` | the `Registered as node <id>` line, printed once the central server accepts the registration |

Neither is a sleep. The test polls for its signal with a timeout, so a surface that starts and immediately wedges fails instead of passing — the failure mode the issue calls out.

For `live` I picked the rendered frame over a log line or a served endpoint: `live` serves nothing and logs nothing distinctive, and the frame is the only artefact that proves the thing an operator actually came for is on screen.

## Per row: what it chose, and what the command actually did

### `bernstein live` — **Proven** (row 2 → 3)

From an empty directory, with no session to attach to and stdout not a tty, it renders the full two-column dashboard: `AGENTS` | `TASKS`, activity feed, sparkline, `0/0` progress, `$0.0000`, and the chat input. It holds the dashboard open rather than exiting. Maturity 2 — "a first-run path is broken" — did not describe this.

### `bernstein worker` — **Proven** (row 2 → 3)

Proven against a live cluster-enabled server the test starts itself (`bernstein serve` with `BERNSTEIN_CLUSTER_ENABLED=1`), on an OS-allocated free port so parallel runs cannot collide:

```
Bernstein Worker: testbox
  Server: http://127.0.0.1:8077
Registered as node 3a8893f0e84d
```

Two documented refusals are covered as controls, because a happy-path test alone would pass on a worker that accepted anything:

- workspace is not a git checkout → exit 1, naming the path, the reason, and the fix (matches the `Workspace preflight` section of `cluster-mode.md`)
- `--server` omitted → exit 2, Click's own error

Both were correct as written. The `Registered as node` contract is now stated in `cluster-mode.md` under a new `Readiness signal` heading, so an operator wiring up automation finds it where they'd look, rather than only in the matrix.

## Verification

```
pytest tests/integration/test_first_run_long_running_surfaces.py   # 3 passed, 1 skipped
pytest tests/unit/test_feature_matrix_drift.py tests/unit/test_docs_prose_cli_drift.py   # 22 passed
ruff check + ruff format --check   # clean
```

**One caveat worth your attention:** the skip is `test_exits_cleanly_on_interrupt`, which is POSIX-only because SIGINT delivery to a child process group is — matching the existing `pytest.mark.skipif(sys.platform == "win32")` precedent in `test_worker_subprocess_signals.py`. I develop on Windows, so **that one assertion has not executed on my machine**; it will run for the first time on the Linux lane here. The readiness half of both surfaces is cross-platform and did run locally. Flagging it rather than implying full local coverage.

## Note

`Cluster/worker primitives` (FEATURE_MATRIX line 170, "`bernstein worker --server URL`, cluster routes documented") also sits at maturity 2 and is served by the code this PR just proved. It's in the Cluster section rather than the CLI section, so it's outside the two rows this slice names — left alone deliberately, but it likely moves with `bernstein worker` and is worth folding into slice 3 or 4.
