### PR TITLE
fix(tui): app.notify renders a toast again (#3933)

### DIFF
--- a/src/bernstein/tui/app.py
+++ b/src/bernstein/tui/app.py
@@ -281,7 +281,9 @@ class BernsteinApp(App[None]):
         self._split = SplitPaneState()
         # TUI-009: toast notification manager
         self._toasts = ToastManager()
-        self._notifications = NotificationHistory()
+        # Not ``_notifications``: Textual's ``App.__init__`` owns that name for
+        # its own toast queue, and shadowing it silently breaks ``self.notify``.
+        self._notification_history = NotificationHistory()
         self._recordings_dir = Path(".sdd/recordings/tui")
         self._session_recorder: SessionRecorder | None = None
         self._recording_started_at = 0.0
@@ -700,7 +702,7 @@ class BernsteinApp(App[None]):
 
     def action_acknowledge_notifications(self) -> None:
         """Mark all notification-center entries as read."""
-        self._notifications.mark_all_read()
+        self._notification_history.mark_all_read()
         self._refresh_notification_center()
 
     def _ensure_panel_visible(self, panel_id: str) -> None:
@@ -1115,7 +1117,7 @@ class BernsteinApp(App[None]):
 
     def _remember_toast(self, toast: Toast) -> None:
         """Mirror a toast into persistent notification history and refresh the UI."""
-        self._notifications.add(
+        self._notification_history.add(
             toast.message,
             level=toast.level.value,
             source=toast.source,
@@ -1127,7 +1129,8 @@ class BernsteinApp(App[None]):
     def _refresh_notification_center(self) -> None:
         """Render the latest notification history into the side panel."""
         self.query_one("#notification-center", NotificationCenterPanel).set_history(
-            self._notifications.get_history(limit=5), self._notifications.get_unread_count()
+            self._notification_history.get_history(limit=5),
+            self._notification_history.get_unread_count(),
         )
 
     @staticmethod

--- a/tests/unit/test_tui_app_notifications.py
+++ b/tests/unit/test_tui_app_notifications.py
@@ -1,0 +1,136 @@
+"""Notification delivery tests for :class:`~bernstein.tui.app.BernsteinApp`.
+
+Two notification surfaces share the app and must not interfere:
+
+* ``self.notify(...)`` -- Textual's own transient toast, used by
+  :mod:`bernstein.tui.approval_panel` to confirm a sent approval.
+* The notification centre panel -- our persistent, read/unread history.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from textual.widgets._toast import Toast as TextualToast
+
+from bernstein.tui.app import BernsteinApp
+from bernstein.tui.approval_panel import ApprovalAction, ApprovalPanel
+from bernstein.tui.notification_badge import NotificationCenterPanel
+from bernstein.tui.toast import ToastLevel
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mount the app in an empty directory so it reads no repository state."""
+    monkeypatch.chdir(tmp_path)
+
+
+def _notification_center_text(app: BernsteinApp) -> str:
+    """Return the plain text the notification centre panel currently renders."""
+    return app.query_one("#notification-center", NotificationCenterPanel).render().plain
+
+
+class TestTextualToasts:
+    """``App.notify`` must reach the screen, not die inside the message pump.
+
+    ``run_test`` suppresses the toast rack unless ``notifications=True``, so
+    every test here opts in -- otherwise the assertions would pass against a
+    subsystem that was never switched on.
+    """
+
+    @pytest.mark.asyncio
+    async def test_notify_renders_a_toast(self) -> None:
+        app = BernsteinApp()
+        async with app.run_test(notifications=True) as pilot:
+            app.notify("Approval sent: task-42")
+            await pilot.pause()
+
+            toasts = list(app.query(TextualToast))
+            assert len(toasts) == 1
+            assert "Approval sent: task-42" in toasts[0].render().plain
+
+    @pytest.mark.asyncio
+    async def test_notify_renders_a_toast_per_notification(self) -> None:
+        app = BernsteinApp()
+        async with app.run_test(notifications=True) as pilot:
+            app.notify("first")
+            app.notify("second", severity="error")
+            await pilot.pause()
+
+            rendered = {toast.render().plain for toast in app.query(TextualToast)}
+            assert rendered == {"first", "second"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("approved", "expected"), [(True, "approved"), (False, "rejected")])
+    async def test_approval_confirmation_reaches_the_operator(self, approved: bool, expected: str) -> None:
+        """The confirmation an operator gets after acting on a tool call."""
+        app = BernsteinApp()
+        async with app.run_test(notifications=True) as pilot:
+            panel = app.query_one(ApprovalPanel)
+            panel.post_message(ApprovalAction(approved=approved, task_id="task-42"))
+            await pilot.pause()
+
+            toasts = list(app.query(TextualToast))
+            assert len(toasts) == 1
+            assert toasts[0].render().plain == f"Approval sent: {expected}"
+
+
+class TestNotificationCentre:
+    """Our own history keeps driving the notification centre panel."""
+
+    @pytest.mark.asyncio
+    async def test_starts_empty(self) -> None:
+        app = BernsteinApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert "No notifications yet." in _notification_center_text(app)
+
+    @pytest.mark.asyncio
+    async def test_remembered_toasts_render_as_unread_history(self) -> None:
+        app = BernsteinApp()
+        async with app.run_test() as pilot:
+            app._remember_toast(app._toasts.add("theme switched", level=ToastLevel.INFO))
+            app._remember_toast(app._toasts.error("worktree missing"))
+            await pilot.pause()
+
+            text = _notification_center_text(app)
+            assert "(2 unread" in text
+            assert "theme switched" in text
+            assert "worktree missing" in text
+            # Newest first, each flagged unread.
+            assert text.index("worktree missing") < text.index("theme switched")
+            assert text.count("new ") == 2
+
+    @pytest.mark.asyncio
+    async def test_acknowledge_clears_the_unread_marker(self) -> None:
+        app = BernsteinApp()
+        async with app.run_test() as pilot:
+            app._remember_toast(app._toasts.error("worktree missing"))
+            await pilot.pause()
+
+            app.action_acknowledge_notifications()
+            await pilot.pause()
+
+            text = _notification_center_text(app)
+            assert "(0 unread" in text
+            assert "worktree missing" in text
+            assert "new " not in text
+
+    @pytest.mark.asyncio
+    async def test_history_panel_shows_only_the_five_newest(self) -> None:
+        app = BernsteinApp()
+        async with app.run_test() as pilot:
+            for index in range(7):
+                app._remember_toast(app._toasts.add(f"event-{index}", level=ToastLevel.INFO))
+            await pilot.pause()
+
+            text = _notification_center_text(app)
+            assert "(7 unread" in text
+            assert "event-0" not in text
+            assert "event-1" not in text
+            for index in range(2, 7):
+                assert f"event-{index}" in text


### PR DESCRIPTION
Closes #3933.

## Problem

`BernsteinApp.__init__` assigned our `NotificationHistory` to `self._notifications` — a name Textual's own `App.__init__` already owns for its toast queue. Textual's toast path calls `.add()`, `del`, `.clear()` on that object, and `ToastRack.show` evaluates `bool(...)`, tests `in`, and iterates it. `NotificationHistory` supports none of that, so the render failed inside the message pump rather than at the call site: `app.notify(...)` never raised, the toast was simply never drawn, and nothing reported why.

The nearest operator-visible casualty is `approval_panel.py`, which calls `self.notify("Approval sent: ...")` after a tool call is approved or rejected. That is the surface where silence costs the most — an approval that was sent looked exactly like one that was dropped.

## Fix

Rename our attribute to `_notification_history`. Nothing outside `src/bernstein/tui/` reads it, and the four call sites are all in `app.py`. `NotificationHistory` itself is unchanged — the bug was the name, not the class.

## Tests

New `tests/unit/test_tui_app_notifications.py`, driving a real `BernsteinApp` through `App.run_test()`:

- `notify(...)` renders a `Toast` whose rendered text carries the message, one per notification.
- The approval-confirmation path posts an `ApprovalAction` to the live `ApprovalPanel` and asserts the operator sees `Approval sent: approved` / `... rejected`.
- The notification centre keeps working: history renders newest-first with unread markers, `action_acknowledge_notifications` clears them, and the panel caps at the five newest.

The assertions are on rendered widget output, not on the attribute name, so they fail on the pre-fix code for the real reason — all four toast tests error with `TypeError: 'NotificationHistory' object is not iterable`.

One wrinkle worth recording for the next person: `run_test()` defaults to `notifications=False`, which suppresses the `ToastRack` entirely. A test that omits the flag passes against a subsystem that was never switched on, so these tests opt in explicitly.

## Verification

| Check | Result |
|---|---|
| `pytest tests/unit/test_tui_app_notifications.py` | 8 passed |
| Same file against pre-fix `app.py` | 4 failed (toast paths), 4 passed (history guard) |
| Surrounding TUI + dashboard suites | 107 passed |
| `mypy src/bernstein/tui/` | 0 errors (was 8, all this collision) |
| `ruff check` / `ruff format --check` | clean |