### PR TITLE
fix(cost): a missing default metrics dir reports empty, not error (#3917)

### DIFF
--- a/src/bernstein/cli/commands/cost.py
+++ b/src/bernstein/cli/commands/cost.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import click
+from click.core import ParameterSource
 from rich.console import Console
 from rich.panel import Panel
 
@@ -648,10 +649,15 @@ def _cost_render_grouped(
     console.print()
 
 
+#: Where ``cost`` looks when nobody says otherwise. Named so the option below and
+#: the missing-directory check cannot drift apart (issue #3917).
+DEFAULT_METRICS_DIR = ".sdd/metrics"
+
+
 @click.group("cost", invoke_without_command=True)
 @click.option(
     "--metrics-dir",
-    default=".sdd/metrics",
+    default=DEFAULT_METRICS_DIR,
     show_default=True,
     help="Directory containing metrics JSONL files.",
 )
@@ -705,11 +711,33 @@ def cost_cmd(
 
     mdir = Path(metrics_dir)
     if not mdir.exists():
+        # A project that has never been run has no metrics directory at all; a project
+        # that has been run and produced nothing has an empty one. Both mean "no cost
+        # data here" to a reader, so a read-only report must not make an error out of
+        # one and a normal empty report out of the other (issue #3917). ``fleet
+        # bulk-cost-report`` is where that asymmetry bites: one never-run project used
+        # to turn the whole sweep's exit status red.
+        #
+        # The refusal is kept when the caller NAMED the directory, because there an
+        # absent path is far more likely to be a typo than a new project, and silently
+        # printing an empty report at a mistyped path is the signal worth keeping.
+        # This turns on the parameter's SOURCE, not its value: someone who types the
+        # default spelling has still named a path.
+        source = ctx.get_parameter_source("metrics_dir")
+        # ``source`` is None only when the callback is driven directly rather than
+        # through click's parameter handling, where there is no source to consult.
+        named = metrics_dir != DEFAULT_METRICS_DIR if source is None else source is not ParameterSource.DEFAULT
+        if named:
+            if as_json or is_json():
+                print_json({"error": f"Metrics directory not found: {mdir}"})
+            else:
+                console.print(f"[red]Metrics directory not found:[/red] {mdir}")
+            raise SystemExit(1)
         if as_json or is_json():
-            print_json({"error": f"Metrics directory not found: {mdir}"})
+            print_json({"rows": [], "totals": {}})
         else:
-            console.print(f"[red]Metrics directory not found:[/red] {mdir}")
-        raise SystemExit(1)
+            console.print("[dim]No metrics data found.[/dim]")
+        return
 
     task_records = _load_tasks_jsonl(mdir)
 

--- a/tests/unit/cost/test_cost_missing_metrics_dir.py
+++ b/tests/unit/cost/test_cost_missing_metrics_dir.py
@@ -65,7 +65,7 @@ def test_an_explicitly_named_metrics_dir_that_does_not_exist_still_says_so(
 ) -> None:
     """A typo must not read as "no data" — that is the signal the fix keeps."""
     proj = _project(tmp_path, metrics=True)
-    typo = _run(proj, "--metrics-dir", str(proj / ".sdd" / "metrcis"))
+    typo = _run(proj, "--metrics-dir", str(proj / ".sdd" / "no-such-metrics-dir"))
 
     assert typo.exit_code == 1
     assert "Metrics directory not found" in typo.output
@@ -73,7 +73,7 @@ def test_an_explicitly_named_metrics_dir_that_does_not_exist_still_says_so(
 
 def test_an_explicit_metrics_dir_typo_is_an_error_in_json_mode_too(tmp_path: Path) -> None:
     proj = _project(tmp_path, metrics=True)
-    typo = _run(proj, "--json", "--metrics-dir", str(proj / ".sdd" / "metrcis"))
+    typo = _run(proj, "--json", "--metrics-dir", str(proj / ".sdd" / "no-such-metrics-dir"))
 
     assert typo.exit_code == 1
     assert "Metrics directory not found" in json.loads(typo.output)["error"]

--- a/tests/unit/cost/test_cost_missing_metrics_dir.py
+++ b/tests/unit/cost/test_cost_missing_metrics_dir.py
@@ -1,0 +1,96 @@
+"""``bernstein cost`` on a project that has never been run (issue #3917).
+
+The property under test is an agreement between two states that mean the same
+thing to a reader: a project with no ``.sdd/metrics`` directory at all, and a
+project whose ``.sdd/metrics`` exists and is empty. Both say "this project has
+no cost data". Only one of them used to be an error, and a read-only report
+that exits non-zero because a directory is absent turns a fleet sweep red for
+every project that has simply not run yet.
+
+The refusal is deliberately kept for a directory the caller named explicitly:
+there, an absent path is far more likely to be a typo than a new project, and
+losing that signal would be a worse trade than the bug it fixes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.cost import cost_cmd
+
+
+def _project(root: Path, *, metrics: bool) -> Path:
+    """A project directory with ``.sdd/metrics`` either absent or present-and-empty."""
+    proj = root / ("empty-metrics" if metrics else "never-run")
+    (proj / ".sdd").mkdir(parents=True)
+    if metrics:
+        (proj / ".sdd" / "metrics").mkdir()
+    return proj
+
+
+def _run(proj: Path, *args: str):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=proj.parent) as _:
+        # ``cost``'s default --metrics-dir is relative, so the project is the cwd.
+        import os
+
+        os.chdir(proj)
+        return runner.invoke(cost_cmd, list(args))
+
+
+def test_a_missing_metrics_dir_reports_the_same_as_an_empty_one(tmp_path: Path) -> None:
+    never_run = _run(_project(tmp_path, metrics=False))
+    empty = _run(_project(tmp_path, metrics=True))
+
+    assert never_run.exit_code == empty.exit_code == 0, (
+        f"never-run rc={never_run.exit_code!r} output={never_run.output!r}; "
+        f"empty rc={empty.exit_code!r} output={empty.output!r}"
+    )
+    assert never_run.output == empty.output
+
+
+def test_the_missing_and_empty_pair_also_agree_in_json_mode(tmp_path: Path) -> None:
+    never_run = _run(_project(tmp_path, metrics=False), "--json")
+    empty = _run(_project(tmp_path, metrics=True), "--json")
+
+    assert never_run.exit_code == empty.exit_code == 0
+    assert json.loads(never_run.output) == json.loads(empty.output)
+
+
+def test_an_explicitly_named_metrics_dir_that_does_not_exist_still_says_so(
+    tmp_path: Path,
+) -> None:
+    """A typo must not read as "no data" — that is the signal the fix keeps."""
+    proj = _project(tmp_path, metrics=True)
+    typo = _run(proj, "--metrics-dir", str(proj / ".sdd" / "metrcis"))
+
+    assert typo.exit_code == 1
+    assert "Metrics directory not found" in typo.output
+
+
+def test_an_explicit_metrics_dir_typo_is_an_error_in_json_mode_too(tmp_path: Path) -> None:
+    proj = _project(tmp_path, metrics=True)
+    typo = _run(proj, "--json", "--metrics-dir", str(proj / ".sdd" / "metrcis"))
+
+    assert typo.exit_code == 1
+    assert "Metrics directory not found" in json.loads(typo.output)["error"]
+
+
+def test_passing_the_default_metrics_dir_explicitly_still_refuses_when_absent(
+    tmp_path: Path,
+) -> None:
+    """The distinction is the parameter *source*, not the parameter value.
+
+    Someone who types ``--metrics-dir .sdd/metrics`` has named a path, so the
+    typo signal applies to them exactly as it does to any other spelling. This
+    pins the mechanism: if the check ever degrades into comparing the string
+    against the default, this is the test that notices.
+    """
+    proj = _project(tmp_path, metrics=False)
+    explicit = _run(proj, "--metrics-dir", ".sdd/metrics")
+
+    assert explicit.exit_code == 1
+    assert "Metrics directory not found" in explicit.output


### PR DESCRIPTION
## What

`bernstein cost` treats a project with no `.sdd/metrics` the same as a project whose
`.sdd/metrics` is empty: both print `No metrics data found.` and exit 0. An
explicitly-passed `--metrics-dir` that does not exist still exits 1 and says so.

Closes #3917.

## Why this side of the decision

The issue offers two remedies in different layers and floats a third that is neither:
tolerate a missing *default* path, keep the refusal for a path the caller named. That
third one is what this does, for a reason worth stating out loud:

**it is the only one of the three that does not touch `bulk.py`, which #3915 is
already sitting on.** Fixing this in the fleet layer would put two open PRs from the same
author on `_bulk_dispatch` and hand you a conflict to resolve. If you would rather it live
in the fleet layer after #3915 lands, say so and I will move it there instead.

## Measured on `5b89547`, in two temp projects

Before:

```
(no .sdd/metrics)     bernstein cost      Metrics directory not found: .sdd/metrics   rc=1
(empty .sdd/metrics)  bernstein cost      No metrics data found.                      rc=0
```

After:

```
(no .sdd/metrics)     bernstein cost      No metrics data found.                      rc=0
(empty .sdd/metrics)  bernstein cost      No metrics data found.                      rc=0
```

and the signal the fix keeps, in the same two projects:

```
bernstein cost --metrics-dir .sdd/metrcis     Metrics directory not found: .sdd/metrcis  rc=1
bernstein cost --json --metrics-dir ...       {{"error": "Metrics directory not found..."}}  rc=1
(no .sdd/metrics) bernstein cost --metrics-dir .sdd/metrics   Metrics directory not found  rc=1
```

**That last row is the mechanism, not a curiosity.** The check turns on the parameter's
*source* (`ctx.get_parameter_source`), not its value — someone who types the default
spelling has still named a path, so the typo signal applies to them too. If this ever
degrades into `metrics_dir != ".sdd/metrics"` the behaviour looks identical until exactly
that case, so there is a test named after it.

The default is now a module constant the option and the check share, so they cannot drift.

## Tests

`tests/unit/cost/test_cost_missing_metrics_dir.py`, named after the properties rather
than the function, as the issue asks:

* `test_a_missing_metrics_dir_reports_the_same_as_an_empty_one` — **fails on pristine
  `main`**: `never-run rc=1 output='Metrics directory not found: .sdd/metrics'; empty
  rc=0 output='No metrics data found.'`
* `test_the_missing_and_empty_pair_also_agree_in_json_mode` — **fails on pristine
  `main`** (`assert 1 == 0`). It compares the parsed envelopes, so the two states are
  indistinguishable to a machine reader too, not just to a person.
* `test_an_explicitly_named_metrics_dir_that_does_not_exist_still_says_so`
* `test_an_explicit_metrics_dir_typo_is_an_error_in_json_mode_too`
* `test_passing_the_default_metrics_dir_explicitly_still_refuses_when_absent`

The last three **pass on pristine `main` on purpose** — they pin the signal this change
is spending nothing of. The two failures were watched with only `src/` reverted; a plain
`git stash` takes the new tests out along with the fix and the run comes back green for
the wrong reason.

## What I did NOT do, and why

**The third acceptance bullet — a fleet sweep reporting success for never-run projects —
is not independently testable on `main` today, and I have not written a test that pretends
otherwise.** `bulk_cost_report` still builds `["cost", "report", ...]` there, so every
project in a sweep comes back rc=2 regardless of this change. That is #3755, i.e. #3915.
The property holds once both land. A fleet-level test that passes today would have to be
written against my own unmerged branch, and an honest one would fail for the other bug.
Happy to add it as a follow-up the day #3915 merges.

**I also have not touched the fixture docstring in `tests/unit/fleet/test_bulk.py`** that
you said stops being a workaround once this lands. That file only exists on #3915's
branch; updating it belongs to whichever of the two lands second, and doing it here would
be the conflict this patch is shaped to avoid.

## Runs

```
$ .venv/bin/python -m pytest tests/unit/cost/test_cost_missing_metrics_dir.py -q
5 passed

$ .venv/bin/python -m pytest tests/unit/cost tests/unit/fleet -q
486 passed in 95.82s        # re-run on 5b89547 after the rebase

$ .venv/bin/python -m pytest tests/unit/cost tests/unit/fleet tests/unit/cli -q
969 passed in 279.16s      # measured on f7e86e8, the head before the rebase

$ .venv/bin/python -m ruff check src/bernstein/cli/commands/cost.py tests/unit/cost/test_cost_missing_metrics_dir.py
All checks passed!

$ .venv/bin/python -m ruff format --check <both files>
2 files already formatted
```

Failing-first, with **only `src/` reverted** so the new tests stay on the tree:

```
FAILED test_a_missing_metrics_dir_reports_the_same_as_an_empty_one
  AssertionError: never-run rc=1 output='Metrics directory not found: .sdd/metrics\n';
                  empty rc=0 output='No metrics data found.\n'
FAILED test_the_missing_and_empty_pair_also_agree_in_json_mode
  assert 1 == 0
2 failed, 3 passed
```

## Not run

* **The full `scripts/run_tests.py` sweep.** This box has 2 cores and that runner spawns
  one process per test file; the targeted directories below are what it can finish. Same
  disclosure as #3915 — assume the full suite is unverified from my side, not green.
* **`pyright`.** Its bundled node cannot start on this box (`libatomic.so.1` is not
  installed and there is no package manager here to add it). `ruff check` and
  `ruff format --check` are clean on both changed files. I would rather say the tool did
  not run than report a result I did not get.

<details>
<summary>AI-assisted</summary>

This patch was written by an autonomous agent. Every number above is a run on the machine
that wrote it rather than an inference: the two failing tests were run against pristine
`main` first and are quoted failing with only `src/` reverted, and the `rc=` rows were
produced in two temp projects with the real CLI. The not-run list is what this box did
not run, rather than what was not attempted.

</details>
