### PR TITLE
test(bootstrap): assert the readiness message with the real timeout constant

### DIFF
--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -57,6 +57,7 @@ from bernstein.core.seed import (
     parse_seed,
 )
 from bernstein.core.server_launch import (
+    _SERVER_READY_TIMEOUT_S,
     BootstrapResult,
     _build_codebase_index,
     _clean_stale_runtime,
@@ -723,7 +724,7 @@ def bootstrap_from_seed(
         from bernstein.cli.errors import BernsteinError
 
         BernsteinError(
-            what=f"Task server on port {port} did not respond within 10.0s",
+            what=f"Task server on port {port} did not respond within {_SERVER_READY_TIMEOUT_S}s",
             why="Server process may have crashed during startup",
             fix="Check .sdd/runtime/server.log for details",
         ).print()
@@ -1459,7 +1460,7 @@ def _bootstrap_from_goal_impl(
             from bernstein.cli.errors import BernsteinError
 
             BernsteinError(
-                what=f"Task server on port {port} did not respond within 10.0s",
+                what=f"Task server on port {port} did not respond within {_SERVER_READY_TIMEOUT_S}s",
                 why="Server process may have crashed during startup",
                 fix="Check .sdd/runtime/server.log for details",
             ).print()

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -300,6 +300,52 @@ def test_bootstrap_from_seed_exits_when_server_never_becomes_ready(
             bootstrap_from_seed(tmp_path / "bernstein.yaml", tmp_path)
 
 
+def test_bootstrap_from_seed_timeout_message_derives_from_ready_constant(
+    tmp_path: Path,
+    invariants_module: types.ModuleType,
+) -> None:
+    """The timeout error message must show the real wait budget, not a stale literal."""
+    from bernstein.core.server_launch import _SERVER_READY_TIMEOUT_S
+
+    from bernstein.cli.utils.errors import BernsteinError
+
+    printed: list[str] = []
+
+    def _capture_print(self: BernsteinError) -> None:
+        printed.append(self.what)
+
+    with ExitStack() as stack:
+        stack.enter_context(patch.dict(sys.modules, {"bernstein.evolution.invariants": invariants_module}))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.console", MagicMock()))
+        stack.enter_context(
+            patch("bernstein.core.orchestration.bootstrap.concurrent.futures.ThreadPoolExecutor", _Executor)
+        )
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.parse_seed", return_value=_seed()))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.preflight_checks"))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.ensure_sdd"))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._clean_stale_runtime"))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._discover_catalog"))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._build_codebase_index"))
+        stack.enter_context(
+            patch("bernstein.core.orchestration.bootstrap._resolve_bind_host", return_value="127.0.0.1")
+        )
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._resolve_auth_token", return_value=None))
+        stack.enter_context(
+            patch("bernstein.core.orchestration.bootstrap._resolve_server_url", return_value="http://server")
+        )
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.supervised_server", return_value=111))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._wait_for_server", return_value=False))
+        stack.enter_context(patch.object(BernsteinError, "print", _capture_print))
+        with pytest.raises(SystemExit):
+            bootstrap_from_seed(tmp_path / "bernstein.yaml", tmp_path)
+
+    assert printed, "expected the timeout error to be printed"
+    assert str(_SERVER_READY_TIMEOUT_S) in printed[0], (
+        f"rendered message {printed[0]!r} must carry the real budget {_SERVER_READY_TIMEOUT_S}"
+    )
+    assert "10.0s" not in printed[0], f"rendered message {printed[0]!r} still has the stale literal"
+
+
 def test_bootstrap_from_goal_autowrites_seed_on_first_run(
     tmp_path: Path,
     invariants_module: types.ModuleType,


### PR DESCRIPTION
## What

The task-server readiness error reported a hardcoded `10.0s` budget while the actual wait is `_SERVER_READY_TIMEOUT_S = 30.0` (`src/bernstein/core/server/server_launch.py:32`, deadline loop at `:402`). The string literal lived in two call sites in `bootstrap.py` (:`726`, :`1462`).

An operator-facing error that understates its own timeout by 3x turns every downstream doc and every operator's mental model wrong with it (this was surfaced while reviewing #3897, where the docs almost shipped "the readiness budget is a fixed 10s" as fact).

## Fix shape

- The message now derives the number from the same constant the wait uses — `{_SERVER_READY_TIMEOUT_S}s` — no string literal, at both call sites.
- A unit test pins the property: when the server times out, the rendered message contains `str(_SERVER_READY_TIMEOUT_S)` and no longer contains `10.0s`, so the two cannot drift again.

## Verification

- RED: new test failed against the old literal (`'30.0' in '...within 10.0s'`).
- GREEN: `uv run pytest tests/unit/test_bootstrap.py -x -q` → 11 passed.
- `uv run ruff check src/` → all checks passed.
- `uv run mypy src/bernstein/core/orchestration/bootstrap.py` → success.

Closes #3905