### PR TITLE
fix(lint): move None to the end of the delegation-scope return union

### DIFF
--- a/src/bernstein/core/identity/delegation_scope.py
+++ b/src/bernstein/core/identity/delegation_scope.py
@@ -422,7 +422,7 @@ def _parent_index(
     index: int,
     by_hmac: dict[str, int],
     genesis: str,
-) -> int | None | str:
+) -> int | str | None:
     """Resolve a hop's parent index.
 
     Returns the parent's index, ``None`` when the hop is a chain root, or an


### PR DESCRIPTION
\`_parent_index\` in \`delegation_scope.py\` returns \`int | None | str\`. A
newer ruff enables RUF036 (None must sit last in a union) and flags it;
the fix just reorders the annotation to \`int | str | None\` — identical
type, no behavior change.

Scoped identity/delegation tests pass locally (78 passed).