### PR TITLE
fix(cli): declare the replay publish confirmation flag and make --as-json truthful

### DIFF
--- a/docs/operations/replay.md
+++ b/docs/operations/replay.md
@@ -10,8 +10,8 @@ portable, offline-verifiable receipts of the chain.
 |---|---|
 | `bernstein replay <agent_id>` | Render the hash-chained step view; verify chain integrity before display |
 | `bernstein session fork <session_id> --from-step <n>` | Materialise a sibling worktree branched at parent step N; chain becomes a tree |
-| `bernstein replay export <agent_id> -o RECEIPT` | Portable, content-addressed receipt; offline-verifiable with the install public key |
-| `bernstein replay publish <agent_id> -o RECEIPT --opt-in` | Redacted receipt; only path that ever writes outside `.sdd/runtime/` |
+| `bernstein replay export <agent_id> [RECEIPT]` | Portable, content-addressed receipt; offline-verifiable with the install public key |
+| `bernstein replay publish <agent_id> [RECEIPT] --yes-i-want-to-publish` | Redacted receipt; only path that ever writes outside `.sdd/runtime/` |
 | `bernstein replay verify <RECEIPT> [--head HEX]` | Offline verifier |
 | `bernstein replay diff-journal <A> <B>` | Surface the precise field that differs between two chains |
 | `bernstein replay debug <RUN>` | Forensic single-chain walk; refuse a tampered chain and localise the divergent step; emit an offline-verifiable debug receipt |
@@ -225,7 +225,7 @@ matches what was walked.
 
 ## Publish flow (privacy redaction)
 
-`bernstein replay publish <agent_id> --opt-in` runs the configured
+`bernstein replay publish <agent_id> --yes-i-want-to-publish` runs the configured
 `RedactionPolicy` (default redacts `prompt` and `tool_result`),
 re-anchors the chain to the redacted payloads, and writes a receipt
 with the new head hash. The original local chain is untouched. The

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -2028,6 +2028,14 @@ def _replay_from_step(*, run_id: str, sdd_dir: str, from_step: int, as_json: boo
     help="Rebuild deterministic run state by walking the journal to step N.",
 )
 @click.option(
+    "--yes-i-want-to-publish",
+    "yes_i_want_to_publish",
+    is_flag=True,
+    default=False,
+    help="replay publish: confirm writing a redacted receipt outside .sdd/runtime/. "
+    "Only valid with the 'publish' verb; any other verb rejects it.",
+)
+@click.option(
     "--fork-from",
     "fork_from",
     type=int,
@@ -2064,6 +2072,7 @@ def replay_cmd(
     extra_context: str | None,
     verify: bool,
     from_step: int | None,
+    yes_i_want_to_publish: bool,
     fork_from: int | None,
     jump_to_failure: bool,
     sign_key: str | None,
@@ -2088,8 +2097,8 @@ def replay_cmd(
       bernstein replay <RUN_ID> --from-step N     # rebuild state to step N
       bernstein replay diff RUN_A RUN_B           # first-divergence finder
       bernstein replay <AGENT_ID>                 # per-step journal view (#1799)
-      bernstein replay export <AGENT_ID> -o RECEIPT   # portable receipt (#1799)
-      bernstein replay publish <AGENT_ID> -o RECEIPT  # redacted publish (#1799)
+      bernstein replay export <AGENT_ID> [OUT]                          # portable receipt (#1799)
+      bernstein replay publish <AGENT_ID> [OUT] --yes-i-want-to-publish # redacted publish (#1799)
       bernstein replay verify <RECEIPT>           # offline verifier (#1799)
       bernstein replay diff-journal A B           # per-step divergence finder
       bernstein replay debug <RUN>                # forensic single-chain walk (#2605)
@@ -2100,6 +2109,20 @@ def replay_cmd(
     # converting ``replay`` to a full :class:`click.Group` (which would
     # break the back-compat ``bernstein replay <RUN_ID>`` shape).
     args = list(run_id)
+
+    # --yes-i-want-to-publish is declared command-wide (click has no way to
+    # scope an option to one pseudo-subcommand here), so it is reachable on
+    # every verb. Honour it only for ``publish``; anywhere else it is a
+    # named error rather than a silent no-op -- the whole point of this
+    # fix is that an accepted flag must never be quietly ignored (#3976).
+    if yes_i_want_to_publish and not (args and args[0] == "publish"):
+        console.print(
+            "[red]Error:[/red] --yes-i-want-to-publish only applies to "
+            "'bernstein replay publish'; refusing rather than silently "
+            "ignoring it here."
+        )
+        raise SystemExit(2)
+
     if args and args[0] == "diff":
         _replay_diff_dispatch(args[1:], sdd_dir=sdd_dir, as_json=as_json)
         return
@@ -2116,7 +2139,12 @@ def replay_cmd(
         )
         return
     if args and args[0] in {"export", "publish", "verify", "diff-journal"}:
-        _replay_journal_dispatch(args, sdd_dir=sdd_dir, as_json=as_json)
+        _replay_journal_dispatch(
+            args,
+            sdd_dir=sdd_dir,
+            as_json=as_json,
+            yes_i_want_to_publish=yes_i_want_to_publish,
+        )
         return
 
     if len(args) != 1:
@@ -2204,6 +2232,7 @@ def _replay_journal_dispatch(
     *,
     sdd_dir: str,
     as_json: bool,
+    yes_i_want_to_publish: bool = False,
 ) -> None:
     """Dispatch the new ``export | publish | verify | diff-journal`` verbs.
 
@@ -2216,7 +2245,7 @@ def _replay_journal_dispatch(
 
     if verb == "export":
         if len(args) < 2:
-            console.print("[red]Usage:[/red] bernstein replay export <AGENT_ID> [-o OUT]")
+            console.print("[red]Usage:[/red] bernstein replay export <AGENT_ID> [OUT]")
             raise SystemExit(2)
         agent_id = args[1]
         # Output path can be passed as the third positional or default beside .sdd.
@@ -2228,20 +2257,21 @@ def _replay_journal_dispatch(
             agent_id=agent_id,
             sdd_dir=sdd_path,
             output=output,
+            as_json=as_json,
         )
         if rc != 0:
             raise SystemExit(rc)
         return
 
     if verb == "publish":
-        # Publish requires an explicit ``--yes`` style sentinel positional so
-        # operators cannot accidentally publish from a script that just adds
-        # a verb name.
+        # Publish requires the explicit --yes-i-want-to-publish confirmation
+        # (declared on the ``replay`` command and gated to this verb by the
+        # caller) so operators cannot accidentally publish from a script
+        # that just adds a verb name.
         if len(args) < 2:
-            console.print("[red]Usage:[/red] bernstein replay publish <AGENT_ID> [OUT] --opt-in")
+            console.print("[red]Usage:[/red] bernstein replay publish <AGENT_ID> [OUT] --yes-i-want-to-publish")
             raise SystemExit(2)
         agent_id = args[1]
-        opt_in = "--opt-in" in args
         positional_tail = [a for a in args[2:] if not a.startswith("--")]
         output = (
             Path(positional_tail[0])
@@ -2255,7 +2285,8 @@ def _replay_journal_dispatch(
             agent_id=agent_id,
             sdd_dir=sdd_path,
             output=output,
-            opt_in=opt_in,
+            opt_in=yes_i_want_to_publish,
+            as_json=as_json,
         )
         if rc != 0:
             raise SystemExit(rc)
@@ -2277,6 +2308,7 @@ def _replay_journal_dispatch(
             receipt_path=receipt,
             expected_head=expected_head,
             public_key_path=None,
+            as_json=as_json,
         )
         if rc != 0:
             raise SystemExit(rc)

--- a/src/bernstein/cli/commands/replay_cmd.py
+++ b/src/bernstein/cli/commands/replay_cmd.py
@@ -140,6 +140,7 @@ def replay_export(
     output: Path,
     *,
     signer_key_path: Path | None = None,
+    as_json: bool = False,
 ) -> int:
     """Build a portable receipt and write it to *output*. Returns exit code."""
     from bernstein.cli.helpers import console
@@ -173,6 +174,20 @@ def replay_export(
         console.print(f"[red]Export failed:[/red] {exc}")
         return 1
 
+    if as_json:
+        console.print_json(
+            json.dumps(
+                {
+                    "agent_id": agent_id,
+                    "output": str(result.path),
+                    "head_hash": result.head_hash,
+                    "steps": result.steps,
+                    "signed": result.signed,
+                }
+            )
+        )
+        return 0
+
     console.print(f"[green]Exported receipt[/green] -> {result.path}")
     console.print(f"  head_hash: {result.head_hash}")
     console.print(f"  steps:     {result.steps}")
@@ -187,6 +202,7 @@ def replay_publish(
     *,
     opt_in: bool,
     signer_key_path: Path | None = None,
+    as_json: bool = False,
 ) -> int:
     """Publish a privacy-redacted receipt. Returns exit code."""
     from bernstein.cli.helpers import console
@@ -230,6 +246,21 @@ def replay_publish(
         console.print(f"[red]Publish failed:[/red] {exc}")
         return 1
 
+    if as_json:
+        console.print_json(
+            json.dumps(
+                {
+                    "agent_id": agent_id,
+                    "output": str(result.path),
+                    "original_head_hash": result.original_head_hash,
+                    "head_hash": result.head_hash,
+                    "steps": result.steps,
+                    "signed": result.signed,
+                }
+            )
+        )
+        return 0
+
     console.print(f"[green]Published redacted receipt[/green] -> {result.path}")
     console.print(f"  original_head:  {result.original_head_hash}")
     console.print(f"  redacted_head:  {result.head_hash}")
@@ -243,6 +274,7 @@ def replay_verify(
     *,
     expected_head: str | None,
     public_key_path: Path | None,
+    as_json: bool = False,
 ) -> int:
     """Verify a receipt tarball offline. Returns exit code."""
     from bernstein.cli.helpers import console
@@ -273,6 +305,20 @@ def replay_verify(
     except ReceiptError as exc:
         console.print(f"[red]Receipt malformed:[/red] {exc}")
         return 1
+
+    if as_json:
+        console.print_json(
+            json.dumps(
+                {
+                    "ok": result.ok,
+                    "head_hash": result.head_hash,
+                    "steps": result.steps,
+                    "errors": result.errors,
+                    "signed": result.signed,
+                }
+            )
+        )
+        return 0 if result.ok else 1
 
     if result.ok:
         console.print(f"[green]Receipt verified:[/green] head={result.head_hash} steps={result.steps}")

--- a/tests/unit/test_replay_cmd.py
+++ b/tests/unit/test_replay_cmd.py
@@ -8,6 +8,20 @@ from pathlib import Path
 from bernstein.cli.advanced_cmd import replay_cmd
 from click.testing import CliRunner
 
+from bernstein.core.persistence.journal import Journal
+
+
+def _populate_agent_journal(sdd_dir: Path, agent_id: str, n: int = 2) -> str:
+    """Seed a per-step journal for *agent_id* under *sdd_dir*; return its head hash."""
+    journal_dir = sdd_dir / "runtime" / "journal" / agent_id
+    journal = Journal.open(journal_dir)
+    head = ""
+    for i in range(n):
+        entry = journal.append(input_hash=f"a{i}", model="m1", prompt=f"p{i}")
+        head = entry.step_hash
+    journal.close()
+    return head
+
 
 def _write_run(run_dir: Path, *, run_id: str) -> None:
     run_path = run_dir / run_id
@@ -59,3 +73,165 @@ def test_replay_output_shows_metadata_header(tmp_path: Path) -> None:
     assert "Branch:" in result.output
     assert "feature/track-b" in result.output
     assert "SHA:" in result.output
+
+
+# ---------------------------------------------------------------------------
+# issue #3976: export/publish/verify flag defects
+# ---------------------------------------------------------------------------
+
+
+def test_export_usage_string_matches_the_positional_invocation(tmp_path: Path) -> None:
+    """``export`` with no AGENT_ID must show the real (positional) shape.
+
+    The dispatcher has never accepted ``-o``; the destination is the third
+    positional. The old usage string advertised a flag that does not exist.
+    """
+    sdd_dir = tmp_path / ".sdd"
+
+    result = CliRunner().invoke(replay_cmd, ["export", "--sdd-dir", str(sdd_dir)])
+
+    assert result.exit_code == 2
+    assert "-o" not in result.output
+    assert "bernstein replay export <AGENT_ID> [OUT]" in result.output
+
+
+def test_publish_confirmation_flag_actually_completes_a_publish(tmp_path: Path) -> None:
+    """The only spelling the refusal message names must actually work.
+
+    Before the fix, click declared neither ``--yes-i-want-to-publish`` (named
+    by the refusal message) nor ``--opt-in`` (checked by the dispatcher), so
+    ``publish`` could never exit 0.
+    """
+    sdd_dir = tmp_path / ".sdd"
+    _populate_agent_journal(sdd_dir, "agent-1", 1)
+    out = tmp_path / "redacted.tar"
+
+    result = CliRunner().invoke(
+        replay_cmd,
+        ["publish", "agent-1", str(out), "--yes-i-want-to-publish", "--sdd-dir", str(sdd_dir)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+
+
+def test_publish_without_confirmation_still_refuses(tmp_path: Path) -> None:
+    """No flag at all keeps refusing, and names the real flag in the message."""
+    sdd_dir = tmp_path / ".sdd"
+    _populate_agent_journal(sdd_dir, "agent-1", 1)
+    out = tmp_path / "redacted.tar"
+
+    result = CliRunner().invoke(
+        replay_cmd,
+        ["publish", "agent-1", str(out), "--sdd-dir", str(sdd_dir)],
+    )
+
+    assert result.exit_code == 2
+    assert "--yes-i-want-to-publish" in result.output
+    assert not out.exists()
+
+
+def test_dead_opt_in_flag_is_no_longer_accepted_anywhere(tmp_path: Path) -> None:
+    """``--opt-in`` named nothing reachable even before the fix; it is now gone."""
+    sdd_dir = tmp_path / ".sdd"
+    _populate_agent_journal(sdd_dir, "agent-1", 1)
+    out = tmp_path / "redacted.tar"
+
+    result = CliRunner().invoke(
+        replay_cmd,
+        ["publish", "agent-1", str(out), "--opt-in", "--sdd-dir", str(sdd_dir)],
+    )
+
+    assert result.exit_code != 0
+    assert not out.exists()
+
+
+def test_the_confirmation_flag_on_any_other_verb_is_a_named_error(tmp_path: Path) -> None:
+    """Declaring ``--yes-i-want-to-publish`` command-wide must not let other
+    verbs silently accept it -- that would recreate the accepted-but-ignored
+    ``--as-json`` defect this same issue is about."""
+    sdd_dir = tmp_path / ".sdd"
+    _populate_agent_journal(sdd_dir, "agent-1", 1)
+    out = tmp_path / "out.tar"
+
+    result = CliRunner().invoke(
+        replay_cmd,
+        ["export", "agent-1", str(out), "--yes-i-want-to-publish", "--sdd-dir", str(sdd_dir)],
+    )
+
+    assert result.exit_code == 2
+    assert "--yes-i-want-to-publish" in result.output
+    assert not out.exists()
+
+
+def test_the_confirmation_flag_on_plain_run_replay_is_also_a_named_error(tmp_path: Path) -> None:
+    """The guard is verb-agnostic: it fires even off the legacy run-id path."""
+    sdd_dir = tmp_path / ".sdd"
+
+    result = CliRunner().invoke(
+        replay_cmd,
+        ["some-run-id", "--yes-i-want-to-publish", "--sdd-dir", str(sdd_dir)],
+    )
+
+    assert result.exit_code == 2
+    assert "--yes-i-want-to-publish" in result.output
+
+
+def test_as_json_on_export_emits_json_not_silence(tmp_path: Path) -> None:
+    sdd_dir = tmp_path / ".sdd"
+    _populate_agent_journal(sdd_dir, "agent-1", 2)
+    out = tmp_path / "out.tar"
+
+    result = CliRunner().invoke(
+        replay_cmd,
+        ["export", "agent-1", str(out), "--as-json", "--sdd-dir", str(sdd_dir)],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["agent_id"] == "agent-1"
+    assert payload["output"] == str(out)
+    assert payload["head_hash"]
+    assert payload["steps"] == 2
+
+
+def test_as_json_on_publish_emits_json_not_silence(tmp_path: Path) -> None:
+    sdd_dir = tmp_path / ".sdd"
+    _populate_agent_journal(sdd_dir, "agent-1", 1)
+    out = tmp_path / "redacted.tar"
+
+    result = CliRunner().invoke(
+        replay_cmd,
+        [
+            "publish",
+            "agent-1",
+            str(out),
+            "--yes-i-want-to-publish",
+            "--as-json",
+            "--sdd-dir",
+            str(sdd_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["agent_id"] == "agent-1"
+    assert payload["output"] == str(out)
+    assert payload["head_hash"]
+    assert payload["original_head_hash"]
+
+
+def test_as_json_on_receipt_verify_emits_the_verification_result(tmp_path: Path) -> None:
+    sdd_dir = tmp_path / ".sdd"
+    head = _populate_agent_journal(sdd_dir, "agent-1", 2)
+    out = tmp_path / "out.tar"
+    runner = CliRunner()
+    export = runner.invoke(replay_cmd, ["export", "agent-1", str(out), "--sdd-dir", str(sdd_dir)])
+    assert export.exit_code == 0, export.output
+
+    result = runner.invoke(replay_cmd, ["verify", str(out), "--as-json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["head_hash"] == head

--- a/tests/unit/test_replay_journal_cli.py
+++ b/tests/unit/test_replay_journal_cli.py
@@ -8,6 +8,7 @@ above and is exercised by the integration tests.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from bernstein.cli.commands.replay_cmd import (
@@ -103,3 +104,84 @@ def test_replay_diff_journals_returns_1_when_divergent(tmp_path: Path) -> None:
 def test_replay_verify_missing_receipt_returns_2(tmp_path: Path) -> None:
     rc = replay_verify(tmp_path / "missing.tar", expected_head=None, public_key_path=None)
     assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# issue #3976: --as-json must emit a truthful summary, not be silently ignored
+# ---------------------------------------------------------------------------
+
+
+def test_replay_export_as_json_summarises_the_receipt(tmp_path: Path, capsys) -> None:
+    sdd = tmp_path / ".sdd"
+    head = _populate(sdd, "agent-1", 2)
+    out = tmp_path / "out.tar"
+
+    rc = replay_export("agent-1", sdd, out, as_json=True)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "agent_id": "agent-1",
+        "output": str(out),
+        "head_hash": head,
+        "steps": 2,
+        "signed": False,
+    }
+
+
+def test_replay_export_human_output_unchanged_when_as_json_absent(tmp_path: Path, capsys) -> None:
+    sdd = tmp_path / ".sdd"
+    _populate(sdd, "agent-1", 1)
+    out = tmp_path / "out.tar"
+
+    rc = replay_export("agent-1", sdd, out)
+
+    assert rc == 0
+    captured = capsys.readouterr().out
+    assert "Exported receipt" in captured
+    assert not captured.strip().startswith("{")
+
+
+def test_replay_publish_as_json_summarises_the_receipt(tmp_path: Path, capsys) -> None:
+    sdd = tmp_path / ".sdd"
+    _populate(sdd, "agent-1", 1)
+    out = tmp_path / "redacted.tar"
+
+    rc = replay_publish("agent-1", sdd, out, opt_in=True, as_json=True)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["agent_id"] == "agent-1"
+    assert payload["output"] == str(out)
+    assert payload["steps"] == 1
+    assert payload["head_hash"]
+    assert payload["original_head_hash"]
+
+
+def test_replay_publish_human_output_unchanged_when_as_json_absent(tmp_path: Path, capsys) -> None:
+    sdd = tmp_path / ".sdd"
+    _populate(sdd, "agent-1", 1)
+    out = tmp_path / "redacted.tar"
+
+    rc = replay_publish("agent-1", sdd, out, opt_in=True)
+
+    assert rc == 0
+    captured = capsys.readouterr().out
+    assert "Published redacted receipt" in captured
+    assert not captured.strip().startswith("{")
+
+
+def test_replay_verify_as_json_reports_the_verification_result(tmp_path: Path, capsys) -> None:
+    sdd = tmp_path / ".sdd"
+    head = _populate(sdd, "agent-1", 2)
+    out = tmp_path / "out.tar"
+    replay_export("agent-1", sdd, out)
+    capsys.readouterr()  # discard export's own output
+
+    rc = replay_verify(out, expected_head=None, public_key_path=None, as_json=True)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["head_hash"] == head
+    assert payload["steps"] == 2


### PR DESCRIPTION
## Defects

1. **Usage string lies.** `export`'s usage string printed `bernstein replay export <AGENT_ID> [-o OUT]`, but the destination has always been the third positional argument, never a `-o` flag. Fixed to `bernstein replay export <AGENT_ID> [OUT]`.
2. **`--as-json` accepted but ignored** on `export`, `publish`, and receipt-mode `verify`. The `replay` command declares `--as-json` for the whole verb family, but these three verbs never received it, so the flag parsed and did nothing.
3. **`publish` could never complete.** Three layers disagreed on the confirmation flag's name: the refusal message printed `--yes-i-want-to-publish`, the dispatcher checked `"--opt-in" in args`, and click declared neither — so both were rejected by click before the dispatcher ever ran. `opt_in` was permanently `False`.

## Decisions (from the issue thread)

- `--yes-i-want-to-publish` wins; `--opt-in` is removed entirely.
- The flag is declared on the `replay` command (click has no way to scope an option to one pseudo-subcommand here) and honoured only by `publish`. Passing it to any other verb is a **named error**, not a silent no-op — declaring it command-wide and letting other verbs quietly accept it would recreate the exact defect this issue is about.
- `--as-json` on `export`/`publish`/receipt-`verify` now emits a truthful JSON summary of what each function actually knows, rather than falling back to a named error (the payloads all make sense). Human output is unchanged when the flag is absent.

## Fail-before proof (defect 3)

Stashed only the two source files (kept the new test), ran the publish-completes test against unfixed code:

```
$ git stash push -- src/bernstein/cli/commands/advanced_cmd.py src/bernstein/cli/commands/replay_cmd.py
$ uv run python -m pytest tests/unit/test_replay_cmd.py::test_publish_confirmation_flag_actually_completes_a_publish -q

FAILED tests/unit/test_replay_cmd.py::test_publish_confirmation_flag_actually_completes_a_publish
AssertionError: Usage: replay [OPTIONS] RUN_ID...
Try 'replay --help' for help.

Error: No such option: --yes-i-want-to-publish

assert 2 == 0
 +  where 2 = <Result SystemExit(2)>.exit_code
```

Restored via `git stash pop`; full suite green after.

## Final invocation shapes

```
bernstein replay export <AGENT_ID> [OUT] [--as-json]
bernstein replay publish <AGENT_ID> [OUT] --yes-i-want-to-publish [--as-json]
bernstein replay verify <RECEIPT> [--head HEX] [--as-json]
```

`--yes-i-want-to-publish` on any verb other than `publish` exits 2 with a message naming the flag.

## Tests

New, `tests/unit/test_replay_cmd.py` (CLI dispatch, via `CliRunner`):

- `test_export_usage_string_matches_the_positional_invocation`
- `test_publish_confirmation_flag_actually_completes_a_publish`
- `test_publish_without_confirmation_still_refuses`
- `test_dead_opt_in_flag_is_no_longer_accepted_anywhere`
- `test_the_confirmation_flag_on_any_other_verb_is_a_named_error`
- `test_the_confirmation_flag_on_plain_run_replay_is_also_a_named_error`
- `test_as_json_on_export_emits_json_not_silence`
- `test_as_json_on_publish_emits_json_not_silence`
- `test_as_json_on_receipt_verify_emits_the_verification_result`

New, `tests/unit/test_replay_journal_cli.py` (function level):

- `test_replay_export_as_json_summarises_the_receipt`
- `test_replay_export_human_output_unchanged_when_as_json_absent`
- `test_replay_publish_as_json_summarises_the_receipt`
- `test_replay_publish_human_output_unchanged_when_as_json_absent`
- `test_replay_verify_as_json_reports_the_verification_result`

```
$ uv run python -m pytest tests/unit/test_replay_cmd.py tests/unit/test_replay_journal_cli.py tests/unit/cli/test_advanced_cmd_paths.py tests/unit/test_replay_debug_cli.py tests/unit/test_replay_verify_cli.py -q
79 passed

$ uv run python -m pytest tests/unit/test_replay*.py tests/unit/core/replay/ tests/unit/cli/test_advanced_cmd_paths.py tests/unit/test_deterministic_store_replay.py tests/unit/test_wal_replay.py tests/unit/test_routes_replay_path_containment.py -q
246 passed
```

`ruff check`, `ruff format`, and `mypy src/bernstein/cli/commands/advanced_cmd.py src/bernstein/cli/commands/replay_cmd.py` all clean on the touched files.

## Docs

`docs/reference/cli/replay.md` is intentionally untouched — it's being rewritten in #3968 by a contributor right now, and two writers on one file would collide. Docs for this behaviour land in #3968 (in flight, coordinated in #3976). `docs/operations/replay.md` (a different file, operator-workflow doc, not in #3968's scope) had the same stale `-o RECEIPT` / `--opt-in` examples and is updated here to match.

Closes #3976
