### PR TITLE
chore(ci): raise diff-coverage floor to 86%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
-  "diff_coverage_floor_percent": 85,
+  "diff_coverage_floor_percent": 86,
   "head_sha": "5b89547b85a04a7ebc237c1f84e7953ddf39f6eb",
   "line_rate": 0.837,
   "run_id": "31916004059",
   "total_coverage_percent": 83.7,
-  "updated_at": "2026-08-16T00:45:27+00:00"
+  "updated_at": "2026-08-16T08:02:07+00:00"
 }

--- a/tests/unit/test_coverage_ratchet_workflow_yaml.py
+++ b/tests/unit/test_coverage_ratchet_workflow_yaml.py
@@ -233,11 +233,8 @@ def test_privileged_checkout_is_confined_to_commits_from_this_repository(
     """
     guard = workflow["jobs"]["ratchet"]["if"]
 
-    assert (
-        "github.event.workflow_run.head_repository.full_name == github.repository" in guard
-    ), (
-        "without a same-repository guard, a fork PR from a branch named `main` "
-        "reaches the privileged checkout below"
+    assert "github.event.workflow_run.head_repository.full_name == github.repository" in guard, (
+        "without a same-repository guard, a fork PR from a branch named `main` reaches the privileged checkout below"
     )
     assert "github.event.workflow_run.event == 'push'" in guard, (
         "a pull_request-triggered CI run measures the merge commit of an "

--- a/tests/unit/test_issue_decompose_workflow_yaml.py
+++ b/tests/unit/test_issue_decompose_workflow_yaml.py
@@ -100,8 +100,7 @@ def test_starting_the_pipeline_is_a_maintainer_action_not_a_label() -> None:
         condition = _job(name).get("if", "")
         assert isinstance(condition, str)
         assert "github.event.sender.login == 'chernistry'" in condition, (
-            f"job {name!r} runs on a labeled event without checking that a "
-            "maintainer applied the label"
+            f"job {name!r} runs on a labeled event without checking that a maintainer applied the label"
         )
 
 


### PR DESCRIPTION
Weekly nudge of the LEVEL 1 diff-coverage floor.

The diff-coverage gate in `.github/workflows/ci.yml` reads
`diff_coverage_floor_percent` from `.coverage-baseline.json`.
This PR raises that floor so every subsequent PR must cover a
slightly higher share of its changed lines.

New floor: **86%**.

The gate stays advisory (`continue-on-error`) until an operator
promotes it; see `docs/operations/coverage-ratchet.md` for the
promotion and override procedure. If the increment is too steep
for the current trunk, close this PR - the floor only moves when
the PR merges.

Generated by `.github/workflows/coverage-ratchet-weekly.yml`.