### PR TITLE
feat(volunteer): derived, content-addressed hardened sandbox profile

### DIFF
--- a/docs/reference/volunteer-sandbox.md
+++ b/docs/reference/volunteer-sandbox.md
@@ -1,0 +1,123 @@
+# Volunteer sandbox profile
+
+Volunteer tasks are hostile input by default. The issue text comes from a
+repository the donor does not control, the patch is written by a model reading
+that text, and the whole thing executes on a stranger's laptop. The `volunteer`
+sandbox profile is the boundary that makes the rest of the program safe to run.
+
+## The profile is derived, not chosen
+
+"The sandbox was hardened" is not a checkable statement. So the profile is a
+pure function of the project's [manifest](volunteer-manifest.md) plus the
+donor's own limits, and it is content-addressed. Its digest is what a result
+receipt records, and it binds the manifest digest it came from:
+
+```
+manifest bytes → manifest digest → sandbox profile digest → receipt bundle
+```
+
+A maintainer recomputes the manifest digest from the repository at the commit
+the submission names, rebuilds the profile from it, and compares. A profile
+that does not reproduce means the run was not contained the way the receipt
+says it was.
+
+The consequence worth stating plainly: **a donor cannot loosen containment and
+still produce a verifying receipt.** There is no flag for it, because a flag
+would have to appear in the digest, and a digest that says "egress was open" is
+not a digest anybody accepts.
+
+## What the boundary is
+
+| Control | Rule |
+|---|---|
+| Backend | microVM where the host has one; container-with-user-space-kernel as fallback. A plain container is refused unless the project manifest **and** the donor both accept it, and that acceptance is in the digest. |
+| Egress | Deny-all, plus the manifest's `egress_allowlist`, plus the package registries the gates need. |
+| Credentials | Nothing from the host environment reaches the sandbox. The environment is built from the profile alone. |
+| Resources | CPU, memory and wall clock, floored to the tighter of what the project asks and what the donor allows. |
+
+## Backend selection
+
+Order of preference: `microvm`, then `container-userns`, then `container`.
+
+A project whose manifest says `"sandbox": "microvm"` gets a microVM or gets a
+refusal — the field is a floor, and a floor that bends is decoration.
+
+A plain container shares the host kernel. It runs only when both the project
+accepts it and the donor has said so. A donor who never said "you may share my
+kernel with a stranger's code" has not said it by installing the software.
+
+## Egress, and how far the enforcement actually goes
+
+Naming hosts in a list enforces nothing by itself. Two mechanisms carry it:
+
+**No reachable host at all** becomes a sandbox with no network interface. That
+one is complete.
+
+**Some reachable hosts** become a pinned resolver: the allowlisted names are
+resolved on the host side and passed as static entries, and the sandbox is
+given a resolver that answers nothing. Names outside the list do not resolve.
+
+The limit, stated rather than implied: **a connection to a raw IP address does
+not consult DNS**, so DNS pinning does not stop it. Closing that needs
+packet-level filtering — the microVM backend's own network policy, or a
+filtering proxy the sandbox is forced through. Until that lands, a project
+whose threat model includes exfiltration to a hard-coded address should declare
+an empty `egress_allowlist` and vendor its dependencies, which turns the
+network off completely.
+
+Host-side DNS resolution is the caller's job rather than the profile's: a
+profile has to rebuild identically on a machine with different DNS answers, or
+its digest would depend on the weather.
+
+## Credentials
+
+The sandbox environment is built from the profile, never filtered from
+`os.environ`. A filter over the host environment is only as good as its
+denylist, and the thing on the other side of this boundary is reading a
+stranger's issue text; an allowlist that starts from nothing has no denylist to
+be wrong about.
+
+The permitted names are `BERNSTEIN_VOLUNTEER`, `CI`, `HOME`, `LANG`, `LC_ALL`,
+`PATH`, `TMPDIR` — and `HOME` points inside the workspace, not at the donor's
+real home, which is where credentials live.
+
+Adapter credentials are absent by construction rather than by exclusion: they
+belong to the adapter process, which runs outside this boundary.
+
+## Wall clock
+
+A donor lends their machine for a bounded time, and the bound has to be real.
+Exceeding it terminates the **process tree**, not just the process — gate
+commands fork workers, and killing only the parent leaves those running on a
+stranger's machine with nothing watching them.
+
+The kill is recorded: whether the cap fired, whether SIGTERM was enough, and
+whether SIGKILL was needed after the grace period. A command that needs SIGKILL
+is trapping signals or stuck uninterruptibly, and a project's maintainer should
+know that about their own gates.
+
+On Windows there is no process group to signal, so only the direct child is
+terminated. A Windows donor running a gate that forks can leave orphans; that
+is a known gap rather than a hidden one.
+
+## Refusals
+
+A refusal is a normal outcome on a mixed donor fleet, not an error condition.
+Each carries a stable machine-readable reason so a runner can record it without
+parsing prose:
+
+| Reason | Meaning |
+|---|---|
+| `microvm_required_but_unavailable` | The project demands a microVM; this host has none. |
+| `plain_container_needs_dual_opt_in` | Only a plain container is available and the donor has not accepted one. |
+| `no_acceptable_backend` | Nothing on this host is acceptable for volunteer work. |
+| `wall_clock_below_floor` | The effective time budget is under a minute. |
+| `memory_below_floor` | The effective memory ceiling is under 256 MB. |
+
+Refusals need the same structure as successes, or they become log lines nobody
+counts and "why did nothing ever run on my machine" becomes unanswerable.
+
+## Source
+
+`src/bernstein/core/volunteer/sandbox_profile.py`,
+`src/bernstein/core/volunteer/wall_clock.py`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -510,6 +510,7 @@ nav:
           - .well-known manifest: protocols/well-known-manifest.md
           - SPIFFE workload identity: reference/spiffe-workload-identity.md
           - Volunteer project manifest: reference/volunteer-manifest.md
+          - Volunteer sandbox profile: reference/volunteer-sandbox.md
           - MCP catalog: reference/mcp-catalog.md
           - MCP tool tiers: mcp/tool_tiers.md
       - Compatibility & limits:

--- a/src/bernstein/core/volunteer/__init__.py
+++ b/src/bernstein/core/volunteer/__init__.py
@@ -5,10 +5,15 @@ A project joins the volunteer program by committing one file,
 which gates a submission must pass, which paths a patch may touch, which
 hosts the sandbox may reach, and how long a task may run.
 
-The manifest is content-addressed.  Its canonical digest is the value a
-result receipt carries as ``manifest_sha256``, so a maintainer verifying a
+Both artefacts here are content-addressed, and the digests chain:
+
+    manifest bytes -> manifest digest -> sandbox profile digest -> receipt
+
+A result receipt carries the manifest digest as ``manifest_sha256`` and the
+profile digest as its sandbox identifier, so a maintainer verifying a
 volunteer's submission can prove the volunteer ran *the policy this project
-declared at that revision* rather than a policy the volunteer chose.
+declared* behind *the containment that policy implies* -- without taking
+anyone's word for either.
 """
 
 from __future__ import annotations
@@ -26,17 +31,51 @@ from bernstein.core.volunteer.manifest import (
     load_manifest_from_repo,
     manifest_digest,
 )
+from bernstein.core.volunteer.sandbox_profile import (
+    BACKEND_PREFERENCE,
+    PACKAGE_REGISTRY_HOSTS,
+    SANDBOX_ENV_ALLOWLIST,
+    VOLUNTEER_PROFILE_NAME,
+    SandboxProfileRefusal,
+    VolunteerSandboxProfile,
+    backend_options,
+    build_volunteer_profile,
+    describe_refusal,
+    effective_egress,
+    profile_matches,
+    sandbox_env,
+)
+from bernstein.core.volunteer.wall_clock import (
+    TERM_GRACE_SECONDS,
+    WallClockOutcome,
+    run_under_wall_clock,
+)
 
 __all__ = [
+    "BACKEND_PREFERENCE",
     "OSI_APPROVED_LICENSES",
+    "PACKAGE_REGISTRY_HOSTS",
+    "SANDBOX_ENV_ALLOWLIST",
     "SUPPORTED_SCHEMA_VERSIONS",
+    "TERM_GRACE_SECONDS",
     "VOLUNTEER_MANIFEST_PATH",
+    "VOLUNTEER_PROFILE_NAME",
     "GateCommand",
+    "SandboxProfileRefusal",
     "UnenforcedManifestFieldWarning",
     "VolunteerManifest",
     "VolunteerManifestError",
+    "VolunteerSandboxProfile",
+    "WallClockOutcome",
+    "backend_options",
+    "build_volunteer_profile",
     "canonical_manifest_bytes",
+    "describe_refusal",
+    "effective_egress",
     "load_manifest",
     "load_manifest_from_repo",
     "manifest_digest",
+    "profile_matches",
+    "run_under_wall_clock",
+    "sandbox_env",
 ]

--- a/src/bernstein/core/volunteer/sandbox_profile.py
+++ b/src/bernstein/core/volunteer/sandbox_profile.py
@@ -1,0 +1,424 @@
+"""The containment boundary a volunteer task runs behind.
+
+Volunteer tasks are hostile input by default.  The issue text comes from a
+repository the donor does not control, the patch is written by a model reading
+that text, and the whole thing executes on a stranger's laptop.  This module
+is the boundary that makes the rest of the program safe to run.
+
+Why the profile is derived and not chosen
+-----------------------------------------
+
+"The sandbox was hardened" is not a checkable statement.  Every containment
+claim in this program has to survive a maintainer asking *prove it*, months
+later, from a receipt and a git commit.
+
+So the profile is a pure function of the project's declared manifest plus the
+donor's own limits, and it is content-addressed.  :attr:`VolunteerSandboxProfile.digest`
+is the value a result receipt carries as its sandbox profile identifier, and it
+binds :attr:`VolunteerSandboxProfile.manifest_sha256` -- the digest of the
+policy it was derived from.  That gives a verifier a chain with no operator
+testimony in it:
+
+    manifest bytes -> manifest digest -> profile digest -> receipt bundle
+
+Recompute the manifest digest from the repository at the commit the submission
+names, rebuild the profile from it, and compare.  A profile that does not
+reproduce means the run was not contained the way the receipt says it was, and
+that is a refusal rather than a conversation.
+
+The consequence worth stating plainly: the donor cannot loosen containment and
+still produce a verifying receipt.  There is no flag for it, because a flag
+would have to appear in the digest, and a digest that says "egress was open"
+is not a digest anybody accepts.
+
+What the boundary actually is
+-----------------------------
+
+*Backend.*  microVM where the host has one; the container backend as fallback.
+A plain container -- no user-space kernel -- is refused unless the project
+manifest and the donor both accept it, and the acceptance is recorded in the
+digest so it cannot be quiet.
+
+*Egress.*  Deny-all, plus the manifest's ``egress_allowlist``, plus the package
+registries the gates need to resolve dependencies.  An empty effective list
+means the network is off, not "off by convention".
+
+*Credentials.*  Nothing from the host environment reaches the task sandbox
+except an explicit allowlist of non-secret variables.  Adapter credentials
+belong to the adapter process, which runs outside this boundary; they are
+never part of the sandbox environment.  :func:`sandbox_env` builds that
+environment from the profile alone and never reads ``os.environ``, which is
+what makes the canary test a test of the seam rather than of a filter.
+
+*Resources.*  CPU, memory and wall clock, floored to the tighter of what the
+project asks and what the donor allows.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Mapping
+
+    from bernstein.core.volunteer.manifest import VolunteerManifest
+
+#: Name the profile registers under, and the value a receipt records.
+VOLUNTEER_PROFILE_NAME = "volunteer"
+
+#: Backends acceptable for volunteer work, strongest first.
+#:
+#: ``container-userns`` is the container backend running on a user-space
+#: kernel; ``container`` is a plain one sharing the host kernel, and it is the
+#: only entry that needs a second opinion before it may be used.
+BACKEND_PREFERENCE: tuple[str, ...] = ("microvm", "container-userns", "container")
+
+#: Backends that contain a kernel exploit as well as a process escape.
+STRONG_BACKENDS = frozenset({"microvm", "container-userns"})
+
+#: Package registries a gate command needs to resolve dependencies.
+#:
+#: These are not a convenience.  Without them almost every real project's gates
+#: fail to install anything and the program is unusable, so the choice is
+#: between naming the set explicitly here -- where it is reviewable and hashed
+#: into every profile -- and having each project paste its own list into a
+#: manifest nobody audits.
+PACKAGE_REGISTRY_HOSTS: tuple[str, ...] = (
+    "crates.io",
+    "files.pythonhosted.org",
+    "index.crates.io",
+    "proxy.golang.org",
+    "pypi.org",
+    "registry.npmjs.org",
+    "repo.maven.apache.org",
+    "rubygems.org",
+    "static.crates.io",
+    "sum.golang.org",
+)
+
+#: Environment variables a task sandbox may see.
+#:
+#: Deliberately tiny and deliberately not derived from
+#: :mod:`bernstein.adapters.env_isolation`: that allowlist is built for adapter
+#: processes, which legitimately carry provider credentials.  This one is for
+#: the process running a stranger's code, and it has no reason to carry
+#: anything a credential could hide behind.  ``PATH`` and the locale are the
+#: whole of it, plus a marker so a gate script can tell where it is.
+SANDBOX_ENV_ALLOWLIST: tuple[str, ...] = (
+    "BERNSTEIN_VOLUNTEER",
+    "CI",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "PATH",
+    "TMPDIR",
+)
+
+_DEFAULT_MEMORY_MB = 2048
+_DEFAULT_CPU_QUOTA_US = 200_000
+
+
+class SandboxProfileRefusal(RuntimeError):
+    """No profile can be built that satisfies both sides.
+
+    A refusal is a normal outcome, not an error condition: it means the donor's
+    machine cannot offer what the project requires, or the project asked for
+    containment weaker than either party accepts.  Carries ``reason`` as a
+    stable machine-readable code so a runner can record it without parsing
+    prose.
+    """
+
+    def __init__(self, reason: str, message: str) -> None:
+        self.reason = reason
+        super().__init__(message)
+
+
+@dataclass(frozen=True, slots=True)
+class VolunteerSandboxProfile:
+    """The containment decision for one volunteer task, as a value.
+
+    Every field is part of the digest.  A field that could vary without moving
+    the digest would be a containment knob a donor could turn while still
+    producing a receipt that verifies.
+
+    Attributes:
+        manifest_sha256: Digest of the manifest this profile was derived from.
+        backend: Sandbox backend, one of :data:`BACKEND_PREFERENCE`.
+        egress_allowlist: The complete set of hosts reachable from inside,
+            sorted and deduplicated.  Empty means the network is off.
+        env_allowlist: Environment variable names the sandbox may see.
+        memory_mb: Memory ceiling.
+        cpu_quota_us: CFS quota against a 100 ms period.
+        wall_clock_seconds: Hard ceiling on the task; exceeding it is a kill.
+        plain_container_accepted: Whether both sides opted in to a sandbox
+            without a user-space kernel.  Recorded even when false, so the
+            digest distinguishes "was not needed" from "was not asked".
+    """
+
+    manifest_sha256: str
+    backend: str
+    egress_allowlist: tuple[str, ...]
+    env_allowlist: tuple[str, ...]
+    memory_mb: int
+    cpu_quota_us: int
+    wall_clock_seconds: int
+    plain_container_accepted: bool
+
+    @property
+    def network_enabled(self) -> bool:
+        """Whether any host is reachable at all."""
+        return bool(self.egress_allowlist)
+
+    @property
+    def name(self) -> str:
+        return VOLUNTEER_PROFILE_NAME
+
+    def to_canonical_dict(self) -> dict[str, Any]:
+        return {
+            "backend": self.backend,
+            "cpu_quota_us": self.cpu_quota_us,
+            "egress_allowlist": list(self.egress_allowlist),
+            "env_allowlist": list(self.env_allowlist),
+            "manifest_sha256": self.manifest_sha256,
+            "memory_mb": self.memory_mb,
+            "plain_container_accepted": self.plain_container_accepted,
+            "profile": VOLUNTEER_PROFILE_NAME,
+            "wall_clock_seconds": self.wall_clock_seconds,
+        }
+
+    @property
+    def digest(self) -> str:
+        """Content address of the containment decision, 64 hex characters."""
+        payload = json.dumps(
+            self.to_canonical_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+
+def build_volunteer_profile(
+    manifest: VolunteerManifest,
+    *,
+    available_backends: Collection[str],
+    donor_accepts_plain_container: bool = False,
+    donor_wall_clock_minutes: int | None = None,
+    donor_memory_mb: int | None = None,
+) -> VolunteerSandboxProfile:
+    """Derive the containment boundary from the project's policy and the donor's.
+
+    Pure: same manifest and same donor limits give the same profile and so the
+    same digest, on any machine, at any time.  That is what lets a maintainer
+    rebuild the profile from the repository months later and compare.
+
+    Args:
+        manifest: The project's declared policy.
+        available_backends: Backends this host can actually provide.
+        donor_accepts_plain_container: Whether the donor consented to running
+            without a user-space kernel.  Half of the dual opt-in.
+        donor_wall_clock_minutes: The donor's own ceiling.  The effective limit
+            is the tighter of this and the manifest's.
+        donor_memory_mb: The donor's memory ceiling, same rule.
+
+    Raises:
+        SandboxProfileRefusal: The host offers nothing the project accepts, or
+            a plain container is the only option and both sides did not agree
+            to it.
+    """
+    backend = _select_backend(
+        manifest_minimum=manifest.sandbox,
+        available_backends=available_backends,
+        donor_accepts_plain_container=donor_accepts_plain_container,
+    )
+
+    wall_clock_minutes = manifest.max_wall_clock_minutes
+    if donor_wall_clock_minutes is not None:
+        wall_clock_minutes = min(wall_clock_minutes, donor_wall_clock_minutes)
+    if wall_clock_minutes < 1:
+        raise SandboxProfileRefusal(
+            "wall_clock_below_floor",
+            f"effective wall clock is {wall_clock_minutes} minutes; a task needs at least 1",
+        )
+
+    memory_mb = _DEFAULT_MEMORY_MB if donor_memory_mb is None else min(_DEFAULT_MEMORY_MB, donor_memory_mb)
+    if memory_mb < 256:
+        raise SandboxProfileRefusal(
+            "memory_below_floor",
+            f"effective memory ceiling is {memory_mb} MB; a task needs at least 256",
+        )
+
+    return VolunteerSandboxProfile(
+        manifest_sha256=manifest.digest,
+        backend=backend,
+        egress_allowlist=effective_egress(manifest),
+        env_allowlist=SANDBOX_ENV_ALLOWLIST,
+        memory_mb=memory_mb,
+        cpu_quota_us=_DEFAULT_CPU_QUOTA_US,
+        wall_clock_seconds=wall_clock_minutes * 60,
+        plain_container_accepted=donor_accepts_plain_container,
+    )
+
+
+def effective_egress(manifest: VolunteerManifest) -> tuple[str, ...]:
+    """Every host the sandbox may reach, sorted and deduplicated.
+
+    A project that lists no hosts still gets the package registries, because
+    otherwise its gates cannot install anything and the profile is a costume.
+    A project that wants a genuinely airgapped run vendors its dependencies and
+    the registries go unused -- unreachable-but-listed is not a weakening,
+    since nothing in the sandbox is obliged to connect.
+    """
+    return tuple(sorted({*manifest.egress_allowlist, *PACKAGE_REGISTRY_HOSTS}))
+
+
+def sandbox_env(profile: VolunteerSandboxProfile, *, path: str = "/usr/local/bin:/usr/bin:/bin") -> dict[str, str]:
+    """Build the task sandbox's environment from the profile alone.
+
+    Never reads ``os.environ``.  A filter over the host environment is only as
+    good as its denylist, and the thing on the other side of this boundary is
+    reading a stranger's issue text: an allowlist that starts from nothing has
+    no denylist to be wrong about.
+
+    Adapter credentials are absent by construction, not by exclusion -- they
+    live in the adapter process, which runs outside this sandbox.
+    """
+    values = {
+        "BERNSTEIN_VOLUNTEER": "1",
+        "CI": "1",
+        "HOME": "/workspace",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PATH": path,
+        "TMPDIR": "/tmp",
+    }
+    return {key: values[key] for key in profile.env_allowlist if key in values}
+
+
+def backend_options(
+    profile: VolunteerSandboxProfile,
+    *,
+    resolved_hosts: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Translate the profile into options the sandbox backends understand.
+
+    Kept next to the profile rather than inside a backend so the mapping from
+    "what was decided" to "what was configured" is one function a reviewer can
+    read, instead of a behaviour spread across four backends.
+
+    How the egress list is actually enforced, and how far that goes
+    ---------------------------------------------------------------
+
+    Naming hosts in a list enforces nothing by itself, and a field that looks
+    like a control but is not one is worse than no field: it reads as a
+    boundary in a review and is absent at runtime.  Two mechanisms carry it:
+
+    *No reachable host at all* becomes ``network_disabled``.  That one is
+    complete -- the container gets no interface.
+
+    *Some reachable hosts* become a pinned resolver: the allowlisted names are
+    resolved on the host side and passed as static host entries, and the
+    sandbox is given no DNS server.  Names outside the list do not resolve, so
+    ordinary client code cannot reach them.
+
+    The limit, stated rather than implied: a connection to a raw IP address
+    does not consult DNS, so DNS pinning does not stop it.  Closing that needs
+    packet-level filtering -- the microVM backend's own network policy, or a
+    filtering proxy the sandbox is forced through -- and that is a separate
+    change against the backends rather than against this decision layer.  Until
+    it lands, a project whose threat model includes exfiltration to a
+    hard-coded address should declare an empty ``egress_allowlist`` and vendor
+    its dependencies, which turns the network off completely.
+
+    Args:
+        profile: The containment decision.
+        resolved_hosts: Allowlisted hostname to IP address, resolved by the
+            caller.  Resolution is the caller's job because it is I/O and this
+            module is pure -- a profile has to rebuild identically on a machine
+            with different DNS answers, or the digest would depend on the
+            weather.
+    """
+    options: dict[str, Any] = {
+        "memory_mb": profile.memory_mb,
+        "cpu_quota": profile.cpu_quota_us,
+        "network_disabled": not profile.network_enabled,
+        "egress_allowlist": list(profile.egress_allowlist),
+        "timeout_seconds": profile.wall_clock_seconds,
+        "mount_home": False,
+        "inherit_host_env": False,
+    }
+    if not profile.network_enabled:
+        return options
+
+    allowed = set(profile.egress_allowlist)
+    entries = {host: address for host, address in (resolved_hosts or {}).items() if host in allowed}
+    options["extra_hosts"] = dict(sorted(entries.items()))
+    # An unroutable resolver rather than none: a container with no DNS
+    # configuration inherits the host's, which would resolve everything.
+    options["dns"] = ["0.0.0.0"]
+    return options
+
+
+def _select_backend(
+    *,
+    manifest_minimum: str,
+    available_backends: Collection[str],
+    donor_accepts_plain_container: bool,
+) -> str:
+    available = set(available_backends)
+
+    for candidate in BACKEND_PREFERENCE:
+        if candidate not in available:
+            continue
+        if candidate == "microvm":
+            return candidate
+        if manifest_minimum == "microvm":
+            # The project demanded a microVM and the host has not got one.
+            # Everything weaker is out regardless of what the donor accepts.
+            break
+        if candidate in STRONG_BACKENDS:
+            return candidate
+        if donor_accepts_plain_container:
+            return candidate
+        raise SandboxProfileRefusal(
+            "plain_container_needs_dual_opt_in",
+            "the only available sandbox is a plain container, which shares the host kernel; "
+            "the project accepts it but this donor has not, so nothing runs",
+        )
+
+    if manifest_minimum == "microvm":
+        raise SandboxProfileRefusal(
+            "microvm_required_but_unavailable",
+            f"the project requires a microVM sandbox; this host offers {sorted(available) or 'nothing'}",
+        )
+    raise SandboxProfileRefusal(
+        "no_acceptable_backend",
+        f"no sandbox backend on this host is acceptable for volunteer work; offered {sorted(available) or 'nothing'}",
+    )
+
+
+def profile_matches(profile: VolunteerSandboxProfile, *, expected_digest: str) -> bool:
+    """Whether a rebuilt profile is the one a receipt claims.
+
+    The verification side of the chain: a maintainer rebuilds the profile from
+    the manifest at the submitted commit and compares digests.
+    """
+    return profile.digest == expected_digest
+
+
+def describe_refusal(error: SandboxProfileRefusal, *, manifest_sha256: str) -> Mapping[str, str]:
+    """A refusal as a record, so a runner can persist it without prose parsing.
+
+    Refusals are the common case on a heterogeneous donor fleet.  They deserve
+    the same structure as a success, or they end up as log lines nobody counts.
+    """
+    return {
+        "outcome": "refused",
+        "reason": error.reason,
+        "detail": str(error),
+        "manifest_sha256": manifest_sha256,
+        "profile": VOLUNTEER_PROFILE_NAME,
+    }

--- a/src/bernstein/core/volunteer/wall_clock.py
+++ b/src/bernstein/core/volunteer/wall_clock.py
@@ -1,0 +1,228 @@
+"""Wall-clock enforcement for volunteer gate commands.
+
+A donor lends their machine for a bounded time.  The bound has to be real: a
+gate command that hangs -- waiting on a prompt, retrying a dead host, looping
+on a model's bad patch -- would otherwise hold a stranger's laptop until they
+notice and kill it themselves.  A volunteer program where that happens twice
+has no volunteers.
+
+Two things here are less obvious than the timeout itself.
+
+*The kill covers the process tree, not the process.*  Gate commands spawn
+children -- ``pytest -n`` forks workers, ``npm test`` shells out, a build
+launches a compiler farm.  Killing only the process this module started leaves
+those children running with no parent watching, which is the exact failure the
+cap exists to prevent, minus the error message.  On POSIX the child is started
+in its own session so the whole group can be signalled at once.
+
+*The kill is recorded, not merely performed.*  :class:`WallClockOutcome` says
+what happened -- whether the process left on its own, whether it took SIGTERM,
+whether it needed SIGKILL after the grace period.  A gate that had to be killed
+produces a refusal, and a refusal a maintainer can read beats a receipt that
+quietly omits the run.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from pathlib import Path
+
+#: Seconds a process gets to exit after SIGTERM before SIGKILL.
+#:
+#: Long enough for a test runner to flush its output and remove its temporary
+#: directories, short enough that a donor is not waiting on a process that has
+#: already been told to stop.
+TERM_GRACE_SECONDS = 5.0
+
+_POSIX = sys.platform != "win32"
+
+
+@dataclass(frozen=True, slots=True)
+class WallClockOutcome:
+    """What happened to one gate command under its ceiling.
+
+    Attributes:
+        killed: Whether the cap fired.  ``False`` means the command finished on
+            its own, whatever its exit code.
+        exit_code: The process's exit status, or ``None`` if it was killed
+            before reporting one.
+        elapsed_seconds: Wall time actually consumed.
+        limit_seconds: The ceiling in force.
+        escalated_to_sigkill: Whether SIGTERM was ignored and SIGKILL followed.
+            Worth recording separately: a command that needs SIGKILL is either
+            wedged in uninterruptible state or trapping signals, and both are
+            worth knowing about a project's gates.
+    """
+
+    killed: bool
+    exit_code: int | None
+    elapsed_seconds: float
+    limit_seconds: int
+    escalated_to_sigkill: bool
+
+    @property
+    def passed(self) -> bool:
+        """A gate passes only by finishing, on time, with status zero."""
+        return not self.killed and self.exit_code == 0
+
+    def as_record(self) -> dict[str, object]:
+        """The outcome as a structure a receipt or refusal can carry."""
+        return {
+            "killed": self.killed,
+            "exit_code": self.exit_code,
+            "elapsed_seconds": round(self.elapsed_seconds, 3),
+            "limit_seconds": self.limit_seconds,
+            "escalated_to_sigkill": self.escalated_to_sigkill,
+        }
+
+
+def run_under_wall_clock(
+    argv: Sequence[str],
+    *,
+    limit_seconds: int,
+    cwd: Path | str | None = None,
+    env: Mapping[str, str] | None = None,
+    grace_seconds: float = TERM_GRACE_SECONDS,
+) -> tuple[WallClockOutcome, bytes, bytes]:
+    """Run a gate command under a hard wall-clock ceiling.
+
+    Executed without a shell -- ``argv`` is the command.  The manifest loader
+    refuses shell strings for the same reason.
+
+    Args:
+        argv: Program and arguments.
+        limit_seconds: Ceiling; exceeding it kills the process tree.
+        cwd: Working directory for the command.
+        env: Complete environment.  Passed through as given; building it from
+            an allowlist is :func:`~bernstein.core.volunteer.sandbox_profile.sandbox_env`'s
+            job, and this function deliberately does not second-guess it.
+        grace_seconds: Time between SIGTERM and SIGKILL.
+
+    Returns:
+        The outcome, plus whatever the process wrote to stdout and stderr
+        before it stopped.  Output captured up to the kill is kept: a hung
+        gate's last lines are usually the reason it hung.
+    """
+    started = time.monotonic()
+    process = subprocess.Popen(
+        list(argv),
+        cwd=str(cwd) if cwd is not None else None,
+        env=dict(env) if env is not None else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=_POSIX,
+    )
+
+    try:
+        stdout, stderr = process.communicate(timeout=limit_seconds)
+    except subprocess.TimeoutExpired:
+        escalated = _terminate_tree(process, grace_seconds=grace_seconds)
+        stdout, stderr = _drain(process)
+        return (
+            WallClockOutcome(
+                killed=True,
+                exit_code=None,
+                elapsed_seconds=time.monotonic() - started,
+                limit_seconds=limit_seconds,
+                escalated_to_sigkill=escalated,
+            ),
+            stdout,
+            stderr,
+        )
+
+    return (
+        WallClockOutcome(
+            killed=False,
+            exit_code=process.returncode,
+            elapsed_seconds=time.monotonic() - started,
+            limit_seconds=limit_seconds,
+            escalated_to_sigkill=False,
+        ),
+        stdout,
+        stderr,
+    )
+
+
+def _terminate_tree(process: subprocess.Popen[bytes], *, grace_seconds: float) -> bool:
+    """Signal the whole process group, escalating if it does not leave.
+
+    Returns whether SIGKILL was needed.
+    """
+    _signal_tree(process, signal.SIGTERM)
+    try:
+        process.wait(timeout=grace_seconds)
+    except subprocess.TimeoutExpired:
+        _signal_tree(process, signal.SIGKILL)
+        with_suppressed_timeout(process)
+        return True
+    return False
+
+
+def _signal_tree(process: subprocess.Popen[bytes], sig: signal.Signals) -> None:
+    """Send a signal to the child's whole group where the platform has groups.
+
+    Guarded against the one way this could go badly wrong.  Signalling a
+    process group kills every member, and if the child ever shared *our* group
+    -- because ``start_new_session`` did not take, or a future edit dropped it
+    -- then the group being signalled would include the orchestrator running
+    this code.  A wall-clock cap that terminates the donor's whole Bernstein
+    session instead of one gate is worse than no cap.  So the group is compared
+    against our own before anything is sent, and a match falls back to
+    signalling the child alone.
+
+    On Windows there is no process group to signal, so the child alone is
+    terminated.  That is a genuine gap rather than a hidden one: a Windows
+    donor running a gate that forks can leave orphans, and the honest place to
+    say so is here.
+    """
+    if not _POSIX:
+        process.kill()
+        return
+    try:
+        group = os.getpgid(process.pid)
+        if group == os.getpgrp():
+            raise _SharedProcessGroup
+        os.killpg(group, sig)
+    except (ProcessLookupError, PermissionError, _SharedProcessGroup):
+        # Already gone, out of reach, or sharing our group: signal the child
+        # alone rather than everything around it.
+        with contextlib.suppress(ProcessLookupError):
+            process.send_signal(sig)
+
+
+class _SharedProcessGroup(Exception):
+    """The child is in our own process group; signalling it would hit us."""
+
+
+def with_suppressed_timeout(process: subprocess.Popen[bytes]) -> None:
+    """Reap a killed process without letting a slow reap raise.
+
+    After SIGKILL there is nothing further to escalate to, so a wait that still
+    times out is reported through the outcome rather than as an exception from
+    the cleanup path.
+    """
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=grace_after_sigkill())
+
+
+def grace_after_sigkill() -> float:
+    """Seconds to wait for the kernel to reap a SIGKILLed process."""
+    return 2.0
+
+
+def _drain(process: subprocess.Popen[bytes]) -> tuple[bytes, bytes]:
+    """Collect whatever the process wrote before it was stopped."""
+    try:
+        return process.communicate(timeout=grace_after_sigkill())
+    except subprocess.TimeoutExpired:
+        return b"", b""

--- a/tests/integration/volunteer/__init__.py
+++ b/tests/integration/volunteer/__init__.py
@@ -1,0 +1,1 @@
+"""Volunteer-workers integration tests."""

--- a/tests/integration/volunteer/test_volunteer_sandbox_egress.py
+++ b/tests/integration/volunteer/test_volunteer_sandbox_egress.py
@@ -1,0 +1,195 @@
+"""Egress containment, verified against a real container rather than a mock.
+
+The unit tests prove the profile *decides* deny-all plus an explicit list.  That
+is a different claim from "a stranger's code cannot reach a host the project
+did not name", and only the second one matters to a donor.  So these tests
+start actual containers from the options
+:func:`~bernstein.core.volunteer.sandbox_profile.backend_options` produces and
+ask the container what it can see.
+
+Skipped without a Docker daemon.  A skipped containment test is honest; a
+mocked one is not.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from typing import Any
+
+import pytest
+
+from bernstein.core.volunteer.manifest import load_manifest
+from bernstein.core.volunteer.sandbox_profile import (
+    backend_options,
+    build_volunteer_profile,
+    sandbox_env,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+IMAGE = "alpine:3"
+
+#: A documentation-reserved address (RFC 5737).  Nothing routes there, which is
+#: what we want: the test asks whether a *name resolves*, not whether a host
+#: answers.  Reaching out to a real service would make the test depend on
+#: somebody else's uptime.
+ALLOWED_HOST = "allowed.test"
+ALLOWED_ADDRESS = "203.0.113.7"
+
+#: A name the manifest never lists.  Real and famously resolvable, so a failure
+#: to resolve it is evidence about the sandbox rather than about the name.
+FORBIDDEN_HOST = "example.com"
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        probe = subprocess.run(
+            ["docker", "info", "--format", "{{.ServerVersion}}"],
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return probe.returncode == 0
+
+
+requires_docker = pytest.mark.skipif(not _docker_available(), reason="needs a running Docker daemon")
+
+
+def _manifest(**overrides: Any) -> Any:
+    payload: dict[str, Any] = {
+        "version": 1,
+        "license": "Apache-2.0",
+        "gates": [["true"]],
+        "sandbox": "container",
+        "max_wall_clock_minutes": 5,
+    }
+    payload.update(overrides)
+    return load_manifest(json.dumps(payload))
+
+
+def _profile(**overrides: Any) -> Any:
+    return build_volunteer_profile(
+        _manifest(**overrides),
+        available_backends=("container",),
+        donor_accepts_plain_container=True,
+    )
+
+
+def _docker_argv(options: dict[str, Any], *, command: str, env: dict[str, str] | None = None) -> list[str]:
+    """Turn profile options into a ``docker run`` invocation.
+
+    Deliberately mechanical and deliberately here: the test builds the command
+    from the options the profile produced, so a profile that stops emitting a
+    control stops applying it here too.  A hand-written docker command would
+    keep passing after the profile lost the field.
+    """
+    argv = ["docker", "run", "--rm"]
+    if options["network_disabled"]:
+        argv += ["--network", "none"]
+    else:
+        for server in options["dns"]:
+            argv += ["--dns", server]
+        for host, address in options["extra_hosts"].items():
+            argv += ["--add-host", f"{host}:{address}"]
+    argv += ["--memory", f"{options['memory_mb']}m"]
+    for key, value in (env or {}).items():
+        argv += ["--env", f"{key}={value}"]
+    argv += [IMAGE, "sh", "-c", command]
+    return argv
+
+
+def _run(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+
+
+@requires_docker
+def test_a_host_the_project_listed_resolves_inside_the_sandbox() -> None:
+    """The allowlist has to permit something, or projects cannot run gates."""
+    options = backend_options(
+        _profile(egress_allowlist=[ALLOWED_HOST]),
+        resolved_hosts={ALLOWED_HOST: ALLOWED_ADDRESS},
+    )
+
+    result = _run(_docker_argv(options, command=f"getent hosts {ALLOWED_HOST}"))
+
+    assert result.returncode == 0, result.stderr
+    assert ALLOWED_ADDRESS in result.stdout
+
+
+@requires_docker
+def test_a_host_the_project_did_not_list_does_not_resolve_inside_the_sandbox() -> None:
+    """The containment claim, asked of the container instead of the dataclass.
+
+    The sandbox is given a resolver that answers nothing and static entries for
+    the allowlist only, so a name outside the list has nowhere to come from.
+    """
+    options = backend_options(
+        _profile(egress_allowlist=[ALLOWED_HOST]),
+        resolved_hosts={ALLOWED_HOST: ALLOWED_ADDRESS},
+    )
+
+    result = _run(_docker_argv(options, command=f"getent hosts {FORBIDDEN_HOST}"))
+
+    assert result.returncode != 0, f"{FORBIDDEN_HOST} resolved inside the sandbox: {result.stdout!r}"
+
+
+@requires_docker
+def test_a_project_that_lists_no_host_gets_no_network_interface() -> None:
+    """The complete case, and the one a project should choose when it can.
+
+    DNS pinning does not stop a connection to a raw IP address.  Turning the
+    interface off does.
+    """
+    import dataclasses
+
+    options = backend_options(dataclasses.replace(_profile(), egress_allowlist=()))
+    assert options["network_disabled"] is True
+
+    result = _run(_docker_argv(options, command="ip -o addr show | grep -v ' lo ' | wc -l"))
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "0", f"the sandbox has a network interface: {result.stdout!r}"
+
+
+@requires_docker
+def test_the_sandbox_environment_carries_no_credential_the_host_holds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The canary test, taken all the way into the container.
+
+    The unit test proves ``sandbox_env`` does not build the value.  This proves
+    the value is not inside the running sandbox, which is the claim a donor
+    actually cares about.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-canary-do-not-leak")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_canary_do_not_leak")
+
+    profile = _profile()
+    options = backend_options(_without_network(profile))
+
+    result = _run(_docker_argv(options, command="env", env=sandbox_env(profile)))
+
+    assert result.returncode == 0, result.stderr
+    assert "canary" not in result.stdout
+    assert "ANTHROPIC_API_KEY" not in result.stdout
+    assert "GITHUB_TOKEN" not in result.stdout
+    assert "HOME=/workspace" in result.stdout
+
+
+def _without_network(profile: Any) -> Any:
+    """The canary check needs no network, so it does not get one."""
+    import dataclasses
+
+    return dataclasses.replace(profile, egress_allowlist=())

--- a/tests/unit/volunteer/test_volunteer_sandbox_profile.py
+++ b/tests/unit/volunteer/test_volunteer_sandbox_profile.py
@@ -1,0 +1,397 @@
+"""The volunteer sandbox profile is a derived, verifiable containment decision.
+
+Tests are named for the property each protects.  The properties worth naming
+here are not "the function returns a dataclass" -- they are the ones a
+maintainer relies on months later when they have a receipt, a commit, and no
+memory of the run: that the profile reproduces from the manifest, that a donor
+cannot loosen it without the digest saying so, and that nothing from the host
+environment reaches the sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import pytest
+
+from bernstein.core.volunteer.manifest import load_manifest
+from bernstein.core.volunteer.sandbox_profile import (
+    BACKEND_PREFERENCE,
+    PACKAGE_REGISTRY_HOSTS,
+    SANDBOX_ENV_ALLOWLIST,
+    VOLUNTEER_PROFILE_NAME,
+    SandboxProfileRefusal,
+    backend_options,
+    build_volunteer_profile,
+    describe_refusal,
+    effective_egress,
+    profile_matches,
+    sandbox_env,
+)
+
+ALL_BACKENDS = ("microvm", "container-userns", "container")
+
+
+def _manifest(**overrides: Any) -> Any:
+    payload: dict[str, Any] = {
+        "version": 1,
+        "license": "Apache-2.0",
+        "gates": [["uv", "run", "pytest", "-q"]],
+        "allowed_paths": ["src/**"],
+        "egress_allowlist": [],
+        "sandbox": "container",
+        "max_wall_clock_minutes": 30,
+        "local_ok": True,
+    }
+    payload.update(overrides)
+    return load_manifest(json.dumps(payload))
+
+
+def _profile(*, manifest: Any = None, backends: Any = ALL_BACKENDS, **kwargs: Any) -> Any:
+    return build_volunteer_profile(
+        manifest if manifest is not None else _manifest(),
+        available_backends=backends,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The profile reproduces, or the chain is worthless
+# ---------------------------------------------------------------------------
+
+
+def test_same_manifest_and_donor_limits_reproduce_the_same_digest() -> None:
+    """The whole verification story rests on this.
+
+    A maintainer rebuilds the profile from the manifest at the submitted commit
+    and compares digests.  If the build were not pure, the comparison would
+    fail for honest runs and the check would be turned off within a week.
+    """
+    first = _profile(donor_wall_clock_minutes=20)
+    second = _profile(donor_wall_clock_minutes=20)
+
+    assert first.digest == second.digest
+    assert profile_matches(second, expected_digest=first.digest)
+
+
+def test_profile_names_the_manifest_it_came_from() -> None:
+    """Without the back-reference the chain has a gap at its most useful link."""
+    manifest = _manifest()
+
+    assert _profile(manifest=manifest).manifest_sha256 == manifest.digest
+
+
+def test_a_different_policy_produces_a_different_profile_digest() -> None:
+    """Two projects with different bars must not share a containment identity."""
+    strict = _manifest(max_wall_clock_minutes=10)
+    loose = _manifest(max_wall_clock_minutes=120)
+
+    assert _profile(manifest=strict).digest != _profile(manifest=loose).digest
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("backend", "container"),
+        ("egress_allowlist", ("example.com",)),
+        ("env_allowlist", ("PATH",)),
+        ("memory_mb", 512),
+        ("cpu_quota_us", 50_000),
+        ("wall_clock_seconds", 60),
+        ("plain_container_accepted", True),
+        ("manifest_sha256", "f" * 64),
+    ],
+)
+def test_every_field_of_the_containment_decision_is_in_the_digest(field: str, value: Any) -> None:
+    """A field outside the digest is a knob a donor could turn quietly.
+
+    The point of hashing the decision is that "the sandbox was hardened" stops
+    being testimony.  Any field the digest does not cover is testimony again.
+    """
+    import dataclasses
+
+    baseline = _profile()
+    mutated = dataclasses.replace(baseline, **{field: value})
+
+    assert mutated.digest != baseline.digest
+
+
+def test_donor_limits_tighten_but_never_loosen_the_project_ceiling() -> None:
+    """A donor lends less time than the project asks for, never more."""
+    manifest = _manifest(max_wall_clock_minutes=30)
+
+    assert _profile(manifest=manifest, donor_wall_clock_minutes=10).wall_clock_seconds == 600
+    assert _profile(manifest=manifest, donor_wall_clock_minutes=600).wall_clock_seconds == 1800
+
+
+# ---------------------------------------------------------------------------
+# No host credential material reaches the sandbox
+# ---------------------------------------------------------------------------
+
+
+def test_a_secret_in_the_worker_environment_is_not_in_the_sandbox_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The canary the issue asks for, at the seam it actually crosses.
+
+    ``sandbox_env`` is what becomes the container's ``--env`` list, so a value
+    absent here is absent inside.  This is a test of construction, not of a
+    filter: the function never reads ``os.environ`` at all.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-canary-do-not-leak")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "canary-aws")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_canary")
+
+    env = sandbox_env(_profile())
+
+    assert "sk-ant-canary-do-not-leak" not in json.dumps(env)
+    assert not {"ANTHROPIC_API_KEY", "AWS_SECRET_ACCESS_KEY", "GITHUB_TOKEN"} & set(env)
+
+
+def test_sandbox_environment_does_not_depend_on_the_host_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An allowlist that starts from nothing has no denylist to get wrong.
+
+    Same profile, wildly different host environment, byte-identical result --
+    which is also what makes the sandbox environment part of a reproducible
+    run rather than a property of whoever's laptop it was.
+    """
+    profile = _profile()
+    before = sandbox_env(profile)
+
+    for index in range(50):
+        monkeypatch.setenv(f"SOME_HOST_VAR_{index}", "value")
+    monkeypatch.setenv("PATH", "/nonsense")
+    monkeypatch.setenv("HOME", "/home/donor")
+
+    assert sandbox_env(profile) == before
+
+
+def test_sandbox_environment_carries_nothing_outside_the_profile_allowlist() -> None:
+    assert set(sandbox_env(_profile())) <= set(SANDBOX_ENV_ALLOWLIST)
+
+
+def test_home_is_inside_the_workspace_not_on_the_host() -> None:
+    """A HOME pointing at the donor's real home is where credentials live."""
+    assert sandbox_env(_profile())["HOME"] == "/workspace"
+    assert backend_options(_profile())["mount_home"] is False
+    assert backend_options(_profile())["inherit_host_env"] is False
+
+
+# ---------------------------------------------------------------------------
+# Egress is deny-all plus an explicit list
+# ---------------------------------------------------------------------------
+
+
+def test_a_host_the_project_did_not_list_is_not_reachable() -> None:
+    manifest = _manifest(egress_allowlist=["api.example.com"])
+
+    reachable = effective_egress(manifest)
+
+    assert "api.example.com" in reachable
+    assert "evil.example" not in reachable
+    assert "github.com" not in reachable
+
+
+def test_package_registries_are_reachable_without_the_project_listing_them() -> None:
+    """Otherwise no real project's gates can install anything.
+
+    Naming the set here keeps it reviewable and hashed into every profile,
+    which is better than every manifest pasting its own list.
+    """
+    reachable = effective_egress(_manifest(egress_allowlist=[]))
+
+    assert set(PACKAGE_REGISTRY_HOSTS) <= set(reachable)
+
+
+def test_egress_list_is_sorted_and_deduplicated_so_two_spellings_hash_alike() -> None:
+    """Order is not policy; a reordered list must not be a different profile."""
+    listed = _manifest(egress_allowlist=["pypi.org", "api.example.com"])
+    reversed_order = _manifest(egress_allowlist=["api.example.com", "pypi.org"])
+
+    assert effective_egress(listed) == effective_egress(reversed_order)
+    assert list(effective_egress(listed)) == sorted(set(effective_egress(listed)))
+
+
+def test_backend_options_disable_the_network_when_nothing_is_reachable() -> None:
+    """An empty effective list has to mean the network is off, not off by convention."""
+    import dataclasses
+
+    airgapped = dataclasses.replace(_profile(), egress_allowlist=())
+
+    assert backend_options(airgapped)["network_disabled"] is True
+    assert backend_options(_profile())["network_disabled"] is False
+
+
+def test_a_reachable_host_is_pinned_to_a_resolved_address() -> None:
+    """The list has to enforce something, or it is a boundary only in review.
+
+    Allowlisted names get static entries; the sandbox gets a resolver that
+    answers nothing, so anything outside the list does not resolve.
+    """
+    manifest = _manifest(egress_allowlist=["api.example.com"])
+    options = backend_options(
+        _profile(manifest=manifest),
+        resolved_hosts={"api.example.com": "203.0.113.7", "pypi.org": "151.101.0.223"},
+    )
+
+    assert options["extra_hosts"] == {"api.example.com": "203.0.113.7", "pypi.org": "151.101.0.223"}
+    assert options["dns"] == ["0.0.0.0"]
+
+
+def test_a_resolved_host_outside_the_allowlist_is_not_pinned() -> None:
+    """A caller that over-resolves must not be able to widen the boundary."""
+    options = backend_options(
+        _profile(),
+        resolved_hosts={"evil.example": "203.0.113.9", "pypi.org": "151.101.0.223"},
+    )
+
+    assert "evil.example" not in options["extra_hosts"]
+
+
+def test_an_airgapped_profile_gets_no_resolver_because_it_gets_no_network() -> None:
+    """Nothing to pin when there is no interface; the stronger control wins."""
+    import dataclasses
+
+    options = backend_options(dataclasses.replace(_profile(), egress_allowlist=()))
+
+    assert options["network_disabled"] is True
+    assert "dns" not in options
+    assert "extra_hosts" not in options
+
+
+def test_backend_options_carry_the_caps_the_profile_decided() -> None:
+    profile = _profile(donor_wall_clock_minutes=5)
+    options = backend_options(profile)
+
+    assert options["timeout_seconds"] == 300
+    assert options["memory_mb"] == profile.memory_mb
+    assert options["cpu_quota"] == profile.cpu_quota_us
+
+
+# ---------------------------------------------------------------------------
+# Backend selection, and the dual opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_microvm_is_preferred_when_the_host_has_one() -> None:
+    assert _profile(backends=ALL_BACKENDS).backend == "microvm"
+    assert BACKEND_PREFERENCE[0] == "microvm"
+
+
+def test_user_space_kernel_container_is_taken_before_a_plain_one() -> None:
+    """It contains a kernel exploit; a plain container does not."""
+    assert _profile(backends=("container-userns", "container")).backend == "container-userns"
+
+
+def test_plain_container_is_refused_when_only_the_project_agreed() -> None:
+    """The dual opt-in: the project's manifest is one consent, not both.
+
+    A donor who never said "you may share my kernel with a stranger's code"
+    has not said it by installing the software.
+    """
+    with pytest.raises(SandboxProfileRefusal) as excinfo:
+        _profile(backends=("container",), donor_accepts_plain_container=False)
+
+    assert excinfo.value.reason == "plain_container_needs_dual_opt_in"
+
+
+def test_plain_container_runs_only_when_both_sides_agreed() -> None:
+    profile = _profile(backends=("container",), donor_accepts_plain_container=True)
+
+    assert profile.backend == "container"
+    assert profile.plain_container_accepted is True
+
+
+def test_the_dual_opt_in_is_visible_in_the_digest() -> None:
+    """A weaker sandbox must not be able to masquerade as the default one."""
+    weak = _profile(backends=("container",), donor_accepts_plain_container=True)
+    strong = _profile(backends=("container-userns",), donor_accepts_plain_container=True)
+
+    assert weak.digest != strong.digest
+
+
+def test_a_project_demanding_a_microvm_does_not_get_a_container() -> None:
+    """The manifest's ``sandbox`` field is a floor, and a floor that bends is decoration."""
+    strict = _manifest(sandbox="microvm")
+
+    with pytest.raises(SandboxProfileRefusal) as excinfo:
+        _profile(manifest=strict, backends=("container-userns", "container"), donor_accepts_plain_container=True)
+
+    assert excinfo.value.reason == "microvm_required_but_unavailable"
+
+
+def test_a_host_with_no_usable_backend_refuses_rather_than_improvising() -> None:
+    with pytest.raises(SandboxProfileRefusal) as excinfo:
+        _profile(backends=())
+
+    assert excinfo.value.reason == "no_acceptable_backend"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "reason"),
+    [
+        ({"donor_wall_clock_minutes": 0}, "wall_clock_below_floor"),
+        ({"donor_memory_mb": 64}, "memory_below_floor"),
+    ],
+)
+def test_a_donor_budget_too_small_to_run_anything_refuses_early(kwargs: Any, reason: str) -> None:
+    """Better a refusal than a task that is killed for certain."""
+    with pytest.raises(SandboxProfileRefusal) as excinfo:
+        _profile(**kwargs)
+
+    assert excinfo.value.reason == reason
+
+
+def test_a_refusal_is_a_record_a_runner_can_persist() -> None:
+    """Refusals are the common case on a mixed donor fleet.
+
+    They need the same structure as a success or they become log lines nobody
+    counts, and "why did nothing ever run on my machine" becomes unanswerable.
+    """
+    manifest = _manifest()
+    try:
+        _profile(manifest=manifest, backends=())
+    except SandboxProfileRefusal as error:
+        record = describe_refusal(error, manifest_sha256=manifest.digest)
+    else:  # pragma: no cover - the call above always refuses
+        pytest.fail("expected a refusal")
+
+    assert record["outcome"] == "refused"
+    assert record["reason"] == "no_acceptable_backend"
+    assert record["manifest_sha256"] == manifest.digest
+    assert record["profile"] == VOLUNTEER_PROFILE_NAME
+
+
+def test_the_environment_allowlist_never_grows_by_accident() -> None:
+    """A pin, so adding a variable is a decision somebody made on purpose.
+
+    Every name here is one more place a credential could hide on its way into
+    a sandbox running a stranger's code.
+    """
+    assert set(SANDBOX_ENV_ALLOWLIST) == {
+        "BERNSTEIN_VOLUNTEER",
+        "CI",
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "PATH",
+        "TMPDIR",
+    }
+    assert not {name for name in SANDBOX_ENV_ALLOWLIST if "KEY" in name or "TOKEN" in name or "SECRET" in name}
+
+
+def test_the_host_environment_is_not_consulted_even_when_it_holds_the_same_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An allowlisted *name* must not become a channel for a host *value*."""
+    monkeypatch.setenv("PATH", "/attacker/controlled")
+    monkeypatch.setenv("HOME", "/home/donor")
+
+    env = sandbox_env(_profile())
+
+    assert env["PATH"] != os.environ["PATH"]
+    assert env["HOME"] == "/workspace"

--- a/tests/unit/volunteer/test_wall_clock.py
+++ b/tests/unit/volunteer/test_wall_clock.py
@@ -1,0 +1,208 @@
+"""The wall-clock cap kills real processes, so these tests spawn real processes.
+
+A timeout tested against a mock proves the mock was configured, not that a
+donor's laptop gets released.  Every test here starts an actual interpreter,
+lets the cap fire or not, and inspects what the operating system did.
+
+The limits are seconds rather than minutes so the file stays fast; the code
+path is the same one a 30-minute gate takes.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from bernstein.core.volunteer.wall_clock import (
+    WallClockOutcome,
+    run_under_wall_clock,
+)
+
+POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+
+
+def _python(script: str) -> list[str]:
+    return [sys.executable, "-c", script]
+
+
+def test_a_command_that_finishes_in_time_is_not_killed() -> None:
+    outcome, stdout, _ = run_under_wall_clock(_python("print('gate ok')"), limit_seconds=10)
+
+    assert outcome.killed is False
+    assert outcome.exit_code == 0
+    assert outcome.passed is True
+    assert b"gate ok" in stdout
+
+
+def test_a_failing_gate_is_a_failure_not_a_kill() -> None:
+    """The two have to stay distinguishable: one is the project's verdict on
+    the patch, the other is the donor's machine being taken back."""
+    outcome, _, _ = run_under_wall_clock(_python("raise SystemExit(3)"), limit_seconds=10)
+
+    assert outcome.killed is False
+    assert outcome.exit_code == 3
+    assert outcome.passed is False
+
+
+def test_a_hanging_gate_is_killed_at_the_cap() -> None:
+    """The property the cap exists for."""
+    started = time.monotonic()
+
+    outcome, _, _ = run_under_wall_clock(_python("import time; time.sleep(60)"), limit_seconds=1)
+
+    assert outcome.killed is True
+    assert outcome.exit_code is None
+    assert outcome.passed is False
+    assert time.monotonic() - started < 20
+
+
+def test_the_kill_is_recorded_with_the_limit_that_fired() -> None:
+    """A killed run produces a refusal, and a refusal has to say why.
+
+    Without the limit in the record a maintainer reading it cannot tell a gate
+    that is genuinely slow from a donor whose budget was set too low.
+    """
+    outcome, _, _ = run_under_wall_clock(_python("import time; time.sleep(60)"), limit_seconds=1)
+    record = outcome.as_record()
+
+    assert record["killed"] is True
+    assert record["limit_seconds"] == 1
+    assert record["exit_code"] is None
+    assert isinstance(record["elapsed_seconds"], float)
+    assert record["elapsed_seconds"] >= 1
+
+
+def test_output_written_before_the_kill_is_kept() -> None:
+    """A hung gate's last lines are usually the reason it hung."""
+    script = "import sys, time; print('starting the gate'); sys.stdout.flush(); time.sleep(60)"
+
+    _, stdout, _ = run_under_wall_clock(_python(script), limit_seconds=1)
+
+    assert b"starting the gate" in stdout
+
+
+@POSIX_ONLY
+def test_a_gate_that_traps_sigterm_is_escalated_to_sigkill() -> None:
+    """Recorded separately because it says something about the project's gates.
+
+    A command that needs SIGKILL is trapping signals or stuck uninterruptibly,
+    and either is worth a maintainer knowing.
+    """
+    script = "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)"
+
+    outcome, _, _ = run_under_wall_clock(_python(script), limit_seconds=1, grace_seconds=0.5)
+
+    assert outcome.killed is True
+    assert outcome.escalated_to_sigkill is True
+
+
+@POSIX_ONLY
+def test_the_kill_reaches_children_the_gate_spawned() -> None:
+    """The failure the cap exists to prevent, minus the error message.
+
+    ``pytest -n`` forks workers, ``npm test`` shells out, a build launches a
+    compiler farm.  Killing only the process we started leaves those running on
+    a stranger's machine with nothing watching them.
+
+    The child writes its own pid to a file, then sleeps far longer than the
+    cap.  After the kill, that pid must be gone.
+    """
+    marker = "child.pid"
+    script = (
+        "import os, time, sys, subprocess\n"
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)'])\n"
+        f"open({marker!r}, 'w').write(str(child.pid))\n"
+        "time.sleep(120)\n"
+    )
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as workdir:
+        outcome, _, _ = run_under_wall_clock(_python(script), limit_seconds=2, cwd=workdir, grace_seconds=0.5)
+        child_pid = int((__import__("pathlib").Path(workdir) / marker).read_text())
+
+    assert outcome.killed is True
+    _assert_process_is_gone(child_pid)
+
+
+def _assert_process_is_gone(pid: int, *, attempts: int = 40) -> None:
+    """Poll rather than assert once: reaping is not instantaneous."""
+    for _ in range(attempts):
+        if not _process_alive(pid):
+            return
+        time.sleep(0.05)
+    pytest.fail(f"pid {pid} survived the wall-clock kill; the gate's children outlived the cap")
+
+
+def _process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    # On Linux a killed-but-unreaped child is a zombie, which still answers
+    # signal 0.  Ask the process table what state it is in.
+    return not _is_zombie(pid)
+
+
+def _is_zombie(pid: int) -> bool:
+    try:
+        status = subprocess.run(
+            ["ps", "-o", "stat=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return status.stdout.strip().startswith("Z")
+
+
+@POSIX_ONLY
+def test_a_child_sharing_our_process_group_is_signalled_alone() -> None:
+    """The guard against the cap taking the orchestrator down with the gate.
+
+    Signalling a process group hits every member.  If the child ever ended up
+    in *our* group -- ``start_new_session`` not taking, or a future edit
+    dropping it -- then a group signal would include the Bernstein session
+    running the task.  A wall-clock cap that kills the donor's whole session
+    instead of one gate is worse than no cap at all.
+
+    Here the child is deliberately started in the parent's group, and the test
+    asserts the parent survived long enough to make the assertion.
+    """
+    from bernstein.core.volunteer import wall_clock
+
+    process = subprocess.Popen(
+        _python("import time; time.sleep(30)"),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=False,
+    )
+    assert os.getpgid(process.pid) == os.getpgrp(), "precondition: the child shares our group"
+
+    try:
+        wall_clock._signal_tree(process, __import__("signal").SIGKILL)
+        process.wait(timeout=10)
+    finally:
+        if process.poll() is None:  # pragma: no cover - only on an unexpected survival
+            process.kill()
+            process.wait(timeout=10)
+
+    assert process.returncode is not None
+    assert os.getpid() > 0, "the test process survived signalling a shared group"
+
+
+def test_outcome_reports_a_passing_gate_only_when_everything_went_right() -> None:
+    """``passed`` is the single thing a runner branches on, so it has to be
+    unambiguous: finished, on time, status zero."""
+    assert WallClockOutcome(False, 0, 1.0, 60, False).passed is True
+    assert WallClockOutcome(False, 1, 1.0, 60, False).passed is False
+    assert WallClockOutcome(True, None, 60.0, 60, False).passed is False
+    assert WallClockOutcome(True, 0, 60.0, 60, True).passed is False


### PR DESCRIPTION
Closes #3868. Rebased onto `main` now that #3907 has landed; this branch carries the sandbox slice alone.

Second slice of the volunteer umbrella (#3863) from the maintainer side. Taking this one deliberately: it is the deepest security boundary in the program and the least reasonable thing to hand to someone as an evening's work.

## The profile is derived, not chosen

"The sandbox was hardened" is not a checkable statement, and every containment claim here has to survive a maintainer asking *prove it* months later from a receipt and a commit.

So the profile is a pure function of the manifest plus the donor's limits, and it is content-addressed. The digest binds `manifest_sha256`, which gives a chain with no operator testimony in it:

```
manifest bytes → manifest digest → profile digest → receipt bundle
```

Rebuild the profile from the manifest at the submitted commit, compare digests. A profile that does not reproduce means the run was not contained the way the receipt says.

The consequence is the point: **a donor cannot loosen containment and still produce a verifying receipt.** There is no flag for it, because a flag would have to appear in the digest, and a digest that says "egress was open" is not one anybody accepts.

## The boundary

| Control | Rule |
|---|---|
| Backend | microVM preferred; `container-userns` fallback; plain container only on dual opt-in, recorded in the digest so it cannot be quiet. A manifest asking for `microvm` gets one or gets a refusal — a floor that bends is decoration. |
| Egress | Deny-all + the manifest's hosts + package registries. |
| Credentials | Environment built *from the profile*, never filtered from `os.environ`. Adapter credentials are absent by construction — they belong to the adapter process, outside this boundary. |
| Resources | CPU, memory, wall clock, floored to the tighter of project and donor. |

## What I changed my mind about mid-implementation

My first pass emitted `egress_allowlist` into the backend options and called it done. That field enforced nothing — Docker has no per-host filter — so it was a control in review and absent at runtime, which is worse than no field.

It is now DNS pinning: allowlisted names resolve from static entries, and the sandbox gets a resolver that answers nothing.

**The limit, stated rather than implied:** a connection to a raw IP address does not consult DNS. Closing that needs packet-level filtering — the microVM backend's own network policy, or a filtering proxy — and that is a change against the backends, not against this decision layer. A project whose threat model includes exfiltration to a hard-coded address should declare an empty `egress_allowlist`, which turns the interface off completely and is tested here.

## Wall clock

Kills the process **tree**. Gate commands fork workers; killing only the parent leaves them running on a stranger's machine, which is the failure the cap exists to prevent minus the error message.

Signalling a process group hits every member, so it is guarded against the case where the child shares our own group — a cap that terminates the donor's whole session instead of one gate is worse than no cap. I found that while mutation-testing the tree kill: with `start_new_session` off, the group signal reached the test runner itself.

Windows has no process group to signal, so only the direct child is terminated. Named in the code and the docs rather than left to be discovered.

## Tests — 163, including four against real containers

All five acceptance criteria are met by tests I ran, not by tests I wrote and hoped for:

| Criterion | Where | Verified |
|---|---|---|
| env canary invisible inside the sandbox | unit + real container | ✅ |
| non-allowlisted egress blocked | real container | ✅ `example.com` does not resolve |
| allowlisted egress permitted | real container | ✅ |
| plain-container refusal without dual opt-in | unit | ✅ |
| wall-clock cap kills and the kill is recorded | real processes | ✅ |

The integration tests build the `docker run` command *from the options the profile produced*, so a profile that stops emitting a control stops applying it there too — a hand-written docker command would keep passing after the profile lost the field. They skip without a daemon; a skipped containment test is honest, a mocked one is not.

Two mutation checks I ran rather than assumed: dropping the process-group session breaks the tree-kill test, and every field of the profile moves the digest.
