### PR TITLE
feat(volunteer): one answer to whether a path is inside a declared scope

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -16,6 +16,7 @@ alwaysApply: false
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `instrumentation.py`        | Wave-3 per-agent instrumentation: LLM calls, tool calls, and conversation history |
 | `parallel_admission.py`     | Parallel-execution admission from a code graph (#3237, scope step 3) |
+| `path_scope.py`             | Which repository-relative paths fall outside a set of globs |
 | `run_auth_token.py`         | Persist and read the auto-generated run Bearer token (issue #2794) |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `admission/`                | Named resource pools with lease-backed admission (#2544) |

--- a/.goosehints
+++ b/.goosehints
@@ -17,6 +17,7 @@ Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Co
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `instrumentation.py`        | Wave-3 per-agent instrumentation: LLM calls, tool calls, and conversation history |
 | `parallel_admission.py`     | Parallel-execution admission from a code graph (#3237, scope step 3) |
+| `path_scope.py`             | Which repository-relative paths fall outside a set of globs |
 | `run_auth_token.py`         | Persist and read the auto-generated run Bearer token (issue #2794) |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `admission/`                | Named resource pools with lease-backed admission (#2544) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Co
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `instrumentation.py`        | Wave-3 per-agent instrumentation: LLM calls, tool calls, and conversation history |
 | `parallel_admission.py`     | Parallel-execution admission from a code graph (#3237, scope step 3) |
+| `path_scope.py`             | Which repository-relative paths fall outside a set of globs |
 | `run_auth_token.py`         | Persist and read the auto-generated run Bearer token (issue #2794) |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `admission/`                | Named resource pools with lease-backed admission (#2544) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Co
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `instrumentation.py`        | Wave-3 per-agent instrumentation: LLM calls, tool calls, and conversation history |
 | `parallel_admission.py`     | Parallel-execution admission from a code graph (#3237, scope step 3) |
+| `path_scope.py`             | Which repository-relative paths fall outside a set of globs |
 | `run_auth_token.py`         | Persist and read the auto-generated run Bearer token (issue #2794) |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `admission/`                | Named resource pools with lease-backed admission (#2544) |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -17,6 +17,7 @@ Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Co
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `instrumentation.py`        | Wave-3 per-agent instrumentation: LLM calls, tool calls, and conversation history |
 | `parallel_admission.py`     | Parallel-execution admission from a code graph (#3237, scope step 3) |
+| `path_scope.py`             | Which repository-relative paths fall outside a set of globs |
 | `run_auth_token.py`         | Persist and read the auto-generated run Bearer token (issue #2794) |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `admission/`                | Named resource pools with lease-backed admission (#2544) |

--- a/docs/reference/volunteer-manifest.md
+++ b/docs/reference/volunteer-manifest.md
@@ -72,6 +72,37 @@ manifest without the field.
 Any other field is preserved and binds to the digest, and the loader warns that
 it does not enforce it.
 
+## What a glob in `allowed_paths` matches
+
+Small on purpose, and the same language a patch is judged against wherever the
+question comes up.
+
+| | |
+|---|---|
+| `*` | any run of characters inside one path segment, including none |
+| `?` | exactly one character inside one path segment |
+| `**` | zero or more whole segments, and only as a complete segment |
+| anything else | itself, including `[` and `]` |
+
+Three consequences worth stating, because each is a place a scope can be wider
+or narrower than its author meant.
+
+**`*` stops at a separator.** `src/*` admits `src/a.py` and refuses
+`src/deep/b.py`. The `fnmatch` in most standard libraries does not draw that
+line, and a scope written expecting it to would admit the whole tree.
+
+**A pattern is not a prefix.** `src` admits a file named `src` and nothing
+under it; `src/**` is how a subtree is admitted. This is the rule people expect
+to work the other way round.
+
+**There are no character classes.** `[abc]` is three literal characters, so a
+half-open bracket in a committed manifest cannot change what the rest of the
+pattern means.
+
+An empty `allowed_paths` admits everything — that is what a project which never
+declared one carries, and it is the reason the list defaults to empty rather
+than to a starter set someone would have to widen.
+
 ## Gates are argv, never shell strings
 
 A gate is an argument vector — `["uv", "run", "pytest", "-q"]`, not

--- a/src/bernstein/core/path_scope.py
+++ b/src/bernstein/core/path_scope.py
@@ -1,0 +1,156 @@
+"""Which repository-relative paths fall outside a set of globs.
+
+Two surfaces need this question answered the same way. A volunteer project's
+manifest declares ``allowed_paths`` and a submission's diff must stay inside it
+(#3869); an agent credential carries ``allowed_files`` and the merge that
+accepts the agent's work must stay inside that (#3781). A patch judged admissible
+by one and inadmissible by the other, for the same paths and the same patterns,
+is a bug in whichever one you were not looking at.
+
+Why not ``fnmatch``: it has no separator. ``fnmatch("src/a/b.py", "src/*")`` is
+true, so a scope meant to admit the files directly under ``src/`` silently
+admits the whole tree beneath it. Four places in this repository reach for
+``fnmatch`` and one of them already carries a comment about working around
+exactly that. Here ``*`` and ``?`` stop at ``/`` and only a whole ``**`` segment
+crosses directories.
+
+The pattern language is deliberately small:
+
+===============  ==========================================================
+``*``            any run of characters within one path segment, including none
+``?``            exactly one character within one path segment
+``**``           zero or more whole segments, and only as a complete segment
+everything else  itself, including ``[`` and ``]`` - there are no character
+                 classes, because a half-open bracket in a stored pattern
+                 should not be able to change what the rest of it means
+===============  ==========================================================
+
+A pattern is not a prefix. ``src`` admits the path ``src`` and nothing under it;
+``src/**`` is how you admit the tree. That is the one rule people expect to work
+the other way, so it is stated here and pinned by a test.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+__all__ = ["normalise_repo_path", "paths_outside_scope"]
+
+
+def normalise_repo_path(path: str) -> str:
+    """Return ``path`` in the spelling this module compares against.
+
+    Backslashes become separators and a leading ``./`` is dropped, so a caller
+    reading paths off a Windows filesystem and one reading them from
+    ``git diff --name-only`` produce the same string for the same file.
+    """
+    normalised = path.replace("\\", "/")
+    while normalised.startswith("./"):
+        normalised = normalised[2:]
+    return normalised
+
+
+@lru_cache(maxsize=512)
+def _compiled(pattern: str) -> re.Pattern[str] | None:
+    """Return the matcher for ``pattern``, or None when it admits nothing.
+
+    An empty pattern is the only unusable one, and it admits nothing rather
+    than everything: a scope that cannot be read must not widen to "no scope",
+    which is the direction that turns a stored typo into an open door.
+    """
+    normalised = normalise_repo_path(pattern)
+    if not normalised:
+        return None
+
+    segments = _collapse_repeated_stars(normalised.split("/"))
+    last = len(segments) - 1
+    parts: list[str] = []
+    for index, segment in enumerate(segments):
+        if segment != "**":
+            # The separator belongs to the segment that follows it, unless a
+            # `**` already accounted for one.
+            if index > 0 and segments[index - 1] != "**":
+                parts.append("/")
+            parts.append(_segment_regex(segment))
+        elif index == last:
+            # Trailing: `src/**` covers `src` itself and everything under it.
+            parts.append("(?:/.*)?" if parts else ".*")
+        elif parts:
+            # Middle: `a/**/b` has to cover `a/b`, so the separators the eaten
+            # segments carried are consumed here and one is emitted for `b`.
+            parts.append("(?:/[^/]+)*/")
+        else:
+            # Leading: `**/b` covers `b` at any depth, including the root.
+            parts.append("(?:[^/]+/)*")
+
+    return re.compile("".join(parts) + r"\Z")
+
+
+def _collapse_repeated_stars(segments: list[str]) -> list[str]:
+    """Fold `a/**/**/b` down to `a/**/b`.
+
+    Two adjacent `**` say nothing the first does not, and each would emit its
+    own separator - which is a pattern that matches nothing rather than
+    everything, the wrong way for a typo to fail loudly.
+    """
+    folded: list[str] = []
+    for segment in segments:
+        if segment == "**" and folded and folded[-1] == "**":
+            continue
+        folded.append(segment)
+    return folded
+
+
+def _segment_regex(segment: str) -> str:
+    """Translate one path segment, where ``*`` and ``?`` stop at a separator."""
+    out: list[str] = []
+    for ch in segment:
+        if ch == "*":
+            out.append("[^/]*")
+        elif ch == "?":
+            out.append("[^/]")
+        else:
+            out.append(re.escape(ch))
+    return "".join(out)
+
+
+def _admits(path: str, patterns: Sequence[str]) -> bool:
+    """True when any pattern admits ``path``."""
+    return any((rx := _compiled(p)) is not None and rx.match(path) for p in patterns)
+
+
+def paths_outside_scope(paths: Iterable[str], patterns: Sequence[str]) -> tuple[str, ...]:
+    """Return the paths no pattern admits, in input order, without repeats.
+
+    Args:
+        paths: Repository-relative paths, as ``git diff --name-only`` prints
+            them. Normalised before comparison.
+        patterns: The declared scope. **Empty means no restriction** - every
+            identity and every manifest that has never set one carries an empty
+            list, so a caller that turned an empty scope into "admit nothing"
+            would refuse all existing work.
+
+    Returns:
+        The offending paths. Empty when everything is in scope, which is also
+        the answer for an empty ``patterns``. Callers name these in the refusal:
+        a scope error that does not say which paths broke it reads as a bug to
+        the first person who hits it.
+    """
+    if not patterns:
+        return ()
+
+    outside: list[str] = []
+    seen: set[str] = set()
+    for raw in paths:
+        path = normalise_repo_path(raw)
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        if not _admits(path, patterns):
+            outside.append(path)
+    return tuple(outside)

--- a/src/bernstein/core/volunteer/manifest.py
+++ b/src/bernstein/core/volunteer/manifest.py
@@ -77,8 +77,10 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.path_scope import paths_outside_scope as _paths_outside_scope
+
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping
     from pathlib import Path
 
 #: Repository-relative location of the manifest.  A project opts in by
@@ -258,6 +260,22 @@ class VolunteerManifest:
     def digest(self) -> str:
         """SHA-256 of the canonical form, as ``manifest_sha256`` carries it."""
         return manifest_digest(self)
+
+    def paths_outside_scope(self, paths: Iterable[str]) -> tuple[str, ...]:
+        """Return the patch paths this project's ``allowed_paths`` does not admit.
+
+        The refusal names these, so a contributor is told which files broke the
+        scope rather than that something did.  An empty ``allowed_paths`` admits
+        everything, which is what a project that never declared one carries.
+
+        Args:
+            paths: Repository-relative paths, as ``git diff --name-only`` prints
+                them.
+
+        Returns:
+            The offending paths in input order, empty when the patch is in scope.
+        """
+        return _paths_outside_scope(paths, self.allowed_paths)
 
 
 def canonical_manifest_bytes(manifest: VolunteerManifest) -> bytes:

--- a/tests/unit/test_path_scope.py
+++ b/tests/unit/test_path_scope.py
@@ -1,0 +1,151 @@
+"""The path-scope matcher, one test per way it could quietly be wrong.
+
+Two callers depend on this answer being the same on both sides: a volunteer
+submission's diff against the project manifest's ``allowed_paths`` (#3869), and
+the merge that accepts an agent's work against the credential's ``allowed_files``
+(#3781). Every test below names a way the matcher could admit something it
+should not, or refuse something everyone has.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.path_scope import normalise_repo_path, paths_outside_scope
+
+
+def test_an_empty_scope_admits_every_path() -> None:
+    """The load-bearing default on both surfaces.
+
+    Every credential and every manifest that has never declared a scope carries
+    an empty list. Reading that as "admit nothing" would refuse all existing
+    work the first time the gate ran.
+    """
+    assert paths_outside_scope(["src/a.py", "/etc/passwd", "../x"], []) == ()
+
+
+def test_a_path_no_pattern_admits_is_reported() -> None:
+    """The whole point: something outside the scope comes back named."""
+    assert paths_outside_scope(["src/a.py", "uv.lock"], ["src/**"]) == ("uv.lock",)
+
+
+def test_a_double_star_segment_crosses_directories() -> None:
+    """`src/**` has to mean the tree, or no realistic scope can be written."""
+    outside = paths_outside_scope(["src/a.py", "src/deep/nested/b.py"], ["src/**"])
+    assert outside == ()
+
+
+def test_a_single_star_does_not_cross_a_directory_separator() -> None:
+    """The `fnmatch` trap, and the reason this module exists.
+
+    ``fnmatch("src/deep/b.py", "src/*")`` is true. A scope meant to admit the
+    files directly under ``src/`` would silently admit everything beneath it,
+    which is the difference between a boundary and a decoration.
+    """
+    assert paths_outside_scope(["src/a.py"], ["src/*"]) == ()
+    assert paths_outside_scope(["src/deep/b.py"], ["src/*"]) == ("src/deep/b.py",)
+
+
+def test_a_pattern_is_not_a_prefix() -> None:
+    """`src` admits the path `src`, not the tree under it.
+
+    This is the rule people expect to work the other way. Getting it wrong
+    widens every scope silently, so it is pinned rather than assumed.
+    """
+    assert paths_outside_scope(["src/a.py"], ["src"]) == ("src/a.py",)
+    assert paths_outside_scope(["src"], ["src"]) == ()
+
+
+def test_a_question_mark_matches_one_character_and_never_a_separator() -> None:
+    assert paths_outside_scope(["src/a.py"], ["src/?.py"]) == ()
+    assert paths_outside_scope(["src/ab.py"], ["src/?.py"]) == ("src/ab.py",)
+    assert paths_outside_scope(["src/a/py"], ["src/a?py"]) == ("src/a/py",)
+
+
+def test_a_middle_double_star_matches_zero_intervening_segments() -> None:
+    """`a/**/b` has to cover `a/b`, or every scope needs two patterns."""
+    assert paths_outside_scope(["a/b", "a/x/b", "a/x/y/b"], ["a/**/b"]) == ()
+    assert paths_outside_scope(["a/x/c"], ["a/**/b"]) == ("a/x/c",)
+
+
+def test_a_bracket_is_a_literal_character_and_not_a_class() -> None:
+    """No character classes, so a half-open bracket cannot rewrite a pattern.
+
+    An unbalanced `[` in a stored scope would otherwise be a regex error or,
+    worse, change what the rest of the pattern means.
+    """
+    assert paths_outside_scope(["src/[a].py"], ["src/[a].py"]) == ()
+    assert paths_outside_scope(["src/a.py"], ["src/[a].py"]) == ("src/a.py",)
+    # An unbalanced bracket is a literal too, not a crash.
+    assert paths_outside_scope(["src/a.py"], ["src/[.py"]) == ("src/a.py",)
+
+
+def test_an_empty_pattern_admits_nothing_rather_than_everything() -> None:
+    """The fail-open direction is the dangerous one.
+
+    A scope entry that cannot be read must not degrade into "no scope". Note
+    this is a single unusable *entry*; an empty pattern *list* still means no
+    restriction, which the first test pins.
+    """
+    assert paths_outside_scope(["src/a.py"], [""]) == ("src/a.py",)
+    assert paths_outside_scope(["src/a.py"], ["", "src/**"]) == ()
+
+
+def test_a_windows_separator_is_read_as_a_separator() -> None:
+    """`git diff` prints `/`; a caller reading the working tree may not.
+
+    Left unnormalised, `src\\a.py` matches no `src/**` pattern and a perfectly
+    in-scope file is refused on one platform only.
+    """
+    assert paths_outside_scope(["src\\a.py"], ["src/**"]) == ()
+    assert paths_outside_scope(["src/a.py"], ["src\\**"]) == ()
+
+
+def test_a_leading_dot_slash_names_the_same_path() -> None:
+    assert paths_outside_scope(["./src/a.py"], ["src/**"]) == ()
+    assert normalise_repo_path("././src/a.py") == "src/a.py"
+
+
+def test_the_report_keeps_input_order_and_does_not_repeat_a_path() -> None:
+    """The refusal message is built from this, and a reader scans it.
+
+    Two rows for one file reads as two problems, and an order that does not
+    match the diff makes a long list hard to check off.
+    """
+    paths = ["z.txt", "src/a.py", "a.txt", "z.txt", "./z.txt"]
+    assert paths_outside_scope(paths, ["src/**"]) == ("z.txt", "a.txt")
+
+
+def test_one_admitting_pattern_is_enough() -> None:
+    """Patterns are alternatives, not conjunctions."""
+    assert paths_outside_scope(["docs/x.md", "src/a.py"], ["src/**", "docs/**"]) == ()
+
+
+@pytest.mark.parametrize("escape", ["../etc/passwd", "/etc/passwd", "~/.ssh/id_rsa"])
+def test_a_path_reaching_outside_the_checkout_is_not_admitted_by_a_subtree_scope(escape: str) -> None:
+    """Validation refuses these shapes as *patterns*; they still arrive as paths.
+
+    A scope of `src/**` must not admit one by accident on the way in - the
+    patterns are anchored at the start, so a leading `/` or `..` cannot be
+    skipped over.
+    """
+    assert paths_outside_scope([escape], ["src/**"]) == (normalise_repo_path(escape),)
+
+
+def test_a_bare_double_star_admits_everything() -> None:
+    """Stated rather than discovered: `**` is a scope that restricts nothing.
+
+    It is the same outcome as an empty list, reached deliberately, and someone
+    writing it should get what they asked for rather than an anchored surprise.
+    """
+    assert paths_outside_scope(["a", "a/b/c.py", "../x"], ["**"]) == ()
+
+
+def test_repeated_double_stars_say_nothing_the_first_did_not() -> None:
+    """`a/**/**/b` folds to `a/**/b` rather than matching nothing.
+
+    Each `**` accounts for its own separator, so two adjacent ones would emit
+    two - a pattern that matches nothing, which is the wrong way for a typo to
+    fail: silently narrower rather than loudly wrong.
+    """
+    assert paths_outside_scope(["a/b", "a/x/y/b"], ["a/**/**/b"]) == ()


### PR DESCRIPTION
Partial implementation of #3869 — its acceptance criterion 3 ("a diff touching a path outside `allowed_paths` is refused before gates run") needs a matcher, and there is not one. This PR is that matcher, not the runner.

## Why it is one module and not two

Two surfaces ask the same question:

| Surface | Scope | Judged against |
|---|---|---|
| Volunteer submission (#3869) | manifest `allowed_paths` | the patch's file list |
| Merge of an agent's work (#3914, decided in #3781) | credential `allowed_files` | `git diff --name-only` for the merge |

A patch admitted by one and refused by the other, for the same paths and the same patterns, is a bug in whichever one you were not looking at. `core/path_scope.py` answers it once; `VolunteerManifest.paths_outside_scope()` is the first caller and the merge gate is the second.

## Why not `fnmatch`

It has no separator:

```python
>>> fnmatch("src/deep/b.py", "src/*")
True
```

A scope meant to admit the files directly under `src/` silently admits the whole tree. Four modules in this repository reach for `fnmatch` for path work, and `core/autoheal/cordon.py:85` already carries a comment about working around exactly this. Here `*` and `?` stop at `/`, and only a whole `**` segment crosses directories.

## The language, and three deliberate narrowings

| | |
|---|---|
| `*` | any run of characters inside one segment, including none |
| `?` | exactly one character inside one segment |
| `**` | zero or more whole segments, only as a complete segment |
| anything else | itself, including `[` and `]` |

- **A pattern is not a prefix.** `src` admits a file named `src` and nothing under it; `src/**` admits the subtree. This is the rule people expect to work the other way, so it is pinned rather than assumed.
- **No character classes.** `[abc]` is three literal characters, so a half-open bracket in a committed manifest cannot change what the rest of the pattern means.
- **An unusable pattern entry admits nothing; an empty pattern *list* admits everything.** The second is load-bearing — every manifest and every credential that has never declared a scope carries `[]`, so reading it as "admit nothing" would refuse all existing work the first time a gate ran. The first is the fail-closed direction for a single broken entry.

## What is untouched

The manifest's validation. It already refuses absolute, drive-qualified, home-relative and escaping patterns at load (`manifest.py:417-437`); this module only answers what an already-valid pattern matches.

## Tests

`tests/unit/test_path_scope.py` — 18 cases, each named for a way the matcher could quietly be wrong rather than for the function it calls. The middle-`**` case (`a/**/b` must cover `a/b`) caught a real separator bug in the first draft, and the repeated-`**` fold exists because two adjacent `**` each emitted their own separator, producing a pattern that matched nothing.

`tests/unit/volunteer/` re-runs green (177 passed with this file).

## Still open on #3869

Everything else: the clone, the prompt sanitisation, the sandboxed adapter run, the gate execution, the receipt bundle, and the refusal record. This is the seam those compose against, and #3871 and #3872 both plug into it.