### PR TITLE
chore(renovate): cap mkdocs-redirects at the bound docs/requirements.in declares

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,16 @@
         "typescript"
       ],
       "allowedVersions": "<7"
+    },
+    {
+      "description": "docs/requirements.txt is a compiled, hash-pinned resolution, so every package appears there as a bare '==' pin and the range that docs/requirements.in declares for it is invisible to the pip_requirements manager. mkdocs-redirects is capped below 1.2.3 in that .in file because 1.2.3 adds a runtime dependency on properdocs; bumping the compiled pin past the cap yields a hash-pinned file with that dependency missing, and 'pip install --require-hashes -r docs/requirements.txt' then fails to resolve it. No workflow installs that file, so the failure lands in the docs build rather than in CI. Lift this together with the cap in docs/requirements.in.",
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "matchPackageNames": [
+        "mkdocs-redirects"
+      ],
+      "allowedVersions": "<1.2.3"
     }
   ]
 }


### PR DESCRIPTION
## What

Declares the `mkdocs-redirects` cap in `renovate.json` that `docs/requirements.in` already declares, so the bot stops proposing versions the constraint file forbids.

## Why

`docs/requirements.txt` is a compiled, hash-pinned resolution of `docs/requirements.in`, so every package appears in it as a bare `==` pin. The `pip_requirements` manager reads only the compiled file, which makes the range declared in the `.in` file invisible to it: it sees `mkdocs-redirects==1.2.2`, offers 1.2.3, and never learns about the `mkdocs-redirects>=1.2,<1.2.3` cap two files over.

That cap is deliberate, and the bump it invites lands broken. mkdocs-redirects 1.2.3 declares:

```
Requires-Dist: mkdocs<=1.6.1,>=1.2
Requires-Dist: properdocs>=1.6.5
```

Bumping only the compiled pin produces a hash-pinned file with `properdocs` absent:

```
$ pip install --dry-run --require-hashes -r docs/requirements.txt
ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    properdocs>=1.6.5 from https://files.pythonhosted.org/.../properdocs-1.6.7-py3-none-any.whl
      (from mkdocs-redirects==1.2.3->-r docs/requirements.txt (line 397))
```

The same command against the current pin resolves and installs all 43 packages cleanly, so the failure is introduced by the bump rather than pre-existing.

It also does not surface in CI. Nothing under `.github/workflows` installs `docs/requirements.txt`; `.readthedocs.yaml` is its only consumer, which puts the failure in the docs build after the merge rather than on the PR that caused it.

Closing the proposal suppresses it for 1.2.3 only. 1.2.4 and later carry the same dependency, so the cap belongs in the config rather than in a series of closed PRs.

## Scope

One `packageRules` entry. No behaviour change to the project itself, and no change to either requirements file - the cap it mirrors is already on `main`.

`renovate-config-validator` reports the same two pre-existing `customManagers[0].managerFilePatterns` errors before and after this change; the pinned validator available via npx is Renovate 37, which predates that field. The added rule contributes no new findings.

## Related

- #3995 tracks the underlying drift between the two files; #3999 adds the gate that fails CI when they disagree. This is the other half - it stops the drift being proposed in the first place, rather than catching it after the fact.
- Whether to take `properdocs` as a docs dependency at all is a separate call, carried by #3979. If that lands, lift this rule together with the cap in `docs/requirements.in`.
