### PR TITLE
fix(api): refuse a non-finite budget_cap on /metrics/predictions

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -104,6 +104,12 @@ rather than as its own attribution is exempted by hand there, with the reason.
 
 ## Fixed
 
+- `GET /metrics/predictions` answers 422 instead of 500 when `budget_cap` or
+  `window_hours` is non-finite. `budget_cap=Infinity` cleared the `ge=0.0`
+  bound (`inf >= 0.0` is true), reached the handler, and was echoed into the
+  response body, where the JSON renderer refused it as non-compliant and the
+  request died as an unhandled server error. Both parameters now reject
+  infinities and `NaN` at validation.
 - The CLI reference no longer names command spellings that do not resolve. It
   claimed `bernstein commit-stats`, `bernstein incident`, and `bernstein
   postmortem` were live deprecated aliases after v4.0.0 removed them, and

--- a/src/bernstein/core/routes/predictive.py
+++ b/src/bernstein/core/routes/predictive.py
@@ -103,6 +103,7 @@ def get_predictions(
         float,
         Query(
             ge=0.0,
+            allow_inf_nan=False,
             description="Budget ceiling in USD (0 = skip budget forecast)",
         ),
     ] = 0.0,
@@ -111,6 +112,7 @@ def get_predictions(
         Query(
             ge=0.1,
             le=72.0,
+            allow_inf_nan=False,
             description="Configured run window in hours (default 4)",
         ),
     ] = 4.0,
@@ -128,6 +130,12 @@ def get_predictions(
 
     Use ``budget_cap`` to enable the budget forecast. The run duration
     forecast requires at least one completed task.
+
+    Both numeric parameters are echoed back in the response body, so both
+    refuse non-finite values with a 422 instead of admitting them: a range
+    bound alone does not exclude them (``inf >= 0.0`` is true, and every
+    comparison against ``NaN`` is false), and the JSON renderer cannot
+    serialise either one.
 
     The budget forecast is scoped to ``tenant_id``: the spend series it is
     built from is narrowed to cost points recorded for the caller's tenant,

--- a/tests/unit/test_predictions_route_non_finite_query.py
+++ b/tests/unit/test_predictions_route_non_finite_query.py
@@ -1,0 +1,80 @@
+"""``GET /metrics/predictions`` refuses a non-finite ``budget_cap``.
+
+``budget_cap`` is a USD ceiling declared as ``Query(ge=0.0)``. That bound
+does not exclude ``+Infinity`` -- ``inf >= 0.0`` is true -- so the value
+passed validation, reached the handler, and was echoed straight back into
+the response body as ``budget_cap_usd``. Starlette's ``JSONResponse``
+serialises with ``json.dumps(..., allow_nan=False)``, which raises
+``ValueError: Out of range float values are not JSON compliant`` on a
+non-finite float. The caller got an unhandled 500 for what is really a
+malformed request. ``NaN`` fails the same way at the renderer; it slips
+past ``ge`` because every comparison against ``NaN`` is false, so the
+bound never rejects it.
+
+These cases go through the ASGI stack rather than calling the handler
+directly: the defect is that validation admits the value in the first
+place, and only a real request exercises the validation layer. The
+client is built with ``raise_server_exceptions=False`` so an unhandled
+handler exception surfaces as the 500 the operator would actually see,
+instead of propagating into the test and masking the status code.
+
+The route's Schemathesis smoke job generates ``Infinity`` only
+occasionally, so this crash reached main behind a green suite. These
+cases pin it deterministically.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bernstein.core.server import create_app
+
+pytestmark = pytest.mark.ci
+
+# Every spelling of a non-finite float that Python's ``float()`` accepts,
+# which is what FastAPI's query coercion ultimately calls.
+NON_FINITE = ["Infinity", "-Infinity", "NaN", "inf", "-inf", "nan"]
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize("value", NON_FINITE)
+def test_non_finite_budget_cap_is_rejected_not_a_server_error(client: TestClient, value: str) -> None:
+    """A non-finite budget ceiling is a bad request, never a 500."""
+    response = client.get("/metrics/predictions", params={"budget_cap": value})
+
+    assert response.status_code == 422, (
+        f"budget_cap={value} returned {response.status_code}; a non-finite ceiling must be "
+        "refused at validation, not crash the JSON renderer downstream"
+    )
+
+
+@pytest.mark.parametrize("value", NON_FINITE)
+def test_non_finite_window_hours_is_rejected_not_a_server_error(client: TestClient, value: str) -> None:
+    """``window_hours`` is echoed back too, so it needs the same guard.
+
+    ``le=72.0`` already excludes ``+Infinity``, but ``-Infinity`` clears
+    it and ``NaN`` clears both bounds, so the range alone is not enough.
+    """
+    response = client.get("/metrics/predictions", params={"window_hours": value})
+
+    assert response.status_code == 422, (
+        f"window_hours={value} returned {response.status_code}; a non-finite window must be "
+        "refused at validation, not crash the JSON renderer downstream"
+    )
+
+
+@pytest.mark.parametrize("value", ["0", "0.0", "12.5", "1e9"])
+def test_finite_budget_cap_still_answers(client: TestClient, value: str) -> None:
+    """The refusal is scoped to non-finite input; ordinary caps still work."""
+    response = client.get("/metrics/predictions", params={"budget_cap": value})
+
+    assert response.status_code == 200
+    assert response.json()["budget_cap_usd"] == float(value)


### PR DESCRIPTION
## What broke

`GET /metrics/predictions?budget_cap=Infinity` returned **500**, not 422.

`budget_cap` is declared `Query(ge=0.0)`. That bound does not exclude
`+Infinity` — `inf >= 0.0` is true — so the value passed validation, reached
the handler, and was echoed straight back into the response body as
`budget_cap_usd`. Starlette's `JSONResponse` serialises with
`json.dumps(..., allow_nan=False)`, which raises:

```
ValueError: Out of range float values are not JSON compliant: inf
```

The caller got an unhandled server error for what is really a malformed
request.

## Fix

`allow_inf_nan=False` on both numeric query parameters, so the refusal happens
at the parameter boundary instead of in the render step. A budget ceiling of
infinity is not a USD amount.

`window_hours` is included deliberately: it is echoed back too, and is
currently safe only by accident of its `le=72.0` bound. `-Infinity` clears
that bound and `NaN` clears both (every comparison against `NaN` is false), so
making the guard explicit means relaxing the range later cannot reopen the
crash.

## Test

`tests/unit/test_predictions_route_non_finite_query.py` drives real requests
through the ASGI stack rather than calling the validator directly — the defect
is that validation admitted the value at all, so only a real request proves the
route is fixed. The client is built with `raise_server_exceptions=False`, so an
unhandled handler exception surfaces as the 500 an operator would actually see
instead of propagating into the test and masking the status code.

Covers `Infinity`, `-Infinity`, `NaN`, `inf`, `-inf`, `nan` on both parameters,
plus finite caps (`0`, `0.0`, `12.5`, `1e9`) to show the refusal is scoped.

Fail-before, against the unfixed route:

```
AssertionError: budget_cap=Infinity returned 500; a non-finite ceiling must be
refused at validation, not crash the JSON renderer downstream
ERROR bernstein.core.server.server_middleware: Unhandled exception in
GET /metrics/predictions: ValueError: Out of range float values are not JSON
compliant: inf
```

Pass-after: 16/16.

The `Schemathesis smoke` job generates `Infinity` only occasionally, so this
crash reached `main` behind a green suite. These cases pin it deterministically.

## Overlap

The same one-line fix is currently carried inside #3955, whose subject is
repairing a crash-torn replay journal. It is unrelated to that branch's scope,
so it is lifted out here. Whichever lands first, the other should drop its copy.

## Checks

- `uv run pytest tests/unit/test_predictions_route_non_finite_query.py` — 16 passed
- `uv run pytest tests/unit/test_openapi_snapshot_drift.py` — 6 passed (snapshot unchanged)
- `uv run pytest tests/unit/test_unreleased_notes_rotation.py` — 10 passed
- `uv run ruff check .` / `ruff format --check` — clean
- `uv run mypy src/bernstein/core/routes/predictive.py` — clean
