### PR TITLE
fix: unblock the grouped dependency bump on lint and license review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -80,6 +80,24 @@ jobs:
           # additional grant, and the reviewer has no rule for LicenseRef-*
           # terms, so the compound fails as a whole. The package is the same
           # one already vendored at 6.x under the same terms.
+          #
+          # crosshair-tool declares "Apache-2.0 AND LicenseRef-scancode-psf-3.7.2
+          # AND MIT AND Python-2.0". Every named half is on the allow-list; the
+          # scancode LicenseRef is the PSF text the allow-list already accepts
+          # as PSF-2.0, under a version-specific identifier the reviewer has no
+          # rule for, so the compound fails as a whole. It is a dev-only
+          # dependency (concolic execution in the security test lane) and is
+          # never resolved into a wheel install.
+          #
+          # python-telegram-bot is LGPL-3.0 (its metadata also names GPL-3.0,
+          # which LGPL-3.0 incorporates by reference). It is an opt-in extra -
+          # `pip install 'bernstein[telegram]'` - so it is absent from a default
+          # install, is imported at arm's length rather than modified or
+          # statically linked, and its copyleft terms do not reach this
+          # project's own Apache-2.0 sources. Already present in the tree at
+          # 22.7 under identical terms; the bump is what made the reviewer look.
           allow-dependencies-licenses: >-
             pkg:githubactions/trufflesecurity/trufflehog,
-            pkg:pypi/protobuf
+            pkg:pypi/protobuf,
+            pkg:pypi/crosshair-tool,
+            pkg:pypi/python-telegram-bot

--- a/src/bernstein/core/identity/delegation_scope.py
+++ b/src/bernstein/core/identity/delegation_scope.py
@@ -422,7 +422,7 @@ def _parent_index(
     index: int,
     by_hmac: dict[str, int],
     genesis: str,
-) -> int | None | str:
+) -> int | str | None:
     """Resolve a hop's parent index.
 
     Returns the parent's index, ``None`` when the hop is a chain root, or an


### PR DESCRIPTION
#3979 (grouped `python-minor-and-patch` bump, 44 updates) fails two gates. Neither failure is the bump's fault, and neither belongs on a bot branch.

**Lint — RUF036.** ruff 0.15.8 flags `int | None | str` at `src/bernstein/core/identity/delegation_scope.py:425`. The union is reordered to `int | str | None`; identical in meaning, passes on both the current and the bumped ruff.

**Dependency review — licenses.** The reviewer only evaluates dependencies a PR *changes*, so the bump is the first time it has looked at these two. Both were already in the tree at the previous pins under identical terms.

| Package | Declared | Why exempt |
|---|---|---|
| `crosshair-tool` | `Apache-2.0 AND LicenseRef-scancode-psf-3.7.2 AND MIT AND Python-2.0` | Every named half is already allow-listed; the LicenseRef is the PSF text the list accepts as `PSF-2.0`, under a version-specific scancode alias the reviewer has no rule for, so the compound fails whole. Dev-only — concolic execution in the security test lane, never resolved into a wheel install |
| `python-telegram-bot` | `GPL-3.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND …` | LGPL-3.0 (the GPL-3.0 half is incorporated by reference). Opt-in extra — `pip install 'bernstein[telegram]'` — absent from a default install, imported at arm's length rather than modified or statically linked, so its terms do not reach this project's Apache-2.0 sources |

Neither exemption widens what the wheel ships. The reasoning is inline in the workflow next to the existing trufflehog and protobuf entries, so the next person reading the allow-list does not have to reconstruct it.

`docs/operations/ci-topology.md` regenerated by `scripts/gen_workflow_topology.py`.