### PR TITLE
fix(cli): let the console survive a legacy Windows code page (#3901)

### DIFF
--- a/src/bernstein/cli/helpers.py
+++ b/src/bernstein/cli/helpers.py
@@ -13,8 +13,8 @@ from typing import Any
 
 import click
 import httpx
-from rich.console import Console
 
+from bernstein.cli.ui import make_console
 from bernstein.core.defaults import SDD_SERVER_PORT
 from bernstein.core.platform_compat import kill_process, kill_process_group
 from bernstein.core.process_utils import is_process_alive as _shared_is_process_alive
@@ -64,7 +64,10 @@ STATUS_COLORS: dict[str, str] = {
     "cancelled": "red",
 }
 
-console = Console()
+# Built through the factory rather than as a bare ``Console()`` so the stream
+# tolerates glyphs a legacy code page cannot encode (#3901). This is the
+# console ``run_confirm.py`` prints the demo's check marks through.
+console = make_console()
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/cli/ui.py
+++ b/src/bernstein/cli/ui.py
@@ -8,8 +8,10 @@ degrade when stdout is not a TTY (e.g. piped output or CI).
 from __future__ import annotations
 
 import operator
+import sys
+from contextlib import suppress
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import IO, Any, cast
 
 from rich.console import Console
 from rich.panel import Panel
@@ -53,7 +55,48 @@ AGENT_STATUS_COLORS: dict[str, str] = {
 # ---------------------------------------------------------------------------
 
 
-def make_console(*, no_color: bool = False) -> Console:
+#: Error policies that substitute for *any* unencodable character. Anything
+#: outside this set - including ``surrogateescape``, which stdout carries by
+#: default on Windows - still raises on a glyph the code page lacks.
+_SUBSTITUTING_ERROR_POLICIES = frozenset(
+    {
+        "replace",
+        "ignore",
+        "xmlcharrefreplace",
+        "backslashreplace",
+        "namereplace",
+    }
+)
+
+
+def _tolerate_unencodable(stream: IO[str] | None) -> None:
+    """Stop *stream* raising on characters its encoding cannot represent.
+
+    The CLI prints U+2713 and similar glyphs. A Windows console on a legacy
+    code page (cp1252 by default outside the US/Western-Europe UTF-8 setups)
+    cannot encode them, and the stream's default ``errors="strict"`` turns
+    that into a ``UnicodeEncodeError`` that aborts the command mid-output
+    rather than degrading the glyph (issue #3901).
+
+    Relaxing to ``errors="replace"`` is a no-op on a UTF-8 stream, which can
+    encode everything, so this only changes behaviour where the alternative
+    is a crash.
+
+    Note that ``strict`` is not the only fatal policy. Python gives stdout
+    ``surrogateescape`` on Windows, which recovers lone surrogates and nothing
+    else, so U+2713 raises there exactly as it does under ``strict``. Only the
+    policies that substitute for any unencodable character are left alone.
+    """
+    reconfigure = getattr(stream, "reconfigure", None)
+    if reconfigure is None:
+        return
+    if (getattr(stream, "errors", None) or "strict") in _SUBSTITUTING_ERROR_POLICIES:
+        return
+    with suppress(Exception):
+        reconfigure(errors="replace")
+
+
+def make_console(*, no_color: bool = False, file: IO[str] | None = None) -> Console:
     """Create a Rich Console with optional color suppression.
 
     When *no_color* is ``True`` the console disables all colour and markup
@@ -62,15 +105,22 @@ def make_console(*, no_color: bool = False) -> Console:
     When stdout is not a TTY the console automatically falls back to
     plain-text output (``force_terminal=False``).
 
+    The target stream is made tolerant of characters its encoding cannot
+    represent, so a legacy Windows code page degrades a glyph instead of
+    aborting the command. Construct consoles through this function rather
+    than calling ``Console()`` directly, or that guarantee is lost.
+
     Args:
         no_color: If True, disable all colour output.
+        file: Stream to write to. Defaults to stdout, as Rich does.
 
     Returns:
         A configured Rich Console instance.
     """
+    _tolerate_unencodable(file if file is not None else sys.stdout)
     if no_color:
-        return Console(no_color=True, force_terminal=False)
-    return Console()
+        return Console(no_color=True, force_terminal=False, file=file)
+    return Console(file=file)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_console_legacy_code_page.py
+++ b/tests/unit/cli/test_console_legacy_code_page.py
@@ -1,0 +1,109 @@
+"""The CLI console survives a legacy code page (issue #3901).
+
+``bernstein demo`` aborts on a Windows console using cp1252 because it prints
+U+2713 and the stream's default ``errors="strict"`` turns an unencodable glyph
+into a ``UnicodeEncodeError`` mid-command.
+
+These render the glyph through a console whose stream really is cp1252 and
+assert it does not raise. Asserting on the arguments ``make_console`` passes
+would pass while ``run_confirm.py`` still died on the real stream, which is the
+failure mode this file exists to prevent.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from bernstein.cli.ui import make_console
+
+_CHECK_MARK = "✓"
+
+
+def _cp1252_stream() -> io.TextIOWrapper:
+    """A text stream with the encoding a default Windows console reports."""
+    return io.TextIOWrapper(io.BytesIO(), encoding="cp1252", newline="")
+
+
+def test_cp1252_stream_cannot_encode_the_check_mark() -> None:
+    """The control: without intervention the glyph really is fatal.
+
+    If this ever stops raising, the tests below stop proving anything.
+    """
+    stream = _cp1252_stream()
+
+    with pytest.raises(UnicodeEncodeError):
+        stream.write(_CHECK_MARK)
+        stream.flush()
+
+
+def test_console_renders_a_check_mark_on_a_legacy_code_page() -> None:
+    """The demo's first status line does not abort the command."""
+    stream = _cp1252_stream()
+    console = make_console(file=stream)
+
+    console.print(f"[green]{_CHECK_MARK}[/green] Flask app with 4 intentional bugs created")
+    stream.flush()
+
+    written = stream.buffer.getvalue().decode("cp1252")  # type: ignore[attr-defined]
+    assert "Flask app with 4 intentional bugs created" in written
+
+
+def test_no_color_console_also_survives_a_legacy_code_page() -> None:
+    """The ``--no-color`` path builds a different Console; it needs the same guarantee."""
+    stream = _cp1252_stream()
+    console = make_console(no_color=True, file=stream)
+
+    console.print(f"{_CHECK_MARK} done")
+    stream.flush()
+
+    assert "done" in stream.buffer.getvalue().decode("cp1252")  # type: ignore[attr-defined]
+
+
+def test_a_utf8_stream_keeps_the_glyph_intact() -> None:
+    """Tolerating unencodable glyphs must not degrade a console that can render them."""
+    stream = io.TextIOWrapper(io.BytesIO(), encoding="utf-8", newline="")
+    console = make_console(file=stream)
+
+    console.print(_CHECK_MARK)
+    stream.flush()
+
+    assert _CHECK_MARK in stream.buffer.getvalue().decode("utf-8")  # type: ignore[attr-defined]
+
+
+def test_surrogateescape_stream_is_still_made_tolerant() -> None:
+    """The real case: Python gives stdout ``surrogateescape`` on Windows.
+
+    That policy recovers lone surrogates and nothing else, so U+2713 raises
+    under it exactly as under ``strict``. Treating it as "already tolerant"
+    is what let the first attempt at this fix pass its tests while
+    ``bernstein demo`` still died on the real stream.
+    """
+    stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1252", errors="surrogateescape", newline="")
+    console = make_console(file=stream)
+
+    console.print(f"{_CHECK_MARK} seeded")
+    stream.flush()
+
+    assert "seeded" in stream.buffer.getvalue().decode("cp1252")  # type: ignore[attr-defined]
+
+
+def test_a_stream_that_already_replaces_is_left_alone() -> None:
+    """An explicit error policy set by the caller is not overridden."""
+    stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1252", errors="xmlcharrefreplace", newline="")
+
+    make_console(file=stream)
+
+    assert stream.errors == "xmlcharrefreplace"
+
+
+def test_shared_cli_console_is_built_through_the_factory() -> None:
+    """``helpers.console`` is what ``run_confirm.py`` prints through.
+
+    A bare ``Console()`` there would reintroduce the defect no matter how the
+    factory behaves, which is exactly how this bug reached a release.
+    """
+    from bernstein.cli import helpers
+
+    assert (helpers.console.file.errors or "strict") != "strict"


### PR DESCRIPTION
Closes #3901. Built to the slice @chernistry described on the issue.

`make_console()` in `cli/ui.py` becomes the one place responsible for a console that survives a code page it cannot fully encode, and `cli/helpers.py` is pointed at it. That module-level `Console()` is what `run_confirm.py:1074` prints through, so fixing only the factory would have left the demo exactly as broken — which was the whole point of the note. The remaining 19 modules that build their own `Console()` are the follow-up.

`make_console()` also gains a `file` parameter, so the behaviour can be exercised against a real stream rather than inferred from constructor arguments.

## The part I got wrong first, because it matters

My first attempt guarded on `errors == "strict"`. It passed its tests and **`bernstein demo` still died**.

Python gives stdout `surrogateescape` on Windows, not `strict`. That policy recovers lone surrogates and nothing else, so U+2713 raises under it exactly as under `strict` — my early return skipped the one stream that mattered. The tests passed because `io.TextIOWrapper(..., encoding="cp1252")` defaults to `strict`, so they exercised a case the real console is never in.

That is precisely the failure you predicted on the issue: *"a test that only inspects the factory's arguments would pass while the demo still dies on line 1074."* Mine inspected a real stream and still missed it, because I picked the wrong real stream.

The guard now allows only the policies that substitute for **any** unencodable character (`replace`, `ignore`, `xmlcharrefreplace`, `backslashreplace`, `namereplace`) and reconfigures everything else. `test_surrogateescape_stream_is_still_made_tolerant` pins that case specifically, with the reason in its docstring.

## Verification, against the real path

`bernstein demo` in a clean directory on a cp1252 console, **no `PYTHONUTF8`**:

```
? Flask app with 4 intentional bugs created
? 4 bug-fix tasks seeded: off-by-one ? missing import ? wrong status code ? broken test
Starting orchestration?
```

`grep -c UnicodeEncodeError` on the full output: **0**. It previously raised at the first line above. The glyph degrades to `?`, which is what "survives a legacy code page" means here — the command completes rather than aborting mid-output.

(The run still ends at the task-server readiness step. That is the separate defect from #3825, not this one.)

```
tests/unit/cli/test_console_legacy_code_page.py    7 passed
tests/unit/cli/                                    472 passed, 17 failed
ruff check / format / mypy (changed files)         clean
```

**Those 17 failures are pre-existing.** I stashed the change and re-ran: 17 before, 17 after, and diffing the `FAILED` lists gives an empty set of new failures. They are Windows-specific things like `test_is_safe_audit_dir_refuses_pseudo_filesystems[/sys/kernel]`.

## Test notes

`test_cp1252_stream_cannot_encode_the_check_mark` is the control — it asserts the glyph really is fatal on an untreated stream. If that ever stops raising, the rest of the file stops proving anything.

`test_shared_cli_console_is_built_through_the_factory` asserts `helpers.console` is not left at a fatal policy. A future bare `Console()` there would reintroduce the defect no matter how the factory behaves, which is how this reached a release in the first place.

`test_a_utf8_stream_keeps_the_glyph_intact` checks the fix does not degrade consoles that can render it — tolerance should not cost the check mark on a UTF-8 terminal.