### PR TITLE
fix(fleet): bulk-cost-report dispatches `cost`, a command that resolves (#3755)

### DIFF
--- a/docs/operations/fleet.md
+++ b/docs/operations/fleet.md
@@ -97,9 +97,10 @@ bernstein fleet bulk-cost-report   [--names …] [--filter …]
 - **`bulk-pause`** - stop the project's daemon (`fleet_cmd.py:239-252`).
 - **`bulk-resume`** - restart the project's daemon
   (`fleet_cmd.py:255-268`).
-- **`bulk-cost-report`** - run `bernstein cost report` against every
-  selected project and emit a JSON envelope per project
-  (`fleet_cmd.py:271-284`).
+- **`bulk-cost-report`** - run `bernstein cost` against every selected
+  project (`fleet_cmd.py:271-284`). The per-project stdout is collected
+  into `BulkActionResult.outputs`; what the command prints is the one
+  aggregate envelope described below, not a per-project one.
 
 Output is a compact JSON blob: `{"action": "...", "succeeded": [...],
 "failed": {project: error_message}}` (`fleet_cmd.py:214-220`).

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -868,7 +868,7 @@ Multi-project dashboard.
 | `list` | List instances discovered under the fleet root. |
 | `ls` | List configured projects without launching the dashboard. |
 | `reload` | Rescan the fleet root and report what would be picked up. |
-| `bulk-cost-report` | Run `bernstein cost report` against every matching project. |
+| `bulk-cost-report` | Run `bernstein cost` against every matching project. |
 | `bulk-pause` / `bulk-resume` / `bulk-stop` | Pause, resume, or stop every matching project. |
 
 The group also accepts `--web [host:]port` to run the web view instead of the TUI. (`cli/commands/fleet_cmd.py:50+`.)

--- a/src/bernstein/cli/commands/fleet_cmd.py
+++ b/src/bernstein/cli/commands/fleet_cmd.py
@@ -311,7 +311,7 @@ def bulk_cost_report_cmd(
     names: tuple[str, ...],
     filter_expression: str | None,
 ) -> None:
-    """Run ``bernstein cost report`` against every matching project."""
+    """Run ``bernstein cost`` against every matching project."""
     config = _resolve_config(ctx.obj.get("config_path"))
     targets = _bulk_target(config, names, filter_expression)
     result = asyncio.run(bulk_cost_report(targets))

--- a/src/bernstein/core/fleet/bulk.py
+++ b/src/bernstein/core/fleet/bulk.py
@@ -234,8 +234,19 @@ async def bulk_cost_report(
     runner: SubprocessRunner | None = None,
     extra_args: list[str] | None = None,
 ) -> BulkActionResult:
-    """Run ``bernstein cost report`` on every selected project."""
-    args = ["cost", "report", *(extra_args or [])]
+    """Run ``bernstein cost`` on every selected project.
+
+    The report is the ``cost`` group's own output: the group is declared
+    ``invoke_without_command=True`` and its callback prints the per-project
+    breakdown titled "Bernstein Cost Report". ``cost report`` was never a
+    registered subcommand (issue #3755), so the dispatch used to hand click a
+    spelling it rejects with exit 2 for every project in the fleet.
+
+    Deliberately not ``cost profile-report``: that one writes a report artifact
+    and appends an event to the project's audit chain, so a fleet-wide read
+    would mutate every project it touched.
+    """
+    args = ["cost", *(extra_args or [])]
     return await _bulk_dispatch("cost-report", projects, args, runner=runner)
 
 

--- a/tests/unit/fleet/test_bulk.py
+++ b/tests/unit/fleet/test_bulk.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import click
 import pytest
 
+from bernstein.cli.main import cli
 from bernstein.core.fleet.aggregator import ProjectSnapshot, ProjectState
 from bernstein.core.fleet.bulk import (
+    bulk_cost_report,
     bulk_pause,
     bulk_resume,
     bulk_stop,
@@ -138,3 +141,86 @@ async def test_bulk_records_failure_per_project(tmp_path: Path) -> None:
     assert "alpha" in result.succeeded
     assert "bravo" in result.failed
     assert "boom" in result.failed["bravo"]
+
+
+def _resolve(path: str) -> click.Command | None:
+    """Walk ``path`` through the real CLI, returning None at the first miss.
+
+    Same walk ``tests/unit/test_cli_command_registration.py`` uses on doc
+    tables; kept local so this file has no cross-test import.
+    """
+    node: click.Command | None = cli
+    for word in path.split():
+        if not isinstance(node, click.Group):
+            return None
+        node = node.get_command(click.Context(node), word)
+        if node is None:
+            return None
+    return node
+
+
+async def _capture_dispatch(project: ProjectConfig) -> list[str]:
+    """Run ``bulk_cost_report`` against a stub runner and return the argv it dispatched."""
+    captured: list[list[str]] = []
+
+    async def runner(cmd: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, str]:
+        captured.append(list(cmd))
+        return 0, "ok", ""
+
+    await bulk_cost_report([project], runner=runner)
+    assert len(captured) == 1
+    # Drop the `python -m bernstein` prefix chosen by `_bernstein_command()`.
+    cmd = captured[0]
+    return cmd[cmd.index("bernstein") + 1 :]
+
+
+@pytest.mark.asyncio
+async def test_bulk_cost_report_dispatches_a_command_that_resolves(tmp_path: Path) -> None:
+    """The argv ``bulk_cost_report`` spawns is a spelling the CLI actually has.
+
+    Guards issue #3755: the dispatch asked for ``bernstein cost report``, which
+    has never been a registered subcommand, so every project in the fleet came
+    back with click's exit 2 and the whole sweep reported failure.  Asserting on
+    the argv rather than on a subprocess keeps the check hermetic; the exit code
+    is pinned separately below.
+    """
+    args = await _capture_dispatch(_project(tmp_path, "alpha"))
+
+    assert _resolve(" ".join(args)) is not None, (
+        f"fleet bulk-cost-report dispatches `bernstein {' '.join(args)}`, "
+        "which does not resolve through the top-level CLI"
+    )
+
+
+@pytest.mark.asyncio
+async def test_bulk_cost_report_passes_extra_args_through(tmp_path: Path) -> None:
+    """``extra_args`` land after the command, so ``--json`` still reaches it."""
+    captured: list[list[str]] = []
+
+    async def runner(cmd: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, str]:
+        captured.append(list(cmd))
+        return 0, "ok", ""
+
+    await bulk_cost_report([_project(tmp_path, "alpha")], runner=runner, extra_args=["--json"])
+    assert captured[0][-1] == "--json"
+
+
+@pytest.mark.asyncio
+async def test_bulk_cost_report_exits_zero_against_a_fixture_project(tmp_path: Path) -> None:
+    """The real subprocess returns 0 for a project that has run bernstein before.
+
+    The argv test above cannot see click's exit code, and "resolves" is not the
+    same claim as "succeeds".  This one spawns the actual interpreter against a
+    fixture project, which is what a fleet operator gets.
+
+    The fixture carries an (empty) ``.sdd/metrics`` directory on purpose: a
+    project that has never run bernstein has no such directory and ``bernstein
+    cost`` exits 1 there.  That asymmetry is a separate defect and is reported
+    on #3755 rather than fixed here.
+    """
+    (tmp_path / ".sdd" / "metrics").mkdir(parents=True)
+    project = _project(tmp_path, "alpha")
+
+    result = await bulk_cost_report([project])
+
+    assert result.succeeded == ["alpha"], f"expected a clean sweep, got failures: {result.failed}"

--- a/tests/unit/test_cli_command_registration.py
+++ b/tests/unit/test_cli_command_registration.py
@@ -498,14 +498,7 @@ def test_subcommand_rows_resolve_and_accept_their_flags(path: str, flags: frozen
 # Spellings a table cell names that do not resolve, each with the reason it is
 # tolerated.  An entry here records a documented invocation that fails; keep
 # this as close to empty as the surface allows.
-UNREGISTERED_MENTION_EXEMPTIONS: dict[str, str] = {
-    "cost report": (
-        "never existed as a command; `bernstein fleet bulk-cost-report` dispatches it "
-        "to every project, so the doc row mirrors a live runtime bug in "
-        "src/bernstein/core/fleet/bulk.py:238 -- tracked separately, fixing it here "
-        "would change fleet behaviour"
-    ),
-}
+UNREGISTERED_MENTION_EXEMPTIONS: dict[str, str] = {}
 
 
 def _table_command_mentions() -> list[pytest.param]:


### PR DESCRIPTION
## What

`bernstein fleet bulk-cost-report` spawns `bernstein cost` instead of `bernstein cost
report`, which has never been a registered subcommand. Docs, both docstrings and the
registration exemption move with it.

Closes #3755.

## Why

Measured on `8882d49` before anything was written, in a temp project:

```
$ bernstein cost report                          # what the dispatch asks for today
Error: No such command 'report'. Did you mean 'profile-report'?     rc=2
```

So every project in the fleet comes back non-zero and the sweep reports failure for all
of them regardless of state, exactly as the issue says.

## How, and the decision the issue left open

The issue asks which command the bulk dispatch should actually run. **The bare `cost`
group.** It is declared `invoke_without_command=True` and its own callback prints the
per-project breakdown — whose panel title is literally `Bernstein Cost Report`. The
`report` in `bulk-cost-report` was naming that output all along, not a subcommand:

```
$ mkdir -p .sdd/metrics && echo '{{"task_id":"t1","agent":"claude","model":"sonnet","cost_usd":0.5,"timestamp":1786000000}}' > .sdd/metrics/tasks.jsonl
$ bernstein cost
                    Bernstein Cost Report (all time)
  Model    Tasks   Tokens In   Tokens Out   Cost USD
  sonnet       1           0            0    $0.5000
  ...                                                              rc=0
```

**Deliberately not `cost profile-report`**, the nearest live surface and the one click
itself suggests. It writes a content-addressed artifact under `.sdd/reports/` and appends
a `cost.profile_report` event to the project's audit chain. A fleet-wide *read* that
mutates the audit chain of every project it touches is a bigger behaviour change than the
one being fixed, and on this repo the chain is the product. Say the word and I will switch
it — but it should be a decision somebody makes on purpose, not the one the fix defaults
into.

`extra_args` still lands after the command, so `--json` and `--last 7d` reach the group's
own options unchanged. There is no CLI flag that feeds `extra_args` today; the test pins
the pass-through so that stays true when one arrives.

## The second defect, reported and not fixed

Same measurement run, one row up:

```
$ cd /tmp/fresh-project && bernstein cost         # no .sdd/metrics directory at all
Metrics directory not found: .sdd/metrics                          rc=1
$ mkdir -p .sdd/metrics && bernstein cost         # directory present but empty
No metrics data found.                                             rc=0
```

A project that has never run bernstein still fails the sweep — a read-only report exits
non-zero because a directory is absent, while an *empty* directory is fine. That is a
different bug with a different remedy (does `cost` treat a missing metrics dir as empty,
or does the fleet sweep tolerate it?), so this PR does not pick one. The fixture in
`test_bulk_cost_report_exits_zero_against_a_fixture_project` creates the directory on
purpose and its docstring says why, so the next reader does not mistake it for noise.

## Docs

`docs/operations/fleet.md` also claimed the command "emit[s] a JSON envelope per project".
It does not: `_print_bulk_result` prints one aggregate `{{action, succeeded, failed}}` and
`BulkActionResult.outputs` — the per-project stdout — is collected and never printed. I
rewrote that clause because it is the same sentence the command name had to change in, and
leaving a false half in a line I was already editing seemed worse than the one-line widen.
No behaviour change; the `outputs` field is untouched.

## Tests

Two of the three fail on pristine `main` and were written and watched failing first:

```
FAILED test_bulk_cost_report_dispatches_a_command_that_resolves
        assert None is not None  where None = _resolve('cost report')
FAILED test_bulk_cost_report_exits_zero_against_a_fixture_project
        AssertionError: expected a clean sweep, got failures:
        {{'alpha': "Error: No such command 'report'. Did you mean 'profile-report'?"}}
2 failed, 8 passed
```

The first walks the dispatched argv through the real `cli` object — the same walk
`test_cli_command_registration.py` runs on doc tables — so it is hermetic and fast. The
second spawns the actual interpreter, because "resolves" is not the same claim as
"succeeds" and the argv test cannot see click's exit code. The third
(`..._passes_extra_args_through`) passes on both trees; it is a guard, not a repro.

`cost report` is dropped from `UNREGISTERED_MENTION_EXEMPTIONS`, which is now empty —
`test_unregistered_mention_exemptions_are_still_needed` requires it, since the spelling no
longer appears in the reference.

## Verification, and what was not run

Python 3.12.3, `pip install -e ".[dev]"` in a venv, against `main` @`8882d49`.

| what | pristine `main` | this branch |
|---|---|---|
| `pytest tests/unit/fleet/test_bulk.py` (new tests present, `src/` reverted) | **2 failed, 8 passed** | — |
| `pytest tests/unit/fleet/ tests/unit/test_cli_command_registration.py` | — | **840 passed, 1 skipped** |
| docs gates: `test_docs_prose_cli_drift` + `test_docs_capability_reachability` + `test_docs_url_hygiene` + `test_naming_policy_docs` + `test_chaos_doc_code_pointers` | — | **47 passed** |
| `ruff check src/` | 1 error (`RUF036`, `core/identity/delegation_scope.py:425`) | **the same 1 error** — pre-existing, not mine, not fixed here |
| `ruff format --check` on the four changed `.py` files | — | 4 already formatted |
| `pyright core/fleet/bulk.py cli/commands/fleet_cmd.py` | 6 errors | **the same 6** — unchanged, and neither file is in `pyrightconfig.strict.json`'s gating set |
| `pyright tests/unit/fleet/test_bulk.py` | 0 errors | **0 errors** |
| `pyright tests/unit/test_cli_command_registration.py` | 24 errors | **the same 24** |

The failing-first run reverted **only** `src/bernstein/core/fleet/bulk.py` and
`src/bernstein/cli/commands/fleet_cmd.py`, keeping the new tests, so the two failures are
the defect and not a missing import. The `ruff`/`pyright` comparisons were made by
stashing and re-running on the same interpreter, not read off CI.

Every row above was re-run from scratch after `main` moved from `f3db7b0` to `8882d49`
mid-work (`#3908`, `#3909` landed); the numbers are the second measurement, not the first.

**Not run, and named rather than left to be found:** the full `scripts/run_tests.py`
sweep. This box has 2 cores and that runner spawns one process per test file over 2000+
tests. What ran is the set this issue's own brief names — `tests/unit/fleet/` and
`tests/unit/test_cli_command_registration.py` — plus the five docs gates, since the change
edits two `docs/` pages. `tests/unit/docs/`, which the brief also names, does not exist in
the tree; the docs tests are `tests/unit/test_docs_*.py` and those are the ones that ran.

<details>
<summary>AI-assisted</summary>

This patch was written by an autonomous agent. Every number above is a run on the machine
that wrote it rather than an inference: the two failing tests were run against pristine
`main` first and are quoted failing, the four `rc=` rows were produced in a temp project,
and the ruff/pyright comparisons were made by stashing the patch and re-running. The
not-run list is what this box did not run, rather than what was not attempted.

</details>
