### PR TITLE
ci(weekly-digest): remove the dead threshold-alert computation

### DIFF
--- a/.github/workflows/ci-weekly-digest.yml
+++ b/.github/workflows/ci-weekly-digest.yml
@@ -19,8 +19,9 @@ name: CI Weekly Digest
 #
 # Rolling, not proliferating: publishing this week's digest auto-closes the
 # prior weeks' digest issues (bot-authored, title-matched only), so exactly
-# one digest issue stays open. A threshold alert fires only when the window
-# contains a real failure.
+# one digest issue stays open. The recommended action for the window is
+# always the first line of the digest body's TL;DR -- there is no separate
+# alert channel.
 #
 # Idempotent: if a digest issue for the current ISO week already exists, the
 # workflow edits it in place rather than opening a duplicate.
@@ -110,7 +111,6 @@ jobs:
 
           # ----- classify + render (unit-tested, deterministic aggregation)
           BODY_FILE="$(mktemp)"
-          ALERT_FILE="$(mktemp)"
           SUMMARY_FILE="$(mktemp)"
           python3 scripts/ci_weekly_digest.py \
             --runs-file "${RUNS_FILE}" \
@@ -119,10 +119,8 @@ jobs:
             --since "${SINCE}" \
             --lookback-days "${LOOKBACK_DAYS}" \
             --body-file "${BODY_FILE}" \
-            --alert-file "${ALERT_FILE}" \
             > "${SUMMARY_FILE}"
 
-          HAS_SIGNAL=$(jq -r '.has_signal' "${SUMMARY_FILE}")
           REAL_FAILURES=$(jq -r '.real_failure_count' "${SUMMARY_FILE}")
           echo "Summary: $(cat "${SUMMARY_FILE}")"
 
@@ -202,7 +200,10 @@ jobs:
               || echo "::warning::failed to close issue #${n}"
           done
 
-          # ----- run summary + hand off signal state to the alert step
+          # ----- run summary. This is the job's only step, so anything the
+          # digest needs to hand off must land here (GITHUB_STEP_SUMMARY) --
+          # a GITHUB_ENV write would have no later step in this job to read
+          # it and would be dead on arrival.
           {
             echo "### CI weekly digest ${WEEK_LABEL}"
             echo ""
@@ -210,12 +211,5 @@ jobs:
             echo "- Digest issue: #${DIGEST_NUMBER}"
             echo "- Closed ${#OLD_DIGESTS[@]} prior digest(s), ${#OPEN_SKIPPED[@]} per-event issue(s)"
           } >> "${GITHUB_STEP_SUMMARY}"
-
-          {
-            echo "HAS_SIGNAL=${HAS_SIGNAL}"
-            echo "REAL_FAILURES=${REAL_FAILURES}"
-            echo "DIGEST_NUMBER=${DIGEST_NUMBER}"
-            echo "ALERT_FILE=${ALERT_FILE}"
-          } >> "${GITHUB_ENV}"
 
           echo "Digest #${DIGEST_NUMBER} published (real failures: ${REAL_FAILURES})."

--- a/scripts/ci_weekly_digest.py
+++ b/scripts/ci_weekly_digest.py
@@ -4,11 +4,11 @@ Consumed by ``.github/workflows/ci-weekly-digest.yml``. Reads workflow-run
 records as JSONL (``--runs-file`` or stdin) plus the rolled-up
 ``auto-release-skipped`` issue numbers, and emits:
 
-* a Markdown body (``--body-file``) for the weekly tracking issue,
-* an optional short alert text (``--alert-file``) written only when there
-  is a real signal, and
-* a compact JSON summary on stdout that the workflow parses to decide
-  whether to raise a threshold alert.
+* a Markdown body (``--body-file``) for the weekly tracking issue, whose
+  TL;DR always leads with ``recommended_action`` -- there is no separate
+  alert path gated on ``has_signal``, and
+* a compact JSON summary on stdout (including ``has_signal``) for the
+  workflow run log.
 
 Why this exists in the shape it does:
 
@@ -289,11 +289,6 @@ def render_body(summary: DigestSummary) -> str:
     return "\n".join(lines) + "\n"
 
 
-def render_alert(summary: DigestSummary) -> str:
-    head = f"CI weekly digest {summary.week_label}: {summary.real_failure_count} real failure(s) on main"
-    return f"{head}\n{summary.recommended_action}"
-
-
 def summary_json(summary: DigestSummary) -> dict[str, object]:
     top = summary.top_offender
     return {
@@ -318,7 +313,6 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--lookback-days", default="7")
     parser.add_argument("--chronic-threshold", type=int, default=DEFAULT_CHRONIC_THRESHOLD)
     parser.add_argument("--body-file", required=True, help="where to write the Markdown body")
-    parser.add_argument("--alert-file", help="write a short alert text here when has_signal is true")
     args = parser.parse_args(argv)
 
     if args.runs_file:
@@ -340,10 +334,6 @@ def main(argv: list[str] | None = None) -> int:
 
     with open(args.body_file, "w", encoding="utf-8") as handle:
         handle.write(render_body(summary))
-
-    if args.alert_file and summary.has_signal:
-        with open(args.alert_file, "w", encoding="utf-8") as handle:
-            handle.write(render_alert(summary))
 
     json.dump(summary_json(summary), sys.stdout, sort_keys=True)
     sys.stdout.write("\n")

--- a/tests/unit/test_ci_weekly_digest.py
+++ b/tests/unit/test_ci_weekly_digest.py
@@ -27,7 +27,6 @@ parse_runs = _MOD.parse_runs
 parse_issue_numbers = _MOD.parse_issue_numbers
 build_summary = _MOD.build_summary
 render_body = _MOD.render_body
-render_alert = _MOD.render_alert
 summary_json = _MOD.summary_json
 main = _MOD.main
 
@@ -208,13 +207,6 @@ def test_body_no_failures_message() -> None:
     assert "_No real failures in the window._" in body
 
 
-def test_alert_only_summarizes_real_signal() -> None:
-    summary = _summary([_run(conclusion="failure", name="CI")])
-    alert = render_alert(summary)
-    assert "2026-W28" in alert
-    assert "1 real failure" in alert
-
-
 # --- summary json ------------------------------------------------------------
 
 
@@ -245,7 +237,6 @@ def test_main_writes_body_and_prints_summary(tmp_path, capsys) -> None:
         encoding="utf-8",
     )
     body_file = tmp_path / "body.md"
-    alert_file = tmp_path / "alert.txt"
     rc = main(
         [
             "--runs-file",
@@ -258,25 +249,21 @@ def test_main_writes_body_and_prints_summary(tmp_path, capsys) -> None:
             "2026-07-05T00:00:00Z",
             "--body-file",
             str(body_file),
-            "--alert-file",
-            str(alert_file),
         ]
     )
     assert rc == 0
     body = body_file.read_text(encoding="utf-8")
     assert "Real CI failures on main: **1**" in body
     assert "- #2485" in body
-    assert alert_file.exists()  # has_signal -> alert written
     printed = json.loads(capsys.readouterr().out)
     assert printed["has_signal"] is True
     assert printed["real_failure_count"] == 1
 
 
-def test_main_skips_alert_file_when_no_signal(tmp_path, capsys) -> None:
+def test_main_reports_no_signal_for_a_clean_or_cancelled_only_week(tmp_path, capsys) -> None:
     runs_file = tmp_path / "runs.jsonl"
     runs_file.write_text("\n".join(_jsonl([_run(conclusion="cancelled")])), encoding="utf-8")
     body_file = tmp_path / "body.md"
-    alert_file = tmp_path / "alert.txt"
     rc = main(
         [
             "--runs-file",
@@ -287,11 +274,8 @@ def test_main_skips_alert_file_when_no_signal(tmp_path, capsys) -> None:
             "2026-07-05T00:00:00Z",
             "--body-file",
             str(body_file),
-            "--alert-file",
-            str(alert_file),
         ]
     )
     assert rc == 0
-    assert not alert_file.exists()  # no signal -> no alert
     printed = json.loads(capsys.readouterr().out)
     assert printed["has_signal"] is False

--- a/tests/unit/test_ci_weekly_digest_workflow_yaml.py
+++ b/tests/unit/test_ci_weekly_digest_workflow_yaml.py
@@ -33,9 +33,15 @@ def _mapping(value: object) -> dict[str, object]:
 
 
 @pytest.fixture(scope="module")
-def digest_run() -> str:
+def workflow_text() -> str:
+    """The raw workflow file text, including header comments."""
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def digest_run(workflow_text: str) -> str:
     """The shell body of the digest build-and-publish step."""
-    parsed = cast("object", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+    parsed = cast("object", yaml.safe_load(workflow_text))
     workflow = _mapping(parsed)
     jobs = _mapping(workflow.get("jobs"))
     digest = _mapping(jobs.get("digest"))
@@ -113,3 +119,39 @@ def test_digest_window_uses_exact_timestamp_cutoff(digest_run: str) -> None:
     assert "SINCE_DATE" not in digest_run, "digest window still truncates SINCE to a midnight date"
     assert "created=>=${SINCE}" in digest_run
     assert "updated:>=${SINCE}" in digest_run
+
+
+# --- item 5: the alert computation must not be dead code (issue #3952) ---------
+#
+# The `digest` job has exactly one step. A GITHUB_ENV write in that step can
+# never be read by anything -- there is no later step in this job, and
+# GITHUB_ENV does not cross job boundaries. Computing an alert file and a
+# has_signal flag just to hand them to GITHUB_ENV was therefore dead code:
+# a week whose numbers crossed the alert threshold produced the same silent
+# digest as a quiet one. Resolution: delete the computation rather than wire
+# a second consumer -- a quarter of weekly digests (12 issues, 4 of them
+# flagged "Chronically red -- assign an owner") produced zero follow-up
+# action on the already-prominent in-body recommendation, so a second
+# notification surfacing the same data was judged not worth the added
+# maintenance surface.
+
+
+def test_step_does_not_write_dead_github_env(digest_run: str) -> None:
+    # Comment prose is allowed to explain *why* (it does); only code is
+    # checked, same idiom as test_collection_commands_do_not_swallow_errors.
+    code = _code_only(digest_run)
+    assert "GITHUB_ENV" not in code, "digest step writes to GITHUB_ENV, but this job has no later step to read it"
+
+
+def test_step_does_not_request_unread_alert_file(digest_run: str) -> None:
+    code = _code_only(digest_run)
+    assert "--alert-file" not in code, "digest step still asks the script to compute an alert file"
+    assert "ALERT_FILE" not in code
+    assert "HAS_SIGNAL" not in code
+
+
+def test_header_does_not_advertise_a_firing_alert(workflow_text: str) -> None:
+    # The header previously claimed "a threshold alert fires" -- untrue, since
+    # nothing ever consumed the computed alert. The header must not restate
+    # that claim once the dead computation is gone.
+    assert "alert fires" not in workflow_text.lower(), "header still advertises a threshold alert nothing implements"


### PR DESCRIPTION
## What

`ci-weekly-digest.yml`'s only step computed an alert file and a
`has_signal` flag, then wrote both to `GITHUB_ENV` as its last action.
That job has exactly one step, so nothing could ever read them — a
week whose numbers crossed the alert threshold produced the same
silent digest as a quiet one. The header comment also claimed "a
threshold alert fires," which was never true.

## Why delete instead of wire

The digest body already leads its TL;DR with the same recommended
action unconditionally (chronic-red workflow, scheduled failure, top
offender, or clean week) — that line doesn't need `has_signal` to be
visible. Checking the last quarter of weekly digests: 12 issues, 4 of
them explicitly flagged `Chronically red: ... Assign an owner to
root-cause or quarantine it` in the TL;DR, and none drew a follow-up
comment, linked PR, or owner assignment beyond the automated
open/close bookkeeping. A second, unwired alert path would have
surfaced the same data through the same channel (a GitHub issue) that
already goes unactioned, so wiring a new consumer (e.g. an escalation
issue) wasn't worth the added maintenance surface. Removed the dead
computation instead.

## Changes

- `.github/workflows/ci-weekly-digest.yml`: drop `ALERT_FILE`,
  `--alert-file`, `HAS_SIGNAL`, and the trailing `GITHUB_ENV` write;
  correct the header comment.
- `scripts/ci_weekly_digest.py`: remove `render_alert()` and the
  `--alert-file` CLI option — unreachable now that nothing passes it.
- `tests/unit/test_ci_weekly_digest_workflow_yaml.py`: new assertions
  pin the invariant — the digest step's only step must not write
  `GITHUB_ENV`, must not reference the removed alert-file plumbing,
  and the header must not advertise a firing alert. Verified these
  fail against the pre-fix workflow text before applying the fix.
- `tests/unit/test_ci_weekly_digest.py`: drop the alert-file-specific
  assertions and the now-removed `render_alert` coverage.

## Testing

```
uv run pytest tests/unit/test_ci_weekly_digest.py tests/unit/test_ci_weekly_digest_workflow_yaml.py tests/unit/test_pull_request_workflow_concurrency_yaml.py -q -p no:cacheprovider
uv run ruff check .
uv run ruff format .
```

All green. `docs/operations/ci-topology.md` regenerated with no diff
(job count, triggers, concurrency, and permissions are unchanged).

Closes #3952
