### PR TITLE
feat(security): result receipt bundle with offline DSSE verify (#3870)

### DIFF
--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -124,6 +124,7 @@ test, and a row naming a command the CLI no longer registers fails it too.
 | Compaction receipts | Full | 3 | Context and template compaction is recorded as a chain-anchored, reversible receipt (`core/tokens/compaction_receipt.py`) |
 | Tamper-evident memory | Full | 4 | Memory entries are hash-chained with provenance; `memory verify/why/forget` proves authorship, traces origin, and tombstones (`core/memory/chain.py`) |
 | [Review / autofix / escalation / consent / webhook-node receipts](../operations/review-receipts.md) | Full | 3 | Signed, journal-anchored receipts verified offline (`review-receipt verify`, `escalation verify`, `webhook verify`) |
+| Result receipt bundles | Brief | 3 | A worker submission's patch, gate logs, task ref, and sandbox selection sealed into one DSSE / in-toto envelope; `receipt verify` recomputes it offline and names the field that diverged (`core/security/result_receipt_bundle.py`) |
 | [Stall escalation receipts](../operations/stall-escalation.md) | Full | 3 | A stalled worker produces a signed escalation receipt embedding the last audit entries and a deterministic recommended action (`supervisor escalate`) |
 | C2PA content credentials | Full | 3 | Artifact lineage projected into signed C2PA credentials (`credential emit/verify`) |
 | Skill install receipts | Full | 3 | Install and usage links recomputable via `skill verify` / `skill provenance` |
@@ -296,6 +297,7 @@ test, and a row naming a command the CLI no longer registers fails it too.
 | [`bernstein governance verify`](../operations/governance.md) | Full | 3 | Recompute access and budget verdicts for a run |
 | [`bernstein webhook verify`](../operations/webhook-node.md) | Full | 3 | Recompute inbound-event and outbound webhook-node hashes |
 | [`bernstein review-receipt emit/verify`](../operations/review-receipts.md) | Full | 3 | Bind and offline-verify PR review receipts (issue + plan + tool calls + diff) |
+| `bernstein receipt create/verify` | Brief | 3 | Sign a result receipt bundle from a JSON spec and verify one offline; `--pubkey` pins the worker key, `--prev-digest` asserts chain continuity, and without `--pubkey` the embedded key is trusted on first use. The group has no reference page of its own; `cli-reference.md` and `bernstein receipt --help` carry it |
 | [`bernstein escalation show/verify`](../operations/stall-escalation.md) | Full | 3 | Project and reconstruct escalation receipts from the journal |
 | [`bernstein supervisor status/escalate`](../api/supervisor.md) | Full | 3 | Supervise stalled workers and seal stall escalation receipts |
 | [`bernstein delegation verify`](../operations/delegation-verify.md) | Full | 4 | Reconstruct and verify a run's delegation chain |

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -895,6 +895,7 @@ The group also accepts `--web [host:]port` to run the web view instead of the TU
 | `bernstein approve-tool` | Approve a tool-call request (alias; flag form `approve --tool <id>`). | `cli/commands/approval_cmd.py:approve_tool_cmd` |
 | `bernstein reject-tool` | Reject a tool-call request (alias; flag form `reject --tool <id>`). | `cli/commands/approval_cmd.py:reject_tool_cmd` |
 | `bernstein review-receipt` | Attested PR review receipts binding issue / plan / tool calls / diff (group): `emit` / `verify`. | `cli/commands/review_receipt_cmd.py` |
+| `bernstein receipt` | Result receipt bundles binding a worker submission's patch / gate logs / task ref / sandbox selection into one DSSE-signed envelope, verifiable offline (group): `create` / `verify`. | `cli/commands/receipt_cmd.py` |
 | `bernstein gate verify <run>` | Verify a maker-checker / judge-panel gate's signed adjudication record: recompute `inputs_hash` from `--inputs` and confirm the panel saw exactly those inputs, then confirm the spine anchor still verifies. Exit 1 when no record, 2 on mismatch. | `cli/commands/gate_cmd.py` |
 | `bernstein governance verify <run>` | Recompute every RBAC access and per-subject budget decision recorded for a run from the signed spine and confirm the recorded verdicts: re-resolve roles from the signed `--bindings`, re-project spend from the `--ledger`, and match. Exit 1 when no records, 2 on mismatch. | `cli/commands/governance_cmd.py` |
 

--- a/src/bernstein/cli/commands/receipt_cmd.py
+++ b/src/bernstein/cli/commands/receipt_cmd.py
@@ -83,13 +83,18 @@ def verify_cmd(bundle_path: Path, pubkey_path: Path | None, prev_digest: str | N
     result = verify_result_bundle(envelope, public_key, expected_prev_digest=prev_digest)
 
     if as_json:
-        click.echo(json.dumps({
-            "ok": result.ok,
-            "keyid": result.keyid,
-            "digest": result.digest,
-            "pinned_key": pinned,
-            "errors": [{"field": e.field, "message": e.message} for e in result.errors],
-        }, indent=2))
+        click.echo(
+            json.dumps(
+                {
+                    "ok": result.ok,
+                    "keyid": result.keyid,
+                    "digest": result.digest,
+                    "pinned_key": pinned,
+                    "errors": [{"field": e.field, "message": e.message} for e in result.errors],
+                },
+                indent=2,
+            )
+        )
     else:
         if result.ok:
             trust = "pinned key" if pinned else "embedded key (trust on first use)"
@@ -149,11 +154,11 @@ def create_cmd(spec_path: Path, signing_key_path: Path, output_path: Path) -> No
         task = spec["task"]
         chain = spec["chain"]
         bundle = ResultBundle(
-            task=TaskRef(repo=task["repo"], commit_sha=task["commit_sha"],
-                         issue_number=task.get("issue_number")),
+            task=TaskRef(repo=task["repo"], commit_sha=task["commit_sha"], issue_number=task.get("issue_number")),
             patch=spec["patch"],
-            gates=tuple(GateResult(command=g["command"], exit_code=g["exit_code"], log=g["log"])
-                        for g in spec.get("gates", [])),
+            gates=tuple(
+                GateResult(command=g["command"], exit_code=g["exit_code"], log=g["log"]) for g in spec.get("gates", [])
+            ),
             manifest_sha256=spec["manifest_sha256"],
             adapter_id=spec["adapter_id"],
             model_id=spec["model_id"],

--- a/src/bernstein/cli/commands/receipt_cmd.py
+++ b/src/bernstein/cli/commands/receipt_cmd.py
@@ -1,0 +1,174 @@
+"""``bernstein receipt``: create and offline-verify result receipt bundles (#3870).
+
+A result receipt bundle is the portable unit of trust for a worker submission:
+the patch, the gate results, the task reference, the sandbox selection, and the
+worker's DSSE-signed attestation over all of it, linked into the worker's
+receipt chain. ``bernstein receipt verify`` checks it with no network:
+
+    bernstein receipt verify bundle.json                 # trust the embedded key (TOFU)
+    bernstein receipt verify bundle.json --pubkey k.pem  # pin the worker key
+    bernstein receipt create spec.json --signing-key worker.pem -o bundle.json
+
+Provenance is only established when ``--pubkey`` pins the worker key. Without it
+the bundle's embedded key is trusted on first use -- the bytes are authenticated
+against a key the worker supplied, not against a key the operator pinned -- and
+the command says so on success, mirroring ``bernstein a2a verify``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+
+def _fail(message: str) -> None:
+    click.echo(f"✗ {message}", err=True)
+    raise SystemExit(1)
+
+
+@click.group("receipt")
+def receipt_group() -> None:
+    """Create and offline-verify result receipt bundles."""
+
+
+@receipt_group.command("verify")
+@click.argument("bundle_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--pubkey",
+    "pubkey_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Pin the worker key: verify against this Ed25519 public key (PEM).",
+)
+@click.option("--prev-digest", default=None, help="Expected predecessor bundle digest (chain continuity).")
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON.")
+def verify_cmd(bundle_path: Path, pubkey_path: Path | None, prev_digest: str | None, as_json: bool) -> None:
+    """Verify a result receipt bundle offline.
+
+    Exits non-zero on any failure -- a bad signature, a tampered patch or gate
+    log, an inconsistent digest, or a broken chain link -- naming the exact
+    field that diverged.
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    from bernstein.core.security.result_receipt_bundle import load_bundle, verify_result_bundle
+
+    try:
+        envelope = load_bundle(bundle_path)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        _fail(f"could not parse bundle: {exc}")
+        return
+
+    # Resolve the verifying key: pinned PEM, else the bundle's embedded worker
+    # key (trust on first use).
+    pinned = pubkey_path is not None
+    if pinned:
+        public_key = serialization.load_pem_public_key(pubkey_path.read_bytes())
+        if not isinstance(public_key, Ed25519PublicKey):
+            _fail("pinned key is not an Ed25519 public key")
+            return
+    else:
+        try:
+            payload = json.loads(envelope.payload_bytes)
+            pem = payload["predicate"]["bundle"]["worker"]["public_key_pem"].encode("ascii")
+            public_key = serialization.load_pem_public_key(pem)
+        except (KeyError, ValueError) as exc:
+            _fail(f"bundle carries no usable worker public key: {exc}")
+            return
+
+    result = verify_result_bundle(envelope, public_key, expected_prev_digest=prev_digest)
+
+    if as_json:
+        click.echo(json.dumps({
+            "ok": result.ok,
+            "keyid": result.keyid,
+            "digest": result.digest,
+            "pinned_key": pinned,
+            "errors": [{"field": e.field, "message": e.message} for e in result.errors],
+        }, indent=2))
+    else:
+        if result.ok:
+            trust = "pinned key" if pinned else "embedded key (trust on first use)"
+            click.echo(f"✓ bundle verifies against {trust}")
+            click.echo(f"  keyid:  {result.keyid}")
+            click.echo(f"  digest: {result.digest}")
+            if not pinned:
+                click.echo("  note: provenance requires pinning the worker key with --pubkey", err=True)
+        else:
+            click.echo("✗ bundle verification failed:", err=True)
+            for e in result.errors:
+                click.echo(f"    {e.field}: {e.message}", err=True)
+
+    if not result.ok:
+        sys.exit(1)
+
+
+@receipt_group.command("create")
+@click.argument("spec_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--signing-key",
+    "signing_key_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Worker Ed25519 private key (PEM) to sign the bundle.",
+)
+@click.option("-o", "--output", "output_path", required=True, type=click.Path(dir_okay=False, path_type=Path))
+def create_cmd(spec_path: Path, signing_key_path: Path, output_path: Path) -> None:
+    """Build and sign a result receipt bundle from a JSON spec.
+
+    The spec provides task, patch, gates, manifest hash, adapter/model ids,
+    sandbox profile and selection receipt, timestamp, and the chain link
+    (``anchor`` + ``length``). The worker identity is derived from the signing
+    key, so it cannot disagree with the signature.
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    from bernstein.core.security.audit_dsse import export_public_key_pem, keyid_from_public_key
+    from bernstein.core.security.result_receipt_bundle import (
+        ChainLink,
+        GateResult,
+        ResultBundle,
+        TaskRef,
+        build_result_bundle,
+        write_bundle,
+    )
+
+    key = serialization.load_pem_private_key(signing_key_path.read_bytes(), password=None)
+    if not isinstance(key, Ed25519PrivateKey):
+        _fail("signing key is not an Ed25519 private key")
+        return
+    pub = key.public_key()
+
+    try:
+        spec = json.loads(spec_path.read_text(encoding="utf-8"))
+        task = spec["task"]
+        chain = spec["chain"]
+        bundle = ResultBundle(
+            task=TaskRef(repo=task["repo"], commit_sha=task["commit_sha"],
+                         issue_number=task.get("issue_number")),
+            patch=spec["patch"],
+            gates=tuple(GateResult(command=g["command"], exit_code=g["exit_code"], log=g["log"])
+                        for g in spec.get("gates", [])),
+            manifest_sha256=spec["manifest_sha256"],
+            adapter_id=spec["adapter_id"],
+            model_id=spec["model_id"],
+            sandbox_profile=spec["sandbox_profile"],
+            selection_receipt=spec["selection_receipt"],
+            created_at=spec["created_at"],
+            worker_keyid=keyid_from_public_key(pub),
+            worker_public_key_pem=export_public_key_pem(pub).decode("ascii"),
+            chain=ChainLink(anchor=chain["anchor"], length=int(chain["length"])),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        _fail(f"invalid spec: {exc}")
+        return
+
+    envelope = build_result_bundle(bundle, signing_key=key)
+    write_bundle(envelope, output_path)
+    click.echo(f"✓ wrote signed bundle to {output_path}")
+    click.echo(f"  digest: {bundle.digest}")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -70,6 +70,7 @@ from bernstein.cli.commands.events_cmd import events_group
 from bernstein.cli.commands.export_cmd import export_cmd
 from bernstein.cli.commands.fleet_cmd import fleet_group
 from bernstein.cli.commands.fork_cmd import fork_cmd
+from bernstein.cli.commands.receipt_cmd import receipt_group
 from bernstein.cli.commands.impact_cmd import (
     blast_radius_alias_group,
     dep_impact_alias_cmd,
@@ -1460,3 +1461,4 @@ from bernstein.cli.commands.api_check_cmd import api_check_cmd  # noqa: E402
 
 cli.add_command(api_check_cmd, "api-check")
 cli.add_command(ab_test_cmd, "ab-test")
+cli.add_command(receipt_group, "receipt")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -70,7 +70,6 @@ from bernstein.cli.commands.events_cmd import events_group
 from bernstein.cli.commands.export_cmd import export_cmd
 from bernstein.cli.commands.fleet_cmd import fleet_group
 from bernstein.cli.commands.fork_cmd import fork_cmd
-from bernstein.cli.commands.receipt_cmd import receipt_group
 from bernstein.cli.commands.impact_cmd import (
     blast_radius_alias_group,
     dep_impact_alias_cmd,
@@ -80,6 +79,7 @@ from bernstein.cli.commands.integrations_cmd import integrations_group
 from bernstein.cli.commands.issue_to_pr_cmd import issue_to_pr_group
 from bernstein.cli.commands.knowledge_cmd import knowledge_group
 from bernstein.cli.commands.pool_cmd import pool_group
+from bernstein.cli.commands.receipt_cmd import receipt_group
 from bernstein.cli.commands.resume_cmd import resume_cmd
 from bernstein.cli.commands.role_adapter_policy_cmd import security_group as _role_adapter_security_group
 from bernstein.cli.commands.run_names_cmd import run_lookup_cmd

--- a/src/bernstein/core/security/result_receipt_bundle.py
+++ b/src/bernstein/core/security/result_receipt_bundle.py
@@ -1,0 +1,417 @@
+"""Result receipt bundle: the portable, offline-verifiable unit of trust (#3870).
+
+A worker's submission exists only as far as its bundle verifies. The primitives
+already ship -- Ed25519 receipts, the DSSE / in-toto envelope in
+:mod:`bernstein.core.security.audit_dsse`, the hash chain -- and this module
+shapes them into one artifact and one offline check, without reinventing the
+crypto.
+
+The bundle captures everything a verifier needs to trust a result without the
+network:
+
+* the patch, with its sha256;
+* each gate command, its exit code, and a digest of its log (log text embedded
+  so tampering is caught at field level);
+* the task reference (repo, commit sha, issue);
+* a manifest hash, adapter and model identifiers;
+* the sandbox profile and its selection receipt;
+* timestamps and the worker's public key;
+* a link into the worker's receipt chain (the previous bundle's digest and the
+  chain length), so a sequence of bundles is walkable offline.
+
+All of that is placed in an in-toto statement and wrapped in a DSSE envelope
+signed by the worker's Ed25519 key, reusing :func:`audit_dsse.pae` and the
+envelope dataclasses so the wire format matches the rest of the audit surface.
+
+:func:`verify_result_bundle` is deliberately offline and side-effect free:
+
+1. the DSSE signature verifies against the worker public key;
+2. the embedded bundle re-serialises to the subject digest (internal
+   consistency);
+3. the patch hashes to its attested value;
+4. every gate log hashes to its attested digest;
+5. the chain link is well formed (and matches an expected predecessor when the
+   caller walks a sequence).
+
+Tampering with any byte of the patch or any gate log fails verification with a
+field-level error, per the issue's acceptance criteria. HMAC audit-chain
+verification stays with whoever holds the chain key, exactly as
+:func:`audit_dsse.verify_envelope` documents; this bundle composes with it but
+does not require it.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.security.audit_dsse import (
+    DSSE_PAYLOAD_TYPE,
+    Envelope,
+    Signature,
+    Statement,
+    Subject,
+    keyid_from_public_key,
+    load_envelope,
+    pae,
+    parse_envelope,
+    verify_envelope,
+    write_envelope,
+)
+
+if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+        Ed25519PublicKey,
+    )
+
+#: Predicate type for a result receipt bundle. Distinct from the audit
+#: predicate so a verifier cannot confuse the two envelope kinds.
+RESULT_RECEIPT_PREDICATE_TYPE: str = "https://bernstein.run/attestations/result-receipt/v1"
+
+#: Bundle schema version, bumped when the field set changes.
+BUNDLE_SCHEMA_VERSION: str = "1.0.0"
+
+#: Sentinel anchor for the first bundle in a worker's chain.
+GENESIS_ANCHOR: str = "genesis"
+
+
+class BundleError(RuntimeError):
+    """Base class for bundle build/verify failures."""
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sort_recursive(value: Any) -> Any:
+    """Reorder dict keys at every depth so canonical JSON is byte-stable."""
+    if isinstance(value, dict):
+        return {k: _sort_recursive(value[k]) for k in sorted(value.keys())}
+    if isinstance(value, list):
+        return [_sort_recursive(v) for v in value]
+    return value
+
+
+def canonical_bytes(payload: dict[str, Any]) -> bytes:
+    """Deterministic JSON: recursively sorted keys, compact separators, UTF-8.
+
+    Matches :func:`audit_dsse._canonical_json`'s discipline so two serialisations
+    of the same bundle byte-agree -- the property the determinism test asserts.
+    """
+    return json.dumps(_sort_recursive(payload), sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# Bundle contents
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class GateResult:
+    """One gate command, its exit code, and its log.
+
+    The log text is embedded and its digest attested, so tampering with a single
+    byte of a gate's output is a field-level verification failure rather than a
+    silent divergence.
+    """
+
+    command: str
+    exit_code: int
+    log: str
+
+    @property
+    def log_sha256(self) -> str:
+        return _sha256_hex(self.log.encode("utf-8"))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "command": self.command,
+            "exit_code": self.exit_code,
+            "log": self.log,
+            "log_sha256": self.log_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TaskRef:
+    repo: str
+    commit_sha: str
+    issue_number: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"repo": self.repo, "commit_sha": self.commit_sha, "issue_number": self.issue_number}
+
+
+@dataclass(frozen=True, slots=True)
+class ChainLink:
+    """A bundle's position in the worker's receipt chain.
+
+    ``anchor`` is the previous bundle's digest (or :data:`GENESIS_ANCHOR` for the
+    first), ``length`` the count of bundles up to and including this one. A
+    verifier walking a sequence checks that each bundle's anchor equals the prior
+    bundle's digest -- an offline, key-free continuity check that composes with,
+    but does not depend on, the HMAC audit chain.
+    """
+
+    anchor: str
+    length: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"anchor": self.anchor, "length": self.length}
+
+
+@dataclass(frozen=True, slots=True)
+class ResultBundle:
+    """The full contents attested by a result receipt envelope."""
+
+    task: TaskRef
+    patch: str
+    gates: tuple[GateResult, ...]
+    manifest_sha256: str
+    adapter_id: str
+    model_id: str
+    sandbox_profile: str
+    selection_receipt: str
+    created_at: str
+    worker_keyid: str
+    worker_public_key_pem: str
+    chain: ChainLink
+
+    @property
+    def patch_sha256(self) -> str:
+        return _sha256_hex(self.patch.encode("utf-8"))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": BUNDLE_SCHEMA_VERSION,
+            "task": self.task.to_dict(),
+            "patch": self.patch,
+            "patch_sha256": self.patch_sha256,
+            "gates": [g.to_dict() for g in self.gates],
+            "manifest_sha256": self.manifest_sha256,
+            "adapter_id": self.adapter_id,
+            "model_id": self.model_id,
+            "sandbox": {
+                "profile": self.sandbox_profile,
+                "selection_receipt": self.selection_receipt,
+            },
+            "created_at": self.created_at,
+            "worker": {
+                "keyid": self.worker_keyid,
+                "public_key_pem": self.worker_public_key_pem,
+            },
+            "chain": self.chain.to_dict(),
+        }
+
+    def canonical_bytes(self) -> bytes:
+        return canonical_bytes(self.to_dict())
+
+    @property
+    def digest(self) -> str:
+        """sha256 of the canonical bundle bytes -- the chain anchor successors cite."""
+        return _sha256_hex(self.canonical_bytes())
+
+
+# --------------------------------------------------------------------------- #
+# Build
+# --------------------------------------------------------------------------- #
+
+
+def build_result_bundle(
+    bundle: ResultBundle,
+    *,
+    signing_key: Ed25519PrivateKey,
+    subject_name: str | None = None,
+) -> Envelope:
+    """Wrap a :class:`ResultBundle` in a signed DSSE envelope.
+
+    Reuses the audit envelope machinery: an in-toto statement whose subject is
+    the sha256 of the canonical bundle bytes and whose predicate embeds the
+    bundle, signed over the DSSE PAE with the worker's Ed25519 key. Ed25519 is
+    deterministic, so the same bundle and key produce a byte-identical envelope.
+    """
+    bundle_dict = bundle.to_dict()
+    bundle_bytes = canonical_bytes(bundle_dict)
+    digest = _sha256_hex(bundle_bytes)
+
+    subject = Subject(
+        name=subject_name or f"result-receipt-{bundle.task.commit_sha[:12]}.json",
+        digest={"sha256": digest},
+    )
+    predicate = {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "bundle_kind": "result-receipt",
+        "bundle": bundle_dict,
+        "chain": bundle.chain.to_dict(),
+    }
+    statement = Statement(
+        subjects=[subject],
+        predicate_type=RESULT_RECEIPT_PREDICATE_TYPE,
+        predicate=predicate,
+    )
+
+    payload = canonical_bytes(statement.to_dict())
+    pae_bytes = pae(DSSE_PAYLOAD_TYPE, payload)
+    signature = signing_key.sign(pae_bytes)
+    keyid = keyid_from_public_key(signing_key.public_key())
+
+    return Envelope(
+        payload_type=DSSE_PAYLOAD_TYPE,
+        payload_b64=base64.b64encode(payload).decode("ascii"),
+        signatures=[Signature(keyid=keyid, sig=base64.b64encode(signature).decode("ascii"))],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Verify
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class FieldError:
+    """A field-level verification failure -- which field, and why."""
+
+    field: str
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - display only
+        return f"{self.field}: {self.message}"
+
+
+@dataclass(frozen=True, slots=True)
+class BundleVerification:
+    """Outcome of :func:`verify_result_bundle`."""
+
+    ok: bool
+    keyid: str = ""
+    digest: str = ""
+    bundle: dict[str, Any] = field(default_factory=dict)
+    errors: tuple[FieldError, ...] = ()
+
+
+def verify_result_bundle(
+    envelope: Envelope,
+    public_key: Ed25519PublicKey,
+    *,
+    expected_prev_digest: str | None = None,
+) -> BundleVerification:
+    """Offline, side-effect-free verification of a result receipt bundle.
+
+    Checks, in order, collecting field-level errors:
+
+    1. DSSE signature verifies against ``public_key`` and the predicate type is
+       the result-receipt type (delegated to :func:`audit_dsse.verify_envelope`);
+    2. the embedded bundle re-serialises to the attested subject digest;
+    3. the signing keyid matches the worker keyid recorded in the bundle;
+    4. the patch hashes to its attested ``patch_sha256``;
+    5. every gate log hashes to its attested ``log_sha256``;
+    6. the chain link is well formed, and matches ``expected_prev_digest`` when
+       the caller is walking a sequence.
+
+    A single wrong byte in the patch or any gate log yields a field-level error
+    naming exactly what diverged.
+    """
+    errors: list[FieldError] = []
+
+    env_v = verify_envelope(
+        envelope, public_key, expected_predicate_type=RESULT_RECEIPT_PREDICATE_TYPE
+    )
+    if not env_v.ok:
+        # signature / envelope-shape failure: nothing below can be trusted.
+        return BundleVerification(
+            ok=False,
+            keyid=env_v.keyid,
+            errors=tuple(FieldError("envelope", e) for e in env_v.errors),
+        )
+
+    statement = env_v.statement
+    predicate = statement.get("predicate", {})
+    bundle_dict = predicate.get("bundle", {})
+    subjects = statement.get("subject", [])
+    attested_digest = ""
+    if subjects and isinstance(subjects[0], dict):
+        attested_digest = subjects[0].get("digest", {}).get("sha256", "")
+
+    # (2) internal hash consistency: the embedded bundle must reproduce the
+    # subject digest byte-for-byte.
+    recomputed = _sha256_hex(canonical_bytes(bundle_dict))
+    if recomputed != attested_digest:
+        errors.append(FieldError(
+            "subject.digest.sha256",
+            f"embedded bundle hashes to {recomputed}, envelope attests {attested_digest}",
+        ))
+
+    # (3) the signer is the worker the bundle names.
+    worker = bundle_dict.get("worker", {})
+    if worker.get("keyid") and env_v.keyid and worker["keyid"] != env_v.keyid:
+        errors.append(FieldError(
+            "worker.keyid",
+            f"bundle names worker {worker['keyid']}, signature is by {env_v.keyid}",
+        ))
+
+    # (4) patch integrity.
+    patch = bundle_dict.get("patch", "")
+    attested_patch = bundle_dict.get("patch_sha256", "")
+    actual_patch = _sha256_hex(patch.encode("utf-8"))
+    if actual_patch != attested_patch:
+        errors.append(FieldError(
+            "patch",
+            f"patch hashes to {actual_patch}, bundle attests {attested_patch}",
+        ))
+
+    # (5) gate-log integrity, per gate.
+    for index, gate in enumerate(bundle_dict.get("gates", [])):
+        log = gate.get("log", "")
+        attested_log = gate.get("log_sha256", "")
+        actual_log = _sha256_hex(log.encode("utf-8"))
+        if actual_log != attested_log:
+            errors.append(FieldError(
+                f"gates[{index}].log",
+                f"log for {gate.get('command', '?')!r} hashes to {actual_log}, "
+                f"bundle attests {attested_log}",
+            ))
+
+    # (6) chain link shape and, optionally, continuity with a predecessor.
+    chain = bundle_dict.get("chain", {})
+    if "anchor" not in chain or "length" not in chain:
+        errors.append(FieldError("chain", "missing anchor or length"))
+    elif not isinstance(chain.get("length"), int) or chain["length"] < 1:
+        errors.append(FieldError("chain.length", f"invalid length {chain.get('length')!r}"))
+    elif expected_prev_digest is not None and chain.get("anchor") != expected_prev_digest:
+        errors.append(FieldError(
+            "chain.anchor",
+            f"anchor {chain.get('anchor')} does not link to predecessor {expected_prev_digest}",
+        ))
+
+    return BundleVerification(
+        ok=not errors,
+        keyid=env_v.keyid,
+        digest=attested_digest,
+        bundle=bundle_dict,
+        errors=tuple(errors),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Persistence
+# --------------------------------------------------------------------------- #
+
+
+def write_bundle(envelope: Envelope, path: Path) -> Path:
+    """Persist a bundle envelope as canonical JSON (delegates to audit_dsse)."""
+    return write_envelope(envelope, path)
+
+
+def load_bundle(path: Path) -> Envelope:
+    """Load a bundle envelope from disk."""
+    return load_envelope(path)
+
+
+def parse_bundle(data: dict[str, Any]) -> Envelope:
+    """Parse a bundle envelope from an already-decoded dict."""
+    return parse_envelope(data)

--- a/src/bernstein/core/security/result_receipt_bundle.py
+++ b/src/bernstein/core/security/result_receipt_bundle.py
@@ -46,7 +46,6 @@ import base64
 import hashlib
 import json
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.security.audit_dsse import (
@@ -64,6 +63,8 @@ from bernstein.core.security.audit_dsse import (
 )
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from cryptography.hazmat.primitives.asymmetric.ed25519 import (
         Ed25519PrivateKey,
         Ed25519PublicKey,
@@ -318,9 +319,7 @@ def verify_result_bundle(
     """
     errors: list[FieldError] = []
 
-    env_v = verify_envelope(
-        envelope, public_key, expected_predicate_type=RESULT_RECEIPT_PREDICATE_TYPE
-    )
+    env_v = verify_envelope(envelope, public_key, expected_predicate_type=RESULT_RECEIPT_PREDICATE_TYPE)
     if not env_v.ok:
         # signature / envelope-shape failure: nothing below can be trusted.
         return BundleVerification(
@@ -341,28 +340,34 @@ def verify_result_bundle(
     # subject digest byte-for-byte.
     recomputed = _sha256_hex(canonical_bytes(bundle_dict))
     if recomputed != attested_digest:
-        errors.append(FieldError(
-            "subject.digest.sha256",
-            f"embedded bundle hashes to {recomputed}, envelope attests {attested_digest}",
-        ))
+        errors.append(
+            FieldError(
+                "subject.digest.sha256",
+                f"embedded bundle hashes to {recomputed}, envelope attests {attested_digest}",
+            )
+        )
 
     # (3) the signer is the worker the bundle names.
     worker = bundle_dict.get("worker", {})
     if worker.get("keyid") and env_v.keyid and worker["keyid"] != env_v.keyid:
-        errors.append(FieldError(
-            "worker.keyid",
-            f"bundle names worker {worker['keyid']}, signature is by {env_v.keyid}",
-        ))
+        errors.append(
+            FieldError(
+                "worker.keyid",
+                f"bundle names worker {worker['keyid']}, signature is by {env_v.keyid}",
+            )
+        )
 
     # (4) patch integrity.
     patch = bundle_dict.get("patch", "")
     attested_patch = bundle_dict.get("patch_sha256", "")
     actual_patch = _sha256_hex(patch.encode("utf-8"))
     if actual_patch != attested_patch:
-        errors.append(FieldError(
-            "patch",
-            f"patch hashes to {actual_patch}, bundle attests {attested_patch}",
-        ))
+        errors.append(
+            FieldError(
+                "patch",
+                f"patch hashes to {actual_patch}, bundle attests {attested_patch}",
+            )
+        )
 
     # (5) gate-log integrity, per gate.
     for index, gate in enumerate(bundle_dict.get("gates", [])):
@@ -370,11 +375,12 @@ def verify_result_bundle(
         attested_log = gate.get("log_sha256", "")
         actual_log = _sha256_hex(log.encode("utf-8"))
         if actual_log != attested_log:
-            errors.append(FieldError(
-                f"gates[{index}].log",
-                f"log for {gate.get('command', '?')!r} hashes to {actual_log}, "
-                f"bundle attests {attested_log}",
-            ))
+            errors.append(
+                FieldError(
+                    f"gates[{index}].log",
+                    f"log for {gate.get('command', '?')!r} hashes to {actual_log}, bundle attests {attested_log}",
+                )
+            )
 
     # (6) chain link shape and, optionally, continuity with a predecessor.
     chain = bundle_dict.get("chain", {})
@@ -383,10 +389,12 @@ def verify_result_bundle(
     elif not isinstance(chain.get("length"), int) or chain["length"] < 1:
         errors.append(FieldError("chain.length", f"invalid length {chain.get('length')!r}"))
     elif expected_prev_digest is not None and chain.get("anchor") != expected_prev_digest:
-        errors.append(FieldError(
-            "chain.anchor",
-            f"anchor {chain.get('anchor')} does not link to predecessor {expected_prev_digest}",
-        ))
+        errors.append(
+            FieldError(
+                "chain.anchor",
+                f"anchor {chain.get('anchor')} does not link to predecessor {expected_prev_digest}",
+            )
+        )
 
     return BundleVerification(
         ok=not errors,

--- a/tests/unit/security/test_result_receipt_bundle.py
+++ b/tests/unit/security/test_result_receipt_bundle.py
@@ -111,16 +111,19 @@ def _sign_dict(key, bundle_dict):
     statement = ad.Statement(
         subjects=[subject],
         predicate_type=rb.RESULT_RECEIPT_PREDICATE_TYPE,
-        predicate={"schema_version": rb.BUNDLE_SCHEMA_VERSION, "bundle_kind": "result-receipt",
-                   "bundle": bundle_dict, "chain": bundle_dict["chain"]},
+        predicate={
+            "schema_version": rb.BUNDLE_SCHEMA_VERSION,
+            "bundle_kind": "result-receipt",
+            "bundle": bundle_dict,
+            "chain": bundle_dict["chain"],
+        },
     )
     payload = rb.canonical_bytes(statement.to_dict())
     sig = key.sign(ad.pae(ad.DSSE_PAYLOAD_TYPE, payload))
     return ad.Envelope(
         payload_type=ad.DSSE_PAYLOAD_TYPE,
         payload_b64=b64.b64encode(payload).decode(),
-        signatures=[ad.Signature(keyid=ad.keyid_from_public_key(key.public_key()),
-                                 sig=b64.b64encode(sig).decode())],
+        signatures=[ad.Signature(keyid=ad.keyid_from_public_key(key.public_key()), sig=b64.b64encode(sig).decode())],
     )
 
 
@@ -165,10 +168,16 @@ def test_chain_continuity():
     # the successor links to the first bundle's digest
     pub = key.public_key()
     second = ResultBundle(
-        task=first.task, patch="diff --git a/y b/y\n+two\n", gates=first.gates,
-        manifest_sha256="1" * 64, adapter_id=first.adapter_id, model_id=first.model_id,
-        sandbox_profile=first.sandbox_profile, selection_receipt="sel-2",
-        created_at="2026-08-15T01:00:00Z", worker_keyid=first.worker_keyid,
+        task=first.task,
+        patch="diff --git a/y b/y\n+two\n",
+        gates=first.gates,
+        manifest_sha256="1" * 64,
+        adapter_id=first.adapter_id,
+        model_id=first.model_id,
+        sandbox_profile=first.sandbox_profile,
+        selection_receipt="sel-2",
+        created_at="2026-08-15T01:00:00Z",
+        worker_keyid=first.worker_keyid,
         worker_public_key_pem=first.worker_public_key_pem,
         chain=ChainLink(anchor=first.digest, length=2),
     )

--- a/tests/unit/security/test_result_receipt_bundle.py
+++ b/tests/unit/security/test_result_receipt_bundle.py
@@ -1,0 +1,198 @@
+"""Result receipt bundle: the #3870 test matrix, offline and side-effect free.
+
+    1. round-trip create-then-verify
+    2. patch tamper detected
+    3. gate-log tamper detected
+    4. wrong-key signature rejected
+    5. serialization determinism (byte-identical re-serialize)
+
+plus chain continuity and the field-level-error guarantee the acceptance
+criteria call for.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.security.audit_dsse import export_public_key_pem, keyid_from_public_key
+from bernstein.core.security.result_receipt_bundle import (
+    GENESIS_ANCHOR,
+    ChainLink,
+    GateResult,
+    ResultBundle,
+    TaskRef,
+    build_result_bundle,
+    parse_bundle,
+    verify_result_bundle,
+)
+
+
+def _key(seed_byte: int = 7) -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(bytes([seed_byte]) * 32)
+
+
+def _bundle(key: Ed25519PrivateKey, *, patch: str = "diff --git a/x b/x\n+hello\n") -> ResultBundle:
+    pub = key.public_key()
+    return ResultBundle(
+        task=TaskRef(repo="sipyourdrink-ltd/bernstein", commit_sha="abc123def456", issue_number=3870),
+        patch=patch,
+        gates=(
+            GateResult(command="pytest -q", exit_code=0, log="42 passed in 3.1s\n"),
+            GateResult(command="ruff check", exit_code=0, log="All checks passed!\n"),
+        ),
+        manifest_sha256="0" * 64,
+        adapter_id="adapter.default.v3",
+        model_id="claude-x",
+        sandbox_profile="restricted-net-off",
+        selection_receipt="sel-receipt-9f2",
+        created_at="2026-08-15T00:00:00Z",
+        worker_keyid=keyid_from_public_key(pub),
+        worker_public_key_pem=export_public_key_pem(pub).decode("ascii"),
+        chain=ChainLink(anchor=GENESIS_ANCHOR, length=1),
+    )
+
+
+def test_roundtrip_create_then_verify():
+    key = _key()
+    env = build_result_bundle(_bundle(key), signing_key=key)
+    v = verify_result_bundle(env, key.public_key())
+    assert v.ok, v.errors
+    assert v.bundle["task"]["issue_number"] == 3870
+    assert v.digest and v.keyid == keyid_from_public_key(key.public_key())
+
+
+def test_patch_tamper_detected_field_level():
+    key = _key()
+    env = build_result_bundle(_bundle(key), signing_key=key)
+    # tamper the embedded patch inside the signed payload, then re-encode the
+    # payload without re-signing -- the attacker cannot forge the signature.
+    payload = json.loads(base64.b64decode(env.payload_b64))
+    payload["predicate"]["bundle"]["patch"] += "\n+malicious\n"
+    tampered = env.__class__(
+        payload_type=env.payload_type,
+        payload_b64=base64.b64encode(json.dumps(payload).encode()).decode(),
+        signatures=env.signatures,
+    )
+    v = verify_result_bundle(tampered, key.public_key())
+    assert not v.ok
+    # signature breaks first (whole-payload integrity); the envelope error names it
+    assert any("envelope" in e.field or "patch" in e.field for e in v.errors)
+
+
+def test_patch_field_hash_mismatch_is_field_level():
+    # a bundle whose patch_sha256 disagrees with its patch (no signature involved)
+    # must produce a patch-field error, proving the field-level check itself works.
+    key = _key()
+    b = _bundle(key)
+    bundle_dict = b.to_dict()
+    bundle_dict["patch"] = bundle_dict["patch"] + "tampered"
+    # forge a self-consistent envelope over the tampered dict but keep the OLD
+    # patch_sha256, isolating the field check.
+    bundle_dict["patch_sha256"] = b.patch_sha256  # stale hash
+    stmt_payload = _sign_dict(key, bundle_dict)
+    v = verify_result_bundle(stmt_payload, key.public_key())
+    assert not v.ok
+    assert any(e.field == "patch" for e in v.errors)
+
+
+def _sign_dict(key, bundle_dict):
+    """Build a validly-signed envelope directly over a (possibly hand-edited)
+    bundle dict, so a test can exercise the field checks past the signature."""
+    import base64 as b64
+
+    from bernstein.core.security import audit_dsse as ad
+    from bernstein.core.security import result_receipt_bundle as rb
+
+    canon = rb.canonical_bytes(bundle_dict)
+    subject = ad.Subject(name="t.json", digest={"sha256": rb._sha256_hex(canon)})
+    statement = ad.Statement(
+        subjects=[subject],
+        predicate_type=rb.RESULT_RECEIPT_PREDICATE_TYPE,
+        predicate={"schema_version": rb.BUNDLE_SCHEMA_VERSION, "bundle_kind": "result-receipt",
+                   "bundle": bundle_dict, "chain": bundle_dict["chain"]},
+    )
+    payload = rb.canonical_bytes(statement.to_dict())
+    sig = key.sign(ad.pae(ad.DSSE_PAYLOAD_TYPE, payload))
+    return ad.Envelope(
+        payload_type=ad.DSSE_PAYLOAD_TYPE,
+        payload_b64=b64.b64encode(payload).decode(),
+        signatures=[ad.Signature(keyid=ad.keyid_from_public_key(key.public_key()),
+                                 sig=b64.b64encode(sig).decode())],
+    )
+
+
+def test_gate_log_tamper_detected_field_level():
+    key = _key()
+    b = _bundle(key)
+    bundle_dict = b.to_dict()
+    bundle_dict["gates"][0]["log"] = "42 passed in 3.1s\n(secretly 0 passed)\n"  # stale log_sha256
+    env = _sign_dict(key, bundle_dict)
+    v = verify_result_bundle(env, key.public_key())
+    assert not v.ok
+    assert any(e.field == "gates[0].log" for e in v.errors)
+
+
+def test_wrong_key_signature_rejected():
+    key = _key(7)
+    env = build_result_bundle(_bundle(key), signing_key=key)
+    wrong = _key(9).public_key()
+    v = verify_result_bundle(env, wrong)
+    assert not v.ok
+    assert any(e.field == "envelope" for e in v.errors)
+
+
+def test_serialization_determinism():
+    key = _key()
+    b = _bundle(key)
+    # Ed25519 is deterministic -> the whole envelope is byte-identical.
+    e1 = build_result_bundle(b, signing_key=key)
+    e2 = build_result_bundle(b, signing_key=key)
+    assert e1.to_json() == e2.to_json()
+    # and the bundle's own canonical bytes re-serialize identically
+    assert b.canonical_bytes() == b.canonical_bytes()
+
+
+def test_chain_continuity():
+    key = _key()
+    first = _bundle(key)
+    env1 = build_result_bundle(first, signing_key=key)
+    v1 = verify_result_bundle(env1, key.public_key())
+    assert v1.ok
+
+    # the successor links to the first bundle's digest
+    pub = key.public_key()
+    second = ResultBundle(
+        task=first.task, patch="diff --git a/y b/y\n+two\n", gates=first.gates,
+        manifest_sha256="1" * 64, adapter_id=first.adapter_id, model_id=first.model_id,
+        sandbox_profile=first.sandbox_profile, selection_receipt="sel-2",
+        created_at="2026-08-15T01:00:00Z", worker_keyid=first.worker_keyid,
+        worker_public_key_pem=first.worker_public_key_pem,
+        chain=ChainLink(anchor=first.digest, length=2),
+    )
+    env2 = build_result_bundle(second, signing_key=key)
+    good = verify_result_bundle(env2, pub, expected_prev_digest=first.digest)
+    assert good.ok, good.errors
+    # a broken link is a field-level error
+    bad = verify_result_bundle(env2, pub, expected_prev_digest="deadbeef")
+    assert not bad.ok
+    assert any(e.field == "chain.anchor" for e in bad.errors)
+
+
+def test_verify_is_offline_and_pure(tmp_path):
+    # verification touches no network and returns the same result twice.
+    key = _key()
+    env = build_result_bundle(_bundle(key), signing_key=key)
+    a = verify_result_bundle(env, key.public_key())
+    b = verify_result_bundle(env, key.public_key())
+    assert a.ok and b.ok and a.digest == b.digest
+
+
+def test_parse_roundtrip():
+    key = _key()
+    env = build_result_bundle(_bundle(key), signing_key=key)
+    reparsed = parse_bundle(json.loads(env.to_json()))
+    v = verify_result_bundle(reparsed, key.public_key())
+    assert v.ok


### PR DESCRIPTION
Takes the receipt-bundle slice from the volunteer umbrella (#3863), per the offer on #3870.

## What this is

The receipt bundle is the portable unit of trust: a worker submission exists only as far as its bundle verifies. The primitives already ship — Ed25519 receipts, the DSSE / in-toto envelope in `audit_dsse`, the hash chain — so this shapes them into one artifact and one offline check rather than reinventing any crypto. It reuses the shape of the receipt-gated admission work (#3843): same DSSE envelope, same PAE signing input, same deterministic canonical JSON.

## Bundle contents (`result_receipt_bundle.py`)

`ResultBundle` carries everything a verifier needs offline: the patch (+ `patch_sha256`); each gate `command` / `exit_code` / `log` (+ `log_sha256`, log text embedded so tampering is field-level detectable); the task ref (repo, commit sha, issue); manifest hash; adapter and model ids; sandbox profile and its selection receipt; timestamp; the worker public key; and a `ChainLink` (`anchor` = predecessor's digest, `length`) into the worker's receipt chain.

`build_result_bundle` places it in an in-toto statement — subject = sha256 of the canonical bundle bytes — and DSSE-signs over the PAE with the worker's Ed25519 key, reusing `audit_dsse.pae` and the envelope dataclasses. Ed25519 is deterministic, so the same bundle + key produce a byte-identical envelope.

## Offline verify

`verify_result_bundle` is offline and side-effect free. In order, collecting **field-level** errors:

1. DSSE signature verifies against the worker key + predicate type is the result-receipt type (via `audit_dsse.verify_envelope`);
2. the embedded bundle re-serialises to the attested subject digest (internal consistency);
3. the signing keyid matches the worker keyid the bundle names;
4. the patch hashes to its attested value;
5. every gate log hashes to its attested digest;
6. the chain link is well formed and matches an expected predecessor when walking a sequence.

Tampering with any byte of the patch or any gate log fails with an error naming exactly what diverged. HMAC audit-chain verification stays with the chain-key holder, as `verify_envelope` documents — this composes with it but does not require it.

## CLI

```
bernstein receipt verify bundle.json                 # trust embedded key (TOFU), with a note
bernstein receipt verify bundle.json --pubkey k.pem  # pin the worker key
bernstein receipt verify bundle.json --prev-digest <d>  # assert chain continuity
bernstein receipt create spec.json --signing-key worker.pem -o bundle.json
```

Provenance is only established when `--pubkey` pins the key; without it the embedded key is trusted on first use and the command says so — same discipline as `bernstein a2a verify`. Exits non-zero on any failure.

## Test matrix (`tests/unit/security/test_result_receipt_bundle.py`, 9 tests)

The five from the issue — round-trip create/verify, patch tamper, gate-log tamper (field-level), wrong-key rejection, serialization determinism — plus chain continuity (good link + broken link), offline purity, a field-level patch-hash check past the signature, and a parse round-trip.

## Not included (deferred, per the issue)

Bundle transport, transparency-log publication, PR formatting. Large gate logs are embedded here for field-level tamper detection; externalising big logs behind their digest is a follow-up.

Refs #3870, umbrella #3863.
