### PR TITLE
fix(scripts): render workflow locators as posix paths, not OS-native

### DIFF
--- a/scripts/gen_workflow_topology.py
+++ b/scripts/gen_workflow_topology.py
@@ -9,7 +9,7 @@ import json
 import re
 import sys
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, cast
 
 import yaml
@@ -25,9 +25,30 @@ SECRET_REF_RE = re.compile(r"\bsecrets\.([A-Z0-9_]+)\b")
 
 @dataclass(frozen=True)
 class WorkflowInfo:
-    """Parsed workflow facts used by the report."""
+    """Parsed workflow facts used by the report.
 
-    path: Path
+    ``path`` is a repository-relative *locator*, not a path you can open.
+
+    That distinction is the fix for #4000. The report embeds this value in
+    five different tables, and it used to hold whatever :func:`Path` the
+    glob produced - a ``WindowsPath`` on Windows, which renders with
+    backslashes and rewrote all 204 rows of the committed report on any
+    regeneration from a Windows machine. CI is Linux, so nothing could see
+    it: ``--check`` exits 0 there whether or not the bug is present.
+
+    Normalising here rather than at the five render sites is deliberate. A
+    rule that five call sites must each remember is a rule that gets
+    forgotten once, and the sixth table is what reintroduces the bug.
+
+    ``PurePosixPath`` is doing two jobs. It renders with forward slashes on
+    every platform, and it has no ``read_text``/``open`` at all - so the
+    type makes "this is a locator, not a file handle" unforgeable rather
+    than a comment somebody has to honour. The file is read in
+    :func:`parse_workflow` before this record exists, so nothing downstream
+    ever wanted to open it.
+    """
+
+    path: PurePosixPath
     name: str
     triggers: tuple[str, ...]
     concurrency: str
@@ -37,6 +58,18 @@ class WorkflowInfo:
     secrets: tuple[str, ...]
     calls: tuple[str, ...]
     artifacts: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        """Coerce whatever path flavour arrived into a posix locator.
+
+        Belt and braces over the annotation. ``parse_workflow`` already
+        passes a ``PurePosixPath``, but the annotation alone is a promise
+        rather than a mechanism - nothing stops a future caller handing in
+        the ``WindowsPath`` straight off the glob, which is exactly how
+        this bug arrived the first time. ``object.__setattr__`` because the
+        dataclass is frozen.
+        """
+        object.__setattr__(self, "path", PurePosixPath(self.path.as_posix()))
 
 
 def _as_mapping(value: object) -> dict[str, object]:
@@ -164,7 +197,8 @@ def parse_workflow(path: Path) -> WorkflowInfo:
     workflow_permissions = _permissions("workflow", doc.get("permissions"))
 
     return WorkflowInfo(
-        path=path,
+        # Normalised at the boundary: the row builders below just render it.
+        path=PurePosixPath(path.as_posix()),
         name=str(doc.get("name", path.name)),
         triggers=_trigger_names(doc),
         concurrency=_scalar(doc.get("concurrency")),

--- a/tests/unit/test_workflow_topology_report.py
+++ b/tests/unit/test_workflow_topology_report.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+from scripts.gen_workflow_topology import WorkflowInfo
 
 REPORT = Path("docs/operations/ci-topology.md")
 
@@ -33,3 +35,69 @@ def test_workflow_topology_report_names_high_risk_edges() -> None:
         "## Artifact Hand-Offs",
     ):
         assert heading in text
+
+
+class TestPathsAreRenderedAsPosixLocators:
+    """#4000: the report embedded OS-native separators.
+
+    These must fail on Linux without the fix, or they are decoration. That
+    is what ``PureWindowsPath`` is for: it renders with backslashes on
+    *every* host, not just on Windows, so the assertion exercises the real
+    defect on the platform CI actually runs.
+
+    A test asserting "no row in the generated report contains a backslash"
+    would NOT do: on Linux the glob yields a ``PosixPath`` and that passes
+    whether or not anything was fixed. It cannot fail where it runs, so it
+    is a comment with a green tick.
+    """
+
+    def info(self, path: Path | PureWindowsPath | PurePosixPath) -> WorkflowInfo:
+        return WorkflowInfo(
+            path=path,  # type: ignore[arg-type]  # the point is that a wrong flavour is coerced
+            name="CI",
+            triggers=("push",),
+            concurrency="-",
+            job_count=1,
+            emitted_checks=(),
+            permissions=(),
+            secrets=(),
+            calls=(),
+            artifacts=(),
+        )
+
+    def test_a_windows_flavoured_path_renders_with_forward_slashes(self) -> None:
+        # The exact shape the Windows glob produces. Before the fix this
+        # renders `.github\workflows\ci.yml` on Linux too.
+        rendered = str(self.info(PureWindowsPath(r".github\workflows\ci.yml")).path)
+        assert rendered == ".github/workflows/ci.yml"
+        assert "\\" not in rendered
+
+    def test_a_posix_path_is_left_alone(self) -> None:
+        rendered = str(self.info(PurePosixPath(".github/workflows/ci.yml")).path)
+        assert rendered == ".github/workflows/ci.yml"
+
+    def test_the_locator_type_cannot_be_opened(self) -> None:
+        # The guarantee behind the type choice: `path` is a locator, not a
+        # file handle. If someone widens it back to `Path` to call
+        # `read_text` on it, this is what says no.
+        assert not hasattr(self.info(PurePosixPath("a/b.yml")).path, "read_text")
+
+    def test_every_locator_in_the_committed_report_is_posix(self) -> None:
+        """The end-to-end backstop, scoped to the locator CELL.
+
+        Not the whole row: ten rows carry a legitimate backslash in the
+        concurrency column, where a `${{ }}` expression is JSON-escaped.
+        Asserting over the row would fail on correct output - a guard that
+        cries wolf, which is how guards get deleted.
+
+        This one passes vacuously on Linux, which is exactly why it is not
+        the only test in this class.
+        """
+        locators = [
+            line.split("|")[1].strip()
+            for line in REPORT.read_text(encoding="utf-8").splitlines()
+            if line.startswith("| .github")
+        ]
+        assert locators, "no workflow locators found in the report - has the format changed?"
+        offenders = [locator for locator in locators if "\\" in locator]
+        assert not offenders, f"{len(offenders)} locator(s) use OS-native separators: {offenders[:3]}"


### PR DESCRIPTION
Closes #4000.

## The decision you left me: boundary, and the type settles it

You leaned boundary but flagged the risk — `WorkflowInfo.path` stops being "a path you can open" and becomes "a repository-relative locator", and if anything downstream opens it I have moved the problem rather than solved it. You had not checked whether anything does. **I did, and nothing does:**

```
159:    text = path.read_text(encoding="utf-8")     <- parse_workflow, BEFORE the record exists
216/231/241/251/255:  str(info.path)               <- the five render sites
263/266:  report_path.exists() / read_text          <- a different variable
```

`WorkflowInfo.path` is assigned once and rendered five times. It is never opened, and never could be — the file is read in `parse_workflow` before the record is constructed.

So the boundary version carries no risk, and I went further than `as_posix()`: **the field type is now `PurePosixPath`**, which does two jobs at once.

- It renders with forward slashes on every platform.
- It has **no `read_text`/`open` at all**, so "this is a locator, not a file handle" is enforced by the type rather than by a docstring somebody has to honour.

That turns your concern inside out. The type change is not the risk of the boundary approach — it is the thing that makes the boundary approach safe permanently. A future contributor cannot widen it back to `Path` and call `read_text` without deleting a test that says no.

Normalisation happens in `__post_init__` as well as at the call site. The annotation alone is a promise; `__post_init__` is the mechanism, and it is what stops a future caller handing in the `WindowsPath` straight off the glob — which is exactly how this arrived the first time.

## You were right about the reordering, and I was wrong

Consequence 2 in my issue does not hold, and thank you for checking it against the tree instead of letting me write a test around it. Every path shares the same directory prefix so the separator cancels out of the comparison, and no workflow filename has an uppercase character for `PureWindowsPath`'s case-folding to bite. **The diff is cosmetic today.** I have not written a stability-of-ordering test, for exactly the reason you gave: it would pass for reasons unrelated to this fix and become decoration.

Consequences 1 and 3 stand, and 3 is the one worth the change.

## The test fails on Linux, which is the whole point

Your framing here was the useful constraint. `tests/unit/test_workflow_topology_report.py` shells out to `--check` and CI is Linux, so "no row in the generated report contains a backslash" passes there whether or not anything is fixed.

**`PureWindowsPath` renders backslashes on every host, not just on Windows.** So the regression test constructs a `WorkflowInfo` with `PureWindowsPath(r".github\workflows\ci.yml")` and asserts the rendered locator is `.github/workflows/ci.yml`. That fails on Linux today and passes after the fix — a real gate on the platform that runs it. No filesystem needed, so the "make the row builder testable" scope you offered was not required.

**Mutation-checked** by reverting only the normalisation and leaving everything else:

```
2 failed, 4 passed
  test_a_windows_flavoured_path_renders_with_forward_slashes   <- the platform-independent one
  test_workflow_topology_report_is_current
```

One test in the class deliberately does **not** fail under that mutation: `test_every_locator_in_the_committed_report_is_posix` passes vacuously on Linux. It is a cheap end-to-end backstop and I have said so in its docstring rather than let it look load-bearing.

## One thing I got wrong while writing the test

My first version of that backstop asserted no backslash anywhere in a row containing `.github`. It **failed against correct output**: ten rows carry a legitimate backslash in the concurrency column, where a `${{ }}` expression is JSON-escaped. Scoped it to the locator cell. Worth mentioning because a guard that reddens on correct output is how guards get deleted — and it was the same class of mistake as the bug, checking the row when the claim was about one cell.

## Scope

Per your list: no `ci-topology.md` in the diff (byte-identical after the fix — I regenerated to confirm), no `ci-topology-heal.yml` runner pin, and #3901 / the `perf_counter` family left alone.

## Verification

```
gen_workflow_topology.py --check   exit 0 on Windows (was 1 on a clean tree)
regenerate + git status            report unchanged
pytest test_workflow_topology_report.py   6 passed
ruff check / format --check        clean
mypy scripts/gen_workflow_topology.py     Success
```

Not run: the full suite. I ran the file this touches and the script itself.