### PR TITLE
style: reformat two workflow-yaml guard tests with the current ruff formatter

### DIFF
--- a/tests/unit/test_coverage_ratchet_workflow_yaml.py
+++ b/tests/unit/test_coverage_ratchet_workflow_yaml.py
@@ -233,11 +233,8 @@ def test_privileged_checkout_is_confined_to_commits_from_this_repository(
     """
     guard = workflow["jobs"]["ratchet"]["if"]
 
-    assert (
-        "github.event.workflow_run.head_repository.full_name == github.repository" in guard
-    ), (
-        "without a same-repository guard, a fork PR from a branch named `main` "
-        "reaches the privileged checkout below"
+    assert "github.event.workflow_run.head_repository.full_name == github.repository" in guard, (
+        "without a same-repository guard, a fork PR from a branch named `main` reaches the privileged checkout below"
     )
     assert "github.event.workflow_run.event == 'push'" in guard, (
         "a pull_request-triggered CI run measures the merge commit of an "

--- a/tests/unit/test_issue_decompose_workflow_yaml.py
+++ b/tests/unit/test_issue_decompose_workflow_yaml.py
@@ -100,8 +100,7 @@ def test_starting_the_pipeline_is_a_maintainer_action_not_a_label() -> None:
         condition = _job(name).get("if", "")
         assert isinstance(condition, str)
         assert "github.event.sender.login == 'chernistry'" in condition, (
-            f"job {name!r} runs on a labeled event without checking that a "
-            "maintainer applied the label"
+            f"job {name!r} runs on a labeled event without checking that a maintainer applied the label"
         )
 
 


### PR DESCRIPTION
## What

`uv run ruff format --check .` on a clean `origin/main` reports two files out of sync with the formatter:

- `tests/unit/test_coverage_ratchet_workflow_yaml.py`
- `tests/unit/test_issue_decompose_workflow_yaml.py`

This runs `ruff format` over exactly those two files. Whitespace and line-wrapping only — no logic change.

## Why the diff looks like this

The formatter joins implicitly concatenated strings when the result fits the 120-character limit, so three multi-line assertion messages collapse onto one line. The resulting message text is byte-identical, and no joined line exceeds the limit.

## Verification

| Check | Result |
|---|---|
| `uv run ruff format --check .` | ✅ `4603 files already formatted` |
| `uv run ruff check <the two files>` | ✅ `All checks passed!` |
| `uv run pytest <the two files> -q -p no:cacheprovider` | ✅ `28 passed` |
| Longest resulting line | 118 chars, under the 120 limit |

Ruff is a floor (`ruff>=0.9`), not an exact pin, and the two places that resolve it disagree on version: `uv.lock` has 0.15.8, `.pre-commit-config.yaml` pins `v0.9.10`. I checked the new form against both — `uvx ruff@0.9.10 format --check` also reports `2 files already formatted`. So this form is a fixed point for both versions and they will not fight over these files. (The previous form was stable only under 0.9.10, which is how the drift arose.)

Cut from a detached worktree at `origin/main`, not from a feature branch.
