### PR TITLE
fix(ci): let the mutation gate actually fail instead of always succeeding

### DIFF
--- a/.github/workflows/mutation-fixed.yml
+++ b/.github/workflows/mutation-fixed.yml
@@ -22,8 +22,13 @@
 # follow-up `summary` job aggregates all JSONs and (on PRs) sticks a
 # single comment with the per-module table.
 #
-# `continue-on-error: true` is set on the matrix jobs while thresholds
-# stabilise - this PR sets up the gate, humans tighten it in follow-ups.
+# `continue-on-error` is per-module (matrix `include` below), not a
+# blanket flag. Six of the seven modules hold their threshold with real
+# margin and gate for real: a kill-rate drop fails the job and, on a
+# merge_group run, blocks the merge queue. `audit_log` is the one pinned
+# exception - see its `include` entry and
+# tests/unit/test_mutation_fixed_workflow_yaml.py:ADVISORY_MODULES for
+# the kill-rate data behind it and the revisit date.
 name: Mutation (fixed critical paths)
 
 on:
@@ -59,9 +64,10 @@ jobs:
     runs-on: ubuntu-latest
     # Hard total cap; per-module budgets enforced inside the harness.
     timeout-minutes: 30
-    # Gate is advisory for the first two weeks. Once the thresholds in
-    # MODULES are calibrated, flip this to `false` (or drop the line).
-    continue-on-error: true
+    # Per-module, driven by matrix.advisory below - not a blanket flag.
+    # `false` means a kill-rate drop on this module fails the job for
+    # real (and blocks the merge queue on a merge_group run).
+    continue-on-error: ${{ matrix.advisory }}
     permissions:
       contents: read
     strategy:
@@ -75,6 +81,32 @@ jobs:
           - lineage_tips
           - lineage_merge
           - config_seed_parser
+        # Per-module advisory flag: `true` opts the module out of the run
+        # conclusion. Keep this closed and reviewed - a module doesn't
+        # get to stay advisory by default (mirrors the
+        # NO_CANCEL_EXCEPTIONS pattern in
+        # tests/unit/test_pull_request_workflow_concurrency_yaml.py).
+        # tests/unit/test_mutation_fixed_workflow_yaml.py:ADVISORY_MODULES
+        # pins the expected set.
+        include:
+          - module: claim_next
+            advisory: false
+          - module: audit_log
+            # 32/80 killed vs a 70% threshold as of the 2026-08-16 weekly
+            # run - a 30-point gap, not sampling noise. Needs test
+            # coverage backfill on src/bernstein/core/security/audit.py
+            # before this can gate for real; revisit 2026-09-15.
+            advisory: true
+          - module: audit_integrity
+            advisory: false
+          - module: lineage_gate
+            advisory: false
+          - module: lineage_tips
+            advisory: false
+          - module: lineage_merge
+            advisory: false
+          - module: config_seed_parser
+            advisory: false
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -114,14 +146,20 @@ jobs:
           mkdir -p mutation-results
           # Per-module budget is enforced inside the harness; this is a
           # belt-and-braces wall-clock cap so a hung mutation can't burn
-          # the full 30-minute job timeout.
+          # the full 30-minute job timeout. The harness's own exit code
+          # (0 pass, 1 gate failure, 2 baseline failure) is this step's
+          # exit code. It used to be swallowed by `|| echo`, so the step
+          # - and with it the job - reported success no matter what the
+          # harness found.
           timeout 1500 uv run python scripts/mutmut_critical.py \
             --only "$MATRIX_MODULE" \
             --quiet \
-            --json "mutation-results/${MATRIX_MODULE}.json" \
-            || echo "harness exited non-zero (gate failure or baseline)"
+            --json "mutation-results/${MATRIX_MODULE}.json"
       - name: Upload module result
-        if: steps.filter.outputs.skip != 'true'
+        # always(): a module below threshold now fails the previous step
+        # for real, and the artifact - the survivor list a human needs to
+        # act on it - must still reach the summary job and PR comment.
+        if: always() && steps.filter.outputs.skip != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mutation-${{ matrix.module }}
@@ -212,7 +250,7 @@ jobs:
                 }
                 body += '\n</details>\n';
               }
-              body += '\n> Gate is **advisory** while thresholds stabilise. To kill survivors locally:\n> `uv run python scripts/mutmut_critical.py --only <module>`';
+              body += '\n> The gate enforces per module; only modules pinned advisory in `mutation-fixed.yml` can fail here without failing the job. To kill survivors locally:\n> `uv run python scripts/mutmut_critical.py --only <module>`';
             }
 
             // Always surface the table in the job summary first, so the

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -168,11 +168,16 @@ audit integrity verifier, lineage v1 trio, seed parser) and gates
 on a per-module kill rate. The module list, per-module thresholds,
 and wall-clock budgets live in `scripts/mutmut_critical.py:MODULES`.
 
-The gate is **advisory** while thresholds calibrate (the matrix job
-sets `continue-on-error: true`). The PR comment posted by the
-workflow summarises each module's score and survivors; until the
-gate is flipped to enforcing, treat a red row as a follow-up TODO,
-not a merge blocker.
+The gate enforces per module: `continue-on-error` in the workflow's
+matrix `include` is `false` for every module that holds its threshold
+with real margin, so a regression there fails the job and, on a
+merge_group run, blocks the merge queue. `audit_log` is the one pinned
+exception - its kill rate is well below threshold and needs test
+backfill on `src/bernstein/core/security/audit.py` before it can gate
+for real (`tests/unit/test_mutation_fixed_workflow_yaml.py:ADVISORY_MODULES`
+is the source of truth for which modules are still advisory). The PR
+comment posted by the workflow summarises each module's score and
+survivors either way.
 
 Reproduce locally:
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -174,8 +174,9 @@ with real margin, so a regression there fails the job and, on a
 merge_group run, blocks the merge queue. `audit_log` is the one pinned
 exception - its kill rate is well below threshold and needs test
 backfill on `src/bernstein/core/security/audit.py` before it can gate
-for real (`tests/unit/test_mutation_fixed_workflow_yaml.py:ADVISORY_MODULES`
-is the source of truth for which modules are still advisory). The PR
+for real (`ADVISORY_MODULES` in
+`tests/unit/test_mutation_fixed_workflow_yaml.py` is pinned to the
+workflow matrix in both directions, so the two cannot drift). The PR
 comment posted by the workflow summarises each module's score and
 survivors either way.
 

--- a/scripts/mutmut_critical.py
+++ b/scripts/mutmut_critical.py
@@ -82,7 +82,11 @@ MODULES: tuple[Module, ...] = (
         threshold=0.70,
         budget_seconds=1200,
         max_candidates=80,
-        note="HMAC-chained audit log writer.",
+        note=(
+            "HMAC-chained audit log writer. Advisory in mutation-fixed.yml "
+            "(32/80 killed as of the 2026-08-16 weekly run) pending test "
+            "coverage backfill; revisit 2026-09-15."
+        ),
     ),
     Module(
         key="audit_integrity",

--- a/tests/unit/test_mutation_fixed_workflow_yaml.py
+++ b/tests/unit/test_mutation_fixed_workflow_yaml.py
@@ -1,0 +1,159 @@
+"""Structural assertions for the fixed critical-path mutation gate.
+
+``mutation-fixed.yml`` shipped 2026-05-17 with a blanket
+``continue-on-error: true`` on the ``mutate`` job and a shell fallback
+(``|| echo ...``) in the harness step that absorbed the harness's own
+exit code. Together the two meant the job - and so the run - reported
+``success`` no matter what ``scripts/mutmut_critical.py`` found. The
+comment called it advisory "for the first two weeks"; nothing revisited
+it for 13 (issue #3953).
+
+Pulling the kill-rate history off a recent scheduled run showed six of
+the seven modules hold their threshold with real margin. ``audit_log``
+does not: 32/80 killed against a 70% threshold, a 30-point gap that
+persisted across every archived run, not sampling noise. This module
+pins the resulting split - most modules gate for real, one stays
+advisory by a reviewed, closed exception with the data that justified
+it - so the exception can't grow by omission.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "mutation-fixed.yml"
+
+# Modules still below their gate threshold. Closed list, reviewed in code:
+# adding a module here without also raising its kill rate (or lowering its
+# threshold in scripts/mutmut_critical.py:MODULES with a documented reason)
+# defeats the gate the same way the blanket continue-on-error used to.
+ADVISORY_MODULES: set[str] = {"audit_log"}
+
+
+def _load() -> dict[object, object]:
+    return cast("dict[object, object]", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+
+
+def _mutate_job() -> dict[str, object]:
+    jobs = _load().get("jobs")
+    assert isinstance(jobs, dict), "mutation-fixed.yml must declare jobs"
+    job = jobs.get("mutate")
+    assert isinstance(job, dict), "mutation-fixed.yml must declare a `mutate` job"
+    return cast("dict[str, object]", job)
+
+
+def _matrix() -> dict[str, object]:
+    strategy = _mutate_job().get("strategy")
+    assert isinstance(strategy, dict), "the mutate job must be matrix-driven"
+    matrix = strategy.get("matrix")
+    assert isinstance(matrix, dict)
+    return cast("dict[str, object]", matrix)
+
+
+def _matrix_modules() -> list[str]:
+    modules = _matrix().get("module")
+    assert isinstance(modules, list) and modules, "matrix.module must list the gated modules"
+    return cast("list[str]", modules)
+
+
+def _matrix_include() -> list[dict[str, object]]:
+    include = _matrix().get("include")
+    assert isinstance(include, list) and include, (
+        "matrix needs an `include` block carrying the per-module advisory flag"
+    )
+    return cast("list[dict[str, object]]", include)
+
+
+def _harness_step() -> dict[str, object]:
+    steps = _mutate_job().get("steps")
+    assert isinstance(steps, list)
+    matches = [s for s in steps if s.get("name") == "Run focused mutation harness"]
+    assert len(matches) == 1, "expected exactly one 'Run focused mutation harness' step"
+    return cast("dict[str, object]", matches[0])
+
+
+def _upload_step() -> dict[str, object]:
+    steps = _mutate_job().get("steps")
+    assert isinstance(steps, list)
+    matches = [s for s in steps if s.get("name") == "Upload module result"]
+    assert len(matches) == 1, "expected exactly one 'Upload module result' step"
+    return cast("dict[str, object]", matches[0])
+
+
+def test_continue_on_error_is_matrix_driven_not_blanket() -> None:
+    """The job-level flag must read per-module state, not a literal `true`.
+
+    A literal `true` is the exact defect from #3953: every module opts out
+    of the run conclusion regardless of its own kill rate.
+    """
+    coe = _mutate_job().get("continue-on-error")
+    assert coe not in (True, "true"), (
+        "continue-on-error is a blanket literal again; a real kill-rate "
+        "regression on any module would render as a green check"
+    )
+    assert isinstance(coe, str) and "matrix" in coe, (
+        "continue-on-error must read a per-module matrix value so only "
+        "modules below threshold can opt out of the run conclusion"
+    )
+
+
+def test_advisory_exception_list_matches_the_pinned_set() -> None:
+    """The matrix `include` advisory flags must match ADVISORY_MODULES exactly.
+
+    Every module not in ADVISORY_MODULES must set advisory: false, i.e. it
+    genuinely gates. This is what keeps a module from staying advisory
+    past the point its own data justifies it, or a new advisory module
+    from sneaking in unreviewed.
+    """
+    modules = set(_matrix_modules())
+    seen: dict[object, bool] = {}
+    for entry in _matrix_include():
+        module = entry.get("module")
+        assert module in modules, f"include entry for unknown module {module!r}"
+        assert "advisory" in entry, f"include entry for {module!r} does not set advisory"
+        advisory = entry["advisory"]
+        assert isinstance(advisory, bool), f"{module!r}'s advisory flag must be a real boolean, got {advisory!r}"
+        seen[module] = advisory
+
+    assert set(seen) == modules, f"every matrix module needs an include entry; missing {modules - set(seen)}"
+
+    actually_advisory = {m for m, advisory in seen.items() if advisory}
+    assert actually_advisory == ADVISORY_MODULES, (
+        f"advisory modules in the workflow ({sorted(actually_advisory)}) do not match "
+        f"the reviewed exception list ({sorted(ADVISORY_MODULES)}); update one or the other deliberately"
+    )
+
+
+def test_harness_step_does_not_swallow_its_own_exit_code() -> None:
+    """The `|| echo` fallback made the step succeed no matter what the
+    harness returned - independent of continue-on-error. Both had to go
+    for the gate to mean anything.
+    """
+    run = _harness_step().get("run")
+    assert isinstance(run, str), "the harness step must be a `run:` step"
+    # Comments are stripped: prose *about* the old `|| echo` fallback (in
+    # the step's own explanatory comment) is not a use of it.
+    code = "\n".join(line for line in run.splitlines() if not line.lstrip().startswith("#"))
+    assert "|| echo" not in code, (
+        "the harness step swallows its own exit code with `|| echo`, so the "
+        "step reports success even when scripts/mutmut_critical.py exits non-zero"
+    )
+    assert "scripts/mutmut_critical.py" in code
+
+
+def test_upload_step_still_runs_after_a_failing_harness() -> None:
+    """Diagnostics must survive a real gate failure.
+
+    Without `always()`, a harness step that now legitimately fails skips
+    the artifact upload that follows it, and the failing module's
+    survivor list never reaches the PR comment / job summary.
+    """
+    condition = _upload_step().get("if", "")
+    assert "always()" in str(condition), (
+        "Upload module result must run with always() so a failing harness step "
+        "still uploads the module's JSON for the summary/PR comment"
+    )


### PR DESCRIPTION
## What

`mutation-fixed.yml`'s `continue-on-error: true` on the `mutate` job has been unconditional since the workflow's first commit (2026-05-17), with a comment framing it as a two-week calibration window. Nothing revisited it in 13 weeks - a real kill-rate regression on any of the seven gated modules rendered as a green check.

A second, independent bug in the same step made that flag mostly moot on its own: the harness invocation ended in `|| echo "harness exited non-zero..."`, which swallows the script's exit code unconditionally. Even with `continue-on-error: false`, the step would still report success no matter what `scripts/mutmut_critical.py` found.

## What changed

- Removed the `|| echo` fallback so the step's exit code is the harness's real exit code (0 pass, 1 gate failure, 2 baseline failure).
- `Upload module result` now runs with `always()`, since a module below threshold can legitimately fail the step before it - the artifact still needs to reach the summary job / PR comment.
- `continue-on-error` moved from a blanket `true` to a per-module value (`matrix.advisory`) via a new `include` block.
- Pulled kill-rate history off the last two weekly scheduled runs plus the latest merge_group run. Six of seven modules hold their threshold with real margin (`claim_next` 77.6%, `audit_integrity` 100%, `lineage_gate` 84.2%, `lineage_tips` 93.3%, `lineage_merge` 75.0%, `config_seed_parser` 77.6%) and are flipped to `advisory: false` - a regression there now fails the job for real and blocks the merge queue on a merge_group run.
- `audit_log` is 32/80 killed against a 70% threshold - a 30-point gap, consistent across every archived run, not sampling noise. It stays advisory, but as a pinned, dated exception rather than an open-ended TODO: `tests/unit/test_mutation_fixed_workflow_yaml.py:ADVISORY_MODULES` is the closed list, and the workflow/script comments carry the data plus a 2026-09-15 revisit date.
- Added `tests/unit/test_mutation_fixed_workflow_yaml.py`: structural tests pinning that `continue-on-error` is matrix-driven (not a literal), the advisory set matches the reviewed list, the harness step doesn't swallow its exit code, and the upload step survives a failing harness.
- Updated `docs/contributing/testing.md`'s description of the gate to match the new behavior.

## Verification

- Ran the unmodified `scripts/mutmut_critical.py` against a deliberately broken `audit_integrity.py` (one inverted HMAC comparison): exits 2, `baseline_ok: false`, `passed: false` - the harness itself fails for real. Reverted before committing.
- Confirmed old vs new step logic under GitHub Actions' default `bash -eo pipefail` step semantics: the old form swallows a non-zero exit to 0, the new form propagates it.
- New structural tests verified fail-before / pass-after against the pre-fix workflow.
- `uv run pytest tests/unit/test_mutation_fixed_workflow_yaml.py tests/unit/test_pull_request_workflow_concurrency_yaml.py tests/unit/test_nightly_deep_tests_workflow_yaml.py tests/unit/test_mutation_setup.py -q` - 64 passed.
- `uv run ruff check .` and `uv run ruff format --check` clean on touched files.
- `actionlint` clean on the workflow.

Closes #3953
