### PR TITLE
chore(ci): ratchet coverage baseline up to 83.7%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
   "diff_coverage_floor_percent": 85,
-  "head_sha": "8882d49ca4b6398e02b009137d84b2c4102f83e3",
-  "line_rate": 0.8368,
-  "run_id": "31913946256",
-  "total_coverage_percent": 83.68,
-  "updated_at": "2026-08-15T23:48:06+00:00"
+  "head_sha": "5b89547b85a04a7ebc237c1f84e7953ddf39f6eb",
+  "line_rate": 0.837,
+  "run_id": "31916004059",
+  "total_coverage_percent": 83.7,
+  "updated_at": "2026-08-16T00:45:27+00:00"
 }


### PR DESCRIPTION
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **83.7%**.

Measured on `5b89547b85a04a7ebc237c1f84e7953ddf39f6eb` from the
`coverage-report` artifact of CI run
[31916004059](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/31916004059).
Those, and the raw Cobertura `line-rate` the percentage was
rounded from, are recorded in the baseline, so the number in the
diff can be re-derived from the file itself:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.