### PR TITLE
Fix stale-row key annotation in TUI task list

### DIFF
--- a/src/bernstein/tui/task_list.py
+++ b/src/bernstein/tui/task_list.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from rich.text import Text
 from textual.widgets import DataTable, Static
+from textual.widgets.data_table import RowKey
 
 from bernstein.tui.accessibility import accessible_status_label, replace_unicode
 
@@ -423,7 +424,7 @@ class TaskListWidget(DataTable[Text]):
         """
         # Build a lookup of incoming rows by task_id
         incoming: dict[str, TaskRow] = {r.task_id: r for r in rows}
-        existing_keys: set[str] = set(self.rows)
+        existing_keys: set[RowKey] = set(self.rows)
 
         # Remove rows no longer present
         for key in existing_keys - incoming.keys():

--- a/src/bernstein/tui/task_list.py
+++ b/src/bernstein/tui/task_list.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import contextlib
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from rich.text import Text
 from textual.widgets import DataTable, Static
-from textual.widgets.data_table import RowKey
 
 from bernstein.tui.accessibility import accessible_status_label, replace_unicode
+
+if TYPE_CHECKING:
+    from textual.widgets.data_table import RowKey
 
 # Sparkline characters for cost trend visualization
 SPARKLINE_CHARS = "▁▂▃▄▅▆▇█"

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -192,6 +192,39 @@ class TestWidgetCreation:
         assert widget is not None
 
 
+class TestTaskListRefresh:
+    """Tests for stale-row cleanup in TaskListWidget."""
+
+    def test_refresh_tasks_removes_stale_rows(self) -> None:
+        widget = TaskListWidget()
+        widget.on_mount()
+        first = TaskRow(
+            task_id="t-1",
+            status="open",
+            role="worker",
+            title="First task",
+            priority=2,
+            model="test",
+            elapsed="1s",
+            session_id="s1",
+        )
+        second = TaskRow(
+            task_id="t-2",
+            status="open",
+            role="worker",
+            title="Second task",
+            priority=2,
+            model="test",
+            elapsed="1s",
+            session_id="s2",
+        )
+        widget.refresh_tasks([first, second])
+        assert {str(key.value) for key in widget.rows} == {"t-1", "t-2"}
+
+        widget.refresh_tasks([first])
+        assert [str(key.value) for key in widget.rows] == ["t-1"]
+
+
 class TestAppInstantiation:
     """Tests that the Textual app can be created."""
 

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from textual.app import App
 
 from bernstein.tui.app import BernsteinApp, _kill_agent, _kill_all_agents
 from bernstein.tui.widgets import (
@@ -195,9 +196,13 @@ class TestWidgetCreation:
 class TestTaskListRefresh:
     """Tests for stale-row cleanup in TaskListWidget."""
 
-    def test_refresh_tasks_removes_stale_rows(self) -> None:
-        widget = TaskListWidget()
-        widget.on_mount()
+    @pytest.mark.asyncio
+    async def test_refresh_tasks_removes_stale_rows(self) -> None:
+        # DataTable.add_column measures its label against `self.app.console`,
+        # so `on_mount` raises LookupError on a widget that is not mounted in
+        # a running app. Drive it through `run_test` and let Textual dispatch
+        # Mount itself, which is also what exercises the real path.
+        app: App[object] = App()
         first = TaskRow(
             task_id="t-1",
             status="open",
@@ -218,11 +223,17 @@ class TestTaskListRefresh:
             elapsed="1s",
             session_id="s2",
         )
-        widget.refresh_tasks([first, second])
-        assert {str(key.value) for key in widget.rows} == {"t-1", "t-2"}
 
-        widget.refresh_tasks([first])
-        assert [str(key.value) for key in widget.rows] == ["t-1"]
+        async with app.run_test() as pilot:
+            widget = TaskListWidget()
+            await app.mount(widget)
+            await pilot.pause()
+
+            widget.refresh_tasks([first, second])
+            assert {str(key.value) for key in widget.rows} == {"t-1", "t-2"}
+
+            widget.refresh_tasks([first])
+            assert [str(key.value) for key in widget.rows] == ["t-1"]
 
 
 class TestAppInstantiation:


### PR DESCRIPTION
Fix the remaining actionable mypy error in `src/bernstein/tui/task_list.py` by annotating `existing_keys` as `set[RowKey]` rather than `set[str]`.

Chose option A from the maintainer guidance: it is annotation-only and describes the real container type without adding runtime normalization. Added a regression test that refreshes `TaskListWidget` twice and asserts stale rows are removed while surviving rows are kept.

mypy before: 9 errors in `src/bernstein/tui/`
mypy after: 8 errors in `src/bernstein/tui/`; the remaining `Notifications` attribute errors are out of scope per guidance.

Fixes #3233