### PR TITLE
ci(branch-protection-audit): read the live ruleset instead of the legacy protection API

### DIFF
--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -1,11 +1,25 @@
 name: Branch protection audit
 
-# Read live branch protection for `main` and compare its required status
-# checks with the in-tree required-check canary expectation. This catches
-# repository-setting drift that workflow-file tests cannot see.
+# Read the live repository ruleset that protects `main` and assert the
+# invariants operators rely on: the merge-queue rule is present, the
+# required status check matches the in-tree canary, force-pushes and
+# branch deletion stay blocked, and no bypass actor can skip the ruleset.
+# This catches repository-setting drift that workflow-file tests cannot
+# see.
+#
+# `main`'s protection is enforced entirely by a repository ruleset, not
+# classic branch protection, so this audit reads the ruleset endpoints
+# (`rules/branches/main`, `rulesets`, `rulesets/{id}`) rather than the
+# classic `branches/main/protection` endpoint. The classic endpoint has no
+# field for `merge_queue` or `bypass_actors` - it cannot represent either
+# invariant, so an audit built on it would stay green exactly when the
+# merge-queue rule is dropped or a bypass actor is added. It is not read
+# here at all, primary or secondary: every invariant it can represent is
+# already covered by the ruleset read, at the cost of one extra live call
+# instead of two.
 #
 # Required secret: BRANCH_PROTECTION_AUDIT_TOKEN
-#   The default GITHUB_TOKEN cannot read branch protection: that endpoint
+#   The default GITHUB_TOKEN cannot read repository rulesets: that surface
 #   requires an admin-scoped token, and Actions cannot be granted admin.
 #   Configure a fine-grained PAT (or GitHub App installation token) with
 #   this repository's:
@@ -36,7 +50,7 @@ jobs:
     permissions:
       contents: read
     env:
-      # Admin-scoped read is required to fetch branch protection; the
+      # Admin-scoped read is required to fetch repository rulesets; the
       # default github.token cannot do it. See the workflow header for the
       # secret's required fine-grained PAT scopes. No github.token fallback.
       GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_AUDIT_TOKEN }}
@@ -58,119 +72,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Read live branch protection
-        run: |
-          set -euo pipefail
-
-          set +e
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "repos/${GITHUB_REPOSITORY}/branches/main/protection" \
-            > branch-protection.json \
-            2> branch-protection.err
-          gh_status=$?
-          set -e
-
-          if [ "${gh_status}" -ne 0 ]; then
-            echo "::error::Unable to read live branch protection for main with GITHUB_TOKEN."
-            echo "::error::GitHub API exit code: ${gh_status}"
-            if [ -s branch-protection.err ]; then
-              while IFS= read -r line; do
-                echo "::error::${line}"
-              done < branch-protection.err
-            fi
-            exit 1
-          fi
-
-      - name: Compare live required contexts with canary
-        run: |
-          python3 - <<'PY'
-          """Compare live required status checks with canary expectations."""
-          from __future__ import annotations
-
-          import json
-          import sys
-          from pathlib import Path
-
-          CANARY = Path(".github/workflows/required-check-canary.yml")
-          PROTECTION = Path("branch-protection.json")
-
-          def fail(message: str) -> None:
-              print(f"::error::{message}")
-              sys.exit(1)
-
-          def read_expected_contexts(path: Path) -> set[str]:
-              if not path.exists():
-                  fail(f"{path} not found")
-
-              for line in path.read_text(encoding="utf-8").splitlines():
-                  stripped = line.strip()
-                  if not stripped.startswith("BRANCH_PROTECTION_CONTEXTS_JSON:"):
-                      continue
-
-                  raw = stripped.split(":", 1)[1].strip()
-                  if raw.startswith(('"', "'")) and raw.endswith(raw[0]):
-                      raw = raw[1:-1]
-                  try:
-                      parsed = json.loads(raw)
-                  except json.JSONDecodeError as exc:
-                      fail(f"{path} has invalid BRANCH_PROTECTION_CONTEXTS_JSON: {exc}")
-                  if not isinstance(parsed, list) or not all(isinstance(item, str) for item in parsed):
-                      fail(f"{path} BRANCH_PROTECTION_CONTEXTS_JSON must be a JSON string list")
-                  contexts = {item for item in parsed if item}
-                  if contexts:
-                      return contexts
-
-              fail(f"{path} does not define BRANCH_PROTECTION_CONTEXTS_JSON")
-              raise AssertionError("unreachable")
-
-          expected = read_expected_contexts(CANARY)
-
-          try:
-              protection = json.loads(PROTECTION.read_text(encoding="utf-8"))
-          except json.JSONDecodeError as exc:
-              fail(f"Live branch protection response is not valid JSON: {exc}")
-
-          if not isinstance(protection, dict):
-              fail("Live branch protection response is not a JSON object")
-
-          required_status_checks = protection.get("required_status_checks")
-          if not isinstance(required_status_checks, dict):
-              fail("Live branch protection for main has no required_status_checks object")
-
-          live: set[str] = set()
-
-          contexts = required_status_checks.get("contexts", [])
-          if isinstance(contexts, list):
-              live.update(context for context in contexts if isinstance(context, str))
-
-          checks = required_status_checks.get("checks", [])
-          if isinstance(checks, list):
-              for check in checks:
-                  if not isinstance(check, dict):
-                      continue
-                  context = check.get("context", check.get("name"))
-                  if isinstance(context, str):
-                      live.add(context)
-
-          if not live:
-              fail("Live branch protection for main has zero required status check contexts")
-
-          missing = sorted(expected - live)
-          extra = sorted(live - expected)
-
-          print("Branch protection audit")
-          print(f"  expected contexts: {sorted(expected)}")
-          print(f"  live contexts    : {sorted(live)}")
-
-          if missing or extra:
-              print("::error::Live branch protection required contexts differ from required-check canary")
-              if missing:
-                  print(f"::error::missing from live protection: {missing}")
-              if extra:
-                  print(f"::error::extra in live protection: {extra}")
-              sys.exit(1)
-
-          print("Live branch protection required contexts match required-check canary.")
-          PY
+      - name: Audit live branch ruleset for main
+        # scripts/check_branch_ruleset_audit.py reads rules/branches/main,
+        # rulesets, and rulesets/{id} (stdlib-only, no `uv sync` needed for
+        # this job) and asserts: merge_queue, non_fast_forward and deletion
+        # rules present; required_status_checks contexts match the
+        # required-check canary; every referenced ruleset is 'active'; no
+        # bypass actor. See the workflow header for why the classic
+        # protection endpoint is not read here.
+        run: python3 scripts/check_branch_ruleset_audit.py

--- a/scripts/check_branch_ruleset_audit.py
+++ b/scripts/check_branch_ruleset_audit.py
@@ -195,11 +195,27 @@ def evaluate(
                 Violation("ruleset_detail", f"ruleset {ruleset_id} detail was not read; cannot verify bypass actors")
             )
             continue
-        bypass_actors = detail.get("bypass_actors")
-        if bypass_actors:
-            name = detail.get("name", "?")
+        name = detail.get("name", "?")
+        if "bypass_actors" not in detail:
+            # Absent and empty are different answers on the wire: the API
+            # omits the key entirely for a caller without Administration:
+            # read, and returns [] only when an admin-scoped caller sees a
+            # genuinely empty list. Treating the omission as "no bypass"
+            # lets an under-scoped BRANCH_PROTECTION_AUDIT_TOKEN skip this
+            # assertion silently while everything else keeps passing.
             violations.append(
-                Violation("bypass_actors", f"ruleset {ruleset_id} ({name}) allows bypass: {bypass_actors}")
+                Violation(
+                    "bypass_actors",
+                    f"ruleset {ruleset_id} ({name}) returned no bypass_actors key -- the API omits "
+                    "it for callers without Administration: read, so bypass is unproven, not empty",
+                )
+            )
+        elif detail["bypass_actors"]:
+            violations.append(
+                Violation(
+                    "bypass_actors",
+                    f"ruleset {ruleset_id} ({name}) allows bypass: {detail['bypass_actors']}",
+                )
             )
 
     return violations

--- a/scripts/check_branch_ruleset_audit.py
+++ b/scripts/check_branch_ruleset_audit.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Audit the live repository ruleset that protects a branch.
+
+`main`'s guarantees - the merge queue, the required status check, blocked
+force-pushes, blocked deletion, no bypass - are enforced entirely by a
+repository **ruleset**, not classic branch protection. The classic
+`GET /repos/{owner}/{repo}/branches/{branch}/protection` endpoint cannot
+represent ruleset-only rules at all: it has no field for `merge_queue` and
+none for `bypass_actors`, so an audit built on it stays silent exactly when
+the merge-queue rule is dropped or a bypass actor is added - the two
+regressions that matter most. Every other invariant it could see is
+already covered by the ruleset read below, so this script does not read
+the classic endpoint in any form, primary or secondary.
+
+Three ruleset-native calls, each pulling distinct weight:
+
+`GET /repos/{owner}/{repo}/rules/branches/{branch}`
+    The effective, GitHub-resolved rule set for the branch - the union of
+    every ruleset that targets it. Source of rule-type presence
+    (`merge_queue`, `non_fast_forward`, `deletion`) and the required
+    status-check contexts.
+
+`GET /repos/{owner}/{repo}/rulesets`
+    Cheap listing of every ruleset with its `enforcement` state. Checked
+    before the per-ruleset detail calls: a ruleset flipped to `evaluate`
+    still contributes rules to the effective set above (GitHub does not
+    drop it), so its rules being present is not proof they are enforced.
+
+`GET /repos/{owner}/{repo}/rulesets/{id}`
+    Full detail for each ruleset referenced by the effective rules - the
+    only place `bypass_actors` is exposed.
+
+Usage::
+
+    python scripts/check_branch_ruleset_audit.py
+    python scripts/check_branch_ruleset_audit.py --repo owner/repo --branch main
+
+Offline, against captured payloads::
+
+    python scripts/check_branch_ruleset_audit.py \\
+        --rules-file rules.json --rulesets-file rulesets.json \\
+        --ruleset-details-file details.json
+
+Exit codes: 0 every invariant holds, 1 one or more invariants violated,
+2 the live state (or required-context canary) could not be read.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CANARY_PATH = REPO_ROOT / ".github" / "workflows" / "required-check-canary.yml"
+CONTEXTS_ENV_KEY = "BRANCH_PROTECTION_CONTEXTS_JSON"
+DEFAULT_BRANCH = "main"
+
+# Rule types that must apply to the branch with no parameters to inspect
+# beyond their presence. `required_status_checks` is checked separately
+# because its contexts have to match the canary, not just exist.
+REQUIRED_PRESENCE_RULE_TYPES = ("merge_queue", "non_fast_forward", "deletion")
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One way the live ruleset disagrees with an audited invariant."""
+
+    rule: str
+    detail: str
+
+
+def read_required_contexts(canary_path: Path | None = None) -> list[str]:
+    """Read required status-check contexts from the in-tree canary.
+
+    Scans for the ``BRANCH_PROTECTION_CONTEXTS_JSON:`` line rather than
+    parsing the file as YAML, so this script carries no dependency beyond
+    the standard library - the same approach the audit workflow used
+    inline before this script existed.
+    """
+    path = CANARY_PATH if canary_path is None else canary_path
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped.startswith(f"{CONTEXTS_ENV_KEY}:"):
+            continue
+        raw = stripped.split(":", 1)[1].strip()
+        if raw.startswith(("'", '"')) and raw.endswith(raw[0]):
+            raw = raw[1:-1]
+        parsed = json.loads(raw)
+        if not isinstance(parsed, list) or not all(isinstance(item, str) for item in parsed):
+            raise ValueError(f"{path} {CONTEXTS_ENV_KEY} must be a JSON list of strings")
+        contexts = [item for item in parsed if item]
+        if contexts:
+            return contexts
+    raise ValueError(f"{path} does not define {CONTEXTS_ENV_KEY}")
+
+
+def _rule_types(rules: list[dict[str, Any]]) -> set[str]:
+    return {rule["type"] for rule in rules if isinstance(rule, dict) and isinstance(rule.get("type"), str)}
+
+
+def _required_status_check_contexts(rules: list[dict[str, Any]]) -> set[str]:
+    contexts: set[str] = set()
+    for rule in rules:
+        if not isinstance(rule, dict) or rule.get("type") != "required_status_checks":
+            continue
+        params = rule.get("parameters")
+        if not isinstance(params, dict):
+            continue
+        for entry in params.get("required_status_checks") or []:
+            if isinstance(entry, dict) and isinstance(entry.get("context"), str):
+                contexts.add(entry["context"])
+    return contexts
+
+
+def _ruleset_ids(rules: list[dict[str, Any]]) -> set[int]:
+    return {rule["ruleset_id"] for rule in rules if isinstance(rule, dict) and isinstance(rule.get("ruleset_id"), int)}
+
+
+def _ruleset_summaries_by_id(rulesets: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    return {entry["id"]: entry for entry in rulesets if isinstance(entry, dict) and isinstance(entry.get("id"), int)}
+
+
+def evaluate(
+    rules: list[dict[str, Any]],
+    rulesets: list[dict[str, Any]],
+    ruleset_details: dict[int, dict[str, Any]],
+    required_contexts: list[str],
+) -> list[Violation]:
+    """Check the branch's effective rules against the audited invariants.
+
+    `rules` is the `rules/branches/{branch}` response (effective rules).
+    `rulesets` is the `rulesets` listing (id + enforcement, no rule detail).
+    `ruleset_details` maps each `ruleset_id` referenced by `rules` to its
+    `rulesets/{id}` response, the only source of `bypass_actors`.
+    """
+    violations: list[Violation] = []
+
+    if not rules:
+        violations.append(Violation("rules", "no rules apply to this branch - protection is effectively absent"))
+        return violations
+
+    present = _rule_types(rules)
+
+    for rule_type in REQUIRED_PRESENCE_RULE_TYPES:
+        if rule_type not in present:
+            violations.append(Violation(rule_type, f"no '{rule_type}' rule applies to this branch"))
+
+    if "required_status_checks" not in present:
+        violations.append(
+            Violation("required_status_checks", "no 'required_status_checks' rule applies to this branch")
+        )
+    else:
+        live = _required_status_check_contexts(rules)
+        expected = set(required_contexts)
+        missing = sorted(expected - live)
+        extra = sorted(live - expected)
+        if missing:
+            violations.append(Violation("required_status_checks", f"missing required context(s): {missing}"))
+        if extra:
+            violations.append(Violation("required_status_checks", f"unexpected required context(s): {extra}"))
+
+    ruleset_summaries = _ruleset_summaries_by_id(rulesets)
+    ids = _ruleset_ids(rules)
+    if not ids:
+        violations.append(
+            Violation("ruleset_id", "no rule in the effective set carries a ruleset_id; cannot verify bypass actors")
+        )
+
+    for ruleset_id in sorted(ids):
+        summary = ruleset_summaries.get(ruleset_id)
+        if summary is None:
+            violations.append(
+                Violation(
+                    "rulesets",
+                    f"ruleset {ruleset_id} backs main's effective rules but is absent from the rulesets listing",
+                )
+            )
+        else:
+            enforcement = summary.get("enforcement")
+            if enforcement != "active":
+                name = summary.get("name", "?")
+                violations.append(
+                    Violation("enforcement", f"ruleset {ruleset_id} ({name}) is '{enforcement}', not 'active'")
+                )
+
+        detail = ruleset_details.get(ruleset_id)
+        if detail is None:
+            violations.append(
+                Violation("ruleset_detail", f"ruleset {ruleset_id} detail was not read; cannot verify bypass actors")
+            )
+            continue
+        bypass_actors = detail.get("bypass_actors")
+        if bypass_actors:
+            name = detail.get("name", "?")
+            violations.append(
+                Violation("bypass_actors", f"ruleset {ruleset_id} ({name}) allows bypass: {bypass_actors}")
+            )
+
+    return violations
+
+
+def _gh(args: list[str]) -> str:
+    """Run a ``gh`` command and return stdout."""
+    try:
+        result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError("the GitHub CLI (gh) is required to audit the live ruleset") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(exc.stderr.strip() or f"gh {' '.join(args)} failed") from exc
+    return result.stdout
+
+
+def fetch_effective_rules(repo: str, branch: str) -> list[dict[str, Any]]:
+    """Read the GitHub-resolved effective rules for `branch`."""
+    payload = json.loads(_gh(["api", f"repos/{repo}/rules/branches/{branch}"]))
+    if not isinstance(payload, list):
+        raise ValueError(f"repos/{repo}/rules/branches/{branch} did not return a list")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def fetch_rulesets(repo: str) -> list[dict[str, Any]]:
+    """List every ruleset on the repository."""
+    payload = json.loads(_gh(["api", f"repos/{repo}/rulesets"]))
+    if not isinstance(payload, list):
+        raise ValueError(f"repos/{repo}/rulesets did not return a list")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def fetch_ruleset_detail(repo: str, ruleset_id: int) -> dict[str, Any]:
+    """Read one ruleset's full detail, including `bypass_actors`."""
+    payload = json.loads(_gh(["api", f"repos/{repo}/rulesets/{ruleset_id}"]))
+    if not isinstance(payload, dict):
+        raise ValueError(f"repos/{repo}/rulesets/{ruleset_id} did not return an object")
+    return payload
+
+
+def _load_json_list(path: str) -> list[dict[str, Any]]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError(f"{path}: expected a JSON list")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _load_ruleset_details_file(path: str) -> dict[int, dict[str, Any]]:
+    """Read `{"<ruleset_id>": {...detail...}}` and key it by int id."""
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected a JSON object keyed by ruleset id")
+    return {int(key): value for key, value in payload.items() if isinstance(value, dict)}
+
+
+def _print_report(repo: str, branch: str, rules: list[dict[str, Any]], violations: list[Violation]) -> None:
+    print(f"Branch ruleset audit for {repo}@{branch}")
+    print(f"  effective rule types: {sorted(_rule_types(rules))}")
+    print(f"  rulesets referenced : {sorted(_ruleset_ids(rules))}")
+
+    if not violations:
+        print("Live branch ruleset satisfies every audited invariant.")
+        return
+
+    print(f"::error::{len(violations)} branch ruleset invariant(s) violated")
+    for violation in violations:
+        print(f"::error title=Branch ruleset audit::{violation.rule}: {violation.detail}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", help="OWNER/REPO (defaults to $GITHUB_REPOSITORY)")
+    parser.add_argument("--branch", default=DEFAULT_BRANCH)
+    parser.add_argument("--rules-file", help="Read effective rules from a file instead of gh api")
+    parser.add_argument("--rulesets-file", help="Read the rulesets listing from a file instead of gh api")
+    parser.add_argument(
+        "--ruleset-details-file",
+        help='Read ruleset detail from a file instead of gh api; JSON object keyed by ruleset id, e.g. {"123": {...}}',
+    )
+    args = parser.parse_args(argv)
+
+    repo = args.repo or os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        print("::error::--repo not given and GITHUB_REPOSITORY is not set")
+        return 2
+
+    try:
+        required_contexts = read_required_contexts()
+    except (OSError, ValueError) as exc:
+        print(f"::error::cannot read required contexts from the required-check canary: {exc}")
+        return 2
+
+    offline = args.rules_file is not None
+
+    try:
+        rules = _load_json_list(args.rules_file) if args.rules_file else fetch_effective_rules(repo, args.branch)
+        rulesets = _load_json_list(args.rulesets_file) if args.rulesets_file else fetch_rulesets(repo)
+
+        ruleset_details: dict[int, dict[str, Any]] = (
+            _load_ruleset_details_file(args.ruleset_details_file) if args.ruleset_details_file else {}
+        )
+        if not offline:
+            for ruleset_id in sorted(_ruleset_ids(rules)):
+                if ruleset_id not in ruleset_details:
+                    ruleset_details[ruleset_id] = fetch_ruleset_detail(repo, ruleset_id)
+    except (OSError, ValueError, RuntimeError) as exc:
+        print(f"::error::Unable to read the live branch ruleset for {repo}@{args.branch}: {exc}")
+        return 2
+
+    violations = evaluate(rules, rulesets, ruleset_details, required_contexts)
+    _print_report(repo, args.branch, rules, violations)
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_branch_ruleset_audit.py
+++ b/tests/unit/scripts/test_check_branch_ruleset_audit.py
@@ -165,6 +165,26 @@ def test_audit_catches_an_added_bypass_actor() -> None:
     assert "OrganizationAdmin" in violations[0].detail
 
 
+def test_a_missing_bypass_actors_key_is_a_violation_not_an_empty_list() -> None:
+    """Absent and empty are different answers on the wire.
+
+    `rulesets/{id}` omits the `bypass_actors` key entirely for a caller
+    without Administration: read, and returns `[]` only when an
+    admin-scoped caller sees a genuinely empty list. An under-scoped
+    BRANCH_PROTECTION_AUDIT_TOKEN therefore produces a 200 whose shape
+    silently skips the one assertion this audit cannot afford to skip --
+    the other two calls need only repo read and keep passing. The fixture
+    mirrors the recorded non-admin response: same ruleset, no key.
+    """
+    details = _details()
+    del details[16719298]["bypass_actors"]
+    violations = evaluate(_rules(), _rulesets(), details, REQUIRED_CONTEXTS)
+    assert len(violations) == 1
+    assert violations[0].rule == "bypass_actors"
+    assert "unproven" in violations[0].detail
+    assert "Administration" in violations[0].detail
+
+
 def test_audit_catches_a_ruleset_flipped_to_evaluate() -> None:
     """A ruleset in `evaluate` mode still contributes rules to the effective
     set, so presence alone does not prove enforcement."""

--- a/tests/unit/scripts/test_check_branch_ruleset_audit.py
+++ b/tests/unit/scripts/test_check_branch_ruleset_audit.py
@@ -1,0 +1,264 @@
+"""Unit tests for ``scripts/check_branch_ruleset_audit.py``.
+
+Classic branch protection has no field for `merge_queue` or
+`bypass_actors`, so an audit built on it cannot see a bypass actor added to
+the ruleset or the merge-queue rule dropped - it stays green while the
+regression that matters most goes uncaught. These tests pin the ruleset-
+native replacement against the real shape of the three endpoints it reads,
+and prove each audited invariant actually fails when it should.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from check_branch_ruleset_audit import (
+    Violation,
+    evaluate,
+    main,
+    read_required_contexts,
+)
+
+REQUIRED_CONTEXTS = ["CI gate"]
+
+# `gh api repos/sipyourdrink-ltd/bernstein/rules/branches/main`, captured
+# 2026-08-16 and trimmed to the fields the audit reads. One ruleset backs
+# every rule; `pull_request` is present live but not audited here - see
+# the script docstring for which invariants are in scope.
+LIVE_RULES_2026_08_16: list[dict[str, Any]] = [
+    {
+        "type": "merge_queue",
+        "parameters": {
+            "merge_method": "SQUASH",
+            "max_entries_to_build": 5,
+            "min_entries_to_merge": 1,
+            "max_entries_to_merge": 1,
+            "min_entries_to_merge_wait_minutes": 0,
+            "grouping_strategy": "ALLGREEN",
+            "check_response_timeout_minutes": 240,
+        },
+        "ruleset_id": 16719298,
+    },
+    {
+        "type": "required_status_checks",
+        "parameters": {
+            "strict_required_status_checks_policy": False,
+            "do_not_enforce_on_create": True,
+            "required_status_checks": [{"context": "CI gate", "integration_id": 15368}],
+        },
+        "ruleset_id": 16719298,
+    },
+    {
+        "type": "pull_request",
+        "parameters": {"required_approving_review_count": 0},
+        "ruleset_id": 16719298,
+    },
+    {"type": "non_fast_forward", "ruleset_id": 16719298},
+    {"type": "deletion", "ruleset_id": 16719298},
+]
+
+# `gh api repos/sipyourdrink-ltd/bernstein/rulesets`, same capture.
+LIVE_RULESETS_2026_08_16: list[dict[str, Any]] = [
+    {"id": 16719298, "name": "main-merge-queue", "target": "branch", "enforcement": "active"},
+]
+
+# `gh api repos/sipyourdrink-ltd/bernstein/rulesets/16719298`, same
+# capture, trimmed to the fields the audit reads.
+LIVE_RULESET_DETAIL_2026_08_16: dict[str, Any] = {
+    "id": 16719298,
+    "name": "main-merge-queue",
+    "enforcement": "active",
+    "bypass_actors": [],
+}
+
+
+def _details() -> dict[int, dict[str, Any]]:
+    return {16719298: json.loads(json.dumps(LIVE_RULESET_DETAIL_2026_08_16))}
+
+
+def _rules() -> list[dict[str, Any]]:
+    return json.loads(json.dumps(LIVE_RULES_2026_08_16))
+
+
+def _rulesets() -> list[dict[str, Any]]:
+    return json.loads(json.dumps(LIVE_RULESETS_2026_08_16))
+
+
+# --------------------------------------------------------------------------
+# The real captured shape passes clean
+# --------------------------------------------------------------------------
+
+
+def test_audit_accepts_the_live_ruleset() -> None:
+    assert evaluate(_rules(), _rulesets(), _details(), REQUIRED_CONTEXTS) == []
+
+
+# --------------------------------------------------------------------------
+# Each audited invariant - proof the check can fail
+# --------------------------------------------------------------------------
+
+
+def test_audit_catches_a_missing_merge_queue_rule() -> None:
+    rules = [r for r in _rules() if r["type"] != "merge_queue"]
+    violations = evaluate(rules, _rulesets(), _details(), REQUIRED_CONTEXTS)
+    assert Violation("merge_queue", "no 'merge_queue' rule applies to this branch") in violations
+
+
+def test_audit_catches_a_missing_non_fast_forward_rule() -> None:
+    rules = [r for r in _rules() if r["type"] != "non_fast_forward"]
+    violations = evaluate(rules, _rulesets(), _details(), REQUIRED_CONTEXTS)
+    assert Violation("non_fast_forward", "no 'non_fast_forward' rule applies to this branch") in violations
+
+
+def test_audit_catches_a_missing_deletion_rule() -> None:
+    rules = [r for r in _rules() if r["type"] != "deletion"]
+    violations = evaluate(rules, _rulesets(), _details(), REQUIRED_CONTEXTS)
+    assert Violation("deletion", "no 'deletion' rule applies to this branch") in violations
+
+
+def test_audit_catches_a_missing_required_status_checks_rule() -> None:
+    rules = [r for r in _rules() if r["type"] != "required_status_checks"]
+    violations = evaluate(rules, _rulesets(), _details(), REQUIRED_CONTEXTS)
+    assert violations == [
+        Violation("required_status_checks", "no 'required_status_checks' rule applies to this branch")
+    ]
+
+
+def test_audit_catches_a_dropped_required_context() -> None:
+    """The concrete scenario the issue names: the wrong context recorded locally."""
+    rules = _rules()
+    for rule in rules:
+        if rule["type"] == "required_status_checks":
+            rule["parameters"]["required_status_checks"] = [{"context": "some-other-check", "integration_id": 1}]
+    violations = evaluate(rules, _rulesets(), _details(), REQUIRED_CONTEXTS)
+    fields = {v.rule for v in violations}
+    assert fields == {"required_status_checks"}
+    details = " ".join(v.detail for v in violations)
+    assert "CI gate" in details
+    assert "some-other-check" in details
+
+
+def test_audit_catches_an_extra_required_context() -> None:
+    rules = _rules()
+    for rule in rules:
+        if rule["type"] == "required_status_checks":
+            rule["parameters"]["required_status_checks"].append({"context": "extra-check", "integration_id": 2})
+    violations = evaluate(rules, _rulesets(), _details(), REQUIRED_CONTEXTS)
+    assert violations == [Violation("required_status_checks", "unexpected required context(s): ['extra-check']")]
+
+
+def test_audit_catches_an_added_bypass_actor() -> None:
+    """The other concrete regression the issue names: a bypass actor added."""
+    details = _details()
+    details[16719298]["bypass_actors"] = [{"actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "always"}]
+    violations = evaluate(_rules(), _rulesets(), details, REQUIRED_CONTEXTS)
+    assert len(violations) == 1
+    assert violations[0].rule == "bypass_actors"
+    assert "OrganizationAdmin" in violations[0].detail
+
+
+def test_audit_catches_a_ruleset_flipped_to_evaluate() -> None:
+    """A ruleset in `evaluate` mode still contributes rules to the effective
+    set, so presence alone does not prove enforcement."""
+    rulesets = _rulesets()
+    rulesets[0]["enforcement"] = "evaluate"
+    violations = evaluate(_rules(), rulesets, _details(), REQUIRED_CONTEXTS)
+    assert violations == [Violation("enforcement", "ruleset 16719298 (main-merge-queue) is 'evaluate', not 'active'")]
+
+
+def test_audit_catches_a_ruleset_missing_from_the_listing() -> None:
+    violations = evaluate(_rules(), [], _details(), REQUIRED_CONTEXTS)
+    assert any(v.rule == "rulesets" for v in violations)
+
+
+def test_audit_catches_a_ruleset_detail_that_was_never_read() -> None:
+    violations = evaluate(_rules(), _rulesets(), {}, REQUIRED_CONTEXTS)
+    assert violations == [
+        Violation("ruleset_detail", "ruleset 16719298 detail was not read; cannot verify bypass actors")
+    ]
+
+
+def test_audit_reports_no_rules_as_a_violation() -> None:
+    violations = evaluate([], _rulesets(), _details(), REQUIRED_CONTEXTS)
+    assert violations == [Violation("rules", "no rules apply to this branch - protection is effectively absent")]
+
+
+def test_audit_ignores_pull_request_rule_changes() -> None:
+    """`pull_request` review policy is not an invariant this audit owns."""
+    rules = _rules()
+    for rule in rules:
+        if rule["type"] == "pull_request":
+            rule["parameters"]["required_approving_review_count"] = 2
+    assert evaluate(rules, _rulesets(), _details(), REQUIRED_CONTEXTS) == []
+
+
+# --------------------------------------------------------------------------
+# Required contexts come from the canary, not a restated constant
+# --------------------------------------------------------------------------
+
+
+def test_required_contexts_come_from_the_canary() -> None:
+    assert read_required_contexts() == REQUIRED_CONTEXTS
+
+
+# --------------------------------------------------------------------------
+# CLI wiring, offline against files (fixture-driven, no network)
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fixture_files(tmp_path: Path) -> dict[str, Path]:
+    rules_path = tmp_path / "rules.json"
+    rulesets_path = tmp_path / "rulesets.json"
+    details_path = tmp_path / "details.json"
+    rules_path.write_text(json.dumps(_rules()), encoding="utf-8")
+    rulesets_path.write_text(json.dumps(_rulesets()), encoding="utf-8")
+    details_path.write_text(json.dumps({"16719298": LIVE_RULESET_DETAIL_2026_08_16}), encoding="utf-8")
+    return {"rules": rules_path, "rulesets": rulesets_path, "details": details_path}
+
+
+def _argv(fixture_files: dict[str, Path]) -> list[str]:
+    return [
+        "--repo",
+        "sipyourdrink-ltd/bernstein",
+        "--rules-file",
+        str(fixture_files["rules"]),
+        "--rulesets-file",
+        str(fixture_files["rulesets"]),
+        "--ruleset-details-file",
+        str(fixture_files["details"]),
+    ]
+
+
+def test_main_exits_zero_when_the_ruleset_matches(
+    fixture_files: dict[str, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(_argv(fixture_files)) == 0
+    assert "satisfies every audited invariant" in capsys.readouterr().out
+
+
+def test_main_exits_one_when_a_bypass_actor_is_added(
+    fixture_files: dict[str, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    details = json.loads(fixture_files["details"].read_text(encoding="utf-8"))
+    details["16719298"]["bypass_actors"] = [{"actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "always"}]
+    fixture_files["details"].write_text(json.dumps(details), encoding="utf-8")
+
+    assert main(_argv(fixture_files)) == 1
+    out = capsys.readouterr().out
+    assert "::error::1 branch ruleset invariant(s) violated" in out
+    assert "bypass_actors" in out
+
+
+def test_main_exits_two_without_a_repo(monkeypatch: pytest.MonkeyPatch, fixture_files: dict[str, Path]) -> None:
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    argv = [a for a in _argv(fixture_files) if a not in ("--repo", "sipyourdrink-ltd/bernstein")]
+    assert main(argv) == 2

--- a/tests/unit/test_branch_protection_audit_workflow_yaml.py
+++ b/tests/unit/test_branch_protection_audit_workflow_yaml.py
@@ -103,32 +103,49 @@ def test_branch_protection_audit_permissions_are_read_only() -> None:
     assert _audit_job(workflow).get("permissions") == {"contents": "read"}
 
 
-def test_branch_protection_audit_reads_main_protection_without_mutating() -> None:
+def test_branch_protection_audit_does_not_read_the_legacy_protection_endpoint() -> None:
+    """Classic protection has no field for `merge_queue` or `bypass_actors`.
+
+    An audit built on it would stay green exactly when the merge-queue
+    rule is dropped or a bypass actor is added - the regressions the
+    ruleset read exists to catch. It is retired outright, not kept as a
+    secondary probe: see the workflow header for why.
+    """
     workflow_text = _workflow_text()
-    assert "gh api" in workflow_text, "audit must read live branch protection through the GitHub API"
-    assert "repos/${GITHUB_REPOSITORY}/branches/main/protection" in workflow_text
+    assert "repos/${GITHUB_REPOSITORY}/branches/main/protection" not in workflow_text
+    assert "gh api" not in workflow_text, (
+        "the workflow delegates to the audited, unit-tested script, not inline gh api calls"
+    )
+
+
+def test_branch_protection_audit_documents_why_the_legacy_endpoint_was_retired() -> None:
+    """`branch-protection-audit.yml` line ~69 used to be the only place this
+    reasoning lived. Pin it in the header so the rationale survives even
+    if nobody reads the PR that made the change."""
+    workflow_text = _workflow_text()
+    assert "merge_queue" in workflow_text
+    assert "bypass_actors" in workflow_text
+    assert "not read here" in workflow_text or "not read" in workflow_text
+
+
+def test_branch_protection_audit_delegates_to_the_ruleset_audit_script_without_mutating() -> None:
+    workflow_text = _workflow_text()
+    assert "scripts/check_branch_ruleset_audit.py" in workflow_text
+    assert Path("scripts/check_branch_ruleset_audit.py").exists()
     assert not re.search(r"\b(?:POST|PUT|PATCH|DELETE)\b", workflow_text), "audit workflow must not mutate settings"
     assert "--method" not in workflow_text
     assert " -X " not in workflow_text
 
 
-def test_branch_protection_audit_compares_live_contexts_with_canary_expectations() -> None:
-    workflow_text = _workflow_text()
+def test_branch_protection_audit_canary_still_defines_the_required_contexts() -> None:
+    """The script reads this file directly; pin its shape here too so a
+    canary regression is caught at the workflow-suite level as well as in
+    `tests/unit/scripts/test_check_branch_ruleset_audit.py`."""
     canary_text = CANARY.read_text(encoding="utf-8")
-
     assert _canary_expected_contexts() == REQUIRED_CONTEXTS
     assert "BRANCH_PROTECTION_CONTEXTS_JSON" in canary_text
-    assert "required-check-canary.yml" in workflow_text
-    assert "BRANCH_PROTECTION_CONTEXTS_JSON" in workflow_text
-    assert "required_status_checks" in workflow_text
-    assert "contexts" in workflow_text
-    assert "checks" in workflow_text
-    assert "missing" in workflow_text
-    assert "extra" in workflow_text
 
 
-def test_branch_protection_audit_fails_when_live_protection_is_unreadable() -> None:
+def test_branch_protection_audit_step_is_not_advisory() -> None:
     workflow_text = _workflow_text()
-    assert "::error::Unable to read live branch protection for main" in workflow_text
-    assert "exit 1" in workflow_text
     assert "continue-on-error: true" not in workflow_text

--- a/tests/unit/test_coverage_ratchet_workflow_yaml.py
+++ b/tests/unit/test_coverage_ratchet_workflow_yaml.py
@@ -233,11 +233,8 @@ def test_privileged_checkout_is_confined_to_commits_from_this_repository(
     """
     guard = workflow["jobs"]["ratchet"]["if"]
 
-    assert (
-        "github.event.workflow_run.head_repository.full_name == github.repository" in guard
-    ), (
-        "without a same-repository guard, a fork PR from a branch named `main` "
-        "reaches the privileged checkout below"
+    assert "github.event.workflow_run.head_repository.full_name == github.repository" in guard, (
+        "without a same-repository guard, a fork PR from a branch named `main` reaches the privileged checkout below"
     )
     assert "github.event.workflow_run.event == 'push'" in guard, (
         "a pull_request-triggered CI run measures the merge commit of an "

--- a/tests/unit/test_issue_decompose_workflow_yaml.py
+++ b/tests/unit/test_issue_decompose_workflow_yaml.py
@@ -100,8 +100,7 @@ def test_starting_the_pipeline_is_a_maintainer_action_not_a_label() -> None:
         condition = _job(name).get("if", "")
         assert isinstance(condition, str)
         assert "github.event.sender.login == 'chernistry'" in condition, (
-            f"job {name!r} runs on a labeled event without checking that a "
-            "maintainer applied the label"
+            f"job {name!r} runs on a labeled event without checking that a maintainer applied the label"
         )
 
 


### PR DESCRIPTION
## What

`branch-protection-audit.yml` used to read the classic `branches/main/protection` endpoint. `main`'s actual guarantees (merge queue, required status check, non-fast-forward, deletion, no bypass) are enforced by a repository ruleset, and the classic endpoint has no field for `merge_queue` or `bypass_actors` — it cannot represent either one. An audit built on it stays green exactly when the merge-queue rule is dropped or a bypass actor is added, which is the regression that matters most.

The audit now reads the ruleset endpoints directly:

- `rules/branches/main` — the effective, GitHub-resolved rule set for the branch
- `rulesets` — enforcement state for every ruleset (a ruleset flipped to `evaluate` still contributes rules to the effective set, so presence alone isn't proof of enforcement)
- `rulesets/{id}` — full detail for each ruleset the effective rules reference, the only place `bypass_actors` is exposed

Asserted invariants: `merge_queue`, `non_fast_forward`, and `deletion` rules present; `required_status_checks` contexts match the required-check canary (missing or extra both fail, same as before); every referenced ruleset is `active`; no bypass actor.

The comparison logic moved out of an inline workflow heredoc into `scripts/check_branch_ruleset_audit.py` so it has its own unit tests with real captured fixtures, instead of only string-matching the workflow YAML.

## Legacy endpoint: retired, not kept as a secondary probe

Checked live: the classic endpoint still returns 200 for this repo (GitHub translates some ruleset fields into the classic response shape), so it isn't broken outright. But it has no representation for `merge_queue` or `bypass_actors` at all, and every field it does translate (required status contexts, force-push/deletion flags) is already covered by the ruleset read. Keeping it as a secondary probe would add a second live call and a second failure mode for zero additional coverage, so it's removed rather than kept.

## Open call the issue left to the implementer

"Fail on unknown extra rules, or only on missing expected ones" — kept matching the prior behavior: an extra required-status-check context fails the audit, same as a missing one. Rule *types* outside the four audited here (e.g. `pull_request`) are left unaudited rather than closed off, so unrelated policy changes don't produce false positives.

## Testing

- `uv run pytest tests/unit/scripts/test_check_branch_ruleset_audit.py tests/unit/test_branch_protection_audit_workflow_yaml.py -q -p no:cacheprovider` — 25 passed
- Fail-before/pass-after verified by hand: the new structural assertions fail against the pre-fix workflow content and pass against the fix
- Each audited invariant (missing rule, dropped/extra context, added bypass actor, ruleset flipped to `evaluate`) has a dedicated test proving `evaluate()` reports it
- `uv run ruff check .` and `uv run ruff format .` clean; `uv run mypy scripts/check_branch_ruleset_audit.py` clean

Closes #3949
