### PR TITLE
fix(cost): read the archive before reporting no data (#3923)

### DIFF
--- a/src/bernstein/cli/commands/cost.py
+++ b/src/bernstein/cli/commands/cost.py
@@ -733,11 +733,18 @@ def cost_cmd(
             else:
                 console.print(f"[red]Metrics directory not found:[/red] {mdir}")
             raise SystemExit(1)
-        if as_json or is_json():
-            print_json({"rows": [], "totals": {}})
-        else:
-            console.print("[dim]No metrics data found.[/dim]")
-        return
+        # Otherwise fall through. An absent default directory is not by itself an
+        # answer: ``_load_archive_tasks`` reads ``.sdd/archive/tasks.jsonl``, which is
+        # a sibling of ``.sdd/metrics`` rather than a child of it, so a project whose
+        # metrics were cleaned but whose archive survived still has data to report
+        # (issue #3923). Returning "no data" here reported on one of the two sources
+        # and spoke for both.
+        #
+        # Nothing below needs the directory to exist: ``_load_jsonl`` returns ``[]``
+        # for an absent path and ``iter_metric_files`` documents the same for an
+        # absent directory. "Is there anything to report" is therefore answered in
+        # exactly one place -- the empty-result branch after the loads -- which is
+        # the only way the metrics half and the archive half cannot drift apart.
 
     task_records = _load_tasks_jsonl(mdir)
 

--- a/tests/unit/cost/test_cost_archive_without_metrics_dir.py
+++ b/tests/unit/cost/test_cost_archive_without_metrics_dir.py
@@ -124,7 +124,7 @@ def test_an_explicitly_named_missing_dir_still_errors_even_with_an_archive(
     print a confident report about a directory the caller misspelled.
     """
     proj = _project(tmp_path, "typo", metrics=True, archived=True)
-    result = _run(proj, "--metrics-dir", str(proj / ".sdd" / "metrcis"))
+    result = _run(proj, "--metrics-dir", str(proj / ".sdd" / "no-such-metrics-dir"))
 
     assert result.exit_code == 1
     assert "Metrics directory not found" in result.output

--- a/tests/unit/cost/test_cost_archive_without_metrics_dir.py
+++ b/tests/unit/cost/test_cost_archive_without_metrics_dir.py
@@ -1,0 +1,130 @@
+"""``bernstein cost`` on a project whose metrics were cleaned but whose archive survived
+(issue #3923).
+
+``.sdd/archive/tasks.jsonl`` is a *sibling* of ``.sdd/metrics``, not a child of it, so
+the two rot on different schedules: ``.sdd/metrics`` is cleaned by hand, by a container
+rebuild, or by anything that treats it as a cache, and the archive is the part meant to
+outlive that. The early "nothing here" return added for #3917 sat in front of the archive
+read, so surviving the cleanup was exactly what hid the data -- reported as
+``No metrics data found.`` at exit 0, which is a confident answer about a source that was
+never consulted.
+
+The property under test is that the *two spellings of the same project* agree: whether or
+not an empty ``.sdd/metrics`` happens to exist, a project with archived tasks reports
+them. An empty directory is not information and must not change an answer.
+
+The neighbours pinned by ``test_cost_missing_metrics_dir.py`` are unchanged and are
+re-asserted here from the archive's side, because this fix moves the code that produces
+them: a project with no data anywhere still reports "no data" at exit 0, and an
+explicitly named directory that does not exist is still an error.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.cost import cost_cmd
+
+ARCHIVED_TASK = {
+    "task_id": "archived-1",
+    "role": "backend",
+    "model": "claude-haiku-4",
+    "tokens_prompt": 400,
+    "tokens_completion": 200,
+    "cost_usd": 0.02,
+    "duration_seconds": 15.0,
+    "agent_id": "agent-archived",
+}
+
+
+def _project(root: Path, name: str, *, metrics: bool, archived: bool) -> Path:
+    """A project whose ``.sdd/metrics`` and ``.sdd/archive`` are independently present."""
+    proj = root / name
+    sdd = proj / ".sdd"
+    sdd.mkdir(parents=True)
+    if metrics:
+        (sdd / "metrics").mkdir()
+    if archived:
+        (sdd / "archive").mkdir()
+        record = dict(ARCHIVED_TASK, timestamp=time.time())
+        (sdd / "archive" / "tasks.jsonl").write_text(json.dumps(record) + "\n")
+    return proj
+
+
+def _run(proj: Path, *args: str):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=proj.parent):
+        # ``cost``'s default --metrics-dir is relative, so the project is the cwd.
+        os.chdir(proj)
+        return runner.invoke(cost_cmd, list(args))
+
+
+def test_archived_tasks_are_reported_when_the_metrics_dir_is_absent(tmp_path: Path) -> None:
+    """The bug itself: data in the archive, no ``.sdd/metrics``, reported as no data."""
+    result = _run(_project(tmp_path, "cleaned", metrics=False, archived=True))
+
+    assert result.exit_code == 0, f"rc={result.exit_code!r} output={result.output!r}"
+    assert "No metrics data found" not in result.output, (
+        "the archive holds a task and the report says there is nothing here"
+    )
+    assert ARCHIVED_TASK["model"] in result.output
+
+
+def test_archived_tasks_are_reported_in_json_mode_too(tmp_path: Path) -> None:
+    result = _run(_project(tmp_path, "cleaned-json", metrics=False, archived=True), "--json")
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["rows"], f"--json reported no rows for an archived task: {payload!r}"
+    assert any(row.get("model") == ARCHIVED_TASK["model"] for row in payload["rows"])
+
+
+def test_an_empty_metrics_dir_does_not_change_the_answer(tmp_path: Path) -> None:
+    """The acceptance criterion: same project, two spellings, identical output.
+
+    This is the test that fails if the archive is ever read from only one of the two
+    paths again. An empty directory carries no information and must not be the
+    difference between reporting a task and denying it exists.
+    """
+    without = _run(_project(tmp_path, "no-metrics-dir", metrics=False, archived=True))
+    with_empty = _run(_project(tmp_path, "empty-metrics-dir", metrics=True, archived=True))
+
+    assert without.exit_code == with_empty.exit_code == 0
+    assert without.output == with_empty.output
+
+
+def test_the_two_spellings_also_agree_in_json_mode(tmp_path: Path) -> None:
+    without = _run(_project(tmp_path, "no-dir-json", metrics=False, archived=True), "--json")
+    with_empty = _run(_project(tmp_path, "empty-dir-json", metrics=True, archived=True), "--json")
+
+    assert without.exit_code == with_empty.exit_code == 0
+    assert json.loads(without.output) == json.loads(with_empty.output)
+
+
+def test_a_project_with_no_data_anywhere_still_reports_no_data(tmp_path: Path) -> None:
+    """#3917's outcome, re-asserted from the archive's side: still quiet, still exit 0."""
+    result = _run(_project(tmp_path, "never-run", metrics=False, archived=False))
+
+    assert result.exit_code == 0, f"rc={result.exit_code!r} output={result.output!r}"
+    assert "No metrics data found" in result.output
+
+
+def test_an_explicitly_named_missing_dir_still_errors_even_with_an_archive(
+    tmp_path: Path,
+) -> None:
+    """A typo is still a typo. Falling through must not swallow the named-path signal.
+
+    The archive is present here on purpose: if the fall-through were placed before the
+    ``named`` check rather than after it, this project would find the archived task and
+    print a confident report about a directory the caller misspelled.
+    """
+    proj = _project(tmp_path, "typo", metrics=True, archived=True)
+    result = _run(proj, "--metrics-dir", str(proj / ".sdd" / "metrcis"))
+
+    assert result.exit_code == 1
+    assert "Metrics directory not found" in result.output


### PR DESCRIPTION
Fixes #3923.

## The decision the issue left open

**Load both sources first, then decide.** The early "nothing here" return is *removed*
rather than paired with an archive-exists check beside it.

I went back and forth on the O(1)-on-a-fleet-sweep argument, and it does not survive
contact with the loaders. Nothing below that branch needs the directory to exist:
`_load_jsonl` returns `[]` for an absent path, and `iter_metric_files` documents
"empty when the directory does not exist" in its own docstring. So falling through costs
one extra `stat` per never-run project, against `fleet bulk-cost-report` spawning a CLI
per project — it is not measurable there.

More to the point, **the archive stat has to happen anyway.** "Is there anything to
report" cannot be answered without reading the archive, so the second check would be
doing the same work in a second place — which is precisely the drift the first option
avoids. After this, exactly one branch decides the question: the empty-result branch
after the loads, which already printed the right thing.

The result is a net deletion from the #3917 code path.

## What is deliberately unchanged

The named-directory refusal, and **the fall-through is placed after it, not before it.**
A caller who misspells `--metrics-dir` still gets `Metrics directory not found` and exit
1 — including in a project whose archive would otherwise have produced a confident report
about a path they typed wrong. `test_an_explicitly_named_missing_dir_still_errors_even_with_an_archive`
pins that ordering, with an archive present on purpose.

`sdd_dir = mdir.parent` is untouched, per Not in scope.

## Tests

Six, in `tests/unit/cost/test_cost_archive_without_metrics_dir.py`.

**Four fail on this branch's parent with only `src/` reverted** (`git stash push
src/bernstein/cli/commands/cost.py`, so the tests stay and the fix goes):

```
FAILED test_archived_tasks_are_reported_when_the_metrics_dir_is_absent
FAILED test_archived_tasks_are_reported_in_json_mode_too
FAILED test_an_empty_metrics_dir_does_not_change_the_answer
FAILED test_the_two_spellings_also_agree_in_json_mode
4 failed, 7 passed
```

The other two pass in **both** states on purpose — they assert neighbours this change
must not move (no data anywhere is still quiet and still exit 0; a named missing dir is
still an error). All five of #3917's tests pass in both states as well; none of them
moved.

Your fourth acceptance criterion — same project with and without an empty `.sdd/metrics`,
identical output — is `test_an_empty_metrics_dir_does_not_change_the_answer`, and its
`--json` twin.

## This stacks on #3921

#3923 is a defect **#3921 introduces**, so the branch is cut from
`fix/3917-cost-missing-metrics-dir` and carries its commit. Merge #3921 first and this
becomes a one-commit PR against `main` with no action from me. If you would rather I
rebase onto `main` after #3921 lands, or fold it into #3921 instead of carrying a second
PR, say which and I will do it — it is your tree.

## What I did not run

**The full `scripts/run_tests.py` sweep was not run** — this box has 2 cores and that
harness is process-per-file over 2000+ tests. What I did run:

```
tests/unit/cost/ + tests/unit/test_cost_cmd_enhanced.py     339 passed in 65.10s
ruff check                                                  All checks passed
ruff format --check                                         2 files already formatted
```

Please do not read that as the suite being green. Your CI is on for fork PRs now, so it
will know better than I do.
