### PR TITLE
fix(replay): a journal line that is not valid UTF-8 is discarded, not raised (#3971)

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -104,6 +104,20 @@ rather than as its own attribution is exempted by hand there, with the reason.
 
 ## Fixed
 
+- A run journal whose trailing bytes are an incomplete multi-byte character no
+  longer wedges the tolerant reader (#3971). `load_events` treated undecodable
+  bytes as an error from the codec rather than as a malformed line, so one
+  class of crash produced two outcomes depending on where in the byte stream it
+  stopped: a discarded physical line index when the write stopped between two
+  characters, and a bare `UnicodeDecodeError` — carrying no line index, and
+  losing every earlier event in the file — when it stopped inside one. Bytes
+  that are not valid UTF-8 now travel the same two reader policies as
+  unparsable JSON: discarded by the tolerant reader and reported in
+  `discarded_line_indices`, raised by `strict=True` as a `JournalParseError`
+  naming the 0-based physical line. Physical line indices are unchanged for
+  every journal that read successfully before. A row whose only defect is one
+  undecodable byte is discarded rather than repaired, so no silently altered
+  event can enter the chain.
 - The CLI reference no longer names command spellings that do not resolve. It
   claimed `bernstein commit-stats`, `bernstein incident`, and `bernstein
   postmortem` were live deprecated aliases after v4.0.0 removed them, and

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import io
 import json
 import logging
 import os
@@ -516,6 +517,30 @@ class JournalParseError(ValueError):
     """
 
 
+def _is_decodable(line: str) -> bool:
+    """Whether *line* came back from a lossless UTF-8 decode.
+
+    ``load_events`` decodes with ``errors="surrogateescape"``, which maps each
+    undecodable byte to a lone surrogate in U+DC80..U+DCFF rather than raising.
+    Those code points cannot be encoded back to UTF-8, so a failed re-encode is
+    an exact test for "this physical line held bytes that are not UTF-8" - and
+    it is exact in the other direction too: no lossless decode can produce a
+    lone surrogate, because UTF-8 cannot carry one.
+
+    The ASCII fast path matters rather than being decoration. Every row this
+    package writes is ASCII (``json.dumps`` escapes non-ASCII by default), so
+    ``str.isascii`` - a flag lookup on CPython, not a scan - answers for the
+    whole journal in the common case and no line is encoded twice.
+    """
+    if line.isascii():
+        return True
+    try:
+        line.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return True
+
+
 def load_events(path: Path, *, strict: bool = False) -> JournalLoadResult:
     """Load all events from a journal JSONL file in append order.
 
@@ -529,15 +554,37 @@ def load_events(path: Path, *, strict: bool = False) -> JournalLoadResult:
       line index. Diagnostic readers (``bernstein audit diagnose``) use this
       so no reported index can ever count parsed rows rather than physical
       journal lines, and no finding is derived from a filtered sequence.
+
+    "Malformed" includes *undecodable*. A crash partway through an append can
+    land inside a multi-byte character as easily as between two, and a strict
+    decode would make the same class of crash produce two different outcomes
+    depending on where in the byte stream it stopped: a discarded line index
+    in one case, a bare ``UnicodeDecodeError`` out of the reader in the other.
+    Bytes that are not valid UTF-8 are therefore surfaced through the same two
+    policies as unparsable JSON - discarded by the tolerant reader, raised as
+    :class:`JournalParseError` naming the physical line by the strict one.
     """
     events: list[dict[str, Any]] = []
     discarded: list[int] = []
     if not path.exists():
         return JournalLoadResult(events=events)
-    with path.open(encoding="utf-8") as f:
+    # Binary handle, decoded through the *same* TextIOWrapper machinery as
+    # ``path.open(encoding="utf-8")``: universal-newline splitting is what
+    # defines a physical line here, and re-implementing it over bytes would
+    # silently renumber every index this function reports (a lone ``\r`` ends
+    # a line in text mode and does not in ``bytes.split(b"\n")``). Only the
+    # error policy changes. ``surrogateescape`` rather than ``replace``
+    # because it is reversible: a caller inspecting or repairing a torn tail
+    # still has the original bytes, which ``replace`` would destroy.
+    with path.open("rb") as raw_file, io.TextIOWrapper(raw_file, encoding="utf-8", errors="surrogateescape") as f:
         for lineno, raw in enumerate(f):
             line = raw.strip()
             if not line:
+                continue
+            if not _is_decodable(line):
+                if strict:
+                    raise JournalParseError(f"undecodable bytes at physical line {lineno} (not valid UTF-8)")
+                discarded.append(lineno)
                 continue
             try:
                 decoded: object = json.loads(line)

--- a/tests/unit/core/replay/test_journal_undecodable.py
+++ b/tests/unit/core/replay/test_journal_undecodable.py
@@ -1,0 +1,201 @@
+"""Undecodable bytes are a discarded physical line, not an exception (#3971).
+
+Every fixture here is built from RAW BYTES rather than from text. A journal
+written through ``str`` cannot hold an incomplete multi-byte character at all -
+the encode would either succeed or raise before anything reached the disk - so a
+text fixture would exercise the JSON parser and never the decode path this
+module is about.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.replay.journal import (
+    JournalParseError,
+    load_events,
+)
+
+# A row shaped like the ones ``EventJournal`` appends. Held as bytes because the
+# point of every fixture below is what is on the disk, not what a str would say.
+_GOOD = tuple(
+    json.dumps(
+        {
+            "event": "step",
+            "index": index,
+            "prev_hash": "",
+            "payload_hash": "p" * 8,
+            "event_hash": f"h{index}" * 4,
+        }
+    ).encode("utf-8")
+    for index in range(3)
+)
+
+# ``"café"`` with the two-byte ``é`` cut after its lead byte: exactly what a
+# crash partway through a write leaves when it stops inside a character.
+_TORN_MID_CHARACTER = json.dumps(
+    {"event": "step", "index": 3, "prev_hash": "", "note": "café"},
+    ensure_ascii=False,
+).encode("utf-8")[:-3]
+
+# The SAME crash, stopped between two characters instead of inside one. This is
+# the control: on a tree without the fix these two files behave differently, and
+# the contract says they must not.
+_TORN_BETWEEN_CHARACTERS = _GOOD[0][:40]
+
+
+def _write(path: Path, *chunks: bytes, sep: bytes = b"\n") -> Path:
+    path.write_bytes(sep.join(chunks))
+    return path
+
+
+def test_tolerant_reader_discards_a_tail_torn_mid_character(tmp_path: Path) -> None:
+    """The documented contract: a partial trailing write cannot wedge a reader."""
+    path = _write(tmp_path / "journal.jsonl", *_GOOD, _TORN_MID_CHARACTER)
+
+    loaded = load_events(path)
+
+    assert loaded.discarded_line_indices == (3,)
+    assert [row["event_hash"] for row in loaded.events] == ["h0" * 4, "h1" * 4, "h2" * 4]
+
+
+def test_strict_reader_raises_journal_parse_error_naming_the_physical_line(
+    tmp_path: Path,
+) -> None:
+    """A diagnostic caller gets the same error type and the same index it gets
+    for unparsable JSON - not a bare ``UnicodeDecodeError`` from the codec."""
+    path = _write(tmp_path / "journal.jsonl", *_GOOD, _TORN_MID_CHARACTER)
+
+    with pytest.raises(JournalParseError) as excinfo:
+        load_events(path, strict=True)
+
+    assert "physical line 3" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("label", "tail"),
+    [
+        ("between characters", _TORN_BETWEEN_CHARACTERS),
+        ("mid character", _TORN_MID_CHARACTER),
+    ],
+)
+def test_both_tear_positions_produce_the_same_outcome(tmp_path: Path, label: str, tail: bytes) -> None:
+    """THE POINT OF THE ISSUE, ASSERTED DIRECTLY.
+
+    One class of crash, two places it can stop, and before the fix the reader
+    reported a discarded line for one and raised out of the codec for the other.
+    Parametrised rather than written twice so the two cases cannot drift.
+    """
+    path = _write(tmp_path / f"{label.replace(' ', '-')}.jsonl", *_GOOD, tail)
+
+    loaded = load_events(path)
+
+    assert loaded.discarded_line_indices == (3,)
+    assert len(loaded.events) == 3
+
+
+def test_undecodable_bytes_in_the_middle_do_not_hide_later_rows(
+    tmp_path: Path,
+) -> None:
+    """A torn tail is the motivating case, but the reader must not stop early on
+    a bad line anywhere: the strict reader's whole job is to see every physical
+    line, and the tolerant one's is to keep going."""
+    path = _write(tmp_path / "journal.jsonl", _GOOD[0], b"\xff\xfe not utf-8", _GOOD[1])
+
+    loaded = load_events(path)
+
+    assert loaded.discarded_line_indices == (1,)
+    assert [row["event_hash"] for row in loaded.events] == ["h0" * 4, "h1" * 4]
+
+
+def test_physical_line_indices_stay_physical_across_universal_newlines(
+    tmp_path: Path,
+) -> None:
+    """The indices are DEFINED by universal-newline splitting, and this pins it.
+
+    The rows here are separated by lone carriage returns, which end a line in
+    text mode and do not in ``bytes.split(b"\\n")``. An implementation that
+    reads bytes and splits on ``\\n`` sees this whole file as physical line 0
+    and would report ``(0,)``; text-mode numbering puts the bad row at 2.
+    """
+    path = _write(
+        tmp_path / "journal.jsonl",
+        _GOOD[0],
+        _GOOD[1],
+        b"\xc3",
+        _GOOD[2],
+        sep=b"\r",
+    )
+
+    loaded = load_events(path)
+
+    assert loaded.discarded_line_indices == (2,)
+    assert len(loaded.events) == 3
+
+
+def test_a_bad_byte_inside_otherwise_valid_json_is_discarded_not_repaired(
+    tmp_path: Path,
+) -> None:
+    """THE TEST THAT PINS THE ERROR POLICY, AND THE REASON IT IS NOT ``replace``.
+
+    This row is syntactically perfect JSON whose only defect is one byte that is
+    not UTF-8, sitting inside a string. A reader that decoded with
+    ``errors="replace"`` would turn that byte into U+FFFD, parse the row, and
+    hand the caller a *silently altered* event whose ``payload_hash`` no longer
+    describes its own payload - a corrupted row admitted to the chain rather
+    than a discarded physical line. The tolerant reader must refuse it, and the
+    strict reader must say which line it was.
+    """
+    row = (
+        b'{"event": "step", "index": 0, "prev_hash": "", "payload_hash": "pppppppp", '
+        b'"event_hash": "h0h0h0h0", "note": "a\xffb"}'
+    )
+    json.loads(row.decode("utf-8", "replace"))  # syntactically valid, only the byte is bad
+    path = _write(tmp_path / "journal.jsonl", row)
+
+    loaded = load_events(path)
+
+    assert loaded.events == []
+    assert loaded.discarded_line_indices == (0,)
+
+    with pytest.raises(JournalParseError, match="physical line 0"):
+        load_events(path, strict=True)
+
+
+def test_a_valid_non_ascii_row_is_not_discarded(tmp_path: Path) -> None:
+    """The fix widens what counts as malformed, so it has to be pinned that it
+    did not widen it to "anything above U+007F"."""
+    row = json.dumps(
+        {"event": "step", "index": 0, "prev_hash": "", "note": "café ☃ 🜁"},
+        ensure_ascii=False,
+    ).encode("utf-8")
+    path = _write(tmp_path / "journal.jsonl", row)
+
+    loaded = load_events(path)
+
+    assert loaded.discarded_line_indices == ()
+    assert loaded.events[0]["note"] == "café ☃ 🜁"
+
+
+def test_an_escaped_lone_surrogate_is_still_a_json_question_not_a_decode_one(
+    tmp_path: Path,
+) -> None:
+    """UNCHANGED BEHAVIOUR, PINNED BECAUSE THE FIX COULD PLAUSIBLY HAVE MOVED IT.
+
+    ``"\\udcff"`` written as a JSON escape is pure ASCII on disk: the bytes are
+    valid UTF-8 and only the decoded *value* holds a lone surrogate. The decode
+    policy has no opinion about that, and this row loaded before the fix and
+    still does. A ``_is_decodable`` check applied to the parsed value instead of
+    to the physical line would start discarding it.
+    """
+    row = rb'{"event": "step", "index": 0, "prev_hash": "", "note": "\udcff"}'
+    assert row.isascii()
+    path = _write(tmp_path / "journal.jsonl", row)
+
+    loaded = load_events(path)
+
+    assert loaded.discarded_line_indices == ()
+    assert loaded.events[0]["note"] == "\udcff"


### PR DESCRIPTION
## What

`load_events` opened the journal with a strict UTF-8 decode, so a journal whose trailing
bytes are an incomplete multi-byte character raised `UnicodeDecodeError` out of the reader
instead of reporting a discarded physical line.

Closes #3971.

## The contract, and the two outcomes it had

The tolerant reader's documented contract is that *"malformed lines are skipped so a
partial trailing write cannot wedge an ordinary reader"*. One class of crash, two places
in the byte stream it can stop, and on `0d9b4dc` those two produced different answers:

```
                              tolerant                      strict=True
torn BETWEEN characters       discarded (3,), 3 events      JournalParseError: physical line 3
torn INSIDE a character       UnicodeDecodeError            UnicodeDecodeError
```

The second row is worse than the table makes it look. The exception comes out of the
`for lineno, raw in enumerate(f)` scan, so the caller loses **every earlier event in the
file**, not just the torn one — the three good rows above it are gone too — and the error
carries no line index, so nothing downstream can name where the journal stopped being
readable.

## One thing the issue overstates, and it is worth saying before the fix

The issue says a crash "can land inside a multi-byte character as easily as between two".
**On this tree it cannot.** `EventJournal.append` renders each row with
`json.dumps(entry, default=str)` (`src/bernstein/core/replay/journal.py:424`), and
`ensure_ascii` defaults to `True`, so every byte this package appends is ASCII:

```
$ python -c 'import json; print(json.dumps({"note": "café"}))'
{"note": "caf\u00e9"}
```

Every fixture in the new test file therefore had to pass `ensure_ascii=False` or write raw
bytes to produce the condition at all.

That does not make the reader right. `load_events` is a public function that takes a
`Path`; its contract is about the bytes on the disk, not about which writer produced them,
and it is already reached by journals this process did not write. The moment anyone passes
`ensure_ascii=False` — a natural change for size or for readability — the tolerant reader
starts raising on a class of crash it exists to absorb, with nothing pinning it. So: the
trigger is narrower today than the issue states, the defect is real, and both belong in
the record.

## How

Same scan, same policies, one thing changed — the decode error policy:

```python
with path.open("rb") as raw_file, io.TextIOWrapper(raw_file, encoding="utf-8", errors="surrogateescape") as f:
```

Three choices in that line, each of which could have gone the other way:

**`TextIOWrapper` rather than reading bytes and splitting.** Physical line indices are what
diagnostic readers report and the issue requires them to stay physical. They are defined by
universal-newline splitting: a lone `\r` ends a line in text mode and does not in
`bytes.split(b"\n")`. Keeping the same wrapper keeps the same line numbering by
construction instead of by a re-implementation that has to be trusted. `test_physical_line_
indices_stay_physical_across_universal_newlines` pins it — a `\r`-separated journal reports
the bad row at index 2, where a bytes-split implementation reports `(0,)`.

**`surrogateescape` rather than `replace`.** `replace` is lossy: the offending byte becomes
U+FFFD, the row then *parses*, and the caller is handed a silently altered event whose
`payload_hash` no longer describes its own payload — a corrupted row admitted to the chain
rather than a discarded line. `surrogateescape` is reversible, which also leaves the
original bytes available to the repair path `#3955` is building.
`test_a_bad_byte_inside_otherwise_valid_json_is_discarded_not_repaired` is the test that
pins this one, and it is the only test that separates the two policies.

**The undecodable check is on the physical line, not on the parsed value.** A JSON-escaped
lone surrogate (`"\udcff"`) is pure ASCII on disk; the bytes are fine and only the decoded
value holds a surrogate. That row loaded before this patch and still does.

`_is_decodable` tests for a lone surrogate by re-encoding, which is exact in both
directions: no lossless UTF-8 decode can produce one, and no lone surrogate can be encoded
back. The `str.isascii()` fast path answers for every row this package writes.

## Tests

`tests/unit/core/replay/test_journal_undecodable.py`, 9 tests, **6 fail on pristine `main`**
(`git stash push src/bernstein/core/replay/journal.py`, rerun, restore):

```
FAILED test_tolerant_reader_discards_a_tail_torn_mid_character
FAILED test_strict_reader_raises_journal_parse_error_naming_the_physical_line
FAILED test_both_tear_positions_produce_the_same_outcome[mid character-...]
FAILED test_undecodable_bytes_in_the_middle_do_not_hide_later_rows
FAILED test_physical_line_indices_stay_physical_across_universal_newlines
FAILED test_a_bad_byte_inside_otherwise_valid_json_is_discarded_not_repaired
6 failed, 3 passed
```

**The 3 that pass on `main` are meant to** and are not a coverage gap: the
`between characters` half of the parametrised pair is the *control* for the pair, and the
other two pin behaviour this patch deliberately does not change — a valid non-ASCII row is
still loaded, and a JSON-escaped lone surrogate is still a JSON question rather than a
decode one.

Every fixture is built from raw bytes, per the issue's fourth acceptance criterion.

## Indices unchanged, checked differentially rather than asserted

The old scan was re-implemented in a scratch script and both were run over 14 journal
shapes chosen to attack the line numbering — plain LF, CRLF, lone CR, mixed separators, no
trailing newline, blank lines, blank CRLF lines, garbage mid-file, a non-dict row, an empty
file, only newlines, embedded NUL bytes, a valid non-ASCII row, and U+2028 inside a string.
Events and `discarded_line_indices` matched on all 14, tolerant and strict:

```
DIFFERENCES: 0
```

## Mutation proofs

Each of these was applied to the patch and the suite re-run:

```
_is_decodable always returns True                     1 failed, 8 passed
errors="surrogateescape" -> "replace"  (at the call)  1 failed, 8 passed
errors="surrogateescape" -> "ignore"                  2 failed, 7 passed
strict does not raise, only discards                  2 failed, 7 passed
TextIOWrapper -> read().decode().split("\n")          1 failed, 8 passed
undecodable line skipped with no discard recorded     5 failed, 4 passed
encode check cannot fail (errors="surrogateescape")   1 failed, 8 passed
unmutated control                                     9 passed
```

One methodology note, because it changes how the first row should be read: the
`surrogateescape -> replace` mutation came back green on its first run. The replacement had
landed in `_is_decodable`'s **docstring**, which mentions the policy, rather than in the
call. Re-run against the call it goes red. The number above is the corrected run.

## Not fixed here, and it is the same defect one function over

`#3955` adds `_torn_tail_indices`, which re-reads the file with
`path.open(encoding="utf-8")` — the same strict decode. The issue puts that site out of
scope for this ticket, so it is untouched. But with this patch merged and that one merged,
the wedge moves rather than clearing: the function whose whole job is to identify a torn
tail still raises on the one tear shape it was written for. Measured here, with its code
copied verbatim from the `#3955` diff and nothing modified:

```
load_events (this PR):      between characters -> discarded (3,)
_torn_tail_indices (#3955):  between characters -> (3,)
load_events (this PR):      mid character      -> discarded (3,)
_torn_tail_indices (#3955):  mid character      -> RAISED UnicodeDecodeError
```

`EventJournal.resume` in that PR calls it on the discard path, so a mid-character tear
would reach the repair suggestion and raise there instead. One line, same shape as this
one, and it is `@Louis20060723`'s to make on his own branch.

**Overlap, since we are in the same two files.** `#3955` adds `JournalRepairResult`
and `repair_journal_tail` *after* `load_events` and edits `resume`; this patch edits the
body of `load_events` and adds a new test file. No line overlap in the source. Both add an
entry to `docs/release-notes/unreleased.md`, which will conflict textually whichever lands
second — trivially, two adjacent bullets. Happy to rebase; say the word and I will.

## Performance

No measurable cost. 50,000 ASCII rows, 12.4 MiB, three runs each:

```
pristine main   0.434s  0.464s  0.400s
this patch      0.401s  0.423s  0.436s
```

## Runs on this box

```
pytest tests/unit/core/replay/test_journal_undecodable.py   9 passed
pytest tests/unit/core/replay/                             79 passed
pytest <10 journal / replay / receipt / suspension files>  280 passed in 67s
pytest tests/unit/test_unreleased_notes_rotation.py        10 passed
pytest tests/unit/test_docs_url_hygiene.py
     + test_format_release_notes_utm.py
     + test_docs_prose_cli_drift.py                        19 passed
ruff check <both source files>                             All checks passed
ruff format --check <both source files>                    2 files already formatted
mypy src/bernstein/core/replay/journal.py                  Success: no issues found
```

**NOT RUN: the full `scripts/run_tests.py` sweep.** Two cores, process-per-file, 2000+
tests. Do not read the numbers above as the whole suite being green — they are the files
this patch touches and their neighbours.

<details>
<summary>AI-assisted</summary>

This patch was written by an autonomous AI agent and no human reviewed the diff. Every
number above is a run on the machine that wrote it rather than an inference: the red list
was produced by stashing `src/` and re-running, the mutation rows by editing the patch and
re-running, the `_torn_tail_indices` rows by executing that function's code from the
`#3955` diff unmodified, and the not-run list is what this box did not run rather than what
was not attempted.

</details>
