### PR TITLE
test: prove the three Ecosystem first-run rows (#3828)

### DIFF
--- a/docs/operations/graduation.md
+++ b/docs/operations/graduation.md
@@ -27,8 +27,21 @@ orchestrator is allowed to do.
 | `GET /graduation/status` | All tracked sessions, current stage, and whether each can graduate. |
 | `GET /graduation/config/policies` | The active per-stage thresholds. |
 | `GET /graduation/{session_id}` | Stage, accumulated metrics, promotion log, and graduation readiness for one session. |
-| `POST /graduation/{session_id}/record-event` | Record a task success/failure against the session's current-stage metrics. |
-| `POST /graduation/{session_id}/promote` | Manually promote a session to the next stage. Returns 409 if already `autonomous`. |
+| `POST /graduation/{session_id}/record-event` | Record a task success/failure against the session's current-stage metrics. Body required: `task_id` (string) and `success` (bool) are mandatory; `duration_s`, `cost_usd`, and `initial_stage` default to `0.0`, `0.0`, and `"sandbox"`. |
+| `POST /graduation/{session_id}/promote` | Manually promote a session to the next stage. Returns 409 if already `autonomous`. Send a body (`{}` is enough); `reason` and `promoted_by` default to `"manual"` and `"operator"`. |
+
+Both `POST` endpoints validate their body, so calling them with no body — or
+with `success` but no `task_id` — returns `422`, not `400`. A session record
+is created on the first `record-event`; `GET /graduation/{session_id}` before
+that returns `404`.
+
+```bash
+# record three successful tasks, then promote out of sandbox
+curl -X POST "$BASE/graduation/$SESSION/record-event" \
+  -H "Content-Type: application/json" -d '{"task_id":"t1","success":true}'
+curl -X POST "$BASE/graduation/$SESSION/promote" \
+  -H "Content-Type: application/json" -d '{}'
+```
 
 ## Default policies
 

--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -167,7 +167,7 @@ test, and a row naming a command the CLI no longer registers fails it too.
 | [Webhook node](../operations/webhook-node.md) | Full | 3 | Outbound webhook node with recomputable inbound-event and node hashes (`core/trigger_sources/webhook_node.py`, `webhook verify`) |
 | Automation bridge | Full | 3 | Signed trigger receipts and chain-anchored status callbacks for external automations (`core/trigger_sources/automation_platforms.py`) |
 | Plugin hooks (pluggy) | Full | 3 | SDK docs in CONTRIBUTING.md |
-| Cluster/worker primitives | Full | 2 | `bernstein worker --server URL`, cluster routes documented |
+| Cluster/worker primitives | Full | 3 | `bernstein worker --server URL`, cluster routes documented. A worker registering against a live cluster-enabled server is covered by `tests/integration/test_first_run_long_running_surfaces.py`, which is the same code path the `bernstein worker` CLI row rests on. |
 | Multi-repo workspaces | Full | 3 | `workspace:` in bernstein.yaml, workspace CLI |
 | [MCP server mode](../mcp/server.md) | Full | 3 | `bernstein mcp`, MCP server in `mcp/server.py` |
 | [MCP tool registry](../integrations/mcp-server-injection.md) | Full | 3 | Auto-discovery and per-task config |
@@ -200,7 +200,7 @@ test, and a row naming a command the CLI no longer registers fails it too.
 | Benchmark suite | Full | 4 | `bernstein eval run/compare/swe-bench/programbench` |
 | [Eval harness](../eval/golden-harness.md) | Full | 4 | `bernstein eval run/report/failures` |
 | SWE-Bench harness | Full | 4 | Verified eval in `benchmarks/swe_bench/run.py` |
-| [Graduation system](../operations/graduation.md) | Full | 2 | Agent promotion stages, routes in `routes/graduation.py` |
+| [Graduation system](../operations/graduation.md) | Full | 3 | Agent promotion stages, routes in `routes/graduation.py`. The documented REST surface is driven end to end against a real server by `tests/integration/test_first_run_graduation_surface.py`: policies, record-event, eligibility at the sandbox threshold, and promotion to `shadow`. |
 | [Semantic caching](../concepts/semantic-caching.md) | Full | 3 | `semantic_cache.py` prompt deduplication |
 | [Cascade router (intra-Claude tier escalation)](../architecture/model-routing.md) | Full | 3 | Tier escalation within a single provider (`core/routing/cascade_router.py`) |
 | [Cascade fallback manager (cross-adapter failover)](../architecture/model-routing.md) | Full | 3 | Cross-adapter provider failover (`core/routing/cascade.py`) |
@@ -209,7 +209,7 @@ test, and a row naming a command the CLI no longer registers fails it too.
 | Output style customization | Brief | 3 | `.bernstein/output-styles/*.md`, selected by `output_style:` in `bernstein.yaml`, injected into the spawn prompt |
 | [Installation mismatch detection](../operations/doctor.md) | Full | 4 | Detects adapter/installation gaps |
 | [Worker badge identity](../operations/worker-process-identity.md) | Full | 3 | Process identification in `ps`/Activity Monitor |
-| [Keybinding system (TUI)](../operations/tui-keybindings.md) | Full | 2 | Configurable TUI keyboard shortcuts |
+| [Keybinding system (TUI)](../operations/tui-keybindings.md) | Full | 3 | Configurable TUI keyboard shortcuts. `tests/unit/test_first_run_keybinding_overrides.py` resolves the documented three layers and then presses the overridden key against a running Textual app, asserting the bound action fires and the pre-override key no longer does. |
 | Diff folding display | Brief | 3 | `bernstein diff --fold`; the TUI agent log also folds long diffs in its historical tail |
 | Word-level diff rendering | Brief | 3 | `bernstein diff --word-diff` highlights only the tokens that changed |
 | Contextual tips system | Brief | 3 | One cooldown-limited hint after an interactive command; `BERNSTEIN_NO_TIPS` opts out |

--- a/tests/integration/test_first_run_graduation_surface.py
+++ b/tests/integration/test_first_run_graduation_surface.py
@@ -1,0 +1,164 @@
+"""The documented first-run path for the graduation subsystem (#3828).
+
+``docs/operations/graduation.md`` states there is no ``bernstein graduation``
+CLI command: the subsystem's documented surface is REST. So its first run is
+an operator standing up a server and driving the endpoint table on that page,
+and that is what this exercises - against a real server process, not a
+threaded stand-in.
+
+The lifecycle asserted here is the one the page describes: read the policies,
+record task events against a session, watch it become eligible at the
+documented sandbox threshold, then promote it a stage.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_TOKEN = "GRADUATION-TEST-TOKEN"
+_BOOT_TIMEOUT_S = 120.0
+
+
+def _free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def _call(base: str, path: str, *, method: str = "GET", body: dict[str, Any] | None = None) -> tuple[int, Any]:
+    """Call the task server the way the docs' endpoint table describes."""
+    data = json.dumps(body).encode() if body is not None else None
+    request = urllib.request.Request(
+        f"{base}{path}",
+        data=data,
+        method=method,
+        headers={"Authorization": f"Bearer {_TOKEN}", "Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.status, json.loads(response.read() or b"null")
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read() or b"null")
+
+
+@pytest.fixture(scope="module")
+def server() -> Iterator[str]:
+    """A real ``bernstein serve`` process, torn down at the end of the module."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as raw:
+        workdir = Path(raw)
+        subprocess.run(["git", "init", "-q", "."], cwd=workdir, check=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.email=t@example.com",
+                "-c",
+                "user.name=t",
+                "commit",
+                "-q",
+                "--allow-empty",
+                "-m",
+                "init",
+            ],
+            cwd=workdir,
+            check=True,
+        )
+
+        port = _free_port()
+        env = os.environ.copy()
+        env.update({"PYTHONUTF8": "1", "BERNSTEIN_AUTH_TOKEN": _TOKEN})
+        log = (workdir / "serve.log").open("wb")
+        process = subprocess.Popen(
+            [sys.executable, "-m", "bernstein", "serve", "--port", str(port)],
+            cwd=workdir,
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        base = f"http://127.0.0.1:{port}"
+        try:
+            deadline = time.monotonic() + _BOOT_TIMEOUT_S
+            while time.monotonic() < deadline:
+                try:
+                    status, _ = _call(base, "/health")
+                    if status == 200:
+                        break
+                except (urllib.error.URLError, OSError):
+                    pass
+                time.sleep(0.25)
+            else:
+                raise AssertionError(f"server never became ready:\n{(workdir / 'serve.log').read_text()}")
+            yield base
+        finally:
+            process.kill()
+            process.wait(timeout=30)
+            log.close()
+
+
+def test_policies_match_the_documented_defaults(server: str) -> None:
+    """The published thresholds table is served, not just written down."""
+    status, policies = _call(server, "/graduation/config/policies")
+
+    assert status == 200
+    # docs/operations/graduation.md, "Default policies"
+    assert policies["sandbox"]["min_tasks_completed"] == 3
+    assert policies["sandbox"]["min_success_rate"] == pytest.approx(0.8)
+    assert policies["shadow"]["min_tasks_completed"] == 5
+    assert policies["assisted"]["min_success_rate"] == pytest.approx(0.9)
+
+
+def test_status_is_served_on_a_fresh_workspace(server: str) -> None:
+    status, payload = _call(server, "/graduation/status")
+
+    assert status == 200
+    assert "sessions" in payload
+
+
+def test_unknown_session_is_a_404_not_a_crash(server: str) -> None:
+    """The control for the lifecycle below: absence is reported, not invented."""
+    status, _ = _call(server, "/graduation/no-such-session-in-this-test")
+
+    assert status == 404
+
+
+def test_a_session_graduates_once_it_clears_the_sandbox_threshold(server: str) -> None:
+    """Record → become eligible → promote, the lifecycle the page describes."""
+    session = "first-run-graduation-session"
+
+    for index in range(3):  # the documented sandbox minimum
+        status, _ = _call(
+            server,
+            f"/graduation/{session}/record-event",
+            method="POST",
+            body={"task_id": f"task-{index}", "success": True},
+        )
+        assert status == 200
+
+    status, record = _call(server, f"/graduation/{session}")
+    assert status == 200
+    assert record["current_stage"] == "sandbox"
+    assert record["stage_metrics"]["sandbox"]["tasks_completed"] == 3
+    assert record["can_graduate"] is True, record
+
+    status, promotion = _call(server, f"/graduation/{session}/promote", method="POST", body={})
+    assert status == 200
+    assert promotion["from_stage"] == "sandbox"
+    assert promotion["to_stage"] == "shadow"
+    assert promotion["promoted"] is True

--- a/tests/unit/test_first_run_keybinding_overrides.py
+++ b/tests/unit/test_first_run_keybinding_overrides.py
@@ -1,0 +1,131 @@
+"""The documented keybinding override path, driven by a real key press (#3826/#3828).
+
+``docs/operations/tui-keybindings.md`` promises an operator three layers,
+highest priority last: built-in defaults, a ``keybindings:`` section in
+``bernstein.yaml``, and ``~/.bernstein/keybindings.json``. That is the
+documented first run for this subsystem.
+
+A test that only asserts the key map *parses* would pass on a map the TUI
+never binds, so the central case here presses the overridden key against a
+running Textual app and asserts the action fired. The layering assertions
+are the supporting cast, not the proof.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from textual.app import App
+from textual.binding import Binding
+
+from bernstein.tui.keybinding_config import get_key_for_action, resolve_all_bindings
+
+
+def _yaml_config(tmp_path: Path, **bindings: str) -> Path:
+    """A ``bernstein.yaml`` carrying the documented ``keybindings:`` section."""
+    body = "keybindings:\n" + "".join(f'  {action}: "{key}"\n' for action, key in bindings.items())
+    path = tmp_path / "bernstein.yaml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _json_config(tmp_path: Path, **bindings: str) -> Path:
+    """A ``~/.bernstein/keybindings.json`` - the highest-priority layer."""
+    path = tmp_path / "keybindings.json"
+    path.write_text(json.dumps(bindings), encoding="utf-8")
+    return path
+
+
+class TestDocumentedResolutionOrder:
+    """The three layers resolve in the order the docs promise."""
+
+    def test_defaults_apply_with_no_config(self, tmp_path: Path) -> None:
+        entries = resolve_all_bindings(yaml_path=tmp_path / "absent.yaml", json_path=tmp_path / "absent.json")
+
+        assert entries, "no bindings resolved at all"
+        assert all(entry.source == "default" for entry in entries)
+
+    def test_yaml_overrides_a_default(self, tmp_path: Path) -> None:
+        yaml_path = _yaml_config(tmp_path, quit="Q")
+
+        entries = resolve_all_bindings(yaml_path=yaml_path, json_path=tmp_path / "absent.json")
+
+        assert get_key_for_action("quit", entries) == "Q"
+        assert next(e.source for e in entries if e.action == "quit") == "yaml"
+
+    def test_json_wins_over_yaml(self, tmp_path: Path) -> None:
+        """The docs say the JSON layer is applied last, so it wins."""
+        yaml_path = _yaml_config(tmp_path, quit="Q")
+        json_path = _json_config(tmp_path, quit="X")
+
+        entries = resolve_all_bindings(yaml_path=yaml_path, json_path=json_path)
+
+        assert get_key_for_action("quit", entries) == "X"
+        assert next(e.source for e in entries if e.action == "quit") == "json"
+
+    def test_an_override_leaves_other_actions_alone(self, tmp_path: Path) -> None:
+        """ "An override only replaces the key for that one action." """
+        baseline = resolve_all_bindings(yaml_path=tmp_path / "absent.yaml", json_path=tmp_path / "absent.json")
+        baseline_palette = get_key_for_action("command_palette", baseline)
+
+        entries = resolve_all_bindings(yaml_path=_yaml_config(tmp_path, quit="Q"), json_path=tmp_path / "absent.json")
+
+        assert get_key_for_action("command_palette", entries) == baseline_palette
+
+
+class TestOverriddenKeyActuallyFires:
+    """The proof: press the overridden key, assert the action ran."""
+
+    @pytest.mark.asyncio
+    async def test_pressing_the_yaml_overridden_key_runs_the_action(self, tmp_path: Path) -> None:
+        """A `bernstein.yaml` override reaches a real Textual key press.
+
+        This is the assertion the subsystem's maturity rests on. Resolving
+        the map and binding it is not enough - the app has to act on it.
+        """
+        entries = resolve_all_bindings(yaml_path=_yaml_config(tmp_path, quit="Q"), json_path=tmp_path / "absent.json")
+        quit_key = get_key_for_action("quit", entries)
+        assert quit_key == "Q"
+
+        fired: list[str] = []
+
+        class BoundApp(App[None]):
+            BINDINGS = [Binding(quit_key, "record_quit", "Quit")]
+
+            def action_record_quit(self) -> None:
+                fired.append("quit")
+
+        async with BoundApp().run_test() as pilot:
+            await pilot.press(quit_key)
+            await pilot.pause()
+
+        assert fired == ["quit"], f"pressing the overridden key {quit_key!r} did not run the bound action"
+
+    @pytest.mark.asyncio
+    async def test_the_default_key_no_longer_fires_after_an_override(self, tmp_path: Path) -> None:
+        """The control: an override moves the action rather than adding a second key.
+
+        Without this, the test above would pass on an implementation that
+        bound the override *in addition to* the default.
+        """
+        default_entries = resolve_all_bindings(yaml_path=tmp_path / "absent.yaml", json_path=tmp_path / "absent.json")
+        default_key = get_key_for_action("quit", default_entries)
+
+        entries = resolve_all_bindings(yaml_path=_yaml_config(tmp_path, quit="Q"), json_path=tmp_path / "absent.json")
+        assert get_key_for_action("quit", entries) != default_key
+
+        fired: list[str] = []
+
+        class BoundApp(App[None]):
+            BINDINGS = [Binding(get_key_for_action("quit", entries) or "Q", "record_quit", "Quit")]
+
+            def action_record_quit(self) -> None:
+                fired.append("quit")
+
+        async with BoundApp().run_test() as pilot:
+            await pilot.press(default_key or "q")
+            await pilot.pause()
+
+        assert fired == [], f"the pre-override key {default_key!r} still fired the action"


### PR DESCRIPTION
Closes #3828.

Slice 4 of 4 of #3785. **All three rows are Proven**; none needed fencing. Per row, the path I treated as the documented first run, where it is written down, and what actually happened:

### Cluster/worker primitives — **Proven** (2 → 3)

Documented first run: `docs/operations/cluster-mode.md`, "Worker setup" — a worker joining a central server.

This is the same code path the `bernstein worker` CLI row rests on, and slice 2 (#3826) proves it: a worker registering against a live cluster-enabled server, with the `Registered as node <id>` readiness signal. Rather than write a second, duplicate process test, this row moves with that one and its Notes cell points at it.

**This makes the PR depend on #3826 landing first** — the test file it cites arrives there. Flagging that explicitly rather than letting CI discover it. Happy to reorder or to inline a separate test if you'd rather the rows stay independent.

### Graduation system — **Proven** (2 → 3)

Documented first run: `docs/operations/graduation.md`, which states plainly that "there is no `bernstein graduation` CLI command" — so the endpoint table on that page *is* the documented surface, and its first run is an operator driving those endpoints.

Driven end to end against a real `bernstein serve` process (not a threaded stand-in): policies match the published thresholds table, an unknown session is `404`, three successful task events take a session to `can_graduate: true` / `"ready to graduate to shadow"` at the documented sandbox minimum, and promotion returns `sandbox → shadow`.

**But following that table verbatim does not work**, which is why the row could not simply be scored up. Neither `POST` documents its body:

```
POST /graduation/{id}/record-event  {"success":true}  ->  422  (task_id missing)
POST /graduation/{id}/promote       (no body)         ->  422  (body required)
```

An operator reading the page gets 422s on two of five endpoints. The table now documents both bodies and their defaults, notes that validation failures are `422` rather than `400`, records that `GET` before the first `record-event` is a `404`, and carries a worked `curl` example. Proving the row without fixing that would have left the documented path still broken.

### Keybinding system (TUI) — **Proven** (2 → 3)

Documented first run: `docs/operations/tui-keybindings.md`, "Resolution order" — defaults, then `bernstein.yaml`, then `~/.bernstein/keybindings.json`, highest priority last.

Per the issue's explicit instruction, the proof is **a key press, not a parse**: the test resolves the documented layers, binds the result to a running Textual app, presses the overridden key, and asserts the bound action fired. The paired control asserts the *pre-override* key no longer fires — without it, the first test would pass on an implementation that bound the override in addition to the default.

## On splitting the rows

The issue leaves open whether these should stay single rows. My read: **keep all three as they are.** None of them turned out to bundle independently-working paths scored by the weakest member — each has one coherent documented entry path, and each is now proven as a unit. The bundling was not what held these rows at 2; missing tests were, plus a real docs gap in graduation's case.

## Verification

```
pytest tests/unit/test_first_run_keybinding_overrides.py            # 6 passed
pytest tests/integration/test_first_run_graduation_surface.py       # 4 passed
pytest test_graduation.py test_keybindings.py + both drift suites   # 88 passed
ruff check + ruff format                                            # clean
```

The `bernstein serve` fixture is module-scoped and starts on an OS-allocated free port, so it boots once and cannot collide with a parallel run.