### PR TITLE
fix(replay): emit JSON on every exit path, not only the successful one

### DIFF
--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -2116,12 +2116,25 @@ def replay_cmd(
     # named error rather than a silent no-op -- the whole point of this
     # fix is that an accepted flag must never be quietly ignored (#3976).
     if yes_i_want_to_publish and not (args and args[0] == "publish"):
-        console.print(
-            "[red]Error:[/red] --yes-i-want-to-publish only applies to "
-            "'bernstein replay publish'; refusing rather than silently "
-            "ignoring it here."
+        # Routed through _fail so this refusal is machine-readable too. It is
+        # a refusal the flag fix itself introduced (#3991), and it had no
+        # JSON form at all -- a caller passing --as-json got prose for the
+        # one error most likely to be produced by a script (#3996).
+        from bernstein.cli.commands.replay_cmd import ReplayError, _fail
+
+        raise SystemExit(
+            _fail(
+                as_json=as_json,
+                error=ReplayError["FLAG_NOT_APPLICABLE"],
+                prose=(
+                    "[red]Error:[/red] --yes-i-want-to-publish only applies to "
+                    "'bernstein replay publish'; refusing rather than silently "
+                    "ignoring it here."
+                ),
+                detail=("--yes-i-want-to-publish only applies to 'bernstein replay publish'"),
+                code=2,
+            )
         )
-        raise SystemExit(2)
 
     if args and args[0] == "diff":
         _replay_diff_dispatch(args[1:], sdd_dir=sdd_dir, as_json=as_json)

--- a/src/bernstein/cli/commands/replay_cmd.py
+++ b/src/bernstein/cli/commands/replay_cmd.py
@@ -51,6 +51,69 @@ logger = logging.getLogger(__name__)
 _DEFAULT_DEBUG_LIMIT = 200
 
 
+#: Machine-readable names for every way a replay receipt verb can refuse.
+#:
+#: A caller branches on these rather than on whether parsing threw, which is
+#: the whole point of #3996: the malformed-receipt failure and the
+#: chain-does-not-verify failure both exited 1, one parseable and one not,
+#: with nothing in the exit code to tell them apart. They route to different
+#: people - "this chain does not verify" is a finding about the run, "this
+#: file is not a receipt" is a finding about the invocation.
+ReplayError = {
+    "AGENT_JOURNAL_MISSING": "agent_journal_missing",
+    "SIGNING_KEY_UNREADABLE": "signing_key_unreadable",
+    "PUBLIC_KEY_UNREADABLE": "public_key_unreadable",
+    "EXPORT_FAILED": "export_failed",
+    "PUBLISH_FAILED": "publish_failed",
+    "CONFIRMATION_REQUIRED": "confirmation_required",
+    "RECEIPT_NOT_FOUND": "receipt_not_found",
+    "RECEIPT_MALFORMED": "receipt_malformed",
+    "FLAG_NOT_APPLICABLE": "flag_not_applicable",
+}
+
+
+def _fail(
+    *,
+    as_json: bool,
+    error: str,
+    prose: str,
+    detail: str,
+    code: int,
+    include_ok: bool = False,
+) -> int:
+    """Emit a refusal on whichever channel ``--as-json`` selected.
+
+    **The invariant this exists to hold: if ``--as-json`` was accepted, every
+    exit path emits JSON.** Half-honouring a machine-readable flag is harder
+    to script against than not offering it, because the caller has no way to
+    discover the exception except in production. Route new refusals through
+    here rather than calling ``console.print`` directly, and the next exit
+    path cannot be added prose-only by accident.
+
+    ``prose`` carries Rich markup for humans; ``detail`` is the same message
+    without it, because markup in a JSON string is noise to a parser.
+
+    ``include_ok`` adds ``"ok": false``. Only ``verify`` sets it: ``ok`` is
+    already part of that surface's success contract, so a client keyed on
+    ``data["ok"]`` keeps working across both outcomes. ``export`` and
+    ``publish`` have no ``ok`` on success, and inventing one on failure alone
+    would mean a key that exists only when things go wrong.
+    """
+    from bernstein.cli.helpers import console
+
+    if as_json:
+        payload: dict[str, object] = {}
+        if include_ok:
+            payload["ok"] = False
+        payload["error"] = error
+        payload["detail"] = detail
+        console.print_json(json.dumps(payload))
+        return code
+
+    console.print(prose)
+    return code
+
+
 def _resolve_agent_dir(sdd_dir: Path, agent_id: str) -> Path:
     """Return the agent journal directory under *sdd_dir*."""
     return agent_journal_dir(sdd_dir, agent_id)
@@ -147,8 +210,13 @@ def replay_export(
 
     agent_dir = _resolve_agent_dir(sdd_dir, agent_id)
     if not agent_dir.exists():
-        console.print(f"[red]No journal for agent[/red] {agent_id}")
-        return 2
+        return _fail(
+            as_json=as_json,
+            error=ReplayError["AGENT_JOURNAL_MISSING"],
+            prose=f"[red]No journal for agent[/red] {agent_id}",
+            detail=f"no journal for agent {agent_id}",
+            code=2,
+        )
 
     signer = None
     if signer_key_path is not None:
@@ -160,8 +228,13 @@ def replay_export(
         try:
             signer = Ed25519FileKeySigner.from_path(signer_key_path)
         except LineageSignerError as exc:
-            console.print(f"[red]Cannot load signing key:[/red] {exc}")
-            return 2
+            return _fail(
+                as_json=as_json,
+                error=ReplayError["SIGNING_KEY_UNREADABLE"],
+                prose=f"[red]Cannot load signing key:[/red] {exc}",
+                detail=str(exc),
+                code=2,
+            )
 
     try:
         result = export_receipt(
@@ -171,8 +244,13 @@ def replay_export(
             signer=signer,
         )
     except ReceiptError as exc:
-        console.print(f"[red]Export failed:[/red] {exc}")
-        return 1
+        return _fail(
+            as_json=as_json,
+            error=ReplayError["EXPORT_FAILED"],
+            prose=f"[red]Export failed:[/red] {exc}",
+            detail=str(exc),
+            code=1,
+        )
 
     if as_json:
         console.print_json(
@@ -208,17 +286,29 @@ def replay_publish(
     from bernstein.cli.helpers import console
 
     if not opt_in:
-        console.print(
-            "[red]Refusing to publish:[/red] pass --yes-i-want-to-publish "
-            "to confirm. Local-only is the default; publish is the only "
-            "path that writes outside .sdd/runtime/."
+        return _fail(
+            as_json=as_json,
+            error=ReplayError["CONFIRMATION_REQUIRED"],
+            prose=(
+                "[red]Refusing to publish:[/red] pass --yes-i-want-to-publish "
+                "to confirm. Local-only is the default; publish is the only "
+                "path that writes outside .sdd/runtime/."
+            ),
+            detail=(
+                "pass --yes-i-want-to-publish to confirm; publish is the only path that writes outside .sdd/runtime/"
+            ),
+            code=2,
         )
-        return 2
 
     agent_dir = _resolve_agent_dir(sdd_dir, agent_id)
     if not agent_dir.exists():
-        console.print(f"[red]No journal for agent[/red] {agent_id}")
-        return 2
+        return _fail(
+            as_json=as_json,
+            error=ReplayError["AGENT_JOURNAL_MISSING"],
+            prose=f"[red]No journal for agent[/red] {agent_id}",
+            detail=f"no journal for agent {agent_id}",
+            code=2,
+        )
 
     signer = None
     if signer_key_path is not None:
@@ -230,8 +320,13 @@ def replay_publish(
         try:
             signer = Ed25519FileKeySigner.from_path(signer_key_path)
         except LineageSignerError as exc:
-            console.print(f"[red]Cannot load signing key:[/red] {exc}")
-            return 2
+            return _fail(
+                as_json=as_json,
+                error=ReplayError["SIGNING_KEY_UNREADABLE"],
+                prose=f"[red]Cannot load signing key:[/red] {exc}",
+                detail=str(exc),
+                code=2,
+            )
 
     try:
         result = publish_receipt(
@@ -243,8 +338,13 @@ def replay_publish(
             signer=signer,
         )
     except PublishError as exc:
-        console.print(f"[red]Publish failed:[/red] {exc}")
-        return 1
+        return _fail(
+            as_json=as_json,
+            error=ReplayError["PUBLISH_FAILED"],
+            prose=f"[red]Publish failed:[/red] {exc}",
+            detail=str(exc),
+            code=1,
+        )
 
     if as_json:
         console.print_json(
@@ -280,8 +380,14 @@ def replay_verify(
     from bernstein.cli.helpers import console
 
     if not receipt_path.exists():
-        console.print(f"[red]Receipt not found:[/red] {receipt_path}")
-        return 2
+        return _fail(
+            as_json=as_json,
+            error=ReplayError["RECEIPT_NOT_FOUND"],
+            prose=f"[red]Receipt not found:[/red] {receipt_path}",
+            detail=f"receipt not found: {receipt_path}",
+            code=2,
+            include_ok=True,
+        )
 
     verifier = None
     if public_key_path is not None:
@@ -293,8 +399,14 @@ def replay_verify(
         try:
             verifier = Ed25519PublicKeyVerifier.from_path(public_key_path)
         except LineageSignerError as exc:
-            console.print(f"[red]Cannot load public key:[/red] {exc}")
-            return 2
+            return _fail(
+                as_json=as_json,
+                error=ReplayError["PUBLIC_KEY_UNREADABLE"],
+                prose=f"[red]Cannot load public key:[/red] {exc}",
+                detail=str(exc),
+                code=2,
+                include_ok=True,
+            )
 
     try:
         result = verify_receipt(
@@ -303,8 +415,14 @@ def replay_verify(
             verifier=verifier,
         )
     except ReceiptError as exc:
-        console.print(f"[red]Receipt malformed:[/red] {exc}")
-        return 1
+        return _fail(
+            as_json=as_json,
+            error=ReplayError["RECEIPT_MALFORMED"],
+            prose=f"[red]Receipt malformed:[/red] {exc}",
+            detail=str(exc),
+            code=1,
+            include_ok=True,
+        )
 
     if as_json:
         console.print_json(

--- a/tests/unit/test_replay_as_json_failure_paths.py
+++ b/tests/unit/test_replay_as_json_failure_paths.py
@@ -1,0 +1,141 @@
+"""``--as-json`` is honoured on every exit path, not just the successful one (#3996).
+
+#3991 made ``export`` / ``publish`` / ``verify`` emit real payloads. It did
+not cover the failure paths, which stayed prose. ``verify`` was the sharp
+case: a receipt that verifies *false* emitted ``{ok: false, errors: [...]}``
+and exited 1, while a *malformed* receipt emitted Rich prose and also exited
+1 - same status, one parseable and one not, with no way to tell which you
+were getting before you tried.
+
+Driven through the real CLI rather than by calling the functions, because
+the wrong-verb refusal lives in ``advanced_cmd``'s dispatcher and never
+reaches ``replay_cmd`` at all. A test that called the functions directly
+would miss the one refusal ``--as-json`` never had any form of.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "bernstein", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def malformed_receipt(tmp_path: Path) -> Path:
+    receipt = tmp_path / "notareceipt.tar"
+    receipt.write_text("this is not a tar archive", encoding="utf-8")
+    return receipt
+
+
+class TestEveryRefusalEmitsJsonWhenAsJsonWasAccepted:
+    """The invariant: if ``--as-json`` was accepted, every exit path emits JSON."""
+
+    @pytest.mark.parametrize(
+        ("label", "args", "expected_error", "expected_code"),
+        [
+            (
+                # The refusal #3991 introduced and gave no machine-readable
+                # form at all - the one most likely to be hit BY a script.
+                "wrong verb",
+                ("replay", "export", "nope", "--yes-i-want-to-publish"),
+                "flag_not_applicable",
+                2,
+            ),
+            ("export missing agent", ("replay", "export", "nope"), "agent_journal_missing", 2),
+            (
+                "publish missing agent",
+                ("replay", "publish", "nope", "--yes-i-want-to-publish"),
+                "agent_journal_missing",
+                2,
+            ),
+            ("publish unconfirmed", ("replay", "publish", "nope"), "confirmation_required", 2),
+        ],
+        ids=["wrong_verb", "export_no_agent", "publish_no_agent", "publish_unconfirmed"],
+    )
+    def test_refusal_is_parseable_and_names_itself(
+        self,
+        tmp_path: Path,
+        label: str,
+        args: tuple[str, ...],
+        expected_error: str,
+        expected_code: int,
+    ) -> None:
+        proc = run_cli(*args, "--as-json", "--sdd-dir", str(tmp_path))
+        payload = json.loads(proc.stdout)  # raises if prose leaked through
+        assert payload["error"] == expected_error, label
+        assert payload["detail"], "a discriminator with no detail is not actionable"
+        assert proc.returncode == expected_code
+
+    def test_verify_missing_receipt(self, tmp_path: Path) -> None:
+        proc = run_cli("replay", "verify", str(tmp_path / "absent.tar"), "--as-json")
+        payload = json.loads(proc.stdout)
+        assert payload["error"] == "receipt_not_found"
+        assert proc.returncode == 2
+
+    def test_verify_malformed_receipt(self, malformed_receipt: Path) -> None:
+        proc = run_cli("replay", "verify", str(malformed_receipt), "--as-json")
+        payload = json.loads(proc.stdout)
+        assert payload["error"] == "receipt_malformed"
+        assert proc.returncode == 1
+
+
+class TestTheDistinctionThatMotivatedThis:
+    def test_a_malformed_receipt_is_told_apart_from_a_chain_that_does_not_verify(self, malformed_receipt: Path) -> None:
+        """Both exit 1. The payload is what routes them to different people.
+
+        "this chain does not verify" is a finding about the run; "this file is
+        not a receipt" is a finding about the invocation. Before this change a
+        caller could only tell them apart by catching a parse exception - which
+        is the problem the flag exists to remove.
+        """
+        proc = run_cli("replay", "verify", str(malformed_receipt), "--as-json")
+        payload = json.loads(proc.stdout)
+        assert proc.returncode == 1
+        # `error` present => the invocation was wrong. A chain that merely
+        # fails to verify carries head_hash/steps/errors and NO `error` key.
+        assert "error" in payload
+        assert "head_hash" not in payload
+
+    def test_verify_keeps_ok_across_both_outcomes(self, malformed_receipt: Path) -> None:
+        # `ok` is already part of verify's success contract, so a client keyed
+        # on data["ok"] degrades sensibly instead of raising KeyError.
+        payload = json.loads(run_cli("replay", "verify", str(malformed_receipt), "--as-json").stdout)
+        assert payload["ok"] is False
+
+    def test_export_and_publish_do_not_invent_an_ok_key(self, tmp_path: Path) -> None:
+        # They have no `ok` on success, so adding one on failure alone would
+        # mean a key that exists only when things go wrong.
+        for args in (("replay", "export", "nope"), ("replay", "publish", "nope")):
+            payload = json.loads(run_cli(*args, "--as-json", "--sdd-dir", str(tmp_path)).stdout)
+            assert "ok" not in payload, args
+
+
+class TestProseIsUnchangedWithoutTheFlag:
+    """The control. If these passed too, the refactor would have broken humans."""
+
+    @pytest.mark.parametrize(
+        ("args", "needle"),
+        [
+            (("replay", "export", "nope"), "No journal for agent"),
+            (("replay", "publish", "nope"), "Refusing to publish"),
+        ],
+        ids=["export", "publish"],
+    )
+    def test_a_human_still_gets_a_sentence(self, tmp_path: Path, args: tuple[str, ...], needle: str) -> None:
+        proc = run_cli(*args, "--sdd-dir", str(tmp_path))
+        flat = " ".join(proc.stdout.split())
+        assert needle in flat
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(proc.stdout)


### PR DESCRIPTION
Closes #3996.

## The decision you left me: reuse the envelope, but only where `ok` already means something

You framed it as A (one envelope, extra key) vs B (distinct shape), and ruled out keys-present-but-null. **I took a disciplined A**, and the discipline is the part worth arguing:

```jsonc
// verify  -- ok is already part of its success contract
{"ok": false, "error": "receipt_malformed", "detail": "receipt is not a valid tar archive: ..."}

// export / publish -- no ok on success, so none on failure
{"error": "agent_journal_missing", "detail": "no journal for agent backend-abc"}
```

Your objection to A was that `steps` and `errors` are meaningless for a file that never parsed, and emitting `"steps": 0` invites someone to plot it. Agreed — so I **omit** them rather than null them. That is not your ruled-out third option: nothing is present-but-null, the object is just smaller. The rule is *every key present is meaningful*, which is what makes `ok` worth keeping and `steps` worth dropping in the same payload.

And `ok` only goes where it already exists. `verify` promises it on success, so a client doing `data["ok"]` degrades sensibly across both outcomes — your strongest argument for A, and it applies to exactly one of the three verbs. `export` and `publish` have no `ok` on success, so adding one on failure alone would mean **a key that exists only when things go wrong** — the worst of both shapes.

## The wrong-verb refusal

Covered, and it needed the dispatcher rather than `replay_cmd`: it lives in `advanced_cmd.py` and exits before dispatch. It is `flag_not_applicable`, exit 2. Worth noting it is the refusal most likely to be produced *by a script* — a human does not typically pass `--yes-i-want-to-publish` to `export` — and it was the one with no machine-readable form at all.

## The invariant is in the code, as you asked

`_fail()` carries it in its docstring, and being the single emitter is what enforces it:

> **if `--as-json` was accepted, every exit path emits JSON**

Nine refusals now route through it. A tenth added with a bare `console.print` is the regression, and the parametrised CLI test is what catches it.

## Verification

Driven through the real CLI (`[sys.executable, "-m", "bernstein", ...]`), not by calling the functions — otherwise the dispatcher refusal is invisible.

```
tests/unit/test_replay_as_json_failure_paths.py    11 passed
tests/unit/test_replay_cmd.py
tests/unit/test_replay_journal_cli.py
tests/unit/test_replay_verify_cli.py               27 passed
ruff check / format --check                        clean
mypy src/bernstein/cli/commands/replay_cmd.py      Success
```

Every failure path, confirmed parseable end to end:

| invocation | exit | payload |
|---|---|---|
| `export … --yes-i-want-to-publish` | 2 | `flag_not_applicable` |
| `export <missing>` | 2 | `agent_journal_missing` |
| `publish <agent>` (unconfirmed) | 2 | `confirmation_required` |
| `verify <absent>` | 2 | `ok:false, receipt_not_found` |
| `verify <malformed>` | 1 | `ok:false, receipt_malformed` |

There is a control class asserting humans still get prose **and** that it is *not* parseable as JSON, so the refactor cannot silently start emitting JSON at a terminal.

Exit codes untouched, per your scope note.

## Docs: deliberately not in this PR, and why

Repo policy is docs-with-code, so I want to be explicit rather than quietly skip it.

`docs/reference/cli/replay.md` is the page that documents `--as-json`, and **#3989 is sitting in the merge queue rewriting exactly that section**. Editing it here would conflict with my own queued PR, and resolving that conflict by hand is how one of the two versions gets silently dropped.

`main`'s copy is still the pre-#3989 page, so there is nothing truthful to amend in place yet either. The sequence I propose, which is the one you set on #3996 anyway:

1. #3989 lands — page becomes truthful about pre-#3991 behaviour.
2. I write the #3991 update I already owe you (the three `accepted, ignored` rows become contracts, the "do not pipe them into a parser" paragraph is deleted, `publish` gets its working example).
3. **This PR's rows go in the same edit** — the failure-path column and the refusal vocabulary.

That is one coherent docs change instead of three partial ones, and it keeps the exit-code paragraph you asked me to preserve as the thing the table hangs off. Say the word if you would rather I block this PR on #3989 landing and do it here instead — I would rather ask than leave the page behind.