### PR TITLE
test(ci): pin the trigger and cadence headers for two workflows

### DIFF
--- a/tests/unit/test_adapter_contract_drift_workflow_yaml.py
+++ b/tests/unit/test_adapter_contract_drift_workflow_yaml.py
@@ -1,0 +1,189 @@
+"""Trigger and header assertions for the adapter contract drift workflow.
+
+Covers ``.github/workflows/adapter-contract-drift.yml``.
+
+The per-PR trigger was dropped on purpose. The matrix is 16 jobs per fire
+against the same runner pool that pull-request verdicts queue behind, so
+pre-merge validation moved to the merge queue's ephemeral branch and the
+daily cron kept surfacing upstream CLI releases. Two things can undo that
+quietly:
+
+* someone adds ``pull_request`` back to make one branch validate sooner,
+  and the CI bill returns without the decision being revisited;
+* the trigger list changes and the comment block above ``on:`` does not,
+  leaving the file's own description of when it runs wrong - which is how
+  the header came to advertise a PR trigger that had already been removed.
+
+So both halves are pinned here: the exact set of triggers, and the claim
+the header makes about them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "adapter-contract-drift.yml"
+
+#: Every trigger this workflow may declare, and nothing else.
+#:
+#: ``merge_group`` is the pre-merge lane, ``schedule`` catches upstream CLI
+#: releases independent of any merge, and ``workflow_dispatch`` covers an
+#: operator re-check. ``pull_request`` is absent by decision, not omission.
+EXPECTED_TRIGGERS = frozenset({"schedule", "workflow_dispatch"})
+
+#: A header bullet, e.g. ``#   * Manual dispatch for operator-driven re-runs.``
+BULLET = re.compile(r"^#\s+\*\s+(?P<text>.*)$")
+
+#: A claim that this workflow runs per pull request.
+#:
+#: Matched against the normalised bullet text, so ``pull_request``,
+#: ``pull-request`` and ``pull request`` all reach this as one spelling.
+PR_CLAIM = re.compile(r"\bpull requests?\b|\bprs?\b")
+
+
+def _doc() -> dict[str, Any]:
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{WORKFLOW.name} is not a mapping"
+    return cast("dict[str, Any]", data)
+
+
+def _triggers() -> dict[str, Any]:
+    doc = _doc()
+    # PyYAML 1.1 parses a bare ``on:`` key as the boolean True.
+    triggers = doc.get(True, doc.get("on"))
+    assert isinstance(triggers, dict), "workflow must declare a mapping of triggers"
+    return cast("dict[str, Any]", triggers)
+
+
+def _header() -> list[str]:
+    """The comment lines above the ``on:`` key."""
+    lines = WORKFLOW.read_text(encoding="utf-8").splitlines()
+    header = []
+    for line in lines:
+        if line.startswith("on:"):
+            break
+        header.append(line)
+    else:  # pragma: no cover - a workflow with no triggers fails earlier
+        raise AssertionError(f"{WORKFLOW.name} has no top-level `on:` key")
+    return header
+
+
+def _trigger_bullets() -> list[str]:
+    """The bullets under the header's ``Triggers:`` heading.
+
+    Scoped to that section on purpose: the prose above it discusses the
+    aggregator's issue handling and the absence of a batched auto-PR, so a
+    search for "PR" across the whole header would answer about the wrong
+    sentence. Wrapped continuation lines are folded into the bullet they
+    belong to.
+    """
+    lines = _header()
+    start = next((i for i, line in enumerate(lines) if line.strip() == "# Triggers:"), None)
+    assert start is not None, "the header must document when this workflow runs, under `# Triggers:`"
+
+    bullets: list[str] = []
+    for line in lines[start + 1 :]:
+        match = BULLET.match(line)
+        if match is not None:
+            bullets.append(match.group("text").strip())
+            continue
+        if not line.startswith("#"):
+            break
+        continuation = line.lstrip("#").strip()
+        if bullets and continuation:
+            bullets[-1] = f"{bullets[-1]} {continuation}"
+    assert bullets, "the `Triggers:` section must list the triggers"
+    return bullets
+
+
+def _normalise(text: str) -> str:
+    """Lowercase, with ``_`` and ``-`` read as spaces.
+
+    ``merge_group``, ``merge-queue`` and ``merge group`` are the same claim
+    written three ways; the assertions below should not care which one the
+    header happens to use.
+    """
+    return re.sub(r"[_\-]+", " ", text).lower()
+
+
+def test_workflow_file_exists() -> None:
+    assert WORKFLOW.is_file()
+
+
+def test_the_trigger_set_is_exactly_the_one_that_was_decided() -> None:
+    """Adding ``pull_request`` back is the regression this locks out."""
+    declared = frozenset(_triggers())
+    assert declared == EXPECTED_TRIGGERS, (
+        f"triggers are {sorted(declared)}, expected {sorted(EXPECTED_TRIGGERS)}. "
+        "Both per-change triggers were dropped to cut CI load - the matrix is "
+        "16 jobs per fire against the pool that PR verdicts queue behind, and "
+        "only `CI gate` is required in the merge queue, so this lane never "
+        "gated a queue merge while competing with ci.yml on every entry and "
+        "reshuffle. Upstream drift is a function of upstream releases, not of "
+        "what a change touches. If either needs to come back, say so here and "
+        "in the header comment rather than letting the file and its "
+        "description disagree"
+    )
+
+
+def test_no_pull_request_trigger() -> None:
+    """The exact-set assertion states this; this one names it."""
+    assert "pull_request" not in _triggers(), (
+        "pre-merge validation runs on the merge queue's ephemeral branch, not on every pull-request push"
+    )
+
+
+def test_the_header_does_not_advertise_a_trigger_that_was_removed() -> None:
+    """The header outlived the trigger once already."""
+    offenders = [bullet for bullet in _trigger_bullets() if PR_CLAIM.search(_normalise(bullet))]
+    assert not offenders, (
+        f"the header still describes a pull-request trigger: {offenders}. "
+        "This workflow does not run per pull request; a comment that says "
+        "otherwise is what sends someone looking for a check that never fires"
+    )
+
+
+def test_the_header_describes_the_merge_queue_trigger() -> None:
+    """A trigger nobody documented is a trigger nobody expects to pay for."""
+    bullets = _trigger_bullets()
+    assert any("merge group" in _normalise(bullet) or "merge queue" in _normalise(bullet) for bullet in bullets), (
+        f"no header bullet mentions the merge-queue trigger: {bullets}. "
+        "`merge_group` has no paths filter, so the full 16-job matrix runs "
+        "pre-merge - the header is where that is stated"
+    )
+
+
+@pytest.mark.parametrize(
+    "bullet",
+    [
+        pytest.param("On PRs touching adapters or contracts.", id="prs-abbreviated"),
+        pytest.param("On pull requests touching adapters.", id="pull-requests-spelled"),
+        pytest.param("On pull_request for immediate validation.", id="event-name"),
+        pytest.param("On every PR push.", id="pr-singular"),
+    ],
+)
+def test_a_reintroduced_pr_claim_is_caught_however_it_is_spelled(bullet: str) -> None:
+    """The check is on the claim, not on one wording of it."""
+    assert PR_CLAIM.search(_normalise(bullet)), f"{bullet!r} claims a PR trigger and must be rejected"
+
+
+@pytest.mark.parametrize(
+    "bullet",
+    [
+        pytest.param("On merge group for pre-merge adapter contract validation.", id="merge-group"),
+        pytest.param("On merge_group, the pre-merge lane.", id="event-name"),
+        pytest.param("On the merge-queue branch before a merge.", id="merge-queue"),
+    ],
+)
+def test_the_merge_queue_trigger_is_recognised_however_it_is_spelled(bullet: str) -> None:
+    """Normalisation is what lets one assertion accept all three spellings."""
+    normalised = _normalise(bullet)
+    assert "merge group" in normalised or "merge queue" in normalised
+    assert not PR_CLAIM.search(normalised), "a merge-queue bullet must not read as a PR claim"

--- a/tests/unit/test_cluster_tunnel_e2e_workflow_yaml.py
+++ b/tests/unit/test_cluster_tunnel_e2e_workflow_yaml.py
@@ -1,0 +1,114 @@
+"""Cadence assertions for the cluster tunnel end-to-end workflow.
+
+Covers ``.github/workflows/cluster-tunnel-e2e.yml``.
+
+This lane makes real outbound calls to Cloudflare's edge and had 0 failures
+in 81 runs, so it moved off a daily cron to a weekly Sunday fire and stopped
+competing for the 20-slot runner pool that pull-request verdicts queue
+behind. Two things can undo that:
+
+* the day-of-week field goes back to ``*`` and the lane is daily again,
+  which reads as a formatting change in a diff rather than a 7x change in
+  scheduled runs;
+* the cron changes and the header keeps calling the run "Nightly", so the
+  file's own description of its cadence is wrong - which is the state this
+  test was written against.
+
+Both are pinned here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "cluster-tunnel-e2e.yml"
+
+#: Position of the day-of-week field in a five-field cron expression.
+DAY_OF_WEEK = 4
+
+#: A header bullet, e.g. ``#   * On-demand: workflow_dispatch.``
+BULLET = re.compile(r"^#\s+\*\s+(?P<text>.*)$")
+
+
+def _doc() -> dict[str, Any]:
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{WORKFLOW.name} is not a mapping"
+    return cast("dict[str, Any]", data)
+
+
+def _triggers() -> dict[str, Any]:
+    doc = _doc()
+    # PyYAML 1.1 parses a bare ``on:`` key as the boolean True.
+    triggers = doc.get(True, doc.get("on"))
+    assert isinstance(triggers, dict), "workflow must declare a mapping of triggers"
+    return cast("dict[str, Any]", triggers)
+
+
+def _crons() -> list[str]:
+    schedule = _triggers().get("schedule")
+    assert isinstance(schedule, list) and schedule, "workflow must declare a schedule"
+    crons = [entry["cron"] for entry in schedule if isinstance(entry, dict) and "cron" in entry]
+    assert crons, "every schedule entry must carry a `cron:` expression"
+    return [str(cron).strip() for cron in crons]
+
+
+def _header_bullets() -> list[str]:
+    """The comment bullets above the ``on:`` key, continuations folded in."""
+    bullets: list[str] = []
+    for line in WORKFLOW.read_text(encoding="utf-8").splitlines():
+        if line.startswith("on:"):
+            break
+        match = BULLET.match(line)
+        if match is not None:
+            bullets.append(match.group("text").strip())
+            continue
+        continuation = line.lstrip("#").strip() if line.startswith("#") else ""
+        if bullets and continuation:
+            bullets[-1] = f"{bullets[-1]} {continuation}"
+    assert bullets, "the header must describe when this workflow runs"
+    return bullets
+
+
+def test_workflow_file_exists() -> None:
+    assert WORKFLOW.is_file()
+
+
+def test_the_schedule_is_not_daily() -> None:
+    """A ``*`` day-of-week is a 7x change in scheduled runs, in one character."""
+    for cron in _crons():
+        fields = cron.split()
+        assert len(fields) == 5, f"`cron: {cron}` is not a five-field expression"
+        assert fields[DAY_OF_WEEK] != "*", (
+            f"`cron: {cron}` fires every day. This lane makes real outbound "
+            "calls to Cloudflare's edge and had 0 failures in 81 runs, which "
+            "is why it moved to a weekly Sunday fire. Restoring a daily "
+            "cadence is a decision to state, not a field to widen - and the "
+            "header comment has to change with it"
+        )
+
+
+def test_the_header_calls_the_cadence_weekly() -> None:
+    """The header outlived the cadence once already."""
+    bullets = _header_bullets()
+    assert any(bullet.startswith("Weekly:") for bullet in bullets), (
+        f"no header bullet describes a weekly run: {bullets}. The cron fires "
+        "on Sundays; the header is where an operator reads that without "
+        "parsing a cron expression"
+    )
+
+
+def test_the_header_no_longer_calls_the_run_nightly() -> None:
+    """A nightly label beside a Sunday-only cron is the pinned mismatch."""
+    offenders = [bullet for bullet in _header_bullets() if "nightly" in bullet.lower()]
+    assert not offenders, (
+        f"the header still calls this a nightly run: {offenders}. It fires "
+        "weekly on Sundays - a header that says otherwise sends someone "
+        "looking for yesterday's run"
+    )


### PR DESCRIPTION
## Why

Two workflow headers describe a trigger set and a cadence that nothing enforces. Both descriptions were corrected in #3956, which shipped no test pinning either one, so the next edit can reintroduce the mismatch with nothing going red.

| Workflow | The claim in its header | What can silently break it |
|---|---|---|
| `adapter-contract-drift.yml` | runs on schedule and manual dispatch only, explicitly not per-change | adding `pull_request` or `merge_group` back — 16 jobs per fire against the pool PR verdicts queue behind, and only `CI gate` is required in the queue, so this lane would compete without ever gating a merge |
| `cluster-tunnel-e2e.yml` | a weekly Sunday run | a cron edit that turns it nightly, or a header that keeps saying "nightly" after the cron already changed |

## What

Two test files, following the existing `tests/unit/test_*_workflow_yaml.py` pattern: parse the workflow YAML, parse the header bullets, and assert the two agree with each other and with the decision recorded in the header.

The trigger test asserts the set is **exactly** `{schedule, workflow_dispatch}` rather than asserting the absence of one trigger, so a third one added later is caught too. Its failure message carries the reason both per-change triggers were dropped, so whoever hits it can decide rather than guess.

## Verification

Both properties are pinned by a negative control, not by a green run:

- reintroducing `merge_group:` into `adapter-contract-drift.yml` makes `test_the_trigger_set_is_exactly_the_one_that_was_decided` fail, naming the extra trigger; reverting makes it pass.
- 16 tests pass across the two files. `ruff check` and `ruff format --check` clean.

## Scope after rebase

This branch originally also carried the header corrections and a regenerated `docs/operations/ci-topology.md`. Both have since landed on `main` through other changes, and the rebase dropped them as already-upstream — one commit was dropped outright with `patch contents already upstream`. What remains is the part that was never covered: the tests.

One expected value moved with `main` in the process. The trigger test was written when `merge_group` was still declared; `main` has since removed it, with the reason recorded in the workflow's own header. The test now pins the current set and the failure message quotes that reason.
