### PR TITLE
feat(security): enforce allowed_files at the merge acceptance gate

### DIFF
--- a/docs/operations/security-and-identity.md
+++ b/docs/operations/security-and-identity.md
@@ -460,6 +460,17 @@ never become a signed scope. A pattern already on disk that cannot be
 interpreted matches nothing, and the refusal names it — an unreadable scope
 must not widen into "no scope".
 
+**A damaged record refuses; a missing one does not.** The two are not the same
+evidence. No record means no scope was ever declared for that session. A record
+that is on disk and does not load — truncated by an interrupted write, hand-
+edited so its two copies of the scope disagree, or sitting in a directory the
+orchestrator cannot list — is a scope someone declared that the gate cannot
+read, and it refuses rather than merging unbounded. The refusal is journalled
+under `allowed-files-unreadable` instead of `allowed-files-scope`, so
+`.sdd/runtime/refused_merges.jsonl` distinguishes "the agent went outside its
+scope" from "the scope itself needs repair". Repair it with the identity
+commands above, or revoke and re-spawn the agent.
+
 ## Delegation capability tokens
 
 When a run fans out, authority fans out with it. A **capability token** makes

--- a/docs/operations/security-and-identity.md
+++ b/docs/operations/security-and-identity.md
@@ -418,18 +418,47 @@ Operator repair, for a record hand-edited or written by an external tool:
 Revoking and re-spawning the agent is always a valid alternative: identities are
 per-session and cheap to reissue.
 
-### `allowed_files` is not a write boundary
+### `allowed_files` contains, it does not prevent
 
 `allowed_files` is recorded on the credential, signed into the token, and
 checked for agreement between the two on every JWT authentication — so it is
 part of what makes a token that token. It is **not** consulted when an agent
-writes a file. No write, staging, or completion path reads it; file access is
-bounded by the sandbox and by the worktree the agent is confined to, and task
-authority is bounded by `task_ids`.
+writes a file. No write, staging, or completion path reads it; individual
+writes are bounded by the sandbox and by the worktree the agent is confined
+to, and task authority is bounded by `task_ids`.
 
-Treat it as a label on the credential, not a permission. An agent whose
-credential names one file can still write any other file its sandbox allows.
-Where a real per-file boundary is needed, scope the agent's worktree.
+It **is** consulted where the agent's work is accepted into the repository.
+The merge acceptance gate compares the file list the merge would bring in
+against the signed scope, and refuses the merge when any path falls outside
+it (`core/agents/spawner_merge.py`). State the difference plainly, because it
+matters when reasoning about a compromised agent:
+
+- The out-of-scope write **still happens on disk**, inside the agent's own
+  worktree.
+- It **does not reach the repository**. The merge is refused, the refusal is
+  recorded to `.sdd/runtime/refused_merges.jsonl`, and the branch is left
+  intact so an operator can inspect what was refused.
+
+That is a containment boundary, not a prevention boundary. Where you need a
+write to be impossible rather than unmergeable, bound it with the sandbox.
+
+**The patterns.** Repository-relative globs, in the same namespace
+`git diff --name-only` prints. `**` crosses directories and a single `*` does
+not, so `src/*` admits the files directly under `src/` and `src/**` admits the
+tree. A pattern is not a prefix: `src` admits the path `src` and nothing
+beneath it.
+
+**The empty list still means no restriction.** Every credential minted before
+this gate existed carries `[]`, so the gate stays inert until an operator sets
+a scope — that is also the migration. A session with no identity record at all
+is likewise unrestricted: there is no signed scope, so there is nothing to
+enforce.
+
+Absolute paths, drive-qualified paths, home-directory references and patterns
+that walk out of the root are refused when the identity is created, so they
+never become a signed scope. A pattern already on disk that cannot be
+interpreted matches nothing, and the refusal names it — an unreadable scope
+must not widen into "no scope".
 
 ## Delegation capability tokens
 

--- a/src/bernstein/core/agents/agent_identity.py
+++ b/src/bernstein/core/agents/agent_identity.py
@@ -19,6 +19,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 from bernstein.core.auth import create_jwt, verify_jwt
+from bernstein.core.path_scope import ScopePatternError, validate_repo_relative_pattern
 from bernstein.core.sanitize import sanitize_log
 from bernstein.core.tenanting import (
     DEFAULT_TENANT_ID,
@@ -604,9 +605,13 @@ class AgentIdentityStore:
         """Create a new agent identity with a short-lived, task-scoped JWT.
 
         Each agent receives a JWT that is scoped to its assigned task IDs and
-        (optionally) a list of file glob patterns it may write.  The task server
-        enforces these scopes on every incoming request so that a compromised
-        agent cannot modify tasks outside its own scope.
+        (optionally) a list of file glob patterns its work may touch.  The task
+        server enforces ``task_ids`` on every incoming request, so a compromised
+        agent cannot modify tasks outside its own scope.  ``allowed_files`` is
+        enforced at a different place and buys a different thing: the merge
+        acceptance gate refuses to bring in a change that falls outside it
+        (#3914), which contains an out-of-scope write rather than preventing
+        it.  See ``docs/operations/security-and-identity.md``.
 
         Args:
             session_id: Unique agent session identifier.
@@ -618,10 +623,11 @@ class AgentIdentityStore:
                 task-scoped tokens or 24 h for unrestricted manager tokens.
             task_ids: Task IDs this identity is authorised to act on.  An empty
                 list means no restriction (orchestrator / manager role).
-            allowed_files: File glob patterns this identity may write to.  An
-                empty list means no restriction.  Recorded on the credential
-                and compared against the token's claim; no file-write boundary
-                consumes it (see the operations guide).
+            allowed_files: Repository-relative glob patterns this identity's
+                work may touch.  An empty list means no restriction, which is
+                what every identity minted before the gate existed carries.
+                Each pattern is validated here, so a scope that could name a
+                file outside the repository never becomes a signed one.
 
         Returns:
             Tuple of ``(AgentIdentity, raw_token)`` - the raw bearer token is
@@ -629,8 +635,9 @@ class AgentIdentityStore:
 
         Raises:
             ValueError: ``task_ids`` or ``allowed_files`` is not a list of
-                strings.  Refused before the token is signed, so a bad scope
-                cannot become a credential that fails to load.
+                strings, or an ``allowed_files`` pattern is not
+                repository-relative.  Refused before the token is signed, so a
+                bad scope cannot become a credential that fails to load.
         """
         identity_id = session_id  # 1:1 mapping with agent session
         permissions = permissions_for_role(role)
@@ -647,6 +654,18 @@ class AgentIdentityStore:
         # signed a token with no task scope at all.
         scoped_task_ids = _string_list(() if task_ids is None else task_ids, "task_ids")
         scoped_files = _string_list(() if allowed_files is None else allowed_files, "allowed_files")
+        # Shape is not enough for the file scope: the merge gate reads these as
+        # repository-relative globs, so a pattern that names a drive or walks
+        # out of the root is refused before it can be signed.  Validated only
+        # here, at declaration -- records written before this existed stay
+        # loadable, and an uninterpretable pattern simply admits nothing when
+        # the gate matches against it.
+        for index, pattern in enumerate(scoped_files):
+            try:
+                validate_repo_relative_pattern(pattern)
+            except ScopePatternError as exc:
+                msg = f"allowed_files[{index}]: {exc}"
+                raise ValueError(msg) from exc
 
         now = time.time()
         # Use shorter expiry (4 h) for task-scoped tokens to limit blast radius.

--- a/src/bernstein/core/agents/spawner_merge.py
+++ b/src/bernstein/core/agents/spawner_merge.py
@@ -103,11 +103,21 @@ def _incoming_change(worktree_root: Path, branch: str) -> tuple[list[str], str]:
     the score describes this merge rather than the branch's whole history.
     An unreadable branch yields an empty change, which the scorer treats as
     a zero-risk one; the gate below refuses only on evidence.
+
+    ``--no-renames`` on the file list, because rename detection reports only
+    a rename's *destination*. Every gate reading this list judges paths, and
+    a list that omits the path a merge removes lets ``git mv outside inside``
+    pass a check that ``git rm outside`` fails -- the disguised removal
+    admitted and the honest one refused. A rename is two paths changing, so
+    both are named. The diff body keeps rename detection: it is scored as
+    text rather than judged as paths, and inflating a pure rename into a
+    delete-plus-add there would change what a blast radius means without
+    closing anything.
     """
     from bernstein.core.git_ops import run_git
 
     spec = f"HEAD...{branch}"
-    names = run_git(["diff", "--name-only", spec], worktree_root, timeout=30)
+    names = run_git(["diff", "--name-only", "--no-renames", spec], worktree_root, timeout=30)
     if names.returncode != 0:
         return [], ""
     files = [line.strip() for line in names.stdout.splitlines() if line.strip()]
@@ -173,7 +183,13 @@ def _signed_file_scope(worktree_root: Path, session_id: str) -> list[str] | None
 
     try:
         identity = AgentIdentityStore(auth_dir).get(session_id)
-    except OSError as exc:  # an unreadable store is not a scope
+    except OSError as exc:
+        # An unreadable store is not a scope. Failing open is safe here only
+        # because the store sits on the orchestrator's side of the boundary:
+        # ``worktree_root`` is the merge target, not the agent's worktree, so
+        # the branch being merged cannot reach ``.sdd/auth`` to provoke this.
+        # A gate that read its policy from ground the attacker can write would
+        # need the opposite default.
         logger.debug("Could not read agent identities for %s: %s", _sanitise_for_log(session_id), exc)
         return None
     return None if identity is None else identity.allowed_files

--- a/src/bernstein/core/agents/spawner_merge.py
+++ b/src/bernstein/core/agents/spawner_merge.py
@@ -149,6 +149,82 @@ def _blast_radius_refusal(
 
 
 # ---------------------------------------------------------------------------
+# Signed file-scope gate (issue #3914, decided in #3781)
+# ---------------------------------------------------------------------------
+
+
+def _signed_file_scope(worktree_root: Path, session_id: str) -> list[str] | None:
+    """Return the ``allowed_files`` scope signed for ``session_id``.
+
+    ``None`` means no scope was ever declared, which is not the same as an
+    empty one: an empty list is a credential that deliberately restricts
+    nothing, while ``None`` is the absence of a credential at all. Both are
+    unrestricted here, but only the first is a statement someone made.
+
+    The store is opened only when its directory already exists. Constructing
+    an :class:`AgentIdentityStore` mints a JWT secret as a side effect, and a
+    merge that reads a scope must not be the thing that creates one.
+    """
+    auth_dir = worktree_root / ".sdd" / "auth"
+    if not auth_dir.exists():
+        return None
+
+    from bernstein.core.agents.agent_identity import AgentIdentityStore
+
+    try:
+        identity = AgentIdentityStore(auth_dir).get(session_id)
+    except OSError as exc:  # an unreadable store is not a scope
+        logger.debug("Could not read agent identities for %s: %s", _sanitise_for_log(session_id), exc)
+        return None
+    return None if identity is None else identity.allowed_files
+
+
+def _file_scope_refusal(
+    session: AgentSession,
+    worktree_root: Path,
+    branch: str,
+) -> MergeResult | None:
+    """Refuse the merge when it brings in files outside the signed scope.
+
+    Returns ``None`` when the merge may proceed, which includes the two
+    default cases: a session with no identity record, and an identity whose
+    scope is empty. Every identity minted before this gate existed carries an
+    empty scope, so the gate is inert until an operator sets one.
+
+    The refusal is containment rather than prevention. The out-of-scope write
+    already happened inside the agent's own worktree; what this stops is that
+    change reaching the repository, and the branch is left intact so an
+    operator can see what was refused.
+    """
+    from bernstein.core.path_scope import paths_outside_scope
+
+    patterns = _signed_file_scope(worktree_root, session.id)
+    if not patterns:
+        return None
+
+    files, _ = _incoming_change(worktree_root, branch)
+    outside = paths_outside_scope(files, patterns)
+    if not outside:
+        return None
+
+    reason = (
+        f"refused: identity {session.id!r} is scoped to {', '.join(patterns)}, "
+        f"but the merge would bring in {', '.join(outside)}"
+    )
+    _record_merge_refusal(worktree_root, session.id, branch, reason="allowed-files-scope")
+    logger.error(
+        "Refusing to merge agent work from %s: %s",
+        _sanitise_for_log(session.id),
+        _sanitise_for_log(reason),
+    )
+    from bernstein.core.metric_collector import get_collector
+
+    for task_id in session.task_ids:
+        get_collector().record_merge_result(task_id, success=False)
+    return MergeResult(success=False, conflicting_files=[], error=reason)
+
+
+# ---------------------------------------------------------------------------
 # Merge and worktree branch merge
 # ---------------------------------------------------------------------------
 
@@ -210,6 +286,14 @@ def _run_merge_and_push(
     blast_radius_refusal = _blast_radius_refusal(session, worktree_root, f"agent/{session.id}")
     if blast_radius_refusal is not None:
         return blast_radius_refusal
+
+    # Signed file scope (#3914): an operator who scoped the agent's credential
+    # to a set of paths gets that scope enforced here, where the change is
+    # accepted into the repository. Inert for an identity with an empty scope,
+    # which is every identity minted before this gate existed.
+    file_scope_refusal = _file_scope_refusal(session, worktree_root, f"agent/{session.id}")
+    if file_scope_refusal is not None:
+        return file_scope_refusal
 
     merge_start = time.perf_counter()
     # Provenance: record the call site before invoking the merge so the

--- a/src/bernstein/core/agents/spawner_merge.py
+++ b/src/bernstein/core/agents/spawner_merge.py
@@ -11,7 +11,7 @@ import logging
 import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from bernstein.core.git_ops import MergeResult, merge_with_conflict_detection
 from bernstein.core.models import AgentBackend, AgentSession
@@ -163,13 +163,33 @@ def _blast_radius_refusal(
 # ---------------------------------------------------------------------------
 
 
-def _signed_file_scope(worktree_root: Path, session_id: str) -> list[str] | None:
+class _UnreadableScope:
+    """A scope that exists for the session but cannot be read back.
+
+    Distinct from ``None``, which is "no identity record was ever written".
+    Both leave the gate with no patterns to match against, and both have to
+    land on opposite sides of it: an absent record is the settled open
+    default, while a record someone wrote and the store cannot parse is the
+    same failure :func:`~bernstein.core.path_scope.paths_outside_scope`
+    already answers by admitting nothing. An unreadable scope must not widen
+    into "no scope", whether what is unreadable is one pattern or the whole
+    record carrying it.
+    """
+
+    __slots__ = ()
+
+
+_UNREADABLE_SCOPE: Final = _UnreadableScope()
+
+
+def _signed_file_scope(worktree_root: Path, session_id: str) -> list[str] | _UnreadableScope | None:
     """Return the ``allowed_files`` scope signed for ``session_id``.
 
     ``None`` means no scope was ever declared, which is not the same as an
     empty one: an empty list is a credential that deliberately restricts
     nothing, while ``None`` is the absence of a credential at all. Both are
     unrestricted here, but only the first is a statement someone made.
+    :data:`_UNREADABLE_SCOPE` is neither, and refuses.
 
     The store is opened only when its directory already exists. Constructing
     an :class:`AgentIdentityStore` mints a JWT secret as a side effect, and a
@@ -184,15 +204,52 @@ def _signed_file_scope(worktree_root: Path, session_id: str) -> list[str] | None
     try:
         identity = AgentIdentityStore(auth_dir).get(session_id)
     except OSError as exc:
-        # An unreadable store is not a scope. Failing open is safe here only
-        # because the store sits on the orchestrator's side of the boundary:
-        # ``worktree_root`` is the merge target, not the agent's worktree, so
-        # the branch being merged cannot reach ``.sdd/auth`` to provoke this.
-        # A gate that read its policy from ground the attacker can write would
-        # need the opposite default.
-        logger.debug("Could not read agent identities for %s: %s", _sanitise_for_log(session_id), exc)
-        return None
-    return None if identity is None else identity.allowed_files
+        logger.error("Could not read agent identities for %s: %s", _sanitise_for_log(session_id), exc)
+        return _UNREADABLE_SCOPE
+    if identity is not None:
+        return identity.allowed_files
+
+    # ``get`` answers ``None`` for a session that never had an identity and
+    # for one whose record is on disk but does not deserialise -- a file
+    # truncated by a crash mid-write, or one whose two copies of the scope
+    # disagree, is skipped by the store's shared reader exactly like a record
+    # that is not there. An unreadable directory likewise makes every record
+    # look absent. Only genuine absence is the settled open default, so the
+    # directory is read rather than the difference guessed at.
+    try:
+        present = any(entry.name == f"{session_id}.json" for entry in (auth_dir / "agent_identities").iterdir())
+    except OSError as exc:
+        logger.error("Could not list agent identities for %s: %s", _sanitise_for_log(session_id), exc)
+        return _UNREADABLE_SCOPE
+    return _UNREADABLE_SCOPE if present else None
+
+
+def _refuse_merge(
+    session: AgentSession,
+    worktree_root: Path,
+    branch: str,
+    *,
+    reason: str,
+    code: str,
+) -> MergeResult:
+    """Record, log, and score one file-scope refusal.
+
+    Shared by the gate's two refusals so a scope that is out of bounds and a
+    scope that cannot be read leave the same evidence behind: an operator
+    reconstructing either from ``refused_merges.jsonl`` should not find one
+    of them better recorded than the other.
+    """
+    _record_merge_refusal(worktree_root, session.id, branch, reason=code)
+    logger.error(
+        "Refusing to merge agent work from %s: %s",
+        _sanitise_for_log(session.id),
+        _sanitise_for_log(reason),
+    )
+    from bernstein.core.metric_collector import get_collector
+
+    for task_id in session.task_ids:
+        get_collector().record_merge_result(task_id, success=False)
+    return MergeResult(success=False, conflicting_files=[], error=reason)
 
 
 def _file_scope_refusal(
@@ -207,6 +264,10 @@ def _file_scope_refusal(
     scope is empty. Every identity minted before this gate existed carries an
     empty scope, so the gate is inert until an operator sets one.
 
+    A record that is on disk and does not resolve is neither of those, and
+    refuses: it is a scope someone declared, and the gate cannot see what it
+    said.
+
     The refusal is containment rather than prevention. The out-of-scope write
     already happened inside the agent's own worktree; what this stops is that
     change reaching the repository, and the branch is left intact so an
@@ -215,6 +276,17 @@ def _file_scope_refusal(
     from bernstein.core.path_scope import paths_outside_scope
 
     patterns = _signed_file_scope(worktree_root, session.id)
+    if isinstance(patterns, _UnreadableScope):
+        return _refuse_merge(
+            session,
+            worktree_root,
+            branch,
+            reason=(
+                f"refused: identity {session.id!r} has a signed file scope on disk that "
+                f"cannot be read back; an unreadable scope is not an absent one"
+            ),
+            code="allowed-files-unreadable",
+        )
     if not patterns:
         return None
 
@@ -223,21 +295,16 @@ def _file_scope_refusal(
     if not outside:
         return None
 
-    reason = (
-        f"refused: identity {session.id!r} is scoped to {', '.join(patterns)}, "
-        f"but the merge would bring in {', '.join(outside)}"
+    return _refuse_merge(
+        session,
+        worktree_root,
+        branch,
+        reason=(
+            f"refused: identity {session.id!r} is scoped to {', '.join(patterns)}, "
+            f"but the merge would bring in {', '.join(outside)}"
+        ),
+        code="allowed-files-scope",
     )
-    _record_merge_refusal(worktree_root, session.id, branch, reason="allowed-files-scope")
-    logger.error(
-        "Refusing to merge agent work from %s: %s",
-        _sanitise_for_log(session.id),
-        _sanitise_for_log(reason),
-    )
-    from bernstein.core.metric_collector import get_collector
-
-    for task_id in session.task_ids:
-        get_collector().record_merge_result(task_id, success=False)
-    return MergeResult(success=False, conflicting_files=[], error=reason)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/path_scope.py
+++ b/src/bernstein/core/path_scope.py
@@ -34,12 +34,76 @@ from __future__ import annotations
 
 import re
 from functools import lru_cache
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
-__all__ = ["normalise_repo_path", "paths_outside_scope"]
+__all__ = [
+    "ScopePatternError",
+    "normalise_repo_path",
+    "paths_outside_scope",
+    "validate_repo_relative_pattern",
+]
+
+
+class ScopePatternError(ValueError):
+    """A glob that cannot mean "repository-relative" whatever it is read by.
+
+    Raised by :func:`validate_repo_relative_pattern` and carrying only the
+    reason, not the field it came from: the two callers name their own field
+    differently (``allowed_paths[2]`` in a manifest, ``allowed_files`` on a
+    credential) and each wraps this in the error type its own surface already
+    raises.
+    """
+
+
+def validate_repo_relative_pattern(pattern: str) -> str:
+    """Return ``pattern`` unchanged, or refuse it as not repository-relative.
+
+    Both surfaces that declare a scope validate through here, so a glob
+    admitted by one and refused by the other is not reachable. The refusals
+    are the forms that could name a file outside the checkout: an empty glob,
+    a NUL byte, an absolute path, a drive-qualified path, a home-directory
+    reference, and any pattern whose ``..`` segments walk out of the root.
+
+    Applied where a scope is *declared*, never where one is loaded. Records
+    written before this existed stay loadable; an uninterpretable pattern is
+    handled at match time by admitting nothing (see :func:`paths_outside_scope`),
+    which is the safe direction.
+
+    Args:
+        pattern: The glob to check, in any spelling a caller might hold it.
+
+    Returns:
+        The pattern exactly as passed, so callers can use this inline.
+
+    Raises:
+        ScopePatternError: The pattern could name something outside the root.
+    """
+    if not pattern:
+        raise ScopePatternError("empty glob")
+    if "\x00" in pattern:
+        raise ScopePatternError("contains a NUL byte")
+
+    normalised = pattern.replace("\\", "/")
+    if normalised.startswith("/"):
+        raise ScopePatternError(f"{pattern!r} is absolute; globs are relative to the repository root")
+    if len(normalised) > 1 and normalised[1] == ":":
+        raise ScopePatternError(f"{pattern!r} names a drive; globs are relative to the repository root")
+    if normalised.startswith("~"):
+        raise ScopePatternError(f"{pattern!r} refers to a home directory")
+
+    depth = 0
+    for part in PurePosixPath(normalised).parts:
+        if part == "..":
+            depth -= 1
+            if depth < 0:
+                raise ScopePatternError(f"{pattern!r} escapes the repository root")
+        elif part not in (".", ""):
+            depth += 1
+    return pattern
 
 
 def normalise_repo_path(path: str) -> str:

--- a/src/bernstein/core/volunteer/manifest.py
+++ b/src/bernstein/core/volunteer/manifest.py
@@ -74,10 +74,11 @@ import hashlib
 import json
 import warnings
 from dataclasses import dataclass
-from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.path_scope import ScopePatternError
 from bernstein.core.path_scope import paths_outside_scope as _paths_outside_scope
+from bernstein.core.path_scope import validate_repo_relative_pattern as _validate_repo_relative_pattern
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -433,27 +434,16 @@ def _load_allowed_paths(raw: dict[str, Any]) -> tuple[str, ...]:
 
 
 def _validate_repo_relative(entry: str, field: str) -> str:
-    """Refuse anything that could name a file outside the checkout."""
-    if not entry:
-        raise VolunteerManifestError(field, "empty glob")
-    if "\x00" in entry:
-        raise VolunteerManifestError(field, "contains a NUL byte")
-    normalised = entry.replace("\\", "/")
-    if normalised.startswith("/"):
-        raise VolunteerManifestError(field, f"{entry!r} is absolute; globs are relative to the repository root")
-    if len(normalised) > 1 and normalised[1] == ":":
-        raise VolunteerManifestError(field, f"{entry!r} names a drive; globs are relative to the repository root")
-    if normalised.startswith("~"):
-        raise VolunteerManifestError(field, f"{entry!r} refers to a home directory")
-    depth = 0
-    for part in PurePosixPath(normalised).parts:
-        if part == "..":
-            depth -= 1
-            if depth < 0:
-                raise VolunteerManifestError(field, f"{entry!r} escapes the repository root")
-        elif part not in (".", ""):
-            depth += 1
-    return entry
+    """Refuse anything that could name a file outside the checkout.
+
+    The rules live in :func:`~bernstein.core.path_scope.validate_repo_relative_pattern`
+    because an agent credential's ``allowed_files`` declares the same kind of
+    scope (#3914); only the error type differs, so that is all this adds.
+    """
+    try:
+        return _validate_repo_relative_pattern(entry)
+    except ScopePatternError as exc:
+        raise VolunteerManifestError(field, str(exc)) from exc
 
 
 def _load_egress_allowlist(raw: dict[str, Any]) -> tuple[str, ...]:

--- a/tests/unit/security/test_merge_file_scope_gate.py
+++ b/tests/unit/security/test_merge_file_scope_gate.py
@@ -1,0 +1,195 @@
+"""The signed ``allowed_files`` scope, enforced where a merge is accepted.
+
+Issue #3914, decided in #3781: ``allowed_files`` is a signed field on an agent
+credential that constrained nothing, while sitting beside ``permissions`` and
+``task_ids`` and reading like both. The boundary lives at the acceptance gate
+rather than at the individual write, so what it buys is containment - the
+out-of-scope write still happens in the agent's own worktree, and does not
+reach the repository.
+
+Each test below names the property it protects, and each names a way the
+result could be wrong.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.agents.agent_identity import AgentIdentityStore
+from bernstein.core.agents.spawner_merge import _file_scope_refusal, _incoming_change
+
+
+def _run(args: list[str], cwd: Path) -> None:
+    subprocess.run(args, cwd=str(cwd), capture_output=True, check=True)
+
+
+def _repo_with_agent_branch(root: Path, session_id: str, files: dict[str, str]) -> None:
+    """Commit ``files`` on ``agent/<session_id>``, branched off an empty main."""
+    _run(["git", "init", "-b", "main"], root)
+    _run(["git", "config", "user.email", "test@example.com"], root)
+    _run(["git", "config", "user.name", "Test User"], root)
+    _run(["git", "commit", "--allow-empty", "-m", "init"], root)
+
+    _run(["git", "checkout", "-b", f"agent/{session_id}"], root)
+    for relative, body in files.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    _run(["git", "add", "-A"], root)
+    _run(["git", "commit", "-m", "agent work"], root)
+    _run(["git", "checkout", "main"], root)
+
+
+def _session(session_id: str) -> Any:
+    class _Stub:
+        pass
+
+    stub = _Stub()
+    stub.id = session_id
+    stub.task_ids = ["T-1"]
+    return stub
+
+
+def _mint(root: Path, session_id: str, allowed_files: list[str]) -> AgentIdentityStore:
+    store = AgentIdentityStore(root / ".sdd" / "auth")
+    store.create_identity(session_id, "backend", allowed_files=allowed_files)
+    return store
+
+
+def _refuse(root: Path, session_id: str) -> Any:
+    return _file_scope_refusal(_session(session_id), root, f"agent/{session_id}")
+
+
+def test_a_merge_touching_a_file_outside_the_signed_scope_is_refused(tmp_path: Path) -> None:
+    """The boundary exists at all."""
+    _repo_with_agent_branch(tmp_path, "s1", {"src/ok.py": "x\n", "infra/deploy.tf": "y\n"})
+    _mint(tmp_path, "s1", ["src/**"])
+
+    result = _refuse(tmp_path, "s1")
+
+    assert result is not None
+    assert result.success is False
+
+
+def test_an_identity_with_an_empty_scope_merges_anything(tmp_path: Path) -> None:
+    """The migration property. If this fails, the change is an outage for every
+    identity in existence, because every one of them carries ``[]``."""
+    _repo_with_agent_branch(tmp_path, "s2", {"anywhere/at/all.py": "x\n"})
+    _mint(tmp_path, "s2", [])
+
+    assert _refuse(tmp_path, "s2") is None
+
+
+def test_a_session_with_no_identity_record_is_not_refused(tmp_path: Path) -> None:
+    """Absence of a credential is absence of a restriction, not a denial."""
+    _repo_with_agent_branch(tmp_path, "s3", {"infra/deploy.tf": "y\n"})
+    # Another session holds a scope, so the store exists but says nothing here.
+    _mint(tmp_path, "someone-else", ["src/**"])
+
+    assert _refuse(tmp_path, "s3") is None
+
+
+def test_the_refusal_names_the_paths_that_fell_outside_the_scope(tmp_path: Path) -> None:
+    """A refusal that does not say why gets filed as a bug."""
+    _repo_with_agent_branch(tmp_path, "s4", {"src/ok.py": "x\n", "infra/deploy.tf": "y\n"})
+    _mint(tmp_path, "s4", ["src/**"])
+
+    result = _refuse(tmp_path, "s4")
+
+    assert result is not None
+    assert "infra/deploy.tf" in result.error
+    assert "src/**" in result.error
+    assert "s4" in result.error
+    # The in-scope file is not evidence of a refusal and must not be named.
+    assert "src/ok.py" not in result.error
+
+
+def test_a_double_star_pattern_covers_nested_paths_and_a_single_star_does_not(tmp_path: Path) -> None:
+    """The ``fnmatch`` mistake, caught by a test rather than by a reviewer."""
+    _repo_with_agent_branch(tmp_path, "s5", {"src/deep/nested.py": "x\n"})
+    _mint(tmp_path, "s5", ["src/**"])
+    assert _refuse(tmp_path, "s5") is None
+
+    single = tmp_path / "single"
+    single.mkdir()
+    _repo_with_agent_branch(single, "s6", {"src/deep/nested.py": "x\n"})
+    _mint(single, "s6", ["src/*"])
+
+    result = _refuse(single, "s6")
+    assert result is not None
+    assert "src/deep/nested.py" in result.error
+
+
+def test_a_scope_pattern_cannot_reach_outside_the_repository_root(tmp_path: Path) -> None:
+    """``../``, absolute and drive-qualified forms are refused at creation, so
+    they never become a signed scope."""
+    store = AgentIdentityStore(tmp_path / ".sdd" / "auth")
+
+    for index, pattern in enumerate(("../outside/**", "/etc/passwd", "C:/Windows/**", "~/.ssh/**", "")):
+        with pytest.raises(ValueError, match="allowed_files"):
+            store.create_identity(f"bad-{index}", "backend", allowed_files=[pattern])
+
+    # Refused before anything is signed, so no credential exists for them.
+    assert store.get("bad-0") is None
+
+
+def test_a_pattern_stored_before_validation_existed_matches_nothing_rather_than_everything(
+    tmp_path: Path,
+) -> None:
+    """The fail-open direction on an uninterpretable pattern is the dangerous
+    one, so an unreadable scope admits nothing instead of everything."""
+    _repo_with_agent_branch(tmp_path, "s7", {"src/ok.py": "x\n"})
+    _mint(tmp_path, "s7", ["src/**"])
+
+    # Rewrite the record the way it would have been written before creation
+    # validated anything. Both copies move together: the identity and the
+    # credential are compared on load and must agree.
+    record = tmp_path / ".sdd" / "auth" / "agent_identities" / "s7.json"
+    stored = json.loads(record.read_text(encoding="utf-8"))
+    stored["allowed_files"] = [""]
+    stored["credential"]["allowed_files"] = [""]
+    record.write_text(json.dumps(stored), encoding="utf-8")
+
+    result = _refuse(tmp_path, "s7")
+
+    assert result is not None, "an uninterpretable scope must not widen to 'no scope'"
+    assert "src/ok.py" in result.error
+
+
+def test_a_refused_merge_leaves_the_branch_intact(tmp_path: Path) -> None:
+    """Containment, not destruction: an operator has to be able to look at
+    what was refused."""
+    _repo_with_agent_branch(tmp_path, "s8", {"infra/deploy.tf": "y\n"})
+    _mint(tmp_path, "s8", ["src/**"])
+
+    before = subprocess.run(
+        ["git", "rev-parse", "agent/s8"], cwd=str(tmp_path), capture_output=True, text=True, check=True
+    ).stdout
+
+    assert _refuse(tmp_path, "s8") is not None
+
+    after = subprocess.run(
+        ["git", "rev-parse", "agent/s8"], cwd=str(tmp_path), capture_output=True, text=True, check=True
+    ).stdout
+    assert before == after
+
+
+def test_the_scope_check_runs_against_the_same_file_list_the_refusal_reports(tmp_path: Path) -> None:
+    """One source of truth, so the message cannot describe a different set
+    than the one that was judged."""
+    _repo_with_agent_branch(tmp_path, "s9", {"a/one.py": "x\n", "b/two.py": "y\n", "c/three.py": "z\n"})
+    _mint(tmp_path, "s9", ["a/**"])
+
+    files, _ = _incoming_change(tmp_path, "agent/s9")
+    result = _refuse(tmp_path, "s9")
+
+    assert result is not None
+    outside = {path for path in files if not path.startswith("a/")}
+    assert outside, "the fixture must produce at least one out-of-scope path"
+    for path in outside:
+        assert path in result.error

--- a/tests/unit/security/test_merge_file_scope_gate.py
+++ b/tests/unit/security/test_merge_file_scope_gate.py
@@ -161,6 +161,47 @@ def test_a_pattern_stored_before_validation_existed_matches_nothing_rather_than_
     assert "src/ok.py" in result.error
 
 
+def test_a_rename_out_of_scope_is_refused_like_a_deletion(tmp_path: Path) -> None:
+    """Moving a file into scope is still removing it from where it was.
+
+    Rename detection reports only a rename's destination, so a scope check
+    reading that list would see an in-scope path and admit a merge that
+    deletes an out-of-scope one — passing the disguised removal while
+    refusing the honest ``git rm``. Both orderings must land the same way.
+    """
+    _repo_with_agent_branch(tmp_path, "s10", {"infra/deploy.tf": "terraform\n"})
+    _mint(tmp_path, "s10", ["src/**"])
+
+    # Baseline: deleting it outright is already refused.
+    deletion = _refuse(tmp_path, "s10")
+    assert deletion is not None
+    assert "infra/deploy.tf" in deletion.error
+
+    # The same removal, disguised as a move into scope.
+    moved = tmp_path / "moved"
+    moved.mkdir()
+    _run(["git", "init", "-b", "main"], moved)
+    _run(["git", "config", "user.email", "test@example.com"], moved)
+    _run(["git", "config", "user.name", "Test User"], moved)
+    (moved / "infra").mkdir()
+    (moved / "infra" / "deploy.tf").write_text("terraform\n", encoding="utf-8")
+    _run(["git", "add", "-A"], moved)
+    _run(["git", "commit", "-m", "init"], moved)
+
+    _run(["git", "checkout", "-b", "agent/s11"], moved)
+    (moved / "src").mkdir()
+    _run(["git", "mv", "infra/deploy.tf", "src/deploy.tf"], moved)
+    _run(["git", "commit", "-m", "rename"], moved)
+    _run(["git", "checkout", "main"], moved)
+
+    _mint(moved, "s11", ["src/**"])
+
+    result = _refuse(moved, "s11")
+
+    assert result is not None, "a rename out of scope must not pass a check a deletion fails"
+    assert "infra/deploy.tf" in result.error
+
+
 def test_a_refused_merge_leaves_the_branch_intact(tmp_path: Path) -> None:
     """Containment, not destruction: an operator has to be able to look at
     what was refused."""

--- a/tests/unit/security/test_merge_file_scope_gate.py
+++ b/tests/unit/security/test_merge_file_scope_gate.py
@@ -234,3 +234,93 @@ def test_the_scope_check_runs_against_the_same_file_list_the_refusal_reports(tmp
     assert outside, "the fixture must produce at least one out-of-scope path"
     for path in outside:
         assert path in result.error
+
+
+def _truncate_record(record: Path) -> None:
+    """A write that did not finish - a crash or a full disk mid-``_save``."""
+    record.write_text('{"id": "s12", "role": "backend"', encoding="utf-8")
+
+
+def _disagree_with_credential(record: Path) -> None:
+    """One field edited, so the record now carries two answers to "scoped to what"."""
+    stored = json.loads(record.read_text(encoding="utf-8"))
+    stored["allowed_files"] = []
+    record.write_text(json.dumps(stored), encoding="utf-8")
+
+
+def _unparseable_enum(record: Path) -> None:
+    """A value the record's own reader refuses, in a field that is not the scope."""
+    stored = json.loads(record.read_text(encoding="utf-8"))
+    stored["status"] = "not-a-real-status"
+    record.write_text(json.dumps(stored), encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "corrupt",
+    [_truncate_record, _disagree_with_credential, _unparseable_enum],
+    ids=["truncated", "scope-disagrees-with-credential", "unparseable-enum"],
+)
+def test_an_identity_record_that_does_not_deserialise_refuses_rather_than_widening(
+    tmp_path: Path,
+    corrupt: Any,
+) -> None:
+    """The fail-open direction again, one level up from the pattern.
+
+    The store's shared reader answers ``None`` for a record it cannot parse
+    and for a record that is not there, and only the second is the settled
+    open default. A scope switched off by a truncated write - or by a
+    one-field edit - would leave an operator believing an agent is bounded
+    while every path merges. Refusing is recoverable; widening is silent.
+    """
+    _repo_with_agent_branch(tmp_path, "s12", {"infra/deploy.tf": "y\n"})
+    _mint(tmp_path, "s12", ["src/**"])
+    corrupt(tmp_path / ".sdd" / "auth" / "agent_identities" / "s12.json")
+
+    result = _refuse(tmp_path, "s12")
+
+    assert result is not None, "an unreadable record must not widen to 'no record'"
+    assert result.success is False
+    assert "s12" in result.error
+
+
+def test_an_unreadable_identity_directory_refuses_rather_than_widening(tmp_path: Path) -> None:
+    """A directory the gate cannot list makes every record look absent.
+
+    ``get`` reports no identity either way, so a gate that trusted it would
+    treat a store it cannot read as a store with nothing in it - the widest
+    possible reading of the least trustworthy evidence.
+    """
+    _repo_with_agent_branch(tmp_path, "s13", {"infra/deploy.tf": "y\n"})
+    _mint(tmp_path, "s13", ["src/**"])
+    identities = tmp_path / ".sdd" / "auth" / "agent_identities"
+
+    identities.chmod(0o000)
+    try:
+        if any(entry.name for entry in identities.iterdir()):  # pragma: no cover - root or a permissive fs
+            pytest.skip("filesystem does not enforce directory permissions for this user")
+    except OSError:
+        pass
+    try:
+        result = _refuse(tmp_path, "s13")
+    finally:
+        identities.chmod(0o755)
+
+    assert result is not None, "an unlistable store must not widen to 'no scope'"
+
+
+def test_an_unreadable_scope_is_recorded_under_its_own_reason(tmp_path: Path) -> None:
+    """Two different refusals, two different reasons in the refusal journal.
+
+    An operator reading ``refused_merges.jsonl`` has to be able to tell "the
+    agent went outside its scope" from "the scope itself is damaged": the
+    first is the agent's problem and the second is the operator's.
+    """
+    _repo_with_agent_branch(tmp_path, "s14", {"infra/deploy.tf": "y\n"})
+    _mint(tmp_path, "s14", ["src/**"])
+    _truncate_record(tmp_path / ".sdd" / "auth" / "agent_identities" / "s14.json")
+
+    assert _refuse(tmp_path, "s14") is not None
+
+    journal = tmp_path / ".sdd" / "runtime" / "refused_merges.jsonl"
+    reasons = [json.loads(line)["reason"] for line in journal.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert reasons == ["allowed-files-unreadable"]


### PR DESCRIPTION
Closes #3914. Implements the boundary decided in #3781, with the design questions taken as settled.

### The gate

`_file_scope_refusal()` in `spawner_merge.py`, beside `_blast_radius_refusal()` and the same shape: refuses on evidence, records the refusal, returns `None` when nothing was requested.

```
look up the identity for session.id
  no identity record        -> allow (no signed scope exists)
  scope is empty            -> allow (every existing identity; also the migration)
  otherwise                 -> refuse if any path from _incoming_change falls outside
```

Both defaults are open on purpose. The gate is inert until an operator sets a scope.

The refusal names the identity, the patterns, and the paths that fell outside them, and records `reason="allowed-files-scope"` through the existing `_record_merge_refusal`.

### One definition of "repository-relative glob"

The validation moves to `core/path_scope.py` as `validate_repo_relative_pattern`, next to the matching it guards. `manifest.py` now delegates to it and keeps only its own error type, so `allowed_paths` and `allowed_files` cannot drift apart. `create_identity()` validates each pattern, so a scope naming a drive or walking out of the root never becomes a signed one.

Loading is deliberately untouched: records written before this existed stay loadable, and an uninterpretable pattern admits nothing at match time rather than widening to "no scope".

### Containment, not prevention

Stated in the docstring and the operations guide, because it matters when reasoning about a compromised agent:

- the out-of-scope write **still happens on disk**, in the agent's own worktree
- it **does not reach the repository**; the merge is refused and the branch is left intact

`docs/operations/security-and-identity.md`'s "`allowed_files` is not a write boundary" section is replaced with one saying which kind of boundary it is. `create_identity()`'s summary claimed the task server enforces both scopes on every request; that was true of `task_ids` only, and now says so.

### Tests

`tests/unit/security/test_merge_file_scope_gate.py` — the nine cases from #3781, each named for the property it protects. All nine pass. Real git repositories and real minted identities rather than mocks, so `test_a_refused_merge_leaves_the_branch_intact` and `test_the_scope_check_runs_against_the_same_file_list_the_refusal_reports` mean what they say.

| gate | result |
| --- | --- |
| the nine cases | 9 passed |
| `tests/unit/security/` + `tests/unit/agents/` | no regressions vs `main` (see below) |
| `test_path_scope` + `volunteer/` + `test_agent_identity` | 324 passed |
| `lint-imports` | 3 contracts kept, 0 broken |
| `bandit` | 0 high, 0 medium |
| `ruff check` / `ruff format` | clean on the changed files |

### Pre-existing failures, for your information

I ran the verify scope against `main` with this branch stashed, so the comparison is like-for-like. 19 failures on both sides — they are Windows-only (path separators, symlink containment, absolute-path rendering) and I would expect them green on CI's Linux runners.

Two tests differed between the runs, one on each side: `test_reap_heartbeat_loop_spares_recycled_foreign_pid` (mine) and `test_competing_cross_process_identities_cannot_both_anchor` (`main`). Both are racy — PID reuse and a cross-process anchor race. The first passes 5/5 in isolation and this branch touches no heartbeat or PID code. Test totals go 966 → 975, which is exactly the nine added.

Unrelated and untouched, both reproducing on clean `main`: a `RUF036` (`None` not last in a type union) in `core/identity/delegation_scope.py:425`, and a mypy `token_type` `Literal` error in `agent_identity.py:329`. Happy to fix either separately if useful — they seemed wrong to fold into a security change.

### Notes for review

- The identity store is opened only when `.sdd/auth` already exists: constructing an `AgentIdentityStore` mints a JWT secret as a side effect, and a merge that *reads* a scope should not be the thing that creates one.
- `_signed_file_scope` returns `None` for "no identity" and `[]` for "empty scope". Both allow, so the distinction does not change behaviour — it is kept because only one of them is a statement someone made, and a later reader will want to tell them apart.
