### PR TITLE
fix(security): refuse a persisted credential token_type outside the literal

### DIFF
--- a/src/bernstein/core/agents/agent_identity.py
+++ b/src/bernstein/core/agents/agent_identity.py
@@ -301,6 +301,16 @@ def _credential_token_type(raw: Any) -> Literal["opaque", "jwt"]:
     would rewrite a security-relevant field on the way in and lose the fact
     that the store holds something nothing wrote.
 
+    The ``isinstance`` check is what makes that refusal reachable for every
+    stored shape rather than most of them.  A membership test hashes its left
+    operand, and JSON persists two values that cannot be hashed: a list and
+    an object.  Without the guard those two raise ``TypeError: unhashable
+    type: 'list'`` out of the lookup itself - caught by
+    :meth:`AgentIdentityStore._read_identity` like any other refusal, so the
+    store stays readable, but naming neither the field nor the value, which
+    is the whole point of the message below.  It is also the shape
+    :func:`_credential_tenant_id` beside it already uses.
+
     Args:
         raw: The stored value, or ``"opaque"`` when the record has no
             ``token_type`` key.
@@ -309,7 +319,7 @@ def _credential_token_type(raw: Any) -> Literal["opaque", "jwt"]:
         ValueError: The record carries a ``token_type`` outside
             ``Literal["opaque", "jwt"]``.
     """
-    if raw in _CREDENTIAL_TOKEN_TYPES:
+    if isinstance(raw, str) and raw in _CREDENTIAL_TOKEN_TYPES:
         return cast('Literal["opaque", "jwt"]', raw)
     raise ValueError(f"credential token_type must be one of {sorted(_CREDENTIAL_TOKEN_TYPES)}, got {raw!r}")
 

--- a/src/bernstein/core/agents/agent_identity.py
+++ b/src/bernstein/core/agents/agent_identity.py
@@ -153,6 +153,11 @@ def permissions_for_role(role: str) -> frozenset[str]:
 # former is a pre-field record; see :func:`_credential_tenant_id`.
 _TENANT_KEY_ABSENT: Final[object] = object()
 
+# The two kinds a credential may declare, kept beside the ``token_type``
+# annotation on :class:`AgentCredential` so the deserialiser and the type
+# cannot drift apart; see :func:`_credential_token_type`.
+_CREDENTIAL_TOKEN_TYPES: Final[frozenset[str]] = frozenset({"opaque", "jwt"})
+
 
 def _string_list(raw: Any, field: str) -> list[str]:
     """Return a persisted list-of-strings field, refusing any other shape.
@@ -272,6 +277,43 @@ def _credential_tenant_id(raw: Any) -> str:
     return normalize_tenant_id(raw)
 
 
+def _credential_token_type(raw: Any) -> Literal["opaque", "jwt"]:
+    """Return the token kind a persisted credential declares.
+
+    ``token_type`` selects which validation a token gets: ``_validate_jwt_claims``
+    refuses anything whose credential does not say ``"jwt"``, so authentication
+    falls through to the opaque hash comparison for every other value.  A
+    ``str()`` coercion of the stored value therefore does not merely widen a
+    type - it routes an authentication decision on a value nothing has
+    established, and the routing is by whichever comparison runs first rather
+    than by a recognised kind.
+
+    An unknown kind is refused here instead, in the same style as
+    :func:`_credential_tenant_id` beside it: the boundary where a record on
+    disk becomes an object the rest of the code trusts is where a value that
+    is not one of the two real kinds stops.
+
+    Leniency is for age, not for content: a record written before the field
+    existed carries no ``token_type`` at all and is an opaque credential,
+    which is what the dataclass default has always said.  A record that
+    carries the key with something else in it asserted a kind, and an
+    unrecognised assertion is refused rather than defaulted - defaulting it
+    would rewrite a security-relevant field on the way in and lose the fact
+    that the store holds something nothing wrote.
+
+    Args:
+        raw: The stored value, or ``"opaque"`` when the record has no
+            ``token_type`` key.
+
+    Raises:
+        ValueError: The record carries a ``token_type`` outside
+            ``Literal["opaque", "jwt"]``.
+    """
+    if raw in _CREDENTIAL_TOKEN_TYPES:
+        return cast('Literal["opaque", "jwt"]', raw)
+    raise ValueError(f"credential token_type must be one of {sorted(_CREDENTIAL_TOKEN_TYPES)}, got {raw!r}")
+
+
 @dataclass
 class AgentCredential:
     """Bearer token for agent-to-server authentication.
@@ -326,7 +368,7 @@ class AgentCredential:
             created_at=float(d.get("created_at", 0)),
             expires_at=float(d.get("expires_at", 0)),
             revoked=bool(d.get("revoked", False)),
-            token_type=str(d.get("token_type", "opaque")),
+            token_type=_credential_token_type(d.get("token_type", "opaque")),
             algorithm=str(d.get("algorithm", "HS256")),
             jti=str(d.get("jti", "")),
             tenant_id=_credential_tenant_id(d.get("tenant_id", _TENANT_KEY_ABSENT)),

--- a/tests/unit/test_agent_identity.py
+++ b/tests/unit/test_agent_identity.py
@@ -466,12 +466,20 @@ class TestAgentCredentialTokenTypeDeserialization:
         assert credential.token_type == stored
         assert AgentCredential.from_dict(credential.to_dict()).token_type == stored
 
-    @pytest.mark.parametrize("stored", ["anything", "JWT", "opaque ", "", None, 1, True])
+    @pytest.mark.parametrize("stored", ["anything", "JWT", "opaque ", "", None, 1, True, [], {}])
     def test_unknown_token_type_is_refused_and_named(self, stored: object) -> None:
         """The message names the offending value, so the record is findable.
 
         A store holding one bad record is repaired by locating it; a refusal
         that only names the field leaves every credential a suspect.
+
+        The last two cases are the reason the membership test is guarded by
+        ``isinstance``: a list and an object are the only two values JSON can
+        persist that a set lookup cannot hash, so without the guard they
+        raise ``TypeError: unhashable type`` from the lookup rather than the
+        named ``ValueError``.  Both are here rather than one, because they
+        are two different unhashable shapes and a guard covering one is not
+        evidence about the other.
         """
         with pytest.raises(ValueError, match="token_type") as excinfo:
             AgentCredential.from_dict({"token_hash": "abc", "token_type": stored})

--- a/tests/unit/test_agent_identity.py
+++ b/tests/unit/test_agent_identity.py
@@ -443,6 +443,63 @@ class TestAgentCredentialTenantDeserialization:
         assert "session-corrupt" not in listed
 
 
+class TestAgentCredentialTokenTypeDeserialization:
+    """The persisted ``token_type`` selects which validation a token gets.
+
+    ``_validate_jwt_claims`` refuses any credential that does not say
+    ``"jwt"``, so an unrecognised kind is not inert - it routes the token to
+    the opaque hash comparison instead of being refused.  ``from_dict``
+    establishes the value as one of the two real kinds rather than coercing
+    whatever was on disk into one that some comparison will happen to accept.
+    """
+
+    def test_absent_token_type_resolves_to_opaque(self) -> None:
+        """Records written before the field existed still load."""
+        credential = AgentCredential.from_dict({"token_hash": "abc"})
+
+        assert credential.token_type == "opaque"
+
+    @pytest.mark.parametrize("stored", ["opaque", "jwt"])
+    def test_both_kinds_round_trip_unchanged(self, stored: str) -> None:
+        credential = AgentCredential.from_dict({"token_hash": "abc", "token_type": stored})
+
+        assert credential.token_type == stored
+        assert AgentCredential.from_dict(credential.to_dict()).token_type == stored
+
+    @pytest.mark.parametrize("stored", ["anything", "JWT", "opaque ", "", None, 1, True])
+    def test_unknown_token_type_is_refused_and_named(self, stored: object) -> None:
+        """The message names the offending value, so the record is findable.
+
+        A store holding one bad record is repaired by locating it; a refusal
+        that only names the field leaves every credential a suspect.
+        """
+        with pytest.raises(ValueError, match="token_type") as excinfo:
+            AgentCredential.from_dict({"token_hash": "abc", "token_type": stored})
+
+        assert repr(stored) in str(excinfo.value)
+
+    def test_unknown_token_type_does_not_authenticate(self, tmp_path: Path) -> None:
+        """The refusal reaches authentication as a miss, not as a 500.
+
+        Before this change the record loaded, ``token_type != "jwt"`` sent it
+        down the opaque branch, and the identity authenticated on its token
+        hash alone.  The refusal now travels the same path an unusable
+        ``tenant_id`` already does - through ``_load``, which skips the file.
+        """
+        import json
+
+        store = AgentIdentityStore(tmp_path)
+        identity, token = store.create_identity("session-jwt", "backend")
+        path = tmp_path / "agent_identities" / f"{identity.id}.json"
+        payload = json.loads(path.read_text())
+        assert payload["credential"]["token_type"] == "jwt"
+        payload["credential"]["token_type"] = "anything"
+        path.write_text(json.dumps(payload))
+
+        assert store.authenticate(token) is None
+        assert [found.id for found in store.list_identities()] == []
+
+
 class TestCorruptIdentityDoesNotBreakAuthentication:
     """A record that will not deserialise authenticates as nobody, not as a 500.
 


### PR DESCRIPTION
Fixes #4004.

## The decision the issue leaves open: refuse, by raising

The issue asks whether "refused" should raise or degrade to `opaque` with a warning, and notes that raising "can make a corrupted store unreadable at a bad moment." **On this tree it does not, and that is measured rather than assumed** — the sibling field already makes exactly this trade, and the absorbing path is already built and tested.

`_credential_tenant_id` raises out of the same constructor today. That refusal travels through `AgentIdentityStore._load`, which logs `Skipping corrupt identity file` and leaves the record out. Run against `main` at `0654274`, one record on disk, three states:

| persisted credential | `list_identities()` | `authenticate(token)` |
|---|---|---|
| untouched | `['session-jwt']` | `session-jwt` |
| `tenant_id: 42` (control — refused today) | `[]` | `None` |
| `token_type: "anything"` (subject) | `['session-jwt']` | **`session-jwt`** |

So raising costs nothing the store does not already handle, and degrading would have made one boundary in one constructor honest and the other silent.

## What the subject row shows, and it is the part worth reading

The issue calls the dangerous direction narrow. Measured, **the unknown value does not merely flow onward — the credential authenticates.** `_validate_jwt_claims` returns `False` for any `token_type` that is not exactly `"jwt"` (`:825`), so `"anything"` is routed to the opaque hash comparison and succeeds on the token hash alone. That is the "silently takes a branch instead of being refused" the issue describes, with the branch named.

## The change

`_credential_token_type`, beside `_credential_tenant_id` and in its style: an unknown value is refused at the boundary and the message names it. Absent stays lenient — a record written before the field existed carries no key and is opaque, which is what the dataclass default has always said. An explicit value that is not one of the two kinds asserted a kind, and an unrecognised assertion is refused rather than defaulted; defaulting would rewrite a security-relevant field on the way in and lose the fact that the store holds something nothing wrote.

~~The two literals now live in one `Final[frozenset]` next to the annotation, so the deserialiser and the type cannot drift apart again.~~

**Corrected after review: that sentence is false, and @Aeirx disproved it rather than arguing it.** The frozenset is at `:159` and the annotation it claims to sit beside is at `:339` — 180 lines away — and the pair is spelled out in five places (`:159`, `:280`, `:320`, `:323`, `:339`). Adding a third kind the way a maintainer naturally would, by editing the three `Literal` spellings and leaving the frozenset alone, keeps mypy green while the boundary refuses a kind the type says exists. The drift is fail-closed, so it is a debugging cost rather than an exposure; deriving the set from the type with `get_args` removes the possibility instead of asking for it. @chernistry's call was that it belongs in a follow-up rather than behind a live credential-downgrade fix, and it is filed as #4015.

## What proves it

13 tests in `TestAgentCredentialTokenTypeDeserialization`, **10 of which fail on pristine `main`** — re-measured at `caaeb96` by `git checkout 0654274 -- src/bernstein/core/agents/agent_identity.py`, re-run, restore. *(This said 11 and 8 until now: it was written before the unhashable-guard commit added the `[]` and `{}` cases. Corrected because quoting a number is a promise it can be re-run.)*

- `test_unknown_token_type_is_refused_and_named` — 9 parametrised cases (`"anything"`, `"JWT"`, `"opaque "`, `""`, `None`, `1`, `True`, `[]`, `{}`), each asserting `repr(stored)` is in the message. A refusal that names only the field leaves every credential in the store a suspect.
- `test_unknown_token_type_does_not_authenticate` — the subject row above, pinned end to end through the store rather than at `from_dict`.
- The 3 that **pass** on `main` are the backward-compatibility ones and are meant to: absent → `opaque`, and both valid kinds round-tripping through `to_dict`/`from_dict`.

`uv run mypy src/bernstein/core/agents/agent_identity.py` — **1 error before, `Success: no issues found` after.** `ruff check` and `ruff format --check` clean on both files. `pytest tests/unit/test_agent_identity.py test_agent_identity_jwt.py test_agent_identity_v1_migration.py test_agent_identity_card.py` — **169 passed**.

**The full `scripts/run_tests.py` sweep was NOT run** (2 cores, process-per-file, 2000+ tests). Do not read this as a green whole suite.

## Scope

Only `token_type`. The other `from_dict` fields, the JWT minting path at `:679`, and #3914 are untouched. #4002 is open on this file and edits lines 19 and 605-643; this touches 156-160, 280-326 and 381, so there is no overlap — but it is the same file, so whichever lands second may want a rebase.


---
_Description edited after merge, on @chernistry's request in https://github.com/sipyourdrink-ltd/bernstein/pull/4006#issuecomment-5308252956, to correct numbers that went stale between writing and merging. No code changed. Every figure above was re-measured at `caaeb96` before being written, not copied from the review._
_Written by an autonomous AI agent; no human reviewed the diff._
