### PR TITLE
feat(contributing): route area PRs to the area steward without a write grant

### DIFF
--- a/.github/workflows/area-steward-review.yml
+++ b/.github/workflows/area-steward-review.yml
@@ -1,0 +1,74 @@
+name: Area steward review
+
+# Routes pull requests that touch an area to that area's steward for
+# review (CONTRIBUTING "Areas"). Most docs PRs come from forks, so this
+# must run on `pull_request_target`: the default `pull_request` event
+# gets a read-only token on fork PRs and cannot request reviewers.
+#
+# Safety note (zizmor dangerous-triggers): the privileged context here
+# executes nothing from the PR. The job:
+#   - has NO checkout step at all - the steward mapping lives in this
+#     file, on the trusted base ref;
+#   - never interpolates PR-controlled text into a `run:` block (author
+#     login and PR number pass through env, and the login is only ever
+#     compared for equality, never executed);
+#   - holds `pull-requests: write` and nothing else, with no secrets
+#     beyond `GITHUB_TOKEN`.
+#
+# Stewards hold triage, not write, so CODEOWNERS cannot route to them -
+# GitHub ignores code owners without write access. This workflow is the
+# routing half of the Areas clause until a steward's write grant.
+on:  # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+    paths:
+      - 'docs/**'
+
+concurrency:
+  group: area-steward-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# Default-deny at workflow scope; the job re-asserts the one narrow
+# write scope it needs (Scorecard token-permissions).
+permissions: {}
+
+jobs:
+  request-steward:
+    name: Request docs steward review
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # The docs area steward (issue #3935). One steward, one constant;
+      # a second area gets a second paths entry and a mapping when it
+      # actually exists.
+      STEWARD: Chirag6722
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+      - name: Request review from the area steward
+        run: |
+          set -euo pipefail
+          if [ "${PR_AUTHOR}" = "${STEWARD}" ]; then
+            echo "::notice::PR author is the docs steward; nothing to route."
+            exit 0
+          fi
+          # A failure here almost always means the steward's collaborator
+          # invitation is still pending - review requests only reach
+          # collaborators. That is a routing gap to surface, not a defect
+          # in the PR under review, so warn and stay green rather than
+          # painting a contributor's PR red for it.
+          if gh api -X POST "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
+               -f "reviewers[]=${STEWARD}" > /dev/null; then
+            echo "::notice::requested docs-steward review from ${STEWARD} on #${PR_NUMBER}."
+          else
+            echo "::warning::could not request docs-steward review from ${STEWARD}; their collaborator invitation may still be pending."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,18 @@ week working against one is not.
 
 ### Areas
 
-Land three changes in one area and the area is yours if you want it:
-you are named in [CODEOWNERS](.github/CODEOWNERS) for it, and changes
-there come to you for review. Areas are adapters, the web dashboard,
-the terminal UI, docs, and packaging.
+Land three changes in one area and the area is yours if you want it -
+open an issue saying so. As the area's steward you get triage access,
+and every pull request touching the area is routed to you for review
+automatically (`.github/workflows/area-steward-review.yml`). Areas are
+adapters, the web dashboard, the terminal UI, docs, and packaging.
+
+Stewardship starts at triage rather than write, because write access
+on this repository reaches the release workflows and their publishing
+credentials, and that surface is kept least-privilege. After a
+stretch of established stewardship the write grant follows, and with
+it your entry in [CODEOWNERS](.github/CODEOWNERS) - GitHub only
+honors code owners who hold write.
 
 This is not ceremonial. An area with a name against it gets a second
 reader who knows it; an area with nobody against it accumulates

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -15,6 +15,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/adapter-conformance-canary.yml | Adapter conformance canary | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "adapter-conformance-canary"} | 1 |
 | .github/workflows/adapter-contract-drift.yml | Adapter contract drift | merge_group, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "adapter-contract-drift-${{ github.ref }}"} | 2 |
 | .github/workflows/airgap-e2e.yml | Airgap E2E | pull_request, push, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "airgap-e2e-${{ github.ref }}"} | 1 |
+| .github/workflows/area-steward-review.yml | Area steward review | pull_request_target | {"cancel-in-progress": "true", "group": "area-steward-${{ github.event.pull_request.number }}"} | 1 |
 | .github/workflows/auto-heal.yml | Auto-heal v2 | workflow_call | - | 2 |
 | .github/workflows/auto-release.yml | Auto-release | workflow_call | - | 5 |
 | .github/workflows/bernstein-ci-fix.yml | Bernstein CI Fix | workflow_call | - | 4 |
@@ -80,6 +81,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/adapter-conformance-canary.yml | canary: Canary matrix |
 | .github/workflows/adapter-contract-drift.yml | aggregate: Aggregate drift report<br>check: ${{ matrix.adapter }} |
 | .github/workflows/airgap-e2e.yml | airgap-e2e: Airgap E2E (Linux, real cosign + gpg + unshare) |
+| .github/workflows/area-steward-review.yml | request-steward: Request docs steward review |
 | .github/workflows/auto-heal.yml | heal: Apply chosen strategy<br>triage: Triage and classify |
 | .github/workflows/auto-release.yml | alert-on-stale-release-trigger: Alert on stale release trigger<br>detect-stale-alerts: Detect open auto-release-skipped issues<br>gate: Release gate<br>release: Tag release<br>sweep-stale-alerts-on-success: Close auto-release-skipped issues on green main |
 | .github/workflows/bernstein-ci-fix.yml | fallback-issue: Open ci-fix issue (fallback)<br>fix: Auto-heal with Bernstein<br>tier3-shadow: Tier-3 OpenRouter shadow-mode escalation<br>triage: Triage CI failure |
@@ -145,6 +147,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/adapter-conformance-canary.yml | workflow: {"contents": "read"}<br>canary: {"contents": "write", "issues": "write", "pull-requests": "write"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |
 | .github/workflows/adapter-contract-drift.yml | workflow: {"contents": "read"}<br>aggregate: {"contents": "read", "issues": "write"}<br>check: {"contents": "read"} | ADAPTER_CONTRACT_ANTHROPIC_API_KEY, ADAPTER_CONTRACT_GEMINI_API_KEY, ADAPTER_CONTRACT_OPENAI_API_KEY, GITHUB_TOKEN |
 | .github/workflows/airgap-e2e.yml | workflow: {"contents": "read"} | - |
+| .github/workflows/area-steward-review.yml | request-steward: {"pull-requests": "write"} | GITHUB_TOKEN |
 | .github/workflows/auto-heal.yml | heal: {"attestations": "write", "contents": "write", "id-token": "write", "pull-requests": "write"}<br>triage: {"actions": "read", "contents": "read", "pull-requests": "read"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |
 | .github/workflows/auto-release.yml | alert-on-stale-release-trigger: {"contents": "read", "issues": "write"}<br>detect-stale-alerts: {"contents": "read", "issues": "read"}<br>gate: {"contents": "read"}<br>release: {"actions": "write", "contents": "write"}<br>sweep-stale-alerts-on-success: {"contents": "read", "issues": "write"} | GITHUB_TOKEN |
 | .github/workflows/bernstein-ci-fix.yml | fallback-issue: {"contents": "read", "issues": "write"}<br>fix: {"contents": "write", "issues": "write", "pull-requests": "write"}<br>tier3-shadow: {"actions": "read", "contents": "read"}<br>triage: {"actions": "read", "contents": "read", "pull-requests": "read"} | BERNSTEIN_AUTOSYNC_TOKEN, GEMINI_API_KEY, GITHUB_TOKEN, OPENROUTER_API_KEY_FREE |

--- a/tests/unit/test_area_steward_workflow_yaml.py
+++ b/tests/unit/test_area_steward_workflow_yaml.py
@@ -1,0 +1,121 @@
+"""Structural assertions on the area-steward review-routing workflow.
+
+``.github/workflows/area-steward-review.yml`` implements the routing half
+of the CONTRIBUTING "Areas" clause: pull requests touching a steward's
+area are requested for their review automatically. Stewards hold triage,
+not write, so CODEOWNERS cannot do this - GitHub ignores code owners
+without write access.
+
+The failures this module exists to prevent
+------------------------------------------
+1. **A route that skips fork PRs.** Most docs PRs come from forks, where
+   the plain ``pull_request`` event gets a read-only token that cannot
+   request reviewers. The trigger must stay ``pull_request_target``.
+
+2. **PR code executing in the privileged context.** ``pull_request_target``
+   runs with a write-capable token. The job must never check out or
+   otherwise execute anything from the PR: no checkout step, and no
+   PR-controlled expression interpolated into a ``run:`` block.
+
+3. **Scope creep on the token.** The workflow exists to make one API
+   call. Workflow-level permissions must be default-deny and the job must
+   hold exactly ``pull-requests: write``.
+
+4. **The steward reviewing their own change.** A review request against
+   the PR author 422s and would paint the run red on every PR the steward
+   opens in their own area; the run must branch on author == steward.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "area-steward-review.yml"
+
+
+@pytest.fixture(scope="module")
+def raw() -> str:
+    return _WORKFLOW.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def workflow(raw: str) -> dict:
+    return yaml.safe_load(raw)
+
+
+@pytest.fixture(scope="module")
+def job(workflow: dict) -> dict:
+    jobs = workflow["jobs"]
+    assert len(jobs) == 1, "one routing job; a second job widens the privileged surface"
+    return next(iter(jobs.values()))
+
+
+def test_workflow_file_exists() -> None:
+    assert _WORKFLOW.is_file()
+
+
+def test_routes_fork_prs_too(workflow: dict) -> None:
+    """Plain `pull_request` cannot request reviewers on fork PRs."""
+    on = workflow.get("on", workflow.get(True))
+    assert "pull_request_target" in on, (
+        "fork PRs are most docs PRs; a pull_request trigger gets a read-only "
+        "token there and the steward is never requested"
+    )
+    assert "pull_request" not in on
+
+
+def test_scopes_to_the_docs_area(workflow: dict) -> None:
+    on = workflow.get("on", workflow.get(True))
+    assert on["pull_request_target"]["paths"] == ["docs/**"], (
+        "the route is the Areas clause for the docs steward; widening the "
+        "paths without a steward for the new area requests reviews nobody owns"
+    )
+
+
+def test_privileged_context_executes_nothing_from_the_pr(raw: str, job: dict) -> None:
+    """pull_request_target runs write-capable; PR content must stay data."""
+    for step in job["steps"]:
+        uses = str(step.get("uses", ""))
+        assert "checkout" not in uses, (
+            "a checkout in a pull_request_target job is one `ref:` away from "
+            "executing attacker-controlled code with a write token"
+        )
+    run_blocks = [step["run"] for step in job["steps"] if "run" in step]
+    assert run_blocks, "the routing call itself is a run step"
+    for block in run_blocks:
+        assert "${{" not in block, (
+            "PR-controlled expressions interpolated into run blocks are the "
+            "classic pull_request_target injection; pass values through env"
+        )
+
+
+def test_token_scope_is_review_requests_only(workflow: dict, job: dict) -> None:
+    assert workflow["permissions"] == {}, (
+        "workflow-level permissions must be default-deny; the job re-asserts the one scope it needs"
+    )
+    assert job["permissions"] == {"pull-requests": "write"}
+
+
+def test_the_steward_never_reviews_their_own_change(job: dict) -> None:
+    """Requesting the PR author 422s; every steward-authored docs PR would go red."""
+    env = job.get("env", {})
+    assert "STEWARD" in env and "PR_AUTHOR" in env
+    run = "\n".join(step["run"] for step in job["steps"] if "run" in step)
+    assert re.search(r'"\$\{PR_AUTHOR\}"\s*=\s*"\$\{STEWARD\}"', run), (
+        "the run must branch on author == steward before requesting the review"
+    )
+
+
+def test_the_steward_is_a_constant_not_an_expression(job: dict) -> None:
+    """The reviewer must come from the trusted base ref, never from the event."""
+    steward = str(job["env"]["STEWARD"])
+    assert "${{" not in steward, "a steward name derived from the event lets the PR choose its own reviewer"


### PR DESCRIPTION
## What

The CONTRIBUTING "Areas" clause promised two things in one sentence: a CODEOWNERS entry, and review routing. Its first invocation (#3935) surfaced that they cannot ship together safely. GitHub only honors code owners who hold write access, and write access on this repository reaches the release workflows and their publishing credentials — a surface every other grant here keeps least-privilege. A documented "three landed PRs" path to that surface is the wrong standing offer.

## Fix shape

- **`.github/workflows/area-steward-review.yml`** delivers the routing half without a write grant: every PR touching `docs/**` requests the docs steward's review automatically. Fork PRs included — which is most docs PRs, and why the trigger is `pull_request_target` (the plain `pull_request` event gets a read-only token on forks and cannot request reviewers).
- The privileged context executes nothing from the PR: **no checkout step at all**, no PR-controlled expression inside a `run:` block (values pass through env and are only compared, never executed), one job holding exactly `pull-requests: write`, no secrets beyond `GITHUB_TOKEN`. Same discipline as `pr-labels.yml`, one notch stricter — that workflow at least consumes label rules; this one consumes nothing.
- A review-request failure warns and stays green: it almost always means the steward's collaborator invitation is still pending, which is a routing gap, not a defect in the contributor's PR under review.
- **CONTRIBUTING §Areas** now describes the grant as it actually works: stewardship starts at triage with automatic routing; the write grant and the CODEOWNERS entry follow established stewardship. The promise and the mechanics match.

## Test matrix

`tests/unit/test_area_steward_workflow_yaml.py`, written before the workflow, each named for the property it protects:

| Test | Property |
|---|---|
| `test_routes_fork_prs_too` | the trigger stays `pull_request_target`; plain `pull_request` silently skips fork PRs |
| `test_scopes_to_the_docs_area` | paths stay `docs/**`; widening without a steward requests reviews nobody owns |
| `test_privileged_context_executes_nothing_from_the_pr` | no checkout step, no `${{ }}` inside any `run:` block |
| `test_token_scope_is_review_requests_only` | workflow permissions `{}`, job exactly `pull-requests: write` |
| `test_the_steward_never_reviews_their_own_change` | the author==steward branch exists; a self-request 422s every steward-authored docs PR red |
| `test_the_steward_is_a_constant_not_an_expression` | the reviewer comes from the trusted base ref, never from the event |

## Verification

- `uv run pytest tests/unit/test_area_steward_workflow_yaml.py -q` → 7 passed.
- `zizmor .github/workflows/area-steward-review.yml` → no findings (the `dangerous-triggers` ignore carries the same safety note the repo's existing `pull_request_target` workflows carry).
- `uv run ruff check` / `ruff format --check` → clean.
- `uv run python scripts/check_docs_drift.py` → no drift.

Closes #3935
