### PR TITLE
fix(ci): the coverage ratchet declines a locked branch instead of failing on it

### DIFF
--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -240,67 +240,73 @@ jobs:
           RATCHET_BRANCH: coverage-ratchet/baseline
         run: |
           set -euo pipefail
-          # scripts/coverage_ratchet.py compares the measurement against the
-          # baseline committed on main, NOT against the one the open ratchet
-          # PR already carries. Those two diverge as soon as a ratchet PR is
-          # open: main still holds the old mark while the PR branch holds a
-          # higher one. A later push whose measurement lands between them
-          # still counts as a bump against main, and force-pushing it would
-          # rewrite the open PR with a LOWER high-water mark - the exact
-          # inverse of a monotonic ratchet, and invisible in review because
-          # the PR title changes with it.
+          # Two independent reasons this fire may not touch the open ratchet
+          # PR. This step only *gathers* them; the decision itself lives in
+          # `scripts/coverage_ratchet.py guard` so the rules are covered by
+          # unit tests rather than only by a live queue.
           #
-          # So: read the baseline on the ratchet branch and only proceed when
-          # the new measurement is strictly greater.
+          # 1. scripts/coverage_ratchet.py compares the measurement against
+          #    the baseline committed on main, NOT against the one the open
+          #    ratchet PR already carries. Those two diverge as soon as a
+          #    ratchet PR is open: main still holds the old mark while the PR
+          #    branch holds a higher one. A later push whose measurement
+          #    lands between them still counts as a bump against main, and
+          #    force-pushing it would rewrite the open PR with a LOWER
+          #    high-water mark - the exact inverse of a monotonic ratchet,
+          #    and invisible in review because the PR title changes with it.
+          #
+          # 2. A pull request sitting in the merge queue has its head branch
+          #    locked against pushes, so create-pull-request hard-fails with
+          #    `GH006 ... cannot be updated` for the entire time the ratchet
+          #    PR spends in the queue - one full CI matrix per entry, so not
+          #    a narrow race. That failure is a red mark on main that means
+          #    nothing is wrong, which is the kind that teaches people to
+          #    ignore red marks.
+          #
           # gh prints the API error body to STDOUT on failure, so an
           # emptiness test on the captured output cannot detect a missing
           # branch: a 404 body parses as JSON and then fails on the absent
           # coverage key. Branch on the exit code instead, and separate a
           # missing ref (fine: the ratchet PR merged and its branch was
           # auto-deleted) from every other API failure (loud).
+          rm -f open-baseline.json queued-branches.json
           set +e
           open_json=$(gh api "repos/${REPO}/contents/.coverage-baseline.json?ref=${RATCHET_BRANCH}" \
               -H "Accept: application/vnd.github.raw" 2>gh-err.txt)
           gh_rc=$?
           set -e
           if [ "${gh_rc}" -ne 0 ]; then
-            if grep -qE "HTTP 404|No commit found|Not Found" gh-err.txt; then
-              echo "::notice::no ${RATCHET_BRANCH} baseline (branch absent); opening a fresh ratchet PR."
+            if ! grep -qE "HTTP 404|No commit found|Not Found" gh-err.txt; then
+              echo "::error::could not read the open ratchet baseline (exit ${gh_rc}); refusing to guess."
+              cat gh-err.txt
               rm -f gh-err.txt
-              echo "proceed=true" >> "$GITHUB_OUTPUT"
-              exit 0
+              exit 1
             fi
-            echo "::error::could not read the open ratchet baseline (exit ${gh_rc}); refusing to guess."
-            cat gh-err.txt
-            rm -f gh-err.txt
-            exit 1
+            # No ratchet branch, so no open PR to overwrite and none to be
+            # queued. Leaving open-baseline.json absent is how this step
+            # tells the guard "open a fresh one".
+            echo "::notice::no ${RATCHET_BRANCH} on the remote; the guard will open a fresh ratchet PR."
+          else
+            printf '%s' "${open_json}" > open-baseline.json
           fi
           rm -f gh-err.txt
-          printf '%s' "${open_json}" > open-baseline.json
-          verdict=$(OPEN_BASELINE=open-baseline.json python3 - <<'PY'
-          import json
-          import os
-          import sys
 
-          with open(os.environ["OPEN_BASELINE"], encoding="utf-8") as fh:
-              try:
-                  open_pct = float(json.load(fh)["total_coverage_percent"])
-              except (KeyError, ValueError, TypeError) as exc:
-                  print(f"::error::open ratchet baseline is malformed: {exc!r}", file=sys.stderr)
-                  raise SystemExit(1)
-          measured = float(os.environ["MEASURED"])
-          print(f"{'true' if measured > open_pct else 'false'} {open_pct}")
-          PY
-          )
-          proceed=${verdict%% *}
-          open_pct=${verdict##* }
-          rm -f open-baseline.json
-          if [ "${proceed}" = "true" ]; then
-            echo "::notice::measured ${MEASURED}% > open ratchet PR ${open_pct}%; updating it."
-          else
-            echo "::notice::measured ${MEASURED}% is not above the open ratchet PR's ${open_pct}%; leaving it alone."
-          fi
-          echo "proceed=${proceed}" >> "$GITHUB_OUTPUT"
+          # A failed read here must stay loud. Defaulting the queue to empty
+          # would read as "the branch is pushable" and put (2) straight back.
+          gh api graphql \
+            -f query='query($owner:String!,$name:String!,$base:String!){repository(owner:$owner,name:$name){mergeQueue(branch:$base){entries(first:50){nodes{pullRequest{headRefName}}}}}}' \
+            -f owner="${REPO%%/*}" \
+            -f name="${REPO##*/}" \
+            -f base=main \
+            --jq '[.data.repository.mergeQueue.entries.nodes[]?.pullRequest.headRefName | select(. != null)]' \
+            > queued-branches.json
+
+          uv run python scripts/coverage_ratchet.py guard \
+            --measured "${MEASURED}" \
+            --open-baseline open-baseline.json \
+            --queued-branches queued-branches.json \
+            --ratchet-branch "${RATCHET_BRANCH}"
+          rm -f open-baseline.json queued-branches.json
 
       - name: Open PR with the bumped baseline
         # Only when the ratchet actually clicked (coverage rose) AND the new

--- a/docs/operations/coverage-ratchet.md
+++ b/docs/operations/coverage-ratchet.md
@@ -171,6 +171,27 @@ to record the new high-water mark.
 The baseline write lives in this separate workflow (not in `ci.yml`) so
 `ci.yml`'s gate jobs never need `contents: write`.
 
+### When a fire declines to touch the open ratchet PR
+
+There is only ever one ratchet PR, on the fixed branch
+`coverage-ratchet/baseline`, so each fire updates it in place. The `guard`
+step decides whether this fire may, and it refuses for two unrelated
+reasons. Both print a `::notice::` naming which one it was, and both end
+the run green — nothing is lost by skipping, because the ratchet is
+monotonic and idempotent.
+
+| Notice | Meaning | What to do |
+|---|---|---|
+| `measured N% is not above the open ratchet PR's M%` | The measurement beats the mark on `main` but not the higher one the open PR already carries. Pushing it would move the high-water mark **down**. | Nothing. Merge the open PR when you are ready; the next rise ratchets from there. |
+| `the open ratchet PR is in the merge queue, which locks ... against pushes` | The PR is queued, so GitHub rejects every push to its branch (`GH006`) for the whole time it is in the queue. | Nothing. Once it merges, the branch is free and the next fire opens a fresh PR at whatever the high-water mark is by then. |
+
+The decision itself is `scripts/coverage_ratchet.py guard`; the workflow
+step only gathers the two inputs (the baseline on the ratchet branch, and
+the head branches currently in the merge queue) and hands them over. A
+failed read of either is loud and fails the step rather than defaulting —
+an unreadable queue treated as empty would read as "the branch is
+pushable" and put the `GH006` failure straight back.
+
 ### Which run supplies the measurement
 
 The ratchet may only bump on a measurement of the commit being ratcheted.

--- a/scripts/coverage_ratchet.py
+++ b/scripts/coverage_ratchet.py
@@ -83,7 +83,10 @@ import os
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 # defusedxml is a drop-in for xml.etree.ElementTree that re-exports the
 # stdlib ``ParseError`` and additionally raises ``DefusedXmlException``
@@ -155,6 +158,14 @@ class Decision:
     should_bump: bool
     new_total_pct: float
     exit_code: int
+
+
+@dataclasses.dataclass(frozen=True)
+class GuardVerdict:
+    """Whether the open ratchet PR may be updated, and the reason either way."""
+
+    proceed: bool
+    notice: str
 
 
 def parse_line_rate(coverage_xml: Path) -> float:
@@ -408,6 +419,71 @@ def decide(baseline_pct: float, measured_pct: float, tolerance: float = DEFAULT_
     )
 
 
+def guard_decision(
+    measured_pct: float,
+    open_pct: float | None,
+    queued_branches: Sequence[str],
+    ratchet_branch: str,
+) -> GuardVerdict:
+    """Decide whether this fire may update the single open ratchet PR.
+
+    ``check`` compares the measurement against the baseline committed on
+    ``main``, not against the one the open ratchet PR already carries.
+    Those two diverge the moment a ratchet PR is open, so a measurement
+    landing between them still reads as a bump against ``main`` while
+    force-pushing it would move the open PR's high-water mark *down*.
+    That is the first refusal.
+
+    The second is mechanical rather than arithmetic: while the ratchet PR
+    sits in the merge queue GitHub locks its head branch, and the push
+    fails with ``GH006`` whatever the number says. Skipping costs nothing
+    - the ratchet is monotonic and idempotent, so once the queued PR
+    merges the next fire opens a fresh PR carrying the high-water mark as
+    of then.
+
+    Args:
+        measured_pct: Freshly-measured total coverage percentage.
+        open_pct: Percentage carried by the open ratchet PR, or ``None``
+            when the ratchet branch does not exist (no PR is open).
+        queued_branches: Head branches of the pull requests currently in
+            the merge queue.
+        ratchet_branch: The ratchet's own stable head branch.
+
+    Returns:
+        A :class:`GuardVerdict` carrying the decision and the single log
+        line explaining it.
+    """
+    if open_pct is None:
+        return GuardVerdict(
+            proceed=True,
+            notice=f"no {ratchet_branch} baseline (branch absent); opening a fresh ratchet PR.",
+        )
+
+    # Ordered deliberately: both refusals can hold at once, and the branch
+    # lock is the one that makes the push impossible rather than merely
+    # unwanted. Reporting it first keeps the message deterministic instead
+    # of an artifact of evaluation order.
+    if ratchet_branch in queued_branches:
+        return GuardVerdict(
+            proceed=False,
+            notice=(
+                f"the open ratchet PR is in the merge queue, which locks {ratchet_branch} "
+                f"against pushes; leaving it alone."
+            ),
+        )
+
+    if measured_pct > open_pct:
+        return GuardVerdict(
+            proceed=True,
+            notice=f"measured {measured_pct:g}% > open ratchet PR {open_pct:g}%; updating it.",
+        )
+
+    return GuardVerdict(
+        proceed=False,
+        notice=f"measured {measured_pct:g}% is not above the open ratchet PR's {open_pct:g}%; leaving it alone.",
+    )
+
+
 def next_floor(current: int, step: int = DEFAULT_FLOOR_STEP, cap: int = DEFAULT_FLOOR_CAP) -> int:
     """Compute the next diff-coverage floor for the weekly bump.
 
@@ -606,6 +682,47 @@ def _cmd_verify(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_guard(args: argparse.Namespace) -> int:
+    """Gate the ratchet-PR step on the open PR being both lower and pushable.
+
+    The workflow does the two API reads (it already holds the token) and
+    hands this command their results as files; the decision itself lives
+    here so it can be driven by tests rather than only by a live queue.
+    """
+    open_baseline = Path(args.open_baseline)
+    open_pct: float | None = None
+    if open_baseline.is_file():
+        # Present only when the ratchet branch exists and carries a baseline.
+        try:
+            open_pct = float(json.loads(open_baseline.read_text(encoding="utf-8"))["total_coverage_percent"])
+        except (OSError, ValueError, KeyError, TypeError) as exc:
+            print(f"::error::open ratchet baseline is malformed: {exc!r}", file=sys.stderr)
+            return 1
+
+    # An unreadable queue must never collapse to "empty". Empty means "the
+    # branch is pushable", and reaching that from a failed read is exactly
+    # how the push starts hard-failing on GH006 again while the log claims
+    # everything is fine.
+    try:
+        queued = json.loads(Path(args.queued_branches).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"::error::could not read the merge-queue state: {exc!r}; refusing to guess.", file=sys.stderr)
+        return 1
+    if not isinstance(queued, list) or any(not isinstance(item, str) for item in queued):
+        print("::error::merge-queue state is not a list of branch names; refusing to guess.", file=sys.stderr)
+        return 1
+
+    verdict = guard_decision(
+        measured_pct=float(args.measured),
+        open_pct=open_pct,
+        queued_branches=queued,
+        ratchet_branch=args.ratchet_branch,
+    )
+    print(f"::notice::{verdict.notice}")
+    _emit_github_output(proceed="true" if verdict.proceed else "false")
+    return 0
+
+
 def _cmd_show_floor(args: argparse.Namespace) -> int:
     baseline_path = Path(args.baseline)
     try:
@@ -667,6 +784,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="also fail when the baseline records no line_rate/head_sha",
     )
     p_verify.set_defaults(func=_cmd_verify)
+
+    p_guard = sub.add_parser("guard", help="decide whether the open ratchet PR may be updated")
+    p_guard.add_argument("--measured", required=True, help="freshly-measured total coverage percentage")
+    p_guard.add_argument(
+        "--open-baseline",
+        required=True,
+        help="baseline read off the ratchet branch; an absent file means the branch does not exist",
+    )
+    p_guard.add_argument(
+        "--queued-branches",
+        required=True,
+        help="JSON array of the head branches currently in the merge queue",
+    )
+    p_guard.add_argument("--ratchet-branch", required=True, help="the ratchet's own stable head branch")
+    p_guard.set_defaults(func=_cmd_guard)
 
     p_show = sub.add_parser("show-floor", help="print the current diff-coverage floor")
     p_show.add_argument("--baseline", default=".coverage-baseline.json", help="path to baseline JSON")

--- a/tests/unit/test_coverage_ratchet.py
+++ b/tests/unit/test_coverage_ratchet.py
@@ -593,3 +593,222 @@ def test_committed_baseline_carries_provenance_and_re_derives() -> None:
     assert baseline.line_rate is not None, "committed baseline has no line_rate to verify against"
     assert baseline.head_sha, "committed baseline does not name the commit it was measured on"
     ratchet.verify_baseline_consistency(baseline)
+
+
+# --------------------------------------------------------------------------- #
+# the ratchet-PR guard: is the open PR still pushable?
+# --------------------------------------------------------------------------- #
+#
+# The guard step in ``.github/workflows/coverage-ratchet.yml`` decides
+# whether this fire may update the single open ratchet PR. It refuses for
+# two unrelated reasons and they must stay distinguishable in the log:
+#
+#   * the measurement is not above the mark the open PR already carries -
+#     force-pushing it would move the high-water mark DOWN;
+#   * the open PR is sitting in the merge queue, which locks its branch
+#     against pushes, so the push cannot land whatever the number says.
+#
+# The second one used to be absent, and the create-pull-request step then
+# hard-failed on ``GH006 ... cannot be updated`` for the whole time a
+# ratchet PR spent in the queue - a red mark on main that meant nothing
+# was wrong.
+
+
+RATCHET_BRANCH = "coverage-ratchet/baseline"
+
+
+def test_a_queued_ratchet_pr_refuses_because_its_branch_is_locked() -> None:
+    """A queued PR's branch rejects pushes, so a higher number changes nothing."""
+    verdict = ratchet.guard_decision(
+        measured_pct=91.0,
+        open_pct=83.7,
+        queued_branches=[RATCHET_BRANCH],
+        ratchet_branch=RATCHET_BRANCH,
+    )
+
+    assert verdict.proceed is False
+    assert "merge queue" in verdict.notice
+
+
+def test_the_queued_refusal_is_distinguishable_from_the_downward_refusal() -> None:
+    """Two skip paths, two reasons: a shared message hides which one fired."""
+    queued = ratchet.guard_decision(
+        measured_pct=91.0,
+        open_pct=83.7,
+        queued_branches=[RATCHET_BRANCH],
+        ratchet_branch=RATCHET_BRANCH,
+    )
+    downward = ratchet.guard_decision(
+        measured_pct=83.0,
+        open_pct=83.7,
+        queued_branches=[],
+        ratchet_branch=RATCHET_BRANCH,
+    )
+
+    assert queued.proceed is downward.proceed is False
+    assert queued.notice != downward.notice
+    assert queued.notice not in downward.notice
+    assert downward.notice not in queued.notice
+
+
+def test_an_unrelated_pr_in_the_queue_does_not_block_the_ratchet() -> None:
+    """Only the ratchet's own branch being queued locks the ratchet's branch."""
+    verdict = ratchet.guard_decision(
+        measured_pct=91.0,
+        open_pct=83.7,
+        queued_branches=["fix/3928-something-else", "feat/unrelated"],
+        ratchet_branch=RATCHET_BRANCH,
+    )
+
+    assert verdict.proceed is True
+
+
+def test_an_open_but_unqueued_ratchet_pr_is_still_updated_in_place() -> None:
+    """The pre-existing behaviour: a higher mark rewrites the open PR."""
+    verdict = ratchet.guard_decision(
+        measured_pct=83.71,
+        open_pct=83.7,
+        queued_branches=[],
+        ratchet_branch=RATCHET_BRANCH,
+    )
+
+    assert verdict.proceed is True
+    assert "updating it" in verdict.notice
+
+
+def test_a_measurement_below_the_open_mark_still_refuses() -> None:
+    """The downward guard is what stops the ratchet from running backwards."""
+    verdict = ratchet.guard_decision(
+        measured_pct=83.69,
+        open_pct=83.7,
+        queued_branches=[],
+        ratchet_branch=RATCHET_BRANCH,
+    )
+
+    assert verdict.proceed is False
+    assert "not above" in verdict.notice
+
+
+def test_an_absent_ratchet_branch_opens_a_fresh_pr() -> None:
+    """No open ratchet PR: nothing to guard against, nothing to be queued."""
+    verdict = ratchet.guard_decision(
+        measured_pct=83.71,
+        open_pct=None,
+        queued_branches=[],
+        ratchet_branch=RATCHET_BRANCH,
+    )
+
+    assert verdict.proceed is True
+    assert "fresh" in verdict.notice
+
+
+def test_the_queue_lock_outranks_the_downward_reason() -> None:
+    """Both refusals apply at once; report the one that makes the push impossible.
+
+    The number can be argued about on the next fire. The branch lock cannot:
+    while the PR is queued no push lands, so that is the fact worth logging.
+    Pinning the precedence keeps the message deterministic rather than an
+    artifact of which condition happens to be evaluated first.
+    """
+    verdict = ratchet.guard_decision(
+        measured_pct=83.0,
+        open_pct=83.7,
+        queued_branches=[RATCHET_BRANCH],
+        ratchet_branch=RATCHET_BRANCH,
+    )
+
+    assert verdict.proceed is False
+    assert "merge queue" in verdict.notice
+
+
+def test_guard_command_writes_proceed_false_to_github_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End to end through the subcommand the workflow actually calls."""
+    open_baseline = tmp_path / "open-baseline.json"
+    open_baseline.write_text(json.dumps({"total_coverage_percent": 83.7}), encoding="utf-8")
+    queued = tmp_path / "queued.json"
+    queued.write_text(json.dumps([RATCHET_BRANCH]), encoding="utf-8")
+    gh_output = tmp_path / "gh-output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(gh_output))
+
+    rc = ratchet.main(
+        [
+            "guard",
+            "--measured",
+            "91.0",
+            "--open-baseline",
+            str(open_baseline),
+            "--queued-branches",
+            str(queued),
+            "--ratchet-branch",
+            RATCHET_BRANCH,
+        ]
+    )
+
+    assert rc == 0, "a refusal is a normal outcome, not a job failure"
+    assert "proceed=false" in gh_output.read_text(encoding="utf-8")
+
+
+def test_guard_command_treats_a_missing_open_baseline_as_an_absent_branch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The workflow writes that file only when the branch actually has one."""
+    queued = tmp_path / "queued.json"
+    queued.write_text("[]", encoding="utf-8")
+    gh_output = tmp_path / "gh-output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(gh_output))
+
+    rc = ratchet.main(
+        [
+            "guard",
+            "--measured",
+            "83.71",
+            "--open-baseline",
+            str(tmp_path / "does-not-exist.json"),
+            "--queued-branches",
+            str(queued),
+            "--ratchet-branch",
+            RATCHET_BRANCH,
+        ]
+    )
+
+    assert rc == 0
+    assert "proceed=true" in gh_output.read_text(encoding="utf-8")
+
+
+def test_an_unreadable_queue_file_refuses_instead_of_assuming_an_empty_queue(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parsing the queue as empty on error would re-open the bug it closes.
+
+    An empty queue means "the branch is pushable". Reaching that conclusion
+    from a failed read is how the guard would go back to hard-failing on
+    ``GH006`` while reporting that everything was fine.
+    """
+    open_baseline = tmp_path / "open-baseline.json"
+    open_baseline.write_text(json.dumps({"total_coverage_percent": 83.7}), encoding="utf-8")
+    queued = tmp_path / "queued.json"
+    queued.write_text("{not json", encoding="utf-8")
+    gh_output = tmp_path / "gh-output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(gh_output))
+
+    rc = ratchet.main(
+        [
+            "guard",
+            "--measured",
+            "91.0",
+            "--open-baseline",
+            str(open_baseline),
+            "--queued-branches",
+            str(queued),
+            "--ratchet-branch",
+            RATCHET_BRANCH,
+        ]
+    )
+
+    assert rc != 0, "an unreadable queue must be loud, not silently empty"
+    assert "proceed=true" not in gh_output.read_text(encoding="utf-8") if gh_output.exists() else True

--- a/tests/unit/test_coverage_ratchet_workflow_yaml.py
+++ b/tests/unit/test_coverage_ratchet_workflow_yaml.py
@@ -49,6 +49,14 @@ The failures this module exists to prevent
    must not narrow to ``conclusion == success`` - ``cancel-in-progress``
    cancels most ``main`` runs, so that filter would idle the ratchet just
    as thoroughly.
+
+7. **A push at a branch the merge queue has locked.** While the ratchet PR
+   sits in the queue GitHub rejects every push to its head branch, so
+   ``create-pull-request`` hard-fails with ``GH006`` for one full CI matrix
+   per queue entry. The guard must therefore read the queue as well as the
+   branch baseline, and it must delegate the verdict to
+   ``scripts/coverage_ratchet.py guard`` so the rule is unit-tested rather
+   than re-implemented in shell.
 """
 
 from __future__ import annotations
@@ -136,7 +144,16 @@ def test_downward_guard_exists_and_reads_the_ratchet_branch(steps: list[dict]) -
     assert RATCHET_BRANCH in yaml.safe_dump(guard), (
         "the guard must read the baseline carried by the open ratchet branch, not only the one committed on main"
     )
-    assert "proceed=" in guard["run"]
+    # The step must still end in something that writes `proceed` to
+    # $GITHUB_OUTPUT, or the PR step's `if` is false forever and the ratchet
+    # silently never opens a PR. The write itself moved into the script -
+    # `test_guard_command_writes_proceed_false_to_github_output` in
+    # tests/unit/test_coverage_ratchet.py covers it - so what this asserts
+    # here is that the step actually reaches that script.
+    assert "coverage_ratchet.py guard" in guard["run"], (
+        "the guard step must emit `proceed`; without it the create-pull-request "
+        "step is gated on an output nothing ever sets"
+    )
 
 
 def test_pr_step_is_gated_on_the_downward_guard(steps: list[dict]) -> None:
@@ -284,3 +301,27 @@ def test_a_bumped_baseline_is_verified_before_the_pr_opens(steps: list[dict]) ->
     assert steps.index(verify) < steps.index(_create_pr_step(steps)), (
         "the verify step must run before create-pull-request"
     )
+
+
+def test_guard_reads_the_merge_queue_not_only_the_branch_baseline(steps: list[dict]) -> None:
+    """A queued ratchet PR locks its branch; the number alone cannot see that."""
+    run = _step_by_id(steps, "guard")["run"]
+    assert "mergeQueue" in run, (
+        "the guard must ask whether the open ratchet PR is in the merge queue - "
+        "while it is, every push to its branch is rejected with GH006 whatever "
+        "the measured percentage says"
+    )
+    assert "queued-branches.json" in run
+
+
+def test_guard_delegates_the_verdict_to_the_tested_script(steps: list[dict]) -> None:
+    """One copy of the rule, and it is the copy the unit tests drive.
+
+    An inline re-implementation in shell would drift from
+    ``scripts/coverage_ratchet.py guard`` silently: nothing runs this step
+    except a live ratchet fire on ``main``.
+    """
+    run = _step_by_id(steps, "guard")["run"]
+    assert "coverage_ratchet.py guard" in run
+    assert "--queued-branches" in run
+    assert "--open-baseline" in run


### PR DESCRIPTION
## What

`Total coverage ratchet` failed on `main` whenever the ratchet's own PR was sitting in the merge queue. A queued PR's head branch rejects pushes, and the ratchet updates one long-lived PR in place on `coverage-ratchet/baseline`, so `create-pull-request` hard-failed with `GH006 ... cannot be updated` for the entire time that PR spent in the queue — one full CI matrix per entry, not a narrow race.

`Total coverage ratchet` is not a required context (`CI gate` is the only one), so this never blocked a merge. It only ever produced a red mark on `main` that meant nothing was wrong.

## Fix shape

The `guard` step already reasoned about the open ratchet PR — it asked whether the measurement beat the mark that PR carries. It did not ask whether the PR was still pushable. It now asks both, and declines with a `::notice::` instead of letting the push fail. Skipping costs nothing: the ratchet is monotonic and idempotent, so once the queued PR merges the next fire opens a fresh one at whatever the high-water mark is by then.

The verdict moved out of the inline shell into `scripts/coverage_ratchet.py guard`. Nothing exercises that step except a live ratchet fire on `main`, so a rule that lives only in the shell block cannot be checked before it ships. The workflow now gathers the two inputs — the baseline on the ratchet branch, and the head branches currently in the merge queue — and hands them over. This also brings the pre-existing downward-move refusal under test for the first time.

An unreadable queue fails the step rather than defaulting to empty. An empty queue means "the branch is pushable"; reaching that conclusion from a failed read would restore the exact failure this removes.

## Test matrix

Written before the implementation, each named for the property it protects:

| Test | Property |
|---|---|
| `test_a_queued_ratchet_pr_refuses_because_its_branch_is_locked` | a higher number does not make a locked branch pushable |
| `test_the_queued_refusal_is_distinguishable_from_the_downward_refusal` | two skip paths, two messages; neither is a substring of the other |
| `test_the_queue_lock_outranks_the_downward_reason` | when both hold, the reported reason is deterministic, not evaluation order |
| `test_an_unrelated_pr_in_the_queue_does_not_block_the_ratchet` | only the ratchet's own branch being queued matters |
| `test_an_open_but_unqueued_ratchet_pr_is_still_updated_in_place` | the pre-existing update-in-place path is unchanged |
| `test_a_measurement_below_the_open_mark_still_refuses` | the downward guard still refuses, for its own reason |
| `test_an_absent_ratchet_branch_opens_a_fresh_pr` | no open PR: open one |
| `test_guard_command_writes_proceed_false_to_github_output` | end to end through the subcommand the workflow calls |
| `test_guard_command_treats_a_missing_open_baseline_as_an_absent_branch` | the file-absence contract between the step and the script |
| `test_an_unreadable_queue_file_refuses_instead_of_assuming_an_empty_queue` | a failed read is loud, never silently "pushable" |
| `test_guard_reads_the_merge_queue_not_only_the_branch_baseline` | the workflow actually gathers queue state |
| `test_guard_delegates_the_verdict_to_the_tested_script` | one copy of the rule, and it is the tested copy |

`test_downward_guard_exists_and_reads_the_ratchet_branch` previously asserted a literal `proceed=` in the shell. The write moved into the script, so it now asserts the step reaches that script — the property (the PR step is gated on an output something actually sets) is unchanged, and the write itself is covered by the script test above.

## Verification

- RED: the ten new decision tests failed against `main`'s tree (`AttributeError: guard_decision`); 50 existing passed.
- GREEN: `uv run pytest tests/unit/test_coverage_ratchet.py tests/unit/test_coverage_ratchet_workflow_yaml.py -q` → 79 passed.
- `uv run ruff check` + `ruff format --check` + `uv run mypy scripts/coverage_ratchet.py` → clean.
- `uv run python scripts/check_docs_drift.py` → no drift.
- End-to-end smoke against the live API, running the step's own commands: with `coverage-ratchet/baseline` absent it printed the fresh-PR notice and wrote `proceed=true`; with the ratchet branch injected into the queue list it printed the queue-lock notice and wrote `proceed=false`.

Closes #3928
