### PR TITLE
docs(replay): fix the export invocation and split `--as-json` by what it emits (#3968)

### DIFF
--- a/docs/reference/cli/replay.md
+++ b/docs/reference/cli/replay.md
@@ -157,7 +157,6 @@ Same as `export`, but produces a redacted receipt suitable for publishing. Sensi
 > example lands here with that fix. Use `export` for a local receipt in the
 > meantime -- `publish` differs only in redacting before it writes.
 
-
 ### `bernstein replay verify <RECEIPT>`
 
 Offline verifier for an exported or published receipt. Recomputes the receipt's chain and reports byte-identity or the first divergent step. Exits non-zero on mismatch.

--- a/docs/reference/cli/replay.md
+++ b/docs/reference/cli/replay.md
@@ -4,8 +4,8 @@
 
 - **`bernstein replay <RUN_ID>`** - the original replay, optionally with task-trace re-submission.
 - **`bernstein replay diff RUN_A RUN_B`** - localise the first divergence between two recorded runs.
-- **`bernstein replay export <AGENT_ID> -o RECEIPT`** - write a portable per-step receipt.
-- **`bernstein replay publish <AGENT_ID> -o RECEIPT`** - write a redacted receipt for publishing.
+- **`bernstein replay export <AGENT_ID> [OUT]`** - write a portable per-step receipt.
+- **`bernstein replay publish <AGENT_ID> [OUT]`** - write a redacted receipt for publishing (see #3976: currently not completable).
 - **`bernstein replay verify <RECEIPT>`** - offline verifier for an exported receipt.
 - **`bernstein replay diff-journal A B`** - per-step divergence finder across two journals.
 
@@ -88,6 +88,31 @@ bernstein replay T-abc123 --model opus --extra-context "Make sure tests pass on 
 
 ---
 
+## Machine-readable output (`--as-json`)
+
+The flag is `--as-json`. Every subcommand accepts it, but **only some act on
+it**, which matters if you are scripting:
+
+| Surface | `--as-json` | Emits |
+|---|---|---|
+| `bernstein replay <AGENT_ID>` | yes | `{agent_id, head_hash, steps, entries[]}` |
+| `bernstein replay <RUN_ID> --verify` | yes | chain verdict, head hash, and the divergent step when one exists |
+| `bernstein replay diff-journal A B` | yes | `{diverged, seq, fields_changed[], left_values, right_values, reason}` |
+| `bernstein replay debug ...` | yes | head hash, step count, receipt path, whether it was signed |
+| `bernstein replay export` | **accepted, ignored** | human-readable output regardless |
+| `bernstein replay publish` | **accepted, ignored** | human-readable output regardless |
+| `bernstein replay verify <RECEIPT>` | **accepted, ignored** | human-readable output regardless |
+
+The bottom three exit normally and print prose, with no error saying the flag
+did nothing. Do not pipe them into a parser. Tracked in
+[#3976](https://github.com/sipyourdrink-ltd/bernstein/issues/3976).
+
+**The exit code is the verdict, not the payload.** On the three that ignore the
+flag it is the *only* machine-readable signal there is: `verify` exits non-zero
+on a receipt mismatch while still printing to stdout, so a caller that reads
+stdout and ignores the exit status sees a refused chain as a success. Check the
+exit code first and treat any payload as detail.
+
 ## Subcommands
 
 Beyond the base run/task replay, `bernstein replay` exposes subcommands for diffing runs and for exporting and verifying portable receipts.
@@ -104,21 +129,34 @@ bernstein replay diff 20260415-143022 20260415-150118
 
 Per-step divergence finder across two journals. Like `diff` but operates directly on two journal paths, reporting the first step index where the chains diverge.
 
-### `bernstein replay export <AGENT_ID> -o RECEIPT`
+`--as-json` emits `{diverged, seq, fields_changed[], left_values, right_values, reason}`, and the command exits `1` when `diverged` is true, so the exit code and the payload agree.
 
-Writes a portable per-step receipt for an agent's journal to the path given by `-o`. The receipt carries the step chain and its head hash so it can be verified offline by another party.
+### `bernstein replay export <AGENT_ID> [OUT]`
 
-```bash
-bernstein replay export backend-abc -o receipt.json
-```
+Writes a portable per-step receipt for an agent's journal. The receipt carries the step chain and its head hash so it can be verified offline by another party.
 
-### `bernstein replay publish <AGENT_ID> -o RECEIPT`
-
-Same as `export`, but produces a redacted receipt suitable for publishing. Sensitive fields are stripped while the head hash still anchors the visible steps.
+The destination is an optional **positional** argument, not a flag. Omit it and
+the receipt lands at `.sdd/runtime/receipts/<AGENT_ID>.tar`.
 
 ```bash
-bernstein replay publish backend-abc -o receipt.public.json
+# explicit destination
+bernstein replay export backend-abc receipt.tar
+
+# default destination: .sdd/runtime/receipts/backend-abc.tar
+bernstein replay export backend-abc
 ```
+
+### `bernstein replay publish <AGENT_ID> [OUT]`
+
+Same as `export`, but produces a redacted receipt suitable for publishing. Sensitive fields are stripped while the head hash still anchors the visible steps. The destination is positional, as for `export`.
+
+> **Currently not completable.** `publish` refuses without a confirmation flag
+> and names `--yes-i-want-to-publish`, which the CLI does not declare, so every
+> invocation exits 2. Tracked in
+> [#3976](https://github.com/sipyourdrink-ltd/bernstein/issues/3976); a working
+> example lands here with that fix. Use `export` for a local receipt in the
+> meantime -- `publish` differs only in redacting before it writes.
+
 
 ### `bernstein replay verify <RECEIPT>`
 


### PR DESCRIPTION
Closes #3968, to the re-scoped acceptance criteria.

## The invocation was broken

`-o` is not an option on `replay`. The destination is the third positional (`advanced_cmd.py:2224`), so every documented `export`/`publish` invocation on this page failed:

```
$ bernstein replay export backend-abc -o receipt.json
Error: No such option: -o
```

Fixed to `[OUT]` positional in all six places it appeared (:7, :8, and the two section headings and two examples), and the default destination corrected — it is `.sdd/runtime/receipts/<AGENT_ID>.tar`, not the `receipt.json` the examples implied.

**Checked by running them, not by reading the dispatcher:**

```
$ bernstein replay export backend-abc receipt.tar
No journal for agent backend-abc          <- parses, reaches the code

$ bernstein replay export backend-abc
No journal for agent backend-abc          <- default destination path

$ bernstein replay diff-journal a b --as-json
One or both journals are missing.
```

Reaching a missing-fixture message rather than an option error is the acceptance criterion "runnable as written".

## `--as-json`, split by what it actually does

The flag is accepted on every subcommand and honoured by four: the agent view, `--verify`, `diff-journal`, `debug`. `export`, `publish` and `verify <RECEIPT>` take it, ignore it, and exit normally printing prose.

The table says which is which. The exit-code paragraph is kept and points at the case where it matters most — on the three that ignore the flag the exit status is the *only* machine-readable signal, and `verify` exits non-zero on a receipt mismatch while still printing to stdout, so a caller reading stdout alone sees a refused chain as a success.

## Two things deliberately not in this PR

**The `publish` example.** `publish` cannot currently complete: it refuses without a confirmation flag and names `--yes-i-want-to-publish`, which click does not declare, so every invocation exits 2 (#3976). Rather than print an invocation I know fails, the section carries a note and points at the issue. I will write the working example against your fix PR as you offered.

**The why-explicit-only sentence for `repair`.** Agreed in-thread, but the `repair` section arrives with #3955, which is still open. Writing it here would mean writing against a branch. It follows once that merges.

## Verification

```
scripts/check_docs_drift.py     No drift detected
```

Prose-only, 48 insertions / 10 deletions, one file. No em dashes introduced — this page uses `-` and I kept it.

## Note on the count

The issue says four `-o` occurrences; there are six. :7 and :8 are the summary bullets at the top, which are easy to miss under the section headings. Both are fixed.