### PR TITLE
test(tenant-scope): release the app each case builds, so the heap stops growing (#3927)

### DIFF
--- a/tests/unit/tenant_scope/conftest.py
+++ b/tests/unit/tenant_scope/conftest.py
@@ -148,13 +148,54 @@ def _agent_credential(app: FastAPI, session_id: str, tenant_id: str, task_ids: l
     return Credential(name=session_id, token=token)
 
 
+def _release(app: FastAPI) -> None:
+    """Drop the object graph *app* owns, now that its test is over.
+
+    Dropping this file's own references to the app is not enough, and the
+    reason is worth writing down because it decides the shape of the remedy.
+    An app survives its own test whenever that test served a request through
+    a route declared ``def`` rather than ``async def`` - measured at 0d4e7db
+    over ``/observability/deps``, ``/observability/agents`` and ``/team``
+    (one app retained per case) against ``/recap`` and
+    ``/dashboard/auth/status`` (none).  Walking ``gc.get_referrers`` from one
+    of the survivors reaches the keyword arguments anyio's pytest plugin holds
+    while finalising an async-generator fixture - for ``client`` that is
+    ``{"fx": <Fixture>}`` - and then the event loop's own frames.  All of that
+    is outside this repository, so no amount of care with ``del`` here reaches
+    it, and one retained app per case is what makes this suite's cost
+    quadratic in its own length (#3927).
+
+    What this file *can* decide is how much that retained handle is holding.
+    One app is ~13,100 tracked objects, ~19,700 once it has served a request.
+    Clearing the individual handles - ``state``, ``router.routes``,
+    ``user_middleware``, ``middleware_stack``, ``dependency_overrides``,
+    ``exception_handlers`` - gives back only ~1,400 of them, because the graph
+    stays reachable through whichever handle was not on the list.  Clearing
+    the instance dict gives back all but ~120, which is the same figure as
+    never holding the app at all.  Hence the blunt instrument.  It is safe
+    because nothing may touch the app after this runs and by construction
+    nothing does: ``client`` requests ``fx``, so pytest finalises ``client``
+    first and there is no live transport left by this point.
+
+    What this does NOT do is stop the app *object* being retained - that root
+    is somebody else's - only the graph hanging off it.  A count of live
+    ``FastAPI`` instances therefore still climbs; the heap does not.
+    """
+    app.__dict__.clear()
+
+
 @pytest.fixture()
 async def fx(
     sdd_dir: Path,
     jsonl_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-) -> Fixture:
-    """Build the real app with one task per tenant and every credential type."""
+) -> AsyncIterator[Fixture]:
+    """Build the real app with one task per tenant and every credential type.
+
+    Every test gets its own app - that is the point of the suite, and it is
+    unchanged.  What is new is that the app does not survive the test that
+    used it; see :func:`_release`.
+    """
     monkeypatch.setenv("BERNSTEIN_AUTH_ENABLED", "1")
     monkeypatch.setenv("BERNSTEIN_AUTH_JWT_SECRET", JWT_SECRET)
 
@@ -197,13 +238,20 @@ async def fx(
         "agent_unrestricted": _agent_credential(app, "agent-manager-a", TENANT_A, []),
     }
 
-    return Fixture(
-        app=app,
-        task_a_id=task_a.id,
-        task_b_id=task_b.id,
-        task_default_id=task_default.id,
-        credentials=credentials,
-    )
+    try:
+        yield Fixture(
+            app=app,
+            task_a_id=task_a.id,
+            task_b_id=task_b.id,
+            task_default_id=task_default.id,
+            credentials=credentials,
+        )
+    finally:
+        # ``finally`` rather than a bare statement after the yield: a fixture
+        # generator that is closed rather than resumed - which is what
+        # ``aclose`` does when a run is interrupted - throws ``GeneratorExit``
+        # at the yield, and only a ``finally`` runs then.
+        _release(app)
 
 
 @pytest.fixture()

--- a/tests/unit/tenant_scope/test_fixture_releases_its_app.py
+++ b/tests/unit/tenant_scope/test_fixture_releases_its_app.py
@@ -1,0 +1,144 @@
+"""The app a case builds must not outlive that case.
+
+``fx`` builds a whole ``create_app`` stack per test, deliberately: the suites
+next door prove that one tenant's rows never reach another tenant's view, and
+a fixture shared between cases would let state from one reach the next.  The
+cost of that choice is that the heap grows with the number of cases unless
+each app is released when its case ends, and #3927 is what happens when it is
+not - every subsequent gc pass walks every app ever built, so per-case
+teardown climbs and the file's total cost is quadratic in its own length until
+it crosses the per-file timeout in ``scripts/run_tests.py``.
+
+The property is asserted here rather than eyeballed from a probe, because a
+regression in it is silent: nothing fails, the suite just gets slower until it
+does not finish.  The measurement is the slope, not any single reading - the
+absolute object count depends on what else the session has imported, and the
+app under the current case is alive on purpose in every sample, so it cancels.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+# ``anyio_backend``, ``client``, ``fx``, ``jsonl_path`` and ``sdd_dir`` are
+# fixtures: pytest resolves them from this module's namespace, so importing
+# them here is what makes them available to the tests below.
+from tests.unit.tenant_scope.conftest import (
+    anyio_backend,  # noqa: F401
+    client,  # noqa: F401
+    fx,  # noqa: F401
+    jsonl_path,  # noqa: F401
+    sdd_dir,  # noqa: F401
+)
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+    from tests.unit.tenant_scope.conftest import Fixture
+
+# ruff: noqa: F811
+
+pytestmark = [pytest.mark.ci, pytest.mark.auth_enabled]
+
+# The route each sample calls, and it is the whole reason this file is a
+# useful gate rather than a decoration.  Measured on this tree at 0d4e7db,
+# retention follows how the handler is declared, not what it reads:
+#
+#     /observability/deps    def        1 app retained per case
+#     /observability/agents  def        1 app retained per case
+#     /team                  def        1 app retained per case
+#     /recap                 async def  0
+#     /dashboard/auth/status async def  0
+#
+# So a sampler pointed at an async route sees a flat heap on a tree that
+# retains every app, and passes while proving nothing.  ``/observability/deps``
+# is a plain read with no seeding, and it is one of the routes the suite this
+# file guards actually exercises.
+SAMPLED_ROUTE = "/observability/deps"
+
+# Enough cases to read a slope from, few enough to stay cheap: each one builds
+# a full app, which is the expensive thing this file is about.
+SAMPLES = 5
+
+# One ``create_app`` costs ~13,100 tracked objects on this tree, measured by
+# building three and dropping them; held through a request it is ~19,700.  A
+# released app leaves ~120 behind, the same figure as never holding it at all.
+# The budget sits between the two and far enough from both that it is neither
+# flaky nor vacuous: a tree that retains its apps overshoots it by ~10x, and
+# one that releases them comes in two orders of magnitude under.
+BUDGET_OBJECTS_PER_APP = 2_000
+
+# Filled by the sampling cases below and read by the assertions at the end.
+_live: list[int] = []
+_task_ids: list[str] = []
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize("sample", range(SAMPLES))
+async def test_each_case_gets_a_working_app_of_its_own(
+    fx: Fixture,
+    client: AsyncClient,
+    sample: int,
+) -> None:
+    """Build an app, serve a request from it, and record the heap.
+
+    The request matters: an app that was built and never used holds none of
+    the per-request state that makes the retention expensive, so a sampler
+    that skipped it would measure less than the suite it stands in for.
+    """
+    response = await client.get(SAMPLED_ROUTE, headers=fx.credentials["legacy_bearer"].headers)
+
+    assert response.status_code == 200, f"{SAMPLED_ROUTE} answered {response.status_code}"
+    gc.collect()
+    _live.append(len(gc.get_objects()))
+    _task_ids.append(fx.task_a_id)
+
+
+def test_the_heap_does_not_grow_with_the_number_of_apps_built() -> None:
+    """The apps built by earlier cases are gone by the time later ones run."""
+    if len(_live) < SAMPLES:
+        pytest.skip(f"needs all {SAMPLES} sampling cases in this module to have run")
+
+    # The first sample carries the one-time imports the first request through
+    # the stack performs, which is a fixed cost rather than a per-app one.
+    warm = _live[1:]
+    per_app = (warm[-1] - warm[0]) / (len(warm) - 1)
+
+    assert per_app < BUDGET_OBJECTS_PER_APP, (
+        f"the heap grew by {per_app:.0f} tracked objects per app across "
+        f"{len(warm)} samples {warm}, which is the shape of an app that "
+        f"outlives its case; see conftest._release"
+    )
+
+
+def test_every_case_really_did_build_its_own_app() -> None:
+    """The control on the test above: it must not pass by sharing one app.
+
+    Object identity cannot answer this - a released app's ``id`` is free to be
+    handed to the next one - so this reads the seeded tasks, which are created
+    fresh per app and carry ids that are unique for the life of the session.
+    """
+    if len(_task_ids) < SAMPLES:
+        pytest.skip(f"needs all {SAMPLES} sampling cases in this module to have run")
+
+    assert len(set(_task_ids)) == SAMPLES, f"cases shared an app: {_task_ids}"
+
+
+@pytest.mark.anyio()
+async def test_the_app_is_intact_while_its_own_case_runs(fx: Fixture, client: AsyncClient) -> None:
+    """The release must land after the case, not during it.
+
+    Without this, a ``_release`` that ran too early would satisfy every
+    assertion above while breaking every other suite that shares this
+    conftest, and the failure would surface somewhere else as an unrelated
+    404.
+    """
+    app: Any = fx.app
+
+    assert app.router.routes, "the app under test has no routes"
+    assert app.state.store is not None
+    response = await client.get(SAMPLED_ROUTE, headers=fx.credentials["legacy_bearer"].headers)
+    assert response.status_code == 200


### PR DESCRIPTION
Closes #3927.

`fx` builds a whole `create_app` per case on purpose, and this keeps it that way. What
changes is that the app does not outlive the case that used it.

## What I measured before changing anything

`0d4e7db`, this box, a `pytest_runtest_makereport` plugin counting `gc.get_objects()`
after each teardown — the four-line probe the issue suggests, one hook later so it reads
after the fixtures have been finalised:

| after | live objects | `FastAPI` alive | teardown |
|---|---|---|---|
| 1 | 306,310 | 0 | 0.227s |
| 10 | 307,480 | 0 | 0.216s |
| 20 | 504,095 | 10 | 0.303s |
| 50 | 1,068,927 | 40 | 0.851s |
| 100 | 1,991,749 | 89 | 1.213s |

101 passed in 167.6s under the probe, 146.1s without it.

## The retention does not start at case 1, and where it does start is the finding

Cases 1-10 retain **nothing**. Those are the two `/recap` families. Case 11 is the first
`/observability/deps` case and it is the same shape as case 1 apart from the URL — and
from there it is exactly one retained app per case, all the way to 89 of them.

So I varied only the route: six cases each, counting live `FastAPI` instances inside each
case after its own request, so the count includes the case's own app and a flat 1 is the
clean reading:

| route | declared | apps alive, cases 1-6 |
|---|---|---|
| `/observability/deps` | `def` | 1, 2, 3, 4, 5, 6 |
| `/observability/agents` | `def` | 1, 2, 3, 4, 5, 6 |
| `/team` | `def` | 1, 2, 3, 4, 5, 6 |
| `/recap` | `async def` | 1, 1, 1, 1, 1, 1 |
| `/dashboard/auth/status` | `async def` | 1, 1, 1, 1, 1, 1 |

**An app survives its case if and only if that case served a request through a handler
declared `def` rather than `async def`.** Starlette runs those in a worker thread, which
is the obvious suspect; I am not claiming it, because the process ends the run with one
thread, so whatever holds the reference outlives the thread that ran the handler.
`gc.get_referrers` from a survivor reaches the keyword arguments anyio's plugin holds
while finalising an async-generator fixture — for `client` that is `{"fx": <Fixture>}` —
and then the event loop's own frames. All of it is outside this repository.

**I did not chase that root.** It is a separate ticket and probably a product one rather
than a test one — every sync route in the app is on the same path. What this patch does
is make the surviving handle cheap, which is the direction the issue asks for and is
indifferent to who is holding it.

## The change

`fx` becomes a yield fixture and releases its app in a `finally`. `_release` is
`app.__dict__.clear()`, and the reason it is that blunt is measured rather than assumed —
three apps built, one handle cleared at a time:

| after clearing | still held (3 apps) |
|---|---|
| nothing | 39,352 |
| `state._state` | 39,167 |
| `router.routes` | 35,219 |
| `user_middleware` | 35,102 |
| `middleware_stack` | 35,102 |
| `dependency_overrides` | 35,102 |
| `exception_handlers` | 35,099 |
| `openapi_schema`, `on_startup`, `on_shutdown` | 35,099 |
| `__dict__` | **364** |
| (control) references dropped entirely | 361 |

The tidy version gives back 4,253 of 39,352 — 1,418 per app — because the graph stays
reachable through whichever handle is not on the list. Clearing the instance dict lands on the same figure as never
holding the app. It is safe because nothing may touch the app afterwards and nothing does:
`client` requests `fx`, so pytest finalises `client` first and there is no live transport
left by then. `finally` rather than a statement after the `yield`, so an interrupted run
that closes the generator still releases.

Note what this does **not** do: the app *object* is still retained — that root is not
mine to fix — so a count of live `FastAPI` instances still climbs. Only the graph hanging
off it goes. The heap is what the timeout cares about.

## After

| after | live objects | teardown |
|---|---|---|
| 1 | 306,311 | 0.203s |
| 10 | 307,481 | 0.255s |
| 20 | 310,662 | 0.241s |
| 50 | 320,557 | 0.218s |
| 100 | 336,422 | 0.256s |

Growth per case: **18,714 → 322**. Teardown stops climbing. 101 passed in 110.8s under
the probe against 167.6s, and without the probe it is 103.7s against 146.1s.

## The test, and the version of it that was worthless

`tests/unit/tenant_scope/test_fixture_releases_its_app.py`. Its assertion,
`test_the_heap_does_not_grow_with_the_number_of_apps_built`, reads the slope rather than
any single value, because the absolute count depends on what else the session imported
and the app under the current case is alive in every sample, so it cancels.

**The first version sampled `/recap` and passed on pristine main.** An async route retains
nothing, so it measured a flat heap on a tree that leaks every app. That is why the route
is a named constant with the table above next to it: a sampler pointed at the wrong kind
of route is a green tick that means nothing.

Pointed at `/observability/deps`:

```
E   AssertionError: the heap grew by 19756 tracked objects per app across 4 samples
E   [342936, 362692, 382448, 402204], which is the shape of an app that outlives its
E   case; see conftest._release
E   assert 19756.0 < 2000
1 failed, 7 passed in 10.06s          <- pristine main
8 passed in 9.86s                     <- with this patch
```

Two controls sit beside it, because the assertion above is satisfiable by cheating:

- `test_every_case_really_did_build_its_own_app` — a shared app would also give a flat
  heap. It compares seeded task ids rather than `id(app)`, because a released app's
  address is free to be handed to the next one.
- `test_the_app_is_intact_while_its_own_case_runs` — a `_release` that fired too early
  would satisfy everything above and break every other suite sharing this conftest.

## Run

Everything that reads the changed conftest, plus the lint CI actually runs on `tests/`:

```
tests/unit/test_tenant_scope_dashboard_readers.py   101 passed  103.67s   imports it
tests/unit/tenant_scope/                            148 passed  145.01s   owns it
tests/unit/test_tenant_scoped_readers.py              2 passed    3.40s   neighbour, does NOT share it
ruff format --check src/ tests/ scripts/            4542 files already formatted
ruff check tests/unit/tenant_scope/                 All checks passed
```

`grep -rl "tenant_scope.conftest\|from tests.unit.tenant_scope" tests/` returns four
files; the first two rows above are all of them. The third is there because the name
invites the assumption that it shares the fixture, and it does not.

<details>
<summary>Not run, and I would rather say so</summary>

The full `scripts/run_tests.py` sweep. This box has 2 cores and the runner is
process-per-file over 2,000+ tests. **Do not read this PR as saying the whole suite is
green** — what is green is the file the issue is about, both suites that share the
conftest it changes, ruff and mypy over the touched paths.

I also cannot measure `macos-latest`, which is where the timeout actually fires. What I
can say is that the growth this removes was quadratic in the file's own length and is now
flat, so the margin does not shrink as the file grows.

</details>

<details>
<summary>AI-assisted</summary>

This patch was written by an autonomous agent. Every figure above is a run on the machine
that wrote it rather than an inference: the object counts come from `gc.get_objects()`
after teardown, the per-handle table from building three apps and clearing one attribute
at a time, the route table from six-case probes that vary nothing but the URL, and the
failing output from running the new test against a stashed conftest. The not-run list is
what this box did not run rather than what was not attempted.

</details>
