### PR TITLE
fix(ci): surface contract drift on fork PRs instead of a token-scope error

### DIFF
--- a/.github/workflows/contract-drift-autofix.yml
+++ b/.github/workflows/contract-drift-autofix.yml
@@ -31,12 +31,30 @@ name: "Contract Drift Autofix"
 #   * When the source PR is auto-deleted on merge, there is no orphaned
 #     bot branch left re-targeting to main with a giant diff.
 #
-# Fallback paths (preserved for safety):
-#   * Fork PRs (no push to head ref): post the patch as an idempotent PR
-#     comment with copy-paste-able apply instructions.
+# Fallback paths (same-repo PRs, where the token can write):
 #   * Unhandled drift / LOC-cap trip: open a tracking issue.
 #   * Push to head ref fails (branch protection, lease conflict): post
-#     the patch as a PR comment so the operator can apply locally.
+#     the patch as an idempotent PR comment so the operator can apply it
+#     locally.
+#
+# Fork PRs: report, don't write
+# ----------------------------
+# `permissions:` is a ceiling, not a grant. A pull_request event raised
+# from a fork caps GITHUB_TOKEN at read on every scope, so none of the
+# three write paths above can fire: the push, the PR comment, and the
+# tracking issue all return "Resource not accessible by integration".
+#
+# Attempting one anyway is worse than skipping it. The step fails, and a
+# GitHub permissions error becomes the visible reason the check is red -
+# so the contributor reads a token scope they cannot change instead of
+# the drift they can fix. Observed on PR #3903 (run 31906285880), where
+# the real cause was a CLI command registered without a cli-reference.md
+# entry and the visible failure was `createIssue` 403.
+#
+# So fork PRs terminate at the fork_report step, which renders the
+# captured `[regen] ...` diagnostics (plus the patch, when regen produced
+# one) into the job summary and fails on those. The actionable message is
+# the one on the check.
 #
 # Recursion guards
 # ----------------
@@ -169,12 +187,23 @@ jobs:
         id: regen
         run: |
           set +e
-          uv run python scripts/regen_contract_drift.py --fixture all
+          # Split the streams rather than just letting them land in the log.
+          # The script prints progress to stdout ("running X", "nothing to
+          # add") and the actionable diagnosis to stderr - the line that names
+          # the offending command, e.g. "registered, but neither documented in
+          # cli-reference.md nor exempt: receipt". The reporting steps below
+          # read regen.err back so that line reaches the contributor instead of
+          # staying buried in the raw log.
+          uv run python scripts/regen_contract_drift.py --fixture all \
+            > "${RUNNER_TEMP}/regen.out" 2> "${RUNNER_TEMP}/regen.err"
           # The regen script returns 0 only when at least one fixture was
           # patched. Any non-zero exit means nothing was patched - either
           # because the drift wasn't one of the three known patterns or
           # because the diff exceeded the 30-LOC safety cap.
           regen_status=$?
+          # Replay both streams so the job log is unchanged by the capture.
+          cat "${RUNNER_TEMP}/regen.out"
+          cat "${RUNNER_TEMP}/regen.err" >&2
           echo "regen_status=$regen_status" >> "$GITHUB_OUTPUT"
           exit 0
 
@@ -226,6 +255,127 @@ jobs:
           fi
           exit 0
 
+      - name: Report drift in the job summary and fail (fork PRs)
+        # Fork PRs terminate here. `permissions:` is a ceiling, not a grant: a
+        # pull_request event raised from a fork caps GITHUB_TOKEN at read for
+        # every scope, so neither write fallback below can fire. Attempting one
+        # anyway is worse than skipping it - the step dies with "Resource not
+        # accessible by integration" and that permissions error becomes the
+        # visible reason the check is red, burying the drift that caused it
+        # (observed on PR #3903, run 31906285880, where the real cause was a
+        # command registered without a cli-reference.md entry).
+        #
+        # So render what regen actually said into the job summary and fail on
+        # that instead. The contributor reads "document your new command",
+        # which is a thing they can act on, rather than a token scope they
+        # cannot change.
+        if: >
+          steps.drift.outputs.drift == 'true' &&
+          steps.forkcheck.outputs.is_fork == 'true'
+        id: fork_report
+        env:
+          REGEN_CHANGED: ${{ steps.verify.outputs.changed }}
+          REVERIFY_STATUS: ${{ steps.reverify.outputs.status }}
+          LOC_DELTA: ${{ steps.verify.outputs.loc_delta }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Matches the runner's default shell (bash -eo pipefail) so this
+          # script behaves the same when run by hand.
+          set -euo pipefail
+
+          REGEN_ERR="${RUNNER_TEMP}/regen.err"
+          PATCH_FILE="${RUNNER_TEMP}/contract-drift.patch"
+
+          # Prefer the tagged lines; fall back to raw stderr, then to a pointer
+          # at the step log. An empty summary would reintroduce exactly the
+          # problem this step exists to fix.
+          #
+          # Every grep here is `|| true`: a no-match exits 1, and under `set -e`
+          # a failing command substitution aborts the step -- which would leave
+          # the summary empty and the annotation unwritten, i.e. the silent
+          # failure this whole step exists to prevent.
+          DIAGNOSTICS="$(grep -F '[regen]' "$REGEN_ERR" 2>/dev/null || true)"
+          [ -n "$DIAGNOSTICS" ] || DIAGNOSTICS="$(cat "$REGEN_ERR" 2>/dev/null || true)"
+          [ -n "$DIAGNOSTICS" ] || DIAGNOSTICS="regen emitted no diagnostics; see the 'Regenerate drift fixtures' step log."
+
+          # Markdown backticks are written as \` inside double quotes rather
+          # than inside single quotes: shellcheck reads a single-quoted
+          # backtick as a command substitution that will not expand (SC2016).
+          # A heredoc would read better but cannot be used here -- its body
+          # would have to dedent past this YAML block scalar's indentation.
+          {
+            echo "## Contract drift on this PR"
+            echo
+            echo "One of the contract detectors failed:"
+            echo
+            echo "- \`tests/unit/test_readme_api_coverage.py::test_all_cli_commands_are_documented\`"
+            echo "- \`tests/unit/test_api_v1_routing.py::TestVersionedRoutesParity::test_every_root_route_has_v1_counterpart\`"
+            echo "- \`tests/unit/test_cli_run_params.py::test_run_params_match_cli_call\`"
+            echo
+            echo "\`scripts/regen_contract_drift.py\` reported:"
+            echo
+            echo "\`\`\`"
+            echo "$DIAGNOSTICS"
+            echo "\`\`\`"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${REGEN_CHANGED}" = "true" ] && [ "${REVERIFY_STATUS}" = "0" ] && [ -f "$PATCH_FILE" ]; then
+            # Mechanical drift with a working patch. The bot can neither push
+            # to a fork head ref nor comment on the PR, so hand the patch over.
+            {
+              echo "### How to fix"
+              echo
+              echo "Regen produced a working patch (${LOC_DELTA:-?} LOC, cap: 30). Run it on your branch:"
+              echo
+              echo "\`\`\`bash"
+              echo 'uv run python scripts/regen_contract_drift.py --fixture all'
+              echo 'git commit -am "chore(ci): regenerate contract drift allow-lists"'
+              echo "\`\`\`"
+              echo
+              echo '<details><summary>Patch</summary>'
+              echo
+              echo "\`\`\`diff"
+              cat "$PATCH_FILE"
+              echo "\`\`\`"
+              echo
+              echo '</details>'
+            } >> "$GITHUB_STEP_SUMMARY"
+            SUMMARY_LINE="Contract drift: run 'uv run python scripts/regen_contract_drift.py --fixture all' and commit the result."
+          else
+            # Regen deliberately declined, or its patch did not clear the
+            # detectors. Both need a decision a bot should not make: an
+            # exemption records a reason, and a bot-written one records none.
+            {
+              echo "### How to fix"
+              echo
+              echo "This one is not auto-patchable - it needs a decision, not a regen:"
+              echo
+              echo "- A new CLI command must be documented in \`docs/reference/cli-reference.md\`, or"
+              echo "  recorded in \`UNDOCUMENTED_EXEMPTIONS\` in"
+              echo "  \`tests/unit/test_readme_api_coverage.py\` with the reason it is exempt."
+              echo "- A new root-mounted route needs an \`/api/v1/*\` counterpart, or an entry in"
+              echo "  \`_INFRASTRUCTURE_PATHS\` in \`tests/unit/test_api_v1_routing.py\`."
+              echo "- A new \`run()\` parameter must be forwarded by the \`cli()\` click callback."
+              echo
+              echo "Reproduce locally with:"
+              echo
+              echo "\`\`\`bash"
+              echo 'uv run python scripts/regen_contract_drift.py --fixture all'
+              echo "\`\`\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            SUMMARY_LINE="$(printf '%s' "$DIAGNOSTICS" | grep -F '[regen]' | head -n 1 || true)"
+            [ -n "$SUMMARY_LINE" ] || SUMMARY_LINE="Contract drift could not be auto-patched; see the job summary."
+          fi
+
+          echo "Run: ${RUN_URL}" >> "$GITHUB_STEP_SUMMARY"
+
+          # Annotations are single-line: % and newlines have to be escaped or
+          # the body is truncated at the first one.
+          ANNOTATION="$(printf '%s' "$SUMMARY_LINE" | sed -e 's/%/%25/g' -e 's/\r/%0D/g')"
+          echo "::error title=Contract drift::${ANNOTATION}"
+          exit 1
+
       - name: Commit regen inline to source PR head ref
         # Primary path. Same-repo PRs receive the regen patch directly on
         # their head branch via git push, so the autofix rides into main
@@ -264,17 +414,21 @@ jobs:
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 
       - name: Post drift patch as PR comment (fallback)
-        # Fallback path. Fires when:
-        #   * the PR is from a fork (no push access to head ref), OR
-        #   * the inline push step failed (lease conflict, branch protection,
-        #     transient API outage).
+        # Fallback path for same-repo PRs whose inline push was rejected (lease
+        # conflict, branch protection, transient API outage).
+        #
+        # Fork PRs are excluded: createComment needs pull-requests:write, which
+        # a fork's read-only GITHUB_TOKEN does not have regardless of the
+        # permissions block above, so this step could only 403 there. The
+        # fork_report step renders the same patch into the job summary instead.
+        #
         # Body is idempotent on a hidden marker so re-runs edit the same
         # comment rather than spamming the PR.
         if: >
           steps.drift.outputs.drift == 'true' &&
           steps.verify.outputs.changed == 'true' &&
-          steps.reverify.outputs.status == '0' && (
-            steps.forkcheck.outputs.is_fork == 'true' ||
+          steps.reverify.outputs.status == '0' &&
+          steps.forkcheck.outputs.is_fork == 'false' && (
             steps.inline_push.outcome == 'failure' ||
             steps.inline_push.outputs.pushed != 'true'
           )
@@ -285,7 +439,6 @@ jobs:
           CHANGED_FILES: ${{ steps.verify.outputs.changed_files }}
           LOC_DELTA: ${{ steps.verify.outputs.loc_delta }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          IS_FORK: ${{ steps.forkcheck.outputs.is_fork }}
           INLINE_OUTCOME: ${{ steps.inline_push.outcome }}
         with:
           script: |
@@ -297,12 +450,11 @@ jobs:
             const changedFiles = (process.env.CHANGED_FILES || '').trim();
             const locDelta = process.env.LOC_DELTA || '?';
             const runUrl = process.env.RUN_URL;
-            const isFork = process.env.IS_FORK === 'true';
             const inlineOutcome = process.env.INLINE_OUTCOME || '';
 
-            const reason = isFork
-              ? 'PR is from a fork; the bot cannot push to fork head refs, so apply the patch below manually.'
-              : `Inline autofix push failed (\`${inlineOutcome || 'skipped'}\`). Apply the patch below manually.`;
+            // Fork PRs never reach this step (read-only token), so a failed or
+            // skipped inline push is the only way to get here.
+            const reason = `Inline autofix push failed (\`${inlineOutcome || 'skipped'}\`). Apply the patch below manually.`;
 
             const patchPath = path.join(process.env.RUNNER_TEMP, 'contract-drift.patch');
             let patch = fs.readFileSync(patchPath, 'utf-8');
@@ -401,29 +553,57 @@ jobs:
             }
 
       - name: Fall back to issue when regen could not fix the drift
+        # Same-repo PRs only: gh issue create needs issues:write, which a fork
+        # PR's read-only GITHUB_TOKEN does not have. Running it there fails the
+        # job on "Resource not accessible by integration" and hides the drift,
+        # so forks are routed to the fork_report step instead.
         if: >
-          steps.drift.outputs.drift == 'true' && (
+          steps.drift.outputs.drift == 'true' &&
+          steps.forkcheck.outputs.is_fork == 'false' && (
             steps.verify.outputs.changed != 'true' ||
             steps.reverify.outputs.status != '0'
           )
+        id: issue_fallback
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          set -euo pipefail
           # Title is idempotent on PR number so re-runs don't spam issues.
-          TITLE="Contract drift on PR #${{ github.event.pull_request.number }} could not be auto-patched"
+          TITLE="Contract drift on PR #${PR_NUMBER} could not be auto-patched"
           EXISTING=$(gh issue list --search "$TITLE in:title" --state open --json number --jq '.[0].number // ""')
           if [ -n "$EXISTING" ]; then
             echo "::notice::Issue #$EXISTING already tracks this drift - skipping."
             exit 0
           fi
+
+          # Quote what regen actually said. Listing the possible reasons without
+          # the actual one makes the reader open the run log to find something
+          # the bot already had in hand.
+          # `|| true`: grep exits 1 on no-match, and `set -e` would abort the
+          # step before the issue is ever opened.
+          DIAGNOSTICS="$(grep -F '[regen]' "${RUNNER_TEMP}/regen.err" 2>/dev/null || true)"
+          [ -n "$DIAGNOSTICS" ] || DIAGNOSTICS="(regen emitted no diagnostics; see the run log)"
+
+          BODY_FILE="${RUNNER_TEMP}/drift-issue.md"
+          {
+            echo "Contract drift was detected on PR #${PR_NUMBER} but \`scripts/regen_contract_drift.py\` could not produce a clean patch."
+            echo
+            echo '```'
+            echo "$DIAGNOSTICS"
+            echo '```'
+            echo
+            echo "Possible reasons:"
+            echo "- Drift exceeded the 30-LOC safety cap (real semantic change, not drift)."
+            echo "- Drift pattern is not one of the three the script handles."
+            echo "- The fixture declines to patch itself (an exemption records a decision; a bot-written one records none)."
+            echo "- Regen ran but the targeted tests still fail (regen bug)."
+            echo
+            echo "See workflow run ${RUN_URL} for details. Refs #1273."
+          } > "$BODY_FILE"
+
           gh issue create \
             --title "$TITLE" \
             --label ci,contract-drift,bot \
-            --body "Contract drift was detected on PR #${{ github.event.pull_request.number }} but \`scripts/regen_contract_drift.py\` could not produce a clean patch.
-
-          Possible reasons:
-          - Drift exceeded the 30-LOC safety cap (real semantic change, not drift).
-          - Drift pattern is not one of the three the script handles.
-          - Regen ran but the targeted tests still fail (regen bug).
-
-          See workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for details. Refs #1273."
+            --body-file "$BODY_FILE"

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -276,6 +276,40 @@ Everything else that triggers on `pull_request` is advisory:
 `spa-bundle-freshness`, `spiffe-extra-e2e`, `trufflehog`, `typecheck-ts`,
 `zizmor`.
 
+### Fork pull requests get a read-only token
+
+`permissions:` is a ceiling, not a grant. On a `pull_request` event raised
+from a fork, GitHub caps `GITHUB_TOKEN` at read for **every** scope, whatever
+the workflow or job asks for. A write call made anyway fails with
+`Resource not accessible by integration`.
+
+This matters for any lane whose only output is a write:
+
+| Lane output | Same-repo PR | Fork PR |
+|-------------|--------------|---------|
+| Push to the PR head ref | works | 403 |
+| PR comment | works | 403 |
+| Tracking issue | works | 403 |
+
+The failure mode is worse than doing nothing: the permission error becomes
+the visible reason the check is red, so the contributor reads a token scope
+they cannot change instead of the problem they can fix.
+
+`contract-drift-autofix.yml` is the worked example. Same-repo PRs keep all
+three write paths. Fork PRs skip them and take a report-only path instead:
+the captured `[regen] ...` diagnostics (plus the patch, when regen produced
+one) are written to the job summary and the step fails on those. The
+workflow is advisory, so the red check does not block the merge - it just
+says what to fix. `tests/unit/test_contract_drift_autofix_workflow_yaml.py`
+replays the step guards for both fork states and runs the reporting script
+under the runner's shell, so neither the routing nor the message can
+regress silently.
+
+A lane that needs to write on a fork PR has to move the write off the
+`pull_request` event entirely (`workflow_run`, or a separate
+`pull_request_target` job with a reviewed trigger) rather than widen
+`permissions:`, which does nothing here.
+
 ### Pull requests opened by automation
 
 A pull request created with the Actions token (`secrets.GITHUB_TOKEN`, or

--- a/tests/unit/test_contract_drift_autofix_workflow_yaml.py
+++ b/tests/unit/test_contract_drift_autofix_workflow_yaml.py
@@ -1,21 +1,33 @@
 """Structural assertions on ``.github/workflows/contract-drift-autofix.yml``.
 
-These tests guard the fork-PR fallback path. The workflow pushes the regen
-commit directly to the source PR's head ref via ``git push --force-with-lease``.
-That path works for same-repo PRs only; for fork PRs the default GITHUB_TOKEN
-is read-only on the head repo, so the push step fails. The workflow handles
-that case by detecting the fork up front and routing to the PR-comment path
-instead.
+These tests guard the fork-PR path. The workflow pushes the regen commit
+directly to the source PR's head ref via ``git push --force-with-lease``. That
+works for same-repo PRs only: on a ``pull_request`` event raised from a fork,
+GitHub hands the job a read-only GITHUB_TOKEN no matter what the ``permissions``
+block asks for. Pushing, commenting, and opening an issue all fail there with
+``Resource not accessible by integration``.
 
-If a refactor accidentally removes the fork-detect step or the comment
-fallback, drift on fork PRs would silently fail with no operator signal.
-Lock the structural shape so that regression is caught at unit-test time.
+So fork PRs get neither write fallback. They get the drift rendered into the
+job summary and a failing step, which puts the actionable message
+("document your new command in cli-reference.md") on the red check instead of a
+GitHub permissions error that buries it.
+
+Two layers of assertion:
+
+* structural -- the fork-detect step, the reporting step, and the regen capture
+  it reads all exist and keep their shape;
+* behavioural -- :func:`_steps_that_run` replays the ``if:`` guards against a
+  simulated step context, so the routing is checked for
+  ``head.repo.fork == true`` and ``== false`` rather than by grepping for a
+  substring that happens to be present.
 """
 
 from __future__ import annotations
 
 import ast
+import os
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -104,22 +116,480 @@ def test_inline_push_is_continue_on_error(autofix_steps: list[dict[str, object]]
     )
 
 
-def test_comment_fallback_fires_for_forks_or_failed_push(
+def test_comment_fallback_fires_when_the_push_failed(
     autofix_steps: list[dict[str, object]],
 ) -> None:
-    """The comment-fallback step must trigger when is_fork == 'true' OR when
-    inline_push failed (any reason)."""
+    """The comment-fallback step must trigger when inline_push failed."""
     comment = next((s for s in autofix_steps if s.get("id") == "comment"), None)
     assert comment is not None, (
-        "PR-comment fallback step (id: comment) is missing. Without it, fork PRs "
-        "and lease-conflict same-repo PRs get no drift signal at all."
+        "PR-comment fallback step (id: comment) is missing. Without it, a "
+        "lease-conflict same-repo PR gets no drift signal at all."
     )
     cond = comment.get("if", "")
     assert isinstance(cond, str)
-    assert "is_fork == 'true'" in cond, "comment fallback must fire for fork PRs"
     assert "inline_push.outcome == 'failure'" in cond or "inline_push.outputs.pushed != 'true'" in cond, (
         "comment fallback must fire when inline_push failed"
     )
+
+
+# ---------------------------------------------------------------------------
+# Fork PRs get a read-only token: no write fallback can fire
+# ---------------------------------------------------------------------------
+#
+# ``permissions:`` is a ceiling, not a grant. A ``pull_request`` event from a
+# fork caps GITHUB_TOKEN at read for every scope, so ``issues: write`` and
+# ``pull-requests: write`` on the job buy nothing there. Observed on PR #3903
+# (run 31906285880): the tracking-issue fallback fired on a fork PR and died
+# with ``GraphQL: Resource not accessible by integration (createIssue)``, which
+# is what the contributor saw instead of the real, actionable drift
+# ("registered, but neither documented in cli-reference.md nor exempt:
+# receipt"). The comment fallback shares the mechanism and would fail the same
+# way on the patchable branch.
+
+
+def test_regen_diagnostics_are_captured_to_a_file(
+    autofix_steps: list[dict[str, object]],
+) -> None:
+    """The regen step must persist its output for the reporting steps to read.
+
+    The actionable lines go to the script's *stderr*; stdout carries only
+    progress chatter ("running X", "nothing to add"). Capturing the combined
+    stream into the job log alone is not enough -- a later step has to be able
+    to read the diagnostics back to put them in front of the contributor.
+    """
+    regen = next((s for s in autofix_steps if s.get("id") == "regen"), None)
+    assert regen is not None, "regen step is missing"
+    run = regen.get("run", "")
+    assert isinstance(run, str)
+    assert "regen.err" in run and "2>" in run, (
+        "the regen step must redirect stderr to ${RUNNER_TEMP}/regen.err. The "
+        "'[regen] ...' diagnostics naming the undocumented command are written "
+        "to stderr, and the fork-report step reads them back from that file."
+    )
+    assert 'cat "${RUNNER_TEMP}/regen.err"' in run, (
+        "the captured stderr must still be replayed into the job log; "
+        "redirecting it to a file must not make it invisible in the run output"
+    )
+
+
+def test_fork_report_step_fails_with_the_regen_output(
+    autofix_steps: list[dict[str, object]],
+) -> None:
+    """Fork PRs must fail on the drift itself, not on a permissions error."""
+    report = next((s for s in autofix_steps if s.get("id") == "fork_report"), None)
+    assert report is not None, (
+        "fork-report step (id: fork_report) is missing. Fork PRs cannot reach "
+        "any write fallback, so without it the job's only visible failure is "
+        "'Resource not accessible by integration'."
+    )
+    cond = report.get("if", "")
+    assert isinstance(cond, str)
+    assert "is_fork == 'true'" in cond, "fork_report must be gated on the fork branch"
+
+    run = report.get("run", "")
+    assert isinstance(run, str)
+    assert "GITHUB_STEP_SUMMARY" in run, "fork_report must render the drift into the job summary"
+    assert "::error" in run, "fork_report must emit an error annotation so the message shows on the check"
+    assert "regen.err" in run, "fork_report must render the captured '[regen] ...' diagnostics"
+    assert re.search(r"^\s*exit 1\s*$", run, re.MULTILINE), (
+        "fork_report must fail the job; a green check on unresolved drift tells the contributor there is nothing to do"
+    )
+    assert report.get("continue-on-error") is not True, (
+        "fork_report must not continue-on-error -- failing the job is the point"
+    )
+
+
+def test_write_fallbacks_are_gated_off_forks(autofix_steps: list[dict[str, object]]) -> None:
+    """Both write fallbacks must require a same-repo PR.
+
+    Each one calls an API that a fork PR's read-only token cannot reach, and a
+    403 there is strictly worse than not trying: it replaces the drift message
+    with a GitHub permissions error.
+    """
+    for step_id, api in (("issue_fallback", "issues.create"), ("comment", "issues.createComment")):
+        step = next((s for s in autofix_steps if s.get("id") == step_id), None)
+        assert step is not None, f"{step_id} step is missing"
+        cond = step.get("if", "")
+        assert isinstance(cond, str)
+        assert "is_fork == 'false'" in cond, (
+            f"{step_id} calls {api}, which needs a write-scoped token. It must be "
+            "gated on steps.forkcheck.outputs.is_fork == 'false'."
+        )
+
+
+def test_issue_body_carries_the_regen_diagnostics(
+    autofix_steps: list[dict[str, object]],
+) -> None:
+    """The same-repo tracking issue must say *what* drifted, not just that it did."""
+    step = next((s for s in autofix_steps if s.get("id") == "issue_fallback"), None)
+    assert step is not None
+    run = step.get("run", "")
+    assert isinstance(run, str)
+    assert "regen.err" in run, (
+        "the tracking issue must quote the captured '[regen] ...' diagnostics. "
+        "Listing possible reasons without the actual one makes the reader open "
+        "the run log to find what the bot already knew."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behavioural: run the report script under the runner's real shell
+# ---------------------------------------------------------------------------
+
+# GitHub runs ``run:`` blocks under ``bash --noprofile --norc -eo pipefail``,
+# not plain bash. The difference is not cosmetic here: ``VAR="$(grep ...)"``
+# takes grep's exit status, grep exits 1 when it matches nothing, and ``-e``
+# then aborts the step -- writing no summary and no annotation, which is the
+# silent failure this step exists to prevent. Running the script by hand under
+# plain bash hides that entirely, so exercise it under the real flags.
+_RUNNER_SHELL = ("bash", "--noprofile", "--norc", "-eo", "pipefail")
+
+
+def _fork_report_script(steps: list[dict[str, object]]) -> str:
+    step = next((s for s in steps if s.get("id") == "fork_report"), None)
+    assert step is not None, "fork_report step is missing"
+    run = step.get("run")
+    assert isinstance(run, str)
+    return run
+
+
+def _run_fork_report(
+    script: str,
+    tmp_path: Path,
+    *,
+    regen_err: str,
+    patch: str | None,
+    regen_changed: str,
+    reverify_status: str,
+) -> tuple[int, str, str]:
+    """Execute the step script and return (exit code, summary, annotations)."""
+    runner_temp = tmp_path / "runner_temp"
+    runner_temp.mkdir()
+    (runner_temp / "regen.err").write_text(regen_err, encoding="utf-8")
+    if patch is not None:
+        (runner_temp / "contract-drift.patch").write_text(patch, encoding="utf-8")
+    summary = tmp_path / "summary.md"
+    summary.touch()
+    script_file = tmp_path / "fork_report.sh"
+    script_file.write_text(script, encoding="utf-8")
+
+    completed = subprocess.run(
+        [*_RUNNER_SHELL, str(script_file)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "RUNNER_TEMP": str(runner_temp),
+            "GITHUB_STEP_SUMMARY": str(summary),
+            "REGEN_CHANGED": regen_changed,
+            "REVERIFY_STATUS": reverify_status,
+            "LOC_DELTA": "4",
+            "RUN_URL": "https://example.invalid/runs/1",
+        },
+    )
+    return completed.returncode, summary.read_text(encoding="utf-8"), completed.stdout
+
+
+# The two stderr lines run 31906285880 actually produced.
+_PR_3903_STDERR = (
+    "[regen] UNDOCUMENTED_EXEMPTIONS: registered, but neither documented in "
+    "cli-reference.md nor exempt: receipt\n"
+    "[regen] This fixture does not patch itself: an exemption records a decision, "
+    "and a bot-written one records none.\n"
+)
+
+
+@pytest.mark.parametrize(
+    ("label", "regen_err", "patch", "regen_changed", "reverify_status"),
+    [
+        # PR #3903: regen declined to patch, so it wrote diagnostics and no diff.
+        ("unpatchable", _PR_3903_STDERR, None, "false", ""),
+        # Regen patched cleanly, but the bot cannot push to a fork head ref.
+        ("patchable", "", "--- a/x\n+++ b/x\n+line\n", "true", "0"),
+        # Nothing on stderr and no patch: the step still has to say something.
+        ("silent", "", None, "", ""),
+    ],
+)
+def test_fork_report_script_always_reports_and_fails(
+    autofix_steps: list[dict[str, object]],
+    tmp_path: Path,
+    label: str,
+    regen_err: str,
+    patch: str | None,
+    regen_changed: str,
+    reverify_status: str,
+) -> None:
+    """Under the runner's shell, every branch writes a summary and exits 1."""
+    code, summary, stdout = _run_fork_report(
+        _fork_report_script(autofix_steps),
+        tmp_path,
+        regen_err=regen_err,
+        patch=patch,
+        regen_changed=regen_changed,
+        reverify_status=reverify_status,
+    )
+
+    assert code == 1, f"[{label}] the step must fail so the check goes red on the drift"
+    assert summary.strip(), (
+        f"[{label}] the job summary is empty. A red check with nothing in the "
+        "summary is the failure this step was added to remove."
+    )
+    assert "Contract drift" in summary, f"[{label}] summary must name what failed"
+    annotations = [ln for ln in stdout.splitlines() if ln.startswith("::error")]
+    assert len(annotations) == 1, f"[{label}] expected exactly one error annotation, got {annotations}"
+    assert annotations[0].partition("::")[2].strip(), f"[{label}] the annotation body must not be empty"
+
+
+def test_fork_report_surfaces_the_undocumented_command(
+    autofix_steps: list[dict[str, object]],
+    tmp_path: Path,
+) -> None:
+    """The contributor must read the drift, not a GitHub permissions error.
+
+    Pins the specific message from run 31906285880 end to end: the command name
+    reaches the summary, and the annotation -- the line rendered on the check
+    itself -- carries the actionable half rather than a generic pointer.
+    """
+    _, summary, stdout = _run_fork_report(
+        _fork_report_script(autofix_steps),
+        tmp_path,
+        regen_err=_PR_3903_STDERR,
+        patch=None,
+        regen_changed="false",
+        reverify_status="",
+    )
+
+    assert "nor exempt: receipt" in summary, "the undocumented command must appear in the summary"
+    assert "cli-reference.md" in summary, "the summary must point at the file to edit"
+    assert "Resource not accessible" not in summary
+
+    annotation = next(ln for ln in stdout.splitlines() if ln.startswith("::error"))
+    assert "nor exempt: receipt" in annotation, (
+        "the check annotation must carry the drift itself; a contributor who "
+        "reads only the red check line has to learn what to fix from it"
+    )
+
+
+def test_fork_report_renders_the_patch_when_regen_produced_one(
+    autofix_steps: list[dict[str, object]],
+    tmp_path: Path,
+) -> None:
+    """A fork PR cannot be pushed to or commented on, so the patch goes here."""
+    patch = "--- a/tests/unit/test_api_v1_routing.py\n+++ b/tests/unit/test_api_v1_routing.py\n+    '/healthz',\n"
+    _, summary, _ = _run_fork_report(
+        _fork_report_script(autofix_steps),
+        tmp_path,
+        regen_err="",
+        patch=patch,
+        regen_changed="true",
+        reverify_status="0",
+    )
+
+    assert "/healthz" in summary, "the regen patch must be rendered for the contributor to apply"
+    assert "regen_contract_drift.py --fixture all" in summary, "and the command that reproduces it"
+
+
+# ---------------------------------------------------------------------------
+# Behavioural: replay the step guards for fork == true and fork == false
+# ---------------------------------------------------------------------------
+
+_STEP_OUTPUT_REF = re.compile(r"steps\.([A-Za-z_][\w-]*)\.outputs\.([A-Za-z_][\w-]*)")
+_STEP_OUTCOME_REF = re.compile(r"steps\.([A-Za-z_][\w-]*)\.outcome")
+_EXPR_RESIDUE = re.compile(r"\b(?:and|or|not)\b|==|!=|[()\s]")
+
+
+def _eval_if(expr: str, state: dict[str, dict[str, object]]) -> bool:
+    """Evaluate the slice of GitHub expression syntax these guards use.
+
+    Only ``steps.*`` references, single-quoted literals, ``&&``/``||``/``!``,
+    and ``==``/``!=`` appear in this workflow's step guards. Anything left over
+    after substitution is rejected rather than guessed at, so a guard that
+    later starts reading ``github.event.*`` fails this test loudly instead of
+    evaluating to something arbitrary.
+    """
+
+    def _outputs(match: re.Match[str]) -> str:
+        step, key = match.group(1), match.group(2)
+        outputs = state.get(step, {}).get("outputs", {})
+        assert isinstance(outputs, dict)
+        # A step that did not run contributes '' for every output, exactly as
+        # the real steps context does.
+        return repr(outputs.get(key, ""))
+
+    def _outcome(match: re.Match[str]) -> str:
+        return repr(state.get(match.group(1), {}).get("outcome", "skipped"))
+
+    py = _STEP_OUTCOME_REF.sub(_outcome, _STEP_OUTPUT_REF.sub(_outputs, expr))
+    py = py.replace("&&", " and ").replace("||", " or ")
+    py = re.sub(r"!(?!=)", " not ", py)
+
+    residue = _EXPR_RESIDUE.sub("", re.sub(r"'[^']*'", "", py)).strip()
+    assert not residue, f"unsupported tokens {residue!r} in condition {expr!r}"
+    return bool(eval(py, {"__builtins__": {}}, {}))
+
+
+def _steps_that_run(
+    steps: list[dict[str, object]],
+    results: dict[str, dict[str, object]],
+) -> list[str]:
+    """Replay every step guard in order and return the labels GitHub would run.
+
+    ``results`` maps a step id to the outputs and outcome it produces *when it
+    runs*; a step whose guard is false is recorded as skipped with empty
+    outputs, which is what downstream guards read.
+
+    Step failure is not modelled: no guard in this workflow uses a status
+    function, so a failing step ends the job and everything after it is
+    skipped. :func:`test_fork_pr_stops_at_the_report_step` pins that the
+    reporting step is the last one eligible to run on a fork, which is what
+    makes the omission safe.
+    """
+    state: dict[str, dict[str, object]] = {}
+    ran: list[str] = []
+    for step in steps:
+        step_id = step.get("id")
+        label = step_id or step.get("name") or "<unnamed>"
+        cond = step.get("if")
+        runs = cond is None or _eval_if(str(cond), state)
+        if isinstance(step_id, str):
+            state[step_id] = (
+                results.get(step_id, {"outputs": {}, "outcome": "success"})
+                if runs
+                else {"outputs": {}, "outcome": "skipped"}
+            )
+        if runs:
+            assert isinstance(label, str)
+            ran.append(label)
+    return ran
+
+
+def _results(
+    *,
+    drift: bool,
+    is_fork: bool,
+    regen_changed: bool = False,
+    reverify_ok: bool = False,
+    pushed: bool = True,
+) -> dict[str, dict[str, object]]:
+    """Build the step-context outputs for one end-to-end scenario."""
+    return {
+        "forkcheck": {"outputs": {"is_fork": "true" if is_fork else "false"}, "outcome": "success"},
+        "drift": {
+            "outputs": {"drift": "true" if drift else "false", "status": "1" if drift else "0"},
+            "outcome": "success",
+        },
+        "regen": {"outputs": {"regen_status": "0" if regen_changed else "1"}, "outcome": "success"},
+        "verify": {"outputs": {"changed": "true" if regen_changed else "false"}, "outcome": "success"},
+        "reverify": {"outputs": {"status": "0" if reverify_ok else "1"}, "outcome": "success"},
+        "inline_push": {
+            "outputs": {"pushed": "true"} if pushed else {},
+            "outcome": "success" if pushed else "failure",
+        },
+    }
+
+
+def test_fork_pr_with_unpatchable_drift_reports_instead_of_opening_an_issue(
+    autofix_steps: list[dict[str, object]],
+) -> None:
+    """The exact shape of PR #3903 / run 31906285880.
+
+    ``receipt`` was registered but neither documented nor exempt, regen refused
+    to patch it (an exemption records a decision, and a bot-written one records
+    none), so no diff was produced. The job then tried ``gh issue create``
+    against a read-only token and failed on the permission error, hiding the
+    one line the contributor needed.
+    """
+    ran = _steps_that_run(autofix_steps, _results(drift=True, is_fork=True))
+
+    assert "fork_report" in ran, "a fork PR with unpatchable drift must reach the reporting step"
+    assert "issue_fallback" not in ran, (
+        "the tracking-issue fallback must not run on a fork PR: createIssue 403s "
+        "on the read-only token and the permission error replaces the drift message"
+    )
+    assert "comment" not in ran, "createComment 403s on a fork PR for the same reason"
+    assert "inline_push" not in ran, "there is no push access to a fork head ref"
+
+
+def test_fork_pr_with_patchable_drift_also_reports_instead_of_commenting(
+    autofix_steps: list[dict[str, object]],
+) -> None:
+    """The patchable branch on a fork hits the same read-only token."""
+    ran = _steps_that_run(
+        autofix_steps,
+        _results(drift=True, is_fork=True, regen_changed=True, reverify_ok=True),
+    )
+
+    assert "fork_report" in ran, "a fork PR with a working patch must still get the patch rendered somewhere"
+    assert "comment" not in ran
+    assert "issue_fallback" not in ran
+    assert "inline_push" not in ran
+
+
+def test_fork_pr_stops_at_the_report_step(autofix_steps: list[dict[str, object]]) -> None:
+    """Nothing is eligible to run after the fork report, so its exit 1 loses nothing.
+
+    ``fork_report`` fails the job, and no guard here uses ``always()`` or
+    ``failure()``. This pins the assumption that makes that safe: on a fork, the
+    report is the last eligible step in either drift shape.
+    """
+    for regen_changed, reverify_ok in ((False, False), (True, True)):
+        ran = _steps_that_run(
+            autofix_steps,
+            _results(drift=True, is_fork=True, regen_changed=regen_changed, reverify_ok=reverify_ok),
+        )
+        assert ran[-1] == "fork_report", (
+            f"steps run after fork_report for changed={regen_changed}: {ran[ran.index('fork_report') + 1 :]}. "
+            "fork_report fails the job, so anything after it would be skipped rather than run."
+        )
+
+
+def test_same_repo_pr_with_unpatchable_drift_still_opens_the_issue(
+    autofix_steps: list[dict[str, object]],
+) -> None:
+    """The write path is unchanged where the token can actually write."""
+    ran = _steps_that_run(autofix_steps, _results(drift=True, is_fork=False))
+
+    assert "issue_fallback" in ran, "same-repo PRs keep the tracking-issue fallback"
+    assert "fork_report" not in ran, "the fork report must not fire on a same-repo PR"
+    assert "comment" not in ran, "regen produced no patch, so there is nothing to comment"
+
+
+def test_same_repo_pr_with_patchable_drift_pushes_inline(
+    autofix_steps: list[dict[str, object]],
+) -> None:
+    ran = _steps_that_run(
+        autofix_steps,
+        _results(drift=True, is_fork=False, regen_changed=True, reverify_ok=True),
+    )
+
+    assert "inline_push" in ran, "the primary path must still commit the regen to the source PR head ref"
+    assert "comment" not in ran, "no comment when the push succeeded"
+    assert "issue_fallback" not in ran
+    assert "fork_report" not in ran
+
+
+def test_same_repo_pr_falls_back_to_a_comment_when_the_push_fails(
+    autofix_steps: list[dict[str, object]],
+) -> None:
+    """Branch protection or a lease conflict still routes to the PR comment."""
+    ran = _steps_that_run(
+        autofix_steps,
+        _results(drift=True, is_fork=False, regen_changed=True, reverify_ok=True, pushed=False),
+    )
+
+    assert "inline_push" in ran
+    assert "comment" in ran, "a rejected push must still surface the patch on the PR"
+    assert "issue_fallback" not in ran
+    assert "fork_report" not in ran
+
+
+def test_clean_pr_runs_no_reporting_step(autofix_steps: list[dict[str, object]]) -> None:
+    """No drift means no regen, no report, no issue -- on a fork or otherwise."""
+    for is_fork in (True, False):
+        ran = _steps_that_run(autofix_steps, _results(drift=False, is_fork=is_fork))
+        for step_id in ("regen", "verify", "reverify", "inline_push", "comment", "issue_fallback", "fork_report"):
+            assert step_id not in ran, f"{step_id} ran on a PR with no drift (is_fork={is_fork})"
 
 
 def test_step_actions_are_sha_pinned(autofix_steps: list[dict[str, object]]) -> None:


### PR DESCRIPTION
## What

Fork PRs that hit contract drift now fail with the drift itself in the job summary and the check annotation, instead of failing on `Resource not accessible by integration`.

## Why

`permissions:` is a ceiling, not a grant. On a `pull_request` event raised from a fork, GitHub caps `GITHUB_TOKEN` at read for every scope regardless of what the workflow or job asks for.

The tracking-issue fallback called `gh issue create` anyway:

```
GraphQL: Resource not accessible by integration (createIssue)
##[error]Process completed with exit code 1.
```

Observed on #3903 (run 31906285880, job 95064524942). The drift there was legitimate and actionable - `registered, but neither documented in cli-reference.md nor exempt: receipt` - but that line only ever reached the raw step log. What the contributor saw on the red check was a GitHub permissions error, which points at something they cannot change.

The PR-comment fallback carried the same defect one branch over: it was written to serve fork PRs, but `createComment` needs the same write scope it cannot have there. It did not fire on #3903 only because that drift was unpatchable. Fixing just the issue path would have left fork PRs with *patchable* drift dying the same way, so both are fixed.

## How

Fork PRs terminate at a new report-only step. Both write fallbacks are gated to same-repo PRs, where the token can actually write; those paths are otherwise unchanged.

| Scenario | `inline_push` | `comment` | `issue_fallback` | `fork_report` |
|---|---|---|---|---|
| fork, unpatchable (#3903) | - | - | - | **RUN** |
| fork, patchable | - | - | - | **RUN** |
| same-repo, unpatchable | - | - | **RUN** | - |
| same-repo, patchable, push ok | **RUN** | - | - | - |
| same-repo, push rejected | **RUN** | **RUN** | - | - |
| no drift (either) | - | - | - | - |

Supporting changes:

- The regen step splits stdout and stderr into files so the actionable half can be read back. The actionable lines go to stderr; stdout carries only progress chatter. Both are still replayed into the job log, so the run output is unchanged.
- The tracking issue quotes the diagnostics instead of only listing the reasons drift might not be auto-patchable.
- `docs/operations/ci.md` gains a section on the fork read-only-token rule, since it applies to any lane whose only output is a write.

## What a reviewer should know

**A bug found during verification.** GitHub runs `run:` blocks under `bash --noprofile --norc -eo pipefail`, not plain bash. `VAR="$(grep ...)"` takes grep's exit status, grep exits 1 on no match, and `-e` then aborts the step - writing **no summary and no annotation**, reproducing the exact failure class this PR removes. Testing the script under plain bash hid it completely. Every grep is now `|| true`, the scripts declare `set -euo pipefail` so local runs match CI, and one test executes the script under the runner's real flags.

**Behaviour change on fork PRs.** The job now fails where it previously failed anyway (with a worse message), so no green-to-red regression. `contract-drift-autofix` is advisory, not gating, so the red check does not block a merge - it just says what to fix.

**Test approach.** Alongside the structural assertions, `_steps_that_run` evaluates the `if:` guards against a simulated step context, so routing is verified for `head.repo.fork == true` and `== false` rather than by grepping for a substring. The simulator reproduces run 31906285880's step conclusions exactly. Unsupported expression tokens raise rather than being guessed at, so a guard that later reads `github.event.*` fails loudly.

Both fixes are mutation-tested: reverting the `|| true` fails 3 tests; restoring the missing fork gate fails 3 others.

## Checklist

- [x] `uv run ruff check src/` passes (no `src/` changes in this PR; run to confirm)
- [x] `uv run pyright src/` - no `src/` changes; `mypy` clean on the changed test module
- [x] Targeted suites pass: 436 tests across the workflow guards and the three contract detectors, plus `actionlint` clean on the changed workflow. Full `scripts/run_tests.py` not run locally; CI covers it.
- [x] New code has type hints

### Documentation duty

- [x] README - N/A (CI-internal behaviour)
- [x] `docs/operations/ci.md` updated
- [x] `docs/api/` - N/A (no public surface change)
- [x] `bernstein agents-md sync` - N/A (no new module)
- [x] Tests cover the documented behaviour

Refs #1273.
