### PR TITLE
docs(replay): describe the --as-json contracts that #3991 shipped

### DIFF
--- a/docs/reference/cli/replay.md
+++ b/docs/reference/cli/replay.md
@@ -5,8 +5,8 @@
 - **`bernstein replay <RUN_ID>`** - the original replay, optionally with task-trace re-submission.
 - **`bernstein replay diff RUN_A RUN_B`** - localise the first divergence between two recorded runs.
 - **`bernstein replay export <AGENT_ID> [OUT]`** - write a portable per-step receipt.
-- **`bernstein replay publish <AGENT_ID> [OUT]`** - write a redacted receipt for publishing (see #3976: currently not completable).
-- **`bernstein replay verify <RECEIPT>`** - offline verifier for an exported receipt.
+- **`bernstein replay publish <AGENT_ID> [OUT]`** - write a redacted receipt for publishing (needs `--yes-i-want-to-publish`).
+- **`bernstein replay verify <RECEIPT>`** - offline verifier for an exported or published receipt.
 - **`bernstein replay diff-journal A B`** - per-step divergence finder across two journals.
 
 All subcommands read from the same underlying journal on disk. The base command additionally supports **task-trace replay**, which re-creates a new task from a stored task trace and (optionally) compares the replay's `result_summary` against the original via a colour diff.
@@ -90,27 +90,41 @@ bernstein replay T-abc123 --model opus --extra-context "Make sure tests pass on 
 
 ## Machine-readable output (`--as-json`)
 
-The flag is `--as-json`. Every subcommand accepts it, but **only some act on
-it**, which matters if you are scripting:
+The flag is `--as-json`, and every subcommand emits a payload on success:
 
-| Surface | `--as-json` | Emits |
-|---|---|---|
-| `bernstein replay <AGENT_ID>` | yes | `{agent_id, head_hash, steps, entries[]}` |
-| `bernstein replay <RUN_ID> --verify` | yes | chain verdict, head hash, and the divergent step when one exists |
-| `bernstein replay diff-journal A B` | yes | `{diverged, seq, fields_changed[], left_values, right_values, reason}` |
-| `bernstein replay debug ...` | yes | head hash, step count, receipt path, whether it was signed |
-| `bernstein replay export` | **accepted, ignored** | human-readable output regardless |
-| `bernstein replay publish` | **accepted, ignored** | human-readable output regardless |
-| `bernstein replay verify <RECEIPT>` | **accepted, ignored** | human-readable output regardless |
+| Surface | Emits on success |
+|---|---|
+| `bernstein replay <AGENT_ID>` | `{agent_id, head_hash, steps, entries[]}` |
+| `bernstein replay <RUN_ID> --verify` | chain verdict, head hash, and the divergent step when one exists |
+| `bernstein replay diff-journal A B` | `{diverged, seq, fields_changed[], left_values, right_values, reason}` |
+| `bernstein replay debug ...` | head hash, step count, receipt path, whether it was signed |
+| `bernstein replay export` | `{agent_id, output, head_hash, steps, signed}` |
+| `bernstein replay publish` | the same, **plus `original_head_hash`** |
+| `bernstein replay verify <RECEIPT>` | `{ok, head_hash, steps, errors, signed}` |
 
-The bottom three exit normally and print prose, with no error saying the flag
-did nothing. Do not pipe them into a parser. Tracked in
-[#3976](https://github.com/sipyourdrink-ltd/bernstein/issues/3976).
+`publish` reporting both hashes is the machine-readable form of what redaction
+means: it rewrites the payloads, so the published head is *not* the exported
+one. A script comparing `head_hash` across an export and a publish of the same
+agent would otherwise reasonably conclude something had been corrupted.
 
-**The exit code is the verdict, not the payload.** On the three that ignore the
-flag it is the *only* machine-readable signal there is: `verify` exits non-zero
-on a receipt mismatch while still printing to stdout, so a caller that reads
-stdout and ignores the exit status sees a refused chain as a success. Check the
+**Failure paths are still prose**, on every one of these. That matters most on
+`verify`, which has two different failures that both exit `1`:
+
+- the receipt verifies *false* - emits `{ok: false, ..., errors: [...]}`
+- the receipt is *malformed* - prints prose
+
+Same exit status, one parseable and one not, and no way to tell which you are
+getting before you try. Those route to different people: "this chain does not
+verify" is a finding about the run, "this file is not a receipt" is a finding
+about the invocation. Until that is closed, a scripted caller has to treat a
+parse failure as a third outcome rather than an error. Tracked in
+[#3996](https://github.com/sipyourdrink-ltd/bernstein/issues/3996).
+
+**The exit code is the verdict, not the payload.** This was true when these
+verbs ignored `--as-json` and it stays true now that they honour it: `verify`
+emits a payload *and* exits non-zero on a receipt mismatch, so a caller that
+reads stdout and ignores the exit status still sees a refused chain as a
+success. A payload is not an assertion that the operation succeeded. Check the
 exit code first and treat any payload as detail.
 
 ## Subcommands
@@ -150,12 +164,32 @@ bernstein replay export backend-abc
 
 Same as `export`, but produces a redacted receipt suitable for publishing. Sensitive fields are stripped while the head hash still anchors the visible steps. The destination is positional, as for `export`.
 
-> **Currently not completable.** `publish` refuses without a confirmation flag
-> and names `--yes-i-want-to-publish`, which the CLI does not declare, so every
-> invocation exits 2. Tracked in
-> [#3976](https://github.com/sipyourdrink-ltd/bernstein/issues/3976); a working
-> example lands here with that fix. Use `export` for a local receipt in the
-> meantime -- `publish` differs only in redacting before it writes.
+**`--yes-i-want-to-publish` is required.** Local-only is the default, and
+`publish` is the only path that writes outside `.sdd/runtime/`. Without the flag
+it refuses and exits 2. The flag is scoped to this verb: passing it to `export`,
+`verify` or any other spelling is **refused by name**, not silently dropped.
+
+```bash
+# explicit destination
+bernstein replay publish backend-abc receipt.public.tar --yes-i-want-to-publish
+
+# default destination: .sdd/runtime/receipts/backend-abc.tar
+bernstein replay publish backend-abc --yes-i-want-to-publish
+```
+
+A published receipt is **not** a drop-in substitute for an exported one, in two
+ways worth knowing before you build a pipeline on it:
+
+- **It verifies against the *published* head, not the original.** Keeping the
+  export's `head_hash` to pin against is the correct instinct everywhere else,
+  but `bernstein replay verify <published> --head <original_head_hash>` fails a
+  perfectly good receipt, and the `ok: false` reads as tampering. Pin against
+  `head_hash` from the publish, and keep `original_head_hash` only for
+  correlating the two.
+- **It drops `blob_refs` and ships `blob_digests: []`**, where an exported
+  receipt keeps them. Redaction rewrites the payloads the chain is computed
+  over; that is what makes the head differ, and it is why the visible steps
+  still anchor while the blobs no longer resolve.
 
 ### `bernstein replay verify <RECEIPT>`
 


### PR DESCRIPTION
The same-day update I owed you once #3991 and #3989 both landed. Refs #3968.

## What changed

| Block | Before | Now |
|---|---|---|
| three `accepted, ignored` rows | a warning | the payloads they emit |
| "do not pipe them into a parser" | — | deleted |
| "Currently not completable" on `publish` | — | deleted; working example, and the flag scoping |
| exit-code paragraph | "on the three that ignore the flag" | kept, made true |

**I kept the exit-code paragraph rather than letting the table absorb it**, as you asked on #3968. It needed one correction — it opened with "on the three that ignore the flag" — but the claim survives the fix intact, and I think it is *more* useful now than before: a verb that emits a payload and exits non-zero is more likely to fool a careless caller than one that only printed prose. So it now reads that a payload is not an assertion the operation succeeded.

## The two traps from your #3976 measurements

Both in, and both framed as what they are — failures you hit *because* you did the careful thing:

- **`--head <original_head_hash>` fails a perfectly good published receipt.** Keeping the export's head to pin against is the correct instinct everywhere else, which is exactly why `ok: false` there reads as tampering. The page says pin against the publish's `head_hash` and keep `original_head_hash` only for correlating the two.
- **A published receipt drops `blob_refs` and ships `blob_digests: []`.** Stated as "not a drop-in substitute for an exported one", because the old text described `publish` as "same as `export`, but redacted", which invites exactly the substitution that breaks.

**Provenance, since it is your measurement and not mine:** those two facts come from your verification on #3976. I have not independently reproduced the blob-digest behaviour or the head-pinning failure — I would need a real signed publish round-trip to do it, and I would rather say so than imply I ran it.

What I **did** verify against the running CLI before writing it:

```
publish without the flag        -> refuses, exit 2
--yes-i-want-to-publish on export -> refused by name, not dropped
replay --help                    -> the flag is declared
```

## The gap I documented rather than hid

`--as-json` failure paths are still prose on `main`, so the page says so, next to the table where a scripted caller will actually be looking. The `verify` split gets named explicitly — verifies-false emits JSON, malformed prints prose, both exit `1` — with the routing argument you liked, and a pointer to #3996.

That is deliberately written to describe **current `main`**, not my #4017. When #4017 merges, that paragraph becomes the refusal-vocabulary table and shrinks to a sentence. Truthful now, aspirational never.

`scripts/check_docs_drift.py`: no drift.