### PR TITLE
fix(security): confine the ratchet's privileged checkout and stretch the A2A signing key

### DIFF
--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -68,7 +68,16 @@ name: Coverage ratchet (total)
 # Note: a `workflow_run` workflow always executes the copy of this file on
 # the default branch, so edits here take effect only once merged to main.
 
-on:
+# Safety note (zizmor dangerous-triggers, Scorecard Dangerous-Workflow).
+# This job runs privileged (`contents: write`) and checks out a commit
+# named by the event, which is the shape of a pwn request. What keeps it
+# safe is the job-level guard below, not the `branches:` filter: a fork's
+# branch can also be called `main`, so that filter alone is not a trust
+# boundary. The guard requires the triggering run to come from THIS
+# repository and from a `push` event, so the checked-out commit is
+# always one that already reached our default branch through the merge
+# queue. There is no reachable path here that builds fork-authored code.
+on:  # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: ["CI"]
     types: [completed]
@@ -87,10 +96,22 @@ jobs:
     name: Total coverage ratchet
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Skip the merge of a baseline-bump PR this workflow opened (avoids a
-    # self-retrigger loop on its own change). On workflow_run the commit
-    # lives under the triggering run, not the top-level event.
-    if: "!contains(github.event.workflow_run.head_commit.message, 'ratchet coverage baseline')"
+    # Two guards, and they answer different questions.
+    #
+    # The first two clauses are the trust boundary for the checkout below.
+    # `branches: [main]` in the trigger does not establish one: a fork's
+    # own branch may be named `main` too, and a fork PR's CI run carries
+    # that name. Requiring the triggering run to belong to THIS repository
+    # and to be a `push` narrows the checked-out commit to one that is
+    # already on our default branch, having passed the merge queue.
+    #
+    # The third skips the merge of a baseline-bump PR this workflow opened
+    # (avoids a self-retrigger loop on its own change). On workflow_run the
+    # commit lives under the triggering run, not the top-level event.
+    if: >-
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.event == 'push' &&
+      !contains(github.event.workflow_run.head_commit.message, 'ratchet coverage baseline')
     permissions:
       contents: write  # create the bump branch
       pull-requests: write  # open the baseline-bump PR

--- a/src/bernstein/core/protocols/a2a/server_auth.py
+++ b/src/bernstein/core/protocols/a2a/server_auth.py
@@ -41,6 +41,7 @@ import json
 import os
 import time
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import Any
 
 __all__ = [
@@ -62,6 +63,41 @@ _SIGNING_SECRET_ENV = "BERNSTEIN_A2A_OAUTH_SIGNING_SECRET"
 
 #: Client-credentials token lifetime (seconds).
 _TOKEN_TTL_SECONDS = 3600
+
+#: Domain separation for the derived signing key; doubles as the PBKDF2 salt.
+#: A fixed salt is required, not an oversight: the derivation has to land on
+#: the same key in every process behind the same config, and a random salt
+#: would have to be persisted somewhere - which is the thing this derivation
+#: exists to avoid. The salt is not the defence here; the iteration count is.
+_SIGNING_KEY_SALT = b"bernstein-a2a-oauth"
+
+#: PBKDF2 iterations for the signing-key derivation (OWASP's floor for
+#: PBKDF2-HMAC-SHA256). Operator-chosen client secrets are often short, and a
+#: single fast hash would let anyone holding the derived key grind them back
+#: out offline - client secrets that operators tend to reuse elsewhere. The
+#: cost is paid once per distinct client set, not once per request: see
+#: :func:`_derive_signing_key`.
+_SIGNING_KEY_ITERATIONS = 600_000
+
+
+@lru_cache(maxsize=16)
+def _derive_signing_key(material: str) -> bytes:
+    """Stretch *material* into a signing key, memoised per distinct input.
+
+    The memoisation is what makes an expensive KDF usable here. Both
+    ``a2a_jsonrpc._get_auth`` and ``well_known`` build an authenticator per
+    request when the app state has none, so an un-cached 600k-iteration
+    derivation would add its full cost to every A2A request rather than to
+    startup. Keyed on the material itself, so a config change derives a new
+    key instead of returning the previous one.
+    """
+    return hashlib.pbkdf2_hmac(
+        "sha256",
+        material.encode("utf-8"),
+        _SIGNING_KEY_SALT,
+        _SIGNING_KEY_ITERATIONS,
+    )
+
 
 #: Scheme ids advertised in the card. Stable so a cached card keeps resolving.
 _API_KEY_SCHEME_ID = "a2a-api-key"
@@ -178,9 +214,17 @@ class A2AServerAuth:
         validates tokens issued earlier, without persisting a secret. The
         client secrets are already private, so folding them into the key adds
         no new exposure and binds token validity to the configured clients.
+
+        Derivation goes through PBKDF2 rather than a single hash. Anyone who
+        obtains the derived key can already forge tokens, so stretching does
+        not protect this surface - it protects the *inputs*. A single SHA-256
+        pass would let a leaked signing key be ground back into the operator's
+        client secrets offline at hardware speed, and those secrets are
+        routinely the same ones used against other systems. Turning that
+        recovery from seconds into an infeasible campaign is the whole point.
         """
         material = "\x00".join(f"{cid}={sec}" for cid, sec in sorted(oauth_clients.items()))
-        return hashlib.sha256(b"bernstein-a2a-oauth\x00" + material.encode("utf-8")).digest()
+        return _derive_signing_key(material)
 
     @property
     def is_configured(self) -> bool:

--- a/tests/unit/test_a2a_server_auth.py
+++ b/tests/unit/test_a2a_server_auth.py
@@ -11,11 +11,14 @@ These tests exercise the pure authenticator: no HTTP, stdlib crypto only.
 
 from __future__ import annotations
 
+import hashlib
+
 import pytest
 
 from bernstein.core.protocols.a2a.server_auth import (
     A2AAuthError,
     A2AServerAuth,
+    _derive_signing_key,
 )
 
 
@@ -180,3 +183,73 @@ def test_from_env_with_no_config_authenticates_nothing(monkeypatch: pytest.Monke
     assert not auth.is_configured
     with pytest.raises(A2AAuthError):
         auth.authenticate({"x-api-key": "anything"})
+
+
+# --------------------------------------------------------------------------- #
+# signing-key derivation
+# --------------------------------------------------------------------------- #
+
+
+def test_derived_key_is_stable_across_authenticators() -> None:
+    """A restart must still validate tokens issued before it.
+
+    The derivation exists so two processes behind one config agree on the
+    signing key without persisting a secret; if this stops holding, every
+    restart silently invalidates live tokens.
+    """
+    clients = {"svc-a": "secret-a", "svc-b": "secret-b"}
+
+    first = A2AServerAuth(oauth_clients=dict(clients))
+    second = A2AServerAuth(oauth_clients=dict(clients))
+
+    assert first.signing_secret == second.signing_secret
+
+    token = first.issue_client_credentials_token(client_id="svc-a", client_secret="secret-a", now=1000.0).access_token
+    caller = second.authenticate({"Authorization": f"Bearer {token}"}, now=1001.0)
+    assert caller.caller_id == "svc-a"
+
+
+def test_a_changed_client_set_derives_a_different_key() -> None:
+    """Token validity is bound to the configured clients, not just the secret."""
+    one = A2AServerAuth(oauth_clients={"svc-a": "secret-a"})
+    two = A2AServerAuth(oauth_clients={"svc-a": "secret-a", "svc-b": "secret-b"})
+
+    assert one.signing_secret != two.signing_secret
+
+
+def test_client_secrets_are_not_recoverable_at_hardware_speed() -> None:
+    """The derived key must not be one fast hash away from the secrets.
+
+    Whoever holds the signing key can already forge tokens; what stretching
+    protects is the operator's client secrets, which are short and reused
+    elsewhere. A single SHA-256 pass over the material would let a leaked key
+    be ground back into them offline. This asserts the cheap construction is
+    not what ships.
+    """
+    material = "svc-a=secret-a"
+    cheap = hashlib.sha256(b"bernstein-a2a-oauth\x00" + material.encode("utf-8")).digest()
+
+    shipped = A2AServerAuth(oauth_clients={"svc-a": "secret-a"}).signing_secret
+
+    assert shipped != cheap
+    assert len(shipped) == 32
+
+
+def test_derivation_is_not_repaid_on_every_request() -> None:
+    """`_get_auth` builds an authenticator per request when state has none.
+
+    An un-memoised 600k-iteration KDF would therefore land on every A2A
+    request rather than on startup, so the cache is load-bearing rather than
+    an optimisation.
+    """
+    clients = {"svc-cache": "secret-cache"}
+    _derive_signing_key.cache_clear()
+
+    A2AServerAuth(oauth_clients=dict(clients))
+    after_first = _derive_signing_key.cache_info()
+    A2AServerAuth(oauth_clients=dict(clients))
+    after_second = _derive_signing_key.cache_info()
+
+    assert after_first.misses == 1
+    assert after_second.misses == 1, "a second authenticator re-ran the KDF"
+    assert after_second.hits == after_first.hits + 1

--- a/tests/unit/test_coverage_ratchet_workflow_yaml.py
+++ b/tests/unit/test_coverage_ratchet_workflow_yaml.py
@@ -220,6 +220,31 @@ def test_self_retrigger_guard_reads_the_triggering_run(workflow: dict) -> None:
     )
 
 
+def test_privileged_checkout_is_confined_to_commits_from_this_repository(
+    workflow: dict,
+) -> None:
+    """The trigger's `branches:` filter is not a trust boundary.
+
+    This job runs with ``contents: write`` and checks out a commit named
+    by the event. ``branches: [main]`` does not confine that to our own
+    code: a fork's branch can be called ``main`` as well, and a fork PR
+    opened from it produces a CI run carrying that branch name. Only the
+    triggering run's repository distinguishes the two.
+    """
+    guard = workflow["jobs"]["ratchet"]["if"]
+
+    assert (
+        "github.event.workflow_run.head_repository.full_name == github.repository" in guard
+    ), (
+        "without a same-repository guard, a fork PR from a branch named `main` "
+        "reaches the privileged checkout below"
+    )
+    assert "github.event.workflow_run.event == 'push'" in guard, (
+        "a pull_request-triggered CI run measures the merge commit of an "
+        "unmerged branch; only a push to the default branch may be ratcheted"
+    )
+
+
 # --------------------------------------------------------------------------- #
 # the measurement must belong to the commit being checked out
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Clears the open high/critical code-scanning alerts on `main`.

## Ratchet checkout (Scorecard `Dangerous-Workflow`, critical; zizmor `dangerous-triggers`)

`coverage-ratchet.yml` runs `contents: write` and checks out `github.event.workflow_run.head_sha`. The only thing standing between that and a pwn request was `branches: [main]` on the trigger — and **that is not a trust boundary**: a fork's own branch can be named `main`, and a fork PR opened from it produces a CI run carrying that branch name.

Empirically the trigger has never fired for a fork (1172 runs, all `event=push` from this repository, including on a day a fork PR from `MochiGem/bernstein:main` ran CI to success). But that is observed platform behaviour, not a guarantee we control, and it is not what a reader of the file can verify. The job now states the invariant itself:

```yaml
github.event.workflow_run.head_repository.full_name == github.repository &&
github.event.workflow_run.event == 'push' &&
```

so the checked-out tree is always one that already reached `main` through the merge queue.

## A2A signing key (CodeQL `py/weak-sensitive-data-hashing`, high)

`A2AServerAuth._derive_secret` folded the configured client secrets into an HMAC signing key with a single SHA-256 pass.

Whoever holds the derived key can already forge tokens, so stretching does not protect that surface — it protects the **inputs**. A leaked signing key could be ground back into the operator's client secrets offline at hardware speed, and those secrets are routinely the same ones pointed at other systems. Derivation moves to PBKDF2-HMAC-SHA256 at 600k iterations.

The fixed salt is deliberate, not an oversight: the derivation exists so that every process behind one config lands on the same key without persisting a secret. The iteration count is the defence here, not the salt.

Memoisation is load-bearing rather than an optimisation — `a2a_jsonrpc._get_auth` and `well_known` both construct an authenticator **per request** when app state has none, so an un-cached KDF would put its full cost on every A2A request instead of on startup.

Live tokens issued in the hour before a deploy stop validating (TTL is 3600s); clients re-run the client-credentials grant.

## Tests

Each fails against the pre-change tree:

- `test_privileged_checkout_is_confined_to_commits_from_this_repository` — asserts both guard clauses; without them the fork path reaches the privileged checkout.
- `test_client_secrets_are_not_recoverable_at_hardware_speed` — computes the old cheap construction and asserts it is not what ships.
- `test_derived_key_is_stable_across_authenticators` — a second authenticator still validates the first's token, so a restart does not silently invalidate live tokens.
- `test_derivation_is_not_repaid_on_every_request` — asserts a cache hit rather than a second KDF run.

## Not covered here

Scorecard `Branch-Protection` (#3233, high) is a policy question, not a code fix: `main` does not require approvers or PRs. Requiring PRs would break `ci.yml`'s auto-fix-lint job, which pushes to `main` directly, and requiring approvers deadlocks a single-maintainer repository. Left for a separate decision.
