### PR TITLE
fix(security): refuse a merge whose incoming change cannot be read

### DIFF
--- a/docs/operations/security-and-identity.md
+++ b/docs/operations/security-and-identity.md
@@ -471,6 +471,21 @@ under `allowed-files-unreadable` instead of `allowed-files-scope`, so
 scope" from "the scope itself needs repair". Repair it with the identity
 commands above, or revoke and re-spawn the agent.
 
+**An unreadable change refuses too.** The gate reads the file list a merge
+would bring in, and an empty list means the merge touches nothing — the same
+answer a `git diff` that failed would otherwise give. So a read that does not
+complete refuses instead of returning nothing to judge, journalled under
+`allowed-files-diff-unreadable`. The blast-radius ceiling refuses the same
+change under `blast-radius-unreadable`, for the same reason: an empty change
+scores as the safest possible one.
+
+The case worth knowing about is not the missing branch, where the merge would
+fail anyway. It is the timeout: the file list is read with a 30-second budget
+the merge itself does not share, so a large enough diff can time out here
+while `git merge` still succeeds. Both gates stay inert when nothing was
+asked of them — no ceiling set, no scope declared — so only a failed read
+inside a gate that is actually on can turn into a refusal.
+
 ## Delegation capability tokens
 
 When a run fans out, authority fans out with it. A **capability token** makes

--- a/src/bernstein/core/agents/spawner_merge.py
+++ b/src/bernstein/core/agents/spawner_merge.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -20,8 +21,6 @@ from bernstein.core.traces import AgentTrace, TraceStore, finalize_trace
 from bernstein.plugins.manager import get_plugin_manager
 
 if TYPE_CHECKING:
-    import subprocess
-
     from bernstein.core.agents.container import ContainerManager
     from bernstein.core.agents.in_process_agent import InProcessAgent
     from bernstein.core.agents.warm_pool import PoolSlot, WarmPool
@@ -96,33 +95,85 @@ def _sanitise_for_log(value: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+class IncomingChangeUnreadable(RuntimeError):
+    """The change a merge would bring in could not be computed.
+
+    Raised rather than collapsed into an empty change, because the gates
+    below judge the change by what is in it: no file outside the scope, no
+    score above the ceiling. An empty list answers both of those questions
+    with "nothing to object to", which is exactly what a genuinely empty
+    change answers -- so a read that failed would be indistinguishable from
+    a merge that brings in nothing, and would pass every gate on evidence
+    that was never gathered.
+
+    The benign case is a branch that does not exist, where the merge would
+    fail anyway and nothing lands. The one that matters is the timeout: the
+    file list is read with a 30-second budget the merge itself does not
+    share, so a large enough diff can time out here while ``git merge``
+    still succeeds.
+    """
+
+
+def _incoming_files(worktree_root: Path, branch: str) -> list[str]:
+    """Return the paths merging ``branch`` would touch.
+
+    ``--no-renames``, because rename detection reports only a rename's
+    *destination*. Every gate reading this list judges paths, and a list that
+    omits the path a merge removes lets ``git mv outside inside`` pass a
+    check that ``git rm outside`` fails -- the disguised removal admitted and
+    the honest one refused. A rename is two paths changing, so both are named.
+
+    Raises:
+        IncomingChangeUnreadable: The file list could not be read. An empty
+            list is a change that touches nothing; this is not that.
+    """
+    from bernstein.core.git_ops import run_git
+
+    spec = f"HEAD...{branch}"
+    try:
+        names = run_git(["diff", "--name-only", "--no-renames", spec], worktree_root, timeout=30)
+    except (OSError, subprocess.SubprocessError) as exc:
+        # ``run_git`` raises ``TimeoutExpired`` rather than returning non-zero,
+        # so the case this gate exists for arrives as an exception.
+        msg = f"could not be read: git diff --name-only {spec} did not complete ({exc})"
+        raise IncomingChangeUnreadable(msg) from exc
+    if names.returncode != 0:
+        detail = _sanitise_for_log(names.stderr.strip())
+        msg = f"could not be read: git diff --name-only {spec} exited {names.returncode} ({detail})"
+        raise IncomingChangeUnreadable(msg)
+    return [line.strip() for line in names.stdout.splitlines() if line.strip()]
+
+
 def _incoming_change(worktree_root: Path, branch: str) -> tuple[list[str], str]:
     """Return ``(files, diff_text)`` for what merging ``branch`` would bring in.
 
     Both are computed against the merge base with the checked-out branch, so
     the score describes this merge rather than the branch's whole history.
-    An unreadable branch yields an empty change, which the scorer treats as
-    a zero-risk one; the gate below refuses only on evidence.
 
-    ``--no-renames`` on the file list, because rename detection reports only
-    a rename's *destination*. Every gate reading this list judges paths, and
-    a list that omits the path a merge removes lets ``git mv outside inside``
-    pass a check that ``git rm outside`` fails -- the disguised removal
-    admitted and the honest one refused. A rename is two paths changing, so
-    both are named. The diff body keeps rename detection: it is scored as
-    text rather than judged as paths, and inflating a pure rename into a
-    delete-plus-add there would change what a blast radius means without
-    closing anything.
+    The file list comes from :func:`_incoming_files` and carries its
+    ``--no-renames`` reading. The diff body keeps rename detection: it is
+    scored as text rather than judged as paths, and inflating a pure rename
+    into a delete-plus-add there would change what a blast radius means
+    without closing anything.
+
+    Raises:
+        IncomingChangeUnreadable: Either read failed. Both halves are scored,
+            so a body that did not come out understates the change the same
+            way a missing file list does.
     """
     from bernstein.core.git_ops import run_git
 
+    files = _incoming_files(worktree_root, branch)
     spec = f"HEAD...{branch}"
-    names = run_git(["diff", "--name-only", "--no-renames", spec], worktree_root, timeout=30)
-    if names.returncode != 0:
-        return [], ""
-    files = [line.strip() for line in names.stdout.splitlines() if line.strip()]
-    body = run_git(["diff", spec], worktree_root, timeout=60)
-    return files, body.stdout if body.returncode == 0 else ""
+    try:
+        body = run_git(["diff", spec], worktree_root, timeout=60)
+    except (OSError, subprocess.SubprocessError) as exc:
+        msg = f"could not be read: git diff {spec} did not complete ({exc})"
+        raise IncomingChangeUnreadable(msg) from exc
+    if body.returncode != 0:
+        msg = f"could not be read: git diff {spec} exited {body.returncode} ({_sanitise_for_log(body.stderr.strip())})"
+        raise IncomingChangeUnreadable(msg)
+    return files, body.stdout
 
 
 def _blast_radius_refusal(
@@ -133,29 +184,41 @@ def _blast_radius_refusal(
     """Refuse the merge when it exceeds the operator's blast-radius ceiling.
 
     Returns ``None`` when the merge may proceed, which includes the default
-    case where no ceiling was requested.
+    case where no ceiling was requested. The ceiling is checked first, so a
+    run that never asked for one is not gated by anything here -- including
+    by a change that could not be read.
+
+    A change that could not be read refuses. Scoring needs the change, and
+    the empty one a failed read would otherwise supply scores as the safest
+    possible merge, so an operator who set a ceiling would watch an unjudged
+    change land under it.
     """
     from bernstein.core.lifecycle.blast_radius_gate import ceiling_requested, evaluate_pre_merge
 
     if not ceiling_requested():
         return None
 
-    files, diff_text = _incoming_change(worktree_root, branch)
+    try:
+        files, diff_text = _incoming_change(worktree_root, branch)
+    except IncomingChangeUnreadable as exc:
+        return _refuse_merge(
+            session,
+            worktree_root,
+            branch,
+            reason=f"refused: the change {branch!r} would bring in {exc}",
+            code="blast-radius-unreadable",
+        )
     decision = evaluate_pre_merge(files=files, diff_text=diff_text)
     if decision is None or decision.allowed:
         return None
 
-    _record_merge_refusal(worktree_root, session.id, branch, reason="blast-radius-ceiling")
-    logger.error(
-        "Refusing to merge agent work from %s: %s",
-        _sanitise_for_log(session.id),
-        _sanitise_for_log(decision.reason),
+    return _refuse_merge(
+        session,
+        worktree_root,
+        branch,
+        reason=decision.reason,
+        code="blast-radius-ceiling",
     )
-    from bernstein.core.metric_collector import get_collector
-
-    for task_id in session.task_ids:
-        get_collector().record_merge_result(task_id, success=False)
-    return MergeResult(success=False, conflicting_files=[], error=decision.reason)
 
 
 # ---------------------------------------------------------------------------
@@ -266,7 +329,14 @@ def _file_scope_refusal(
 
     A record that is on disk and does not resolve is neither of those, and
     refuses: it is a scope someone declared, and the gate cannot see what it
-    said.
+    said. A file list that could not be read refuses for the same reason one
+    step further along: the scope is legible and the change is not, and the
+    empty list a failed read would supply says "nothing fell outside" in the
+    same words a merge that touches nothing says it.
+
+    Only the file list is read here. The diff body is what a blast radius is
+    scored from; this gate judges paths, and a body that did not come out
+    tells it nothing it needs.
 
     The refusal is containment rather than prevention. The out-of-scope write
     already happened inside the agent's own worktree; what this stops is that
@@ -290,7 +360,19 @@ def _file_scope_refusal(
     if not patterns:
         return None
 
-    files, _ = _incoming_change(worktree_root, branch)
+    try:
+        files = _incoming_files(worktree_root, branch)
+    except IncomingChangeUnreadable as exc:
+        return _refuse_merge(
+            session,
+            worktree_root,
+            branch,
+            reason=(
+                f"refused: identity {session.id!r} is scoped to {', '.join(patterns)}, "
+                f"but the file list this merge would bring in {exc}"
+            ),
+            code="allowed-files-diff-unreadable",
+        )
     outside = paths_outside_scope(files, patterns)
     if not outside:
         return None

--- a/tests/unit/security/test_merge_file_scope_gate.py
+++ b/tests/unit/security/test_merge_file_scope_gate.py
@@ -17,6 +17,7 @@ import json
 import subprocess
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -324,3 +325,100 @@ def test_an_unreadable_scope_is_recorded_under_its_own_reason(tmp_path: Path) ->
     journal = tmp_path / ".sdd" / "runtime" / "refused_merges.jsonl"
     reasons = [json.loads(line)["reason"] for line in journal.read_text(encoding="utf-8").splitlines() if line.strip()]
     assert reasons == ["allowed-files-unreadable"]
+
+
+# ---------------------------------------------------------------------------
+# The file list itself is evidence, and its absence is not "nothing to judge"
+# ---------------------------------------------------------------------------
+
+
+def _git_diff_fails(*, timeout: bool) -> Any:
+    """Stand in for ``run_git`` so the file-list read fails and nothing else does.
+
+    The two failures are the two the merge path actually sees: a non-zero
+    ``git diff`` (the branch is gone, the object store is damaged), and the
+    30-second timeout a very large diff hits while ``git merge`` itself still
+    succeeds. Only the file-list call is broken, so a gate that reached the
+    scope check on a half-read change would still look like it worked.
+    """
+    from bernstein.core.git_ops import run_git as real_run_git
+
+    def _fake(args: list[str], cwd: Path, **kwargs: Any) -> Any:
+        if args[:2] == ["diff", "--name-only"]:
+            if timeout:
+                raise subprocess.TimeoutExpired(cmd=["git", *args], timeout=30)
+            return type("_Result", (), {"returncode": 128, "stdout": "", "stderr": "fatal: bad revision\n"})()
+        return real_run_git(args, cwd, **kwargs)
+
+    return _fake
+
+
+@pytest.mark.parametrize("timeout", [False, True], ids=["non-zero-exit", "timed-out"])
+def test_a_file_list_that_cannot_be_read_refuses_rather_than_admitting_everything(
+    tmp_path: Path,
+    timeout: bool,
+) -> None:
+    """The fail-open direction, one level below the scope.
+
+    An empty file list reads as "no path fell outside the scope", which is
+    the same answer a genuinely empty change gives. A merge whose file list
+    timed out would land unjudged while the gate reported that it held.
+    """
+    _repo_with_agent_branch(tmp_path, "s15", {"infra/deploy.tf": "y\n"})
+    _mint(tmp_path, "s15", ["src/**"])
+
+    with patch("bernstein.core.git_ops.run_git", _git_diff_fails(timeout=timeout)):
+        result = _refuse(tmp_path, "s15")
+
+    assert result is not None, "an unreadable file list must not read as an empty one"
+    assert result.success is False
+    assert "s15" in result.error
+
+
+def test_an_unreadable_file_list_is_recorded_under_its_own_reason(tmp_path: Path) -> None:
+    """A third refusal, and a third reason.
+
+    "The scope is damaged" and "the change could not be read" are repaired
+    by different people: the first by the operator who owns the credential,
+    the second by whoever owns the repository the diff would not come out of.
+    """
+    _repo_with_agent_branch(tmp_path, "s16", {"infra/deploy.tf": "y\n"})
+    _mint(tmp_path, "s16", ["src/**"])
+
+    with patch("bernstein.core.git_ops.run_git", _git_diff_fails(timeout=False)):
+        assert _refuse(tmp_path, "s16") is not None
+
+    journal = tmp_path / ".sdd" / "runtime" / "refused_merges.jsonl"
+    reasons = [json.loads(line)["reason"] for line in journal.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert reasons == ["allowed-files-diff-unreadable"]
+
+
+def test_an_unreadable_file_list_is_inert_when_no_scope_was_set(tmp_path: Path) -> None:
+    """The asymmetry to preserve.
+
+    Only a failed read refuses, and only where a scope was declared. An
+    identity with an empty scope declared no boundary, so there is nothing
+    for an unreadable change to fall outside of - refusing there would turn
+    every flaky ``git diff`` into a lost merge for every identity minted
+    before the gate existed.
+    """
+    _repo_with_agent_branch(tmp_path, "s17", {"infra/deploy.tf": "y\n"})
+    _mint(tmp_path, "s17", [])
+
+    with patch("bernstein.core.git_ops.run_git", _git_diff_fails(timeout=True)):
+        assert _refuse(tmp_path, "s17") is None
+
+
+def test_a_genuinely_empty_change_is_still_admitted(tmp_path: Path) -> None:
+    """The other half of the distinction being drawn.
+
+    A branch that changes nothing reads back an empty file list, and that
+    list is evidence rather than the absence of it.
+    """
+    _repo_with_agent_branch(tmp_path, "s18", {"src/ok.py": "x\n"})
+    _run(["git", "checkout", "-b", "agent/s19"], tmp_path)
+    _run(["git", "checkout", "main"], tmp_path)
+    _mint(tmp_path, "s19", ["src/**"])
+
+    assert _incoming_change(tmp_path, "agent/s19") == ([], "")
+    assert _refuse(tmp_path, "s19") is None

--- a/tests/unit/test_blast_radius_run_gate.py
+++ b/tests/unit/test_blast_radius_run_gate.py
@@ -15,6 +15,7 @@ throughout the period the flag did nothing.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from typing import TYPE_CHECKING, Any
@@ -223,3 +224,81 @@ def test_unusable_ceiling_refuses_rather_than_continuing(tmp_path: Path) -> None
     assert result is not None
     assert result.success is False
     assert "not-a-float" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# The change being scored has to be readable before a score means anything
+# ---------------------------------------------------------------------------
+
+
+def _git_diff_fails(*, timeout: bool) -> Any:
+    """Stand in for ``run_git`` so only the change read fails.
+
+    The two failures the merge path actually sees: a non-zero ``git diff``,
+    and the timeout a very large diff hits on the file-list call while
+    ``git merge`` itself still succeeds -- the case where the merge lands and
+    the ceiling was never evaluated against it.
+    """
+    from bernstein.core.git_ops import run_git as real_run_git
+
+    def _fake(args: list[str], cwd: Path, **kwargs: Any) -> Any:
+        if args[:2] == ["diff", "--name-only"]:
+            if timeout:
+                raise subprocess.TimeoutExpired(cmd=["git", *args], timeout=30)
+            return type("_Result", (), {"returncode": 128, "stdout": "", "stderr": "fatal: bad revision\n"})()
+        return real_run_git(args, cwd, **kwargs)
+
+    return _fake
+
+
+@pytest.mark.parametrize("timeout", [False, True], ids=["non-zero-exit", "timed-out"])
+def test_merge_refused_when_the_incoming_change_cannot_be_read(tmp_path: Path, timeout: bool) -> None:
+    """An unscorable change must not score as a harmless one.
+
+    An empty file list and an empty diff body are what a zero-risk change
+    looks like, so a failed read walks straight through the ceiling. The
+    merge itself does not depend on that read, so the change lands unjudged
+    while the operator's ceiling reports that it held.
+    """
+    repo = _repo_with_agent_branch(tmp_path, filename=_HARD_ONE_WAY_FILE, body=_HARD_ONE_WAY_BODY)
+    _set_ceiling_via_run_flag(0.2)
+
+    with patch("bernstein.core.git_ops.run_git", _git_diff_fails(timeout=timeout)):
+        result, merge_fn = _merge(repo)
+
+    assert merge_fn.calls == [], "the merge ran on a change the ceiling never saw"
+    assert result is not None
+    assert result.success is False
+    assert "could not be read" in (result.error or "")
+
+
+def test_an_unreadable_change_is_inert_when_no_ceiling_was_requested(tmp_path: Path) -> None:
+    """The asymmetry to preserve: no ceiling, no gate, nothing to fail closed.
+
+    Refusing here would turn every flaky ``git diff`` into a lost merge for
+    every run that never asked for a ceiling at all.
+    """
+    repo = _repo_with_agent_branch(tmp_path, filename=_REVERSIBLE_FILE, body=_REVERSIBLE_BODY)
+    os.environ.pop(ENV_MAX_BLAST_RADIUS, None)
+
+    with patch("bernstein.core.git_ops.run_git", _git_diff_fails(timeout=True)):
+        result, merge_fn = _merge(repo)
+
+    assert merge_fn.calls == [_SESSION_ID], "a run with no ceiling was gated anyway"
+    assert result is not None
+    assert result.success is True
+
+
+def test_an_unreadable_change_is_recorded_under_its_own_reason(tmp_path: Path) -> None:
+    """A ceiling that was exceeded and a change that could not be read are
+    different findings, and an operator reading the refusal journal has to be
+    able to tell which one they are looking at."""
+    repo = _repo_with_agent_branch(tmp_path, filename=_HARD_ONE_WAY_FILE, body=_HARD_ONE_WAY_BODY)
+    _set_ceiling_via_run_flag(0.2)
+
+    with patch("bernstein.core.git_ops.run_git", _git_diff_fails(timeout=False)):
+        _merge(repo)
+
+    journal = repo / ".sdd" / "runtime" / "refused_merges.jsonl"
+    reasons = [json.loads(line)["reason"] for line in journal.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert reasons == ["blast-radius-unreadable"]


### PR DESCRIPTION
## What

A `git diff` that could not be computed no longer disables the two merge gates. `_incoming_change` raises `IncomingChangeUnreadable` instead of collapsing the failure into an empty change, and both gates refuse on it.

> #4002 has since merged (squashed as `e66b3a944`), and this branch is rebased onto `main` — one commit,
> no shared history. Taken out of draft now that it can no longer land ahead of #4002.

## Why

`_incoming_change` returned `([], "")` whenever the file-list read failed, and both consumers read that empty list as "nothing to judge":

- `_blast_radius_refusal` scored it as a zero-risk change.
- `_file_scope_refusal` (#4002) found no path outside the signed `allowed_files` scope.

An empty file list is what a genuinely empty change looks like, so a failed read was indistinguishable from a merge that brings in nothing — and passed every gate on evidence that was never gathered.

The benign case is a branch that does not exist, where the merge itself also fails and nothing lands. The live case is the timeout: the file list is read with a 30-second budget the merge does not share, so a large enough diff can time out here while `git merge` still succeeds, landing a change neither gate inspected.

While writing the failing test I found the timeout is worse than a silent pass: `run_git` raises `TimeoutExpired` rather than returning non-zero, so that case never reached the empty-change path at all — it propagated out of `_run_merge_and_push` uncaught. Both the exception and the non-zero exit are now handled.

## How

- New `IncomingChangeUnreadable`. `_incoming_change` raises it on either read failing; new `_incoming_files` raises it on the file-list read alone.
- `_file_scope_refusal` reads only the file list. It judges paths, so a diff body that did not come out tells it nothing it needs and must not refuse it.
- Each gate refuses under its own reason code in `.sdd/runtime/refused_merges.jsonl`, kept distinct from the refusals already there:

  | Code | Means |
  |---|---|
  | `blast-radius-ceiling` | the ceiling was exceeded |
  | `blast-radius-unreadable` | the change could not be read |
  | `allowed-files-scope` | a path fell outside the signed scope |
  | `allowed-files-unreadable` | the scope itself needs repair (#4002) |
  | `allowed-files-diff-unreadable` | the change could not be read |

- `_blast_radius_refusal` now shares `_refuse_merge` with the file-scope gate rather than duplicating the record/log/score block.

**The asymmetry is preserved.** Each gate checks whether anything was asked of it *before* reading the change, so a run with no ceiling and an identity with no scope are untouched, and a genuinely empty change still merges. Only a failed read inside a gate that is on refuses. Three tests pin exactly that, because the fail-closed direction is the one that turns a flaky `git diff` into a lost merge if it is applied too widely.

## Reviewer notes

Six new tests, each written and watched fail before the fix. The failure is injected at `run_git` so only the change read breaks — a gate that reached its check on a half-read change would still look like it worked.

## Checklist

- [x] `ruff check src/` passes
- [x] `mypy src/bernstein/core/agents/spawner_merge.py` passes
- [x] `python scripts/run_tests.py` passes — note it ignores path arguments and runs all 2247 test files,
      which is what happened here. Two failures, both pre-existing and untouched by this change:
      `test_promptware_properties.py::test_padding_with_benign_lowers_or_holds_score` reproduces on a clean
      checkout of `main` at `e66b3a944`, and `test_run_banner.py::test_bare_invocation_prints_banner_when_splash_disabled`
      passes on its own (8/8 in that file) and failed only under the parallel runner.
- [x] New code has type hints

### Documentation duty

- [ ] User-visible README section updated — N/A, no user-facing surface changed
- [x] `docs/operations/security-and-identity.md` updated with both new reason codes and the timeout case
- [ ] `docs/api/` schema regenerated — N/A, no public surface changed
- [ ] `bernstein agents-md sync` — N/A, no new module
- [x] Tests cover the documented behaviour



