### PR TITLE
ci(decompose): gate pipeline start on the maintainer who applies the label

### DIFF
--- a/.github/workflows/bernstein-issues-decompose.yml
+++ b/.github/workflows/bernstein-issues-decompose.yml
@@ -4,6 +4,14 @@ name: "Bernstein Issue Decompose"
 # first build a read-only plan from the issue text. Repository write
 # authority is granted only after a maintainer has approved the file
 # scope with a bernstein-scope:<path> label.
+#
+# The label is this pipeline's start switch, and applying labels is
+# available to triage-role collaborators. Starting a pipeline that
+# spends API credit and pushes branches stays a maintainer decision,
+# so every privileged job also gates on the SENDER of the labeled
+# event - the account that applied the label - not only on the issue
+# author. A trusted-author issue labeled by anyone else is a silent
+# no-op.
 on:
   issues:
     types: [labeled]
@@ -42,6 +50,7 @@ jobs:
     timeout-minutes: 20
     if: >-
       github.event.label.name == 'bernstein' &&
+      github.event.sender.login == 'chernistry' &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
     permissions:
       contents: read
@@ -123,6 +132,7 @@ jobs:
     timeout-minutes: 5
     if: >-
       github.event.label.name == 'bernstein' &&
+      github.event.sender.login == 'chernistry' &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
     permissions:
       issues: write
@@ -180,6 +190,7 @@ jobs:
       - scope_gate
     if: >-
       github.event.label.name == 'bernstein' &&
+      github.event.sender.login == 'chernistry' &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) &&
       needs.scope_gate.outputs.allowed_scope != ''
     permissions:

--- a/tests/unit/test_issue_decompose_workflow_yaml.py
+++ b/tests/unit/test_issue_decompose_workflow_yaml.py
@@ -87,6 +87,24 @@ def test_decompose_job_requires_trusted_issue_author() -> None:
     assert "COLLABORATOR" in condition
 
 
+def test_starting_the_pipeline_is_a_maintainer_action_not_a_label() -> None:
+    """Applying labels is available to triage-role collaborators.
+
+    The label is this pipeline's start switch, and the pipeline spends
+    API credit and pushes branches, so every privileged job must also
+    gate on WHO applied the label (the event sender), not only on who
+    authored the issue. Otherwise any triage-role collaborator can
+    start the pipeline on their own issue.
+    """
+    for name in ("plan", "scope_gate", "decompose"):
+        condition = _job(name).get("if", "")
+        assert isinstance(condition, str)
+        assert "github.event.sender.login == 'chernistry'" in condition, (
+            f"job {name!r} runs on a labeled event without checking that a "
+            "maintainer applied the label"
+        )
+
+
 def test_untrusted_issue_path_does_not_run_agent_or_receive_llm_secret() -> None:
     job = _job("reject-untrusted-issue")
     condition = job.get("if", "")


### PR DESCRIPTION
## What

The issue-decompose pipeline triggers on `issues: [labeled]` and gates on the issue **author** being a trusted association (`OWNER`/`MEMBER`/`COLLABORATOR`). It never checks **who applied the label** - and applying labels is available to triage-role collaborators, who are collaborators themselves. A triage-role collaborator could open an issue and start the pipeline on it single-handedly.

The pipeline spends API credit and pushes branches, so starting it is a maintainer decision. Every privileged job now also requires `github.event.sender.login` to be the maintainer. A trusted-author issue labeled by anyone else is a silent no-op.

## Why now

The repository just onboarded its first triage-role collaborator (#3935), which turned this from a theoretical gap into a live one. Blast radius was already bounded (the resulting PR still needs human review and the merge queue), but the start switch should not be wider than the decision it represents.

## Tests

- `test_starting_the_pipeline_is_a_maintainer_action_not_a_label` - fails on the previous workflow (no sender gate on `plan`/`scope_gate`/`decompose`), passes now.
- All 8 structural tests green; zizmor: no findings.
