### PR TITLE
fix(replay): event_count counts usable events, through the same scan (#4016)

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -118,6 +118,22 @@ rather than as its own attribution is exempted by hand there, with the reason.
   every journal that read successfully before. A row whose only defect is one
   undecodable byte is discarded rather than repaired, so no silently altered
   event can enter the chain.
+- `EventJournal.event_count()` counts usable events rather than physical lines,
+  and reads through the same scan as `load_events` (#4016). It was the last
+  strict decoder left on the file, so the journal that #3971 made loadable
+  could still raise `UnicodeDecodeError` out of the counter — a `ValueError`
+  subclass, so the method's own `except OSError` never caught it — on the two
+  call sites that take an injected journal rather than one opened through
+  `EventJournal.resume`. The count also disagreed with the writer by one on a
+  journal carrying any malformed row, including rows that are pure ASCII and
+  raise no decode question: `resume` continues the chain from
+  `len(load_events(path).events)`, so `event_count() - 1`, which is how every
+  caller names the row it just appended, could name a row that is not in the
+  journal. The relationship is now `event_count() == len(load_events(path).events)`
+  and is asserted rather than described. The `except OSError` is unchanged and
+  now means only what it says: no decode error can reach it. Counting parsed
+  rows costs a JSON parse per row where the old scan cost a `strip()`
+  (~12x on a 20,000-row journal).
 - The CLI reference no longer names command spellings that do not resolve. It
   claimed `bernstein commit-stats`, `bernstein incident`, and `bernstein
   postmortem` were live deprecated aliases after v4.0.0 removed them, and

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -444,12 +444,33 @@ class EventJournal:
                     logger.warning("EventJournal observer failed for event %r: %s", event, exc)
 
     def event_count(self) -> int:
-        """Return the number of events recorded so far."""
-        if not self._path.exists():
-            return 0
+        """Return the number of events recorded so far.
+
+        The relationship to the other reader, in one sentence:
+        ``event_count() == len(load_events(path).events)``. Counting
+        *usable* events rather than physical lines is not a preference -
+        it is the only count the rest of the class already agrees with.
+        :meth:`resume` continues the chain from ``len(events)``, so a row
+        appended after a malformed one carries that index and not a line
+        number; the read side recovers the same value from the row's own
+        ``index`` field (``run_artifacts._row_to_record``). Every caller
+        spells this ``event_count() - 1`` to name the row it just wrote,
+        and a physical-line count would name a row that is not there.
+
+        Sharing the scan rather than re-implementing it is also what keeps
+        the two readers on one decode policy: a strict decode here made a
+        journal torn mid-character raise :class:`UnicodeDecodeError` out
+        of a method whose failure mode is documented as ``0``, because
+        that error derives from :class:`ValueError` and not from
+        :class:`OSError`. The handler below is now exactly what it says -
+        an unreadable file - since no decode error can reach it.
+
+        This costs a JSON parse per row where the old scan cost a strip
+        (~12x on a 20k-row journal), which is the price of returning a
+        number the writer and the read side both agree with.
+        """
         try:
-            with self._path.open(encoding="utf-8") as f:
-                return sum(1 for line in f if line.strip())
+            return len(load_events(self._path).events)
         except OSError:
             return 0
 

--- a/tests/unit/core/replay/test_journal_undecodable.py
+++ b/tests/unit/core/replay/test_journal_undecodable.py
@@ -1,10 +1,15 @@
-"""Undecodable bytes are a discarded physical line, not an exception (#3971).
+"""Undecodable bytes are a discarded physical line, not an exception (#3971, #4016).
 
 Every fixture here is built from RAW BYTES rather than from text. A journal
 written through ``str`` cannot hold an incomplete multi-byte character at all -
 the encode would either succeed or raise before anything reached the disk - so a
 text fixture would exercise the JSON parser and never the decode path this
 module is about.
+
+#3971 covers ``load_events``; #4016 covers ``EventJournal.event_count``, the
+sibling reader of the same file, in the final section. They share this module
+because they share the fixtures: the two readers agreeing about one file *is*
+the contract, and splitting them would let the fixtures drift apart.
 """
 
 from __future__ import annotations
@@ -15,6 +20,7 @@ from pathlib import Path
 import pytest
 
 from bernstein.core.replay.journal import (
+    EventJournal,
     JournalParseError,
     load_events,
 )
@@ -199,3 +205,132 @@ def test_an_escaped_lone_surrogate_is_still_a_json_question_not_a_decode_one(
 
     assert loaded.discarded_line_indices == ()
     assert loaded.events[0]["note"] == "\udcff"
+
+
+# ---------------------------------------------------------------------------
+# EventJournal.event_count (#4016) - the sibling reader of load_events.
+#
+# Same file, same crash, and until this landed a different decode policy. The
+# fixtures stay raw bytes for the reason in the module docstring above.
+# ---------------------------------------------------------------------------
+
+# A row that is valid UTF-8 and unparsable JSON: the tear stopped after a
+# newline-free prefix rather than inside a character. It is the control that
+# separates the two policies, because no decode question arises for it at all
+# and the old counter still disagreed with ``load_events`` by one.
+_UNPARSABLE_JSON = _GOOD[0][:40].replace(b"\n", b"")
+
+# A row that decodes and parses and is still not an event.
+_NON_OBJECT_ROW = b'"just a string"'
+
+
+def _journal_over(sdd_dir: Path, *chunks: bytes) -> EventJournal:
+    """An ``EventJournal`` whose file already holds ``chunks`` on disk.
+
+    The plain constructor rather than ``resume`` on purpose: ``resume`` calls
+    ``load_events`` and refuses any file with a discarded line, so it can never
+    reach ``event_count`` on the fixtures below. The reachable callers are the
+    ones handed an injected journal - ``activity.record_activity_result`` and
+    ``subagent_delegation`` - and that journal is the orchestrator's plainly
+    constructed ``_recorder``.
+    """
+    journal = EventJournal(run_id="run-count", sdd_dir=sdd_dir)
+    _write(journal.path, *chunks)
+    return journal
+
+
+def test_event_count_survives_a_tail_torn_mid_character(tmp_path: Path) -> None:
+    """THE ISSUE, ASSERTED DIRECTLY.
+
+    ``UnicodeDecodeError`` derives from ``ValueError``, so the method's own
+    ``except OSError`` never caught it and it propagated out of a counter
+    documented to answer ``0`` when it cannot read.
+    """
+    journal = _journal_over(tmp_path, *_GOOD, _TORN_MID_CHARACTER)
+
+    assert journal.event_count() == 3
+
+
+@pytest.mark.parametrize(
+    ("label", "tail"),
+    [
+        ("clean", None),
+        ("torn mid character", _TORN_MID_CHARACTER),
+        ("torn between characters", _TORN_BETWEEN_CHARACTERS),
+        ("valid utf-8, unparsable json", _UNPARSABLE_JSON),
+        ("non-object row", _NON_OBJECT_ROW),
+    ],
+)
+def test_event_count_is_len_load_events(tmp_path: Path, label: str, tail: bytes | None) -> None:
+    """THE RELATIONSHIP THE ISSUE ASKED TO HAVE ASSERTED RATHER THAN DESCRIBED.
+
+    ``event_count() == len(load_events(path).events)``, for every shape of bad
+    row and for a clean journal. The ``clean`` case is the control: it passes
+    on either policy, so a run where only it is green is a run where these
+    fixtures stopped reaching the counter.
+
+    The last two cases carry no decode question at all - they are pure ASCII -
+    and the old counter still disagreed by one on both. Fixing only the decode
+    would have left them, which is the third policy the issue warns about.
+    """
+    chunks = (*_GOOD, tail) if tail is not None else _GOOD
+    journal = _journal_over(tmp_path / label.replace(" ", "-").replace(",", ""), *chunks)
+
+    assert journal.event_count() == len(load_events(journal.path).events)
+
+
+def test_event_count_is_the_index_resume_would_continue_from(tmp_path: Path) -> None:
+    """Why *skip* and not *count*, tied to the writer rather than to taste.
+
+    ``resume`` sets its next index to ``len(events)``, so the row appended
+    after a malformed one carries that number - not a line number. A counter
+    that disagreed would make ``event_count() - 1``, which is how every caller
+    spells "the row I just wrote", name a row that is not in the journal.
+    """
+    chained = EventJournal(run_id="run-count", sdd_dir=tmp_path)
+    for index in range(3):
+        chained.record(f"step-{index}")
+
+    resumed = EventJournal.resume(run_id="run-count", sdd_dir=tmp_path)
+    resumed.record("appended-after-resume")
+    appended = load_events(resumed.path).events[-1]
+
+    assert resumed.event_count() - 1 == appended["index"]
+
+
+def test_event_count_still_answers_zero_when_the_file_cannot_be_read(
+    tmp_path: Path,
+) -> None:
+    """The ``except OSError`` is now exactly what it says.
+
+    No decode error can reach it any more, so the handler's remaining job is
+    the one it is named for. A directory standing where the journal file
+    belongs raises ``IsADirectoryError`` - an ``OSError`` - from the open.
+    """
+    journal = EventJournal(run_id="run-count", sdd_dir=tmp_path)
+    journal.path.mkdir(parents=True, exist_ok=True)
+
+    assert journal.event_count() == 0
+
+
+def test_event_count_does_not_swallow_a_non_oserror(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The handler stays NARROW, and that is the whole shape of this bug.
+
+    The defect was a ``ValueError`` subclass reaching a caller as an exception
+    because ``except OSError`` did not catch it. Widening the handler to
+    ``Exception`` would have "fixed" that by turning any future reader failure
+    into a silent ``0`` - a wrong count is worse than a raised one here,
+    because ``event_count() - 1`` would then stamp ``-1`` into a receipt.
+    Nothing about the scan being shared prevents that widening, so it is
+    pinned: a non-``OSError`` out of the reader propagates.
+    """
+    journal = EventJournal(run_id="run-count", sdd_dir=tmp_path)
+    journal.record("one")
+
+    def _boom(*_args: object, **_kwargs: object) -> object:
+        raise ValueError("reader failed for some reason that is not I/O")
+
+    monkeypatch.setattr("bernstein.core.replay.journal.load_events", _boom)
+
+    with pytest.raises(ValueError, match="not I/O"):
+        journal.event_count()


### PR DESCRIPTION
## What

`EventJournal.event_count()` was the last strict decoder left on the journal file, so the
tail #3971 made loadable still raised `UnicodeDecodeError` out of the counter. It now reads
through `load_events`, which puts both readers of this file on one scan and one decode
policy.

Closes #4016. Thank you for the offer — this is the sibling reader, so it is the same fix.

## The decision you left open: **skip**, and the tree decides it rather than taste

You framed it as *count vs skip*. Measured on `9cf4213`, the tree already answers:

* `resume()` sets `journal._index = len(events)` (`journal.py:354`) — the count of **usable**
  events. So a row appended after a malformed one carries that number and not a line number.
* The read side recovers the same value from the row's own `index` field:
  `run_artifacts._row_to_record` is `journal_index=int(row.get("index", 0))` (`:581`), and the
  write side of the *same* field is `journal_index=journal.event_count() - 1` (`:718`).

So `event_count()` is not choosing a convention — it is the only reader of that file that
could disagree with the writer, and `event_count() - 1` is how every caller names the row it
just appended. A physical-line count names a row that is not in the journal.

The relationship is now one sentence in the docstring and an assertion in the tests:
`event_count() == len(load_events(path).events)`.

## Measurements, with a control that can fail

Four journals, each three good rows plus one tail. `resume()` shown because it is what stands
in front of most of the call sites (below). Before / after this branch:

| tail on the file | `event_count()` before | after | `len(load_events().events)` | `resume()` |
|---|---|---|---|---|
| **A — clean (control)** | `3` | `3` | `3` | `_index=3` |
| **B — torn mid-character** (your premise) | **`UnicodeDecodeError`** | `3` | `3` | `ValueError`, refuses |
| **C — valid UTF-8, unparsable JSON** | **`4`** | `3` | `3` | `ValueError`, refuses |
| **D — non-object row** | **`4`** | `3` | `3` | `ValueError`, refuses |

The control holds at 3 everywhere, so the rows above it are the fixtures reaching the counter
rather than a broken harness.

**C and D are the part worth reading.** They carry no decode question at all — pure ASCII —
and the old counter was still off by one on both. That is the trap you named: fixing only the
decode leaves a counter tolerant of bad bytes that still counts unparsable rows. It is also
live on `main` today, without any torn write involved.

## Two corrections to the issue, and both narrow it

**1. Three of the four call sites you list cannot reach this crash.** `suspension.py:404`,
`suspension.py:1174` and `checkpoint_retry.py:304` take their journal from
`EventJournal.resume`, which calls `load_events` and raises `ValueError` on any
`discarded_line_indices` *before* `event_count()` runs (row B above). Those paths fail closed
at resume; they do not "load fine and then die counting it". `run_artifacts.py:718` and
`checkpoint_retry.py:616` are behind `resume` too.

The reachable sites are the ones handed an **injected** journal — `activity.py:448` and
`subagent_delegation.py:304` — where the journal is the orchestrator's plainly constructed
`_recorder` (`orchestrator.py:698`), never verified on open. Both call `event_count()`
*before* `record()`, to predict the index the row is about to carry.

**2. Your call-site list is missing three.** `run_artifacts.py:718`,
`subagent_delegation.py:304` and `checkpoint_retry.py:616` also go through `event_count()`.

## The cost, stated rather than buried

Counting parsed rows means a JSON parse per row where the old scan cost a `strip()`. On a
20,000-row / 9.4 MiB journal, timed on this box:

```
physical-line count (before)   13.6 ms
decode-tolerant, no parse      12.0 ms
parse, count only             160.9 ms
load_events + len (this PR)   186.8 ms
```

**~12x**, and it is the policy and not the implementation: counting without building the list
recovers 14% of it, because the parse is the cost. `event_count()` is O(n) on a journal that
grows, called once per activity result, so a long run pays O(n²) — as it did before, 12x
cheaper. I did not try to hide this behind a cheaper scan that answers a different question.
**If you would rather keep the old cost and take only the decode fix, say so and I will cut it
back** — but that lands the third policy your issue warns about, so I did not choose it for you.

## Reported and deliberately not fixed

`event_count()` disagrees with the writer on a second path, with a perfectly clean journal:

```
plain ctor over an existing 3-row file:  _index=0   event_count()=3
after one record():   the row's own "index" is 0,   event_count() - 1 is 3
```

The plain constructor starts at index 0 even when the file has rows — deliberate, per its
docstring, for the one-journal-per-run lifetime. But where it does happen, `event_count() - 1`
is wrong by the number of pre-existing rows and no decode question is involved. Fixing it
means deciding whether `_index` or the file is authoritative, which is bigger than this
ticket. Left alone; happy to take it as a follow-up if you want it.

## Tests

Added to `tests/unit/core/replay/test_journal_undecodable.py` — the module your issue points
at — because the two readers agreeing about **one file** is the contract, and splitting them
would let the fixtures drift. Every fixture is raw bytes, per that module's docstring.

* `test_event_count_survives_a_tail_torn_mid_character`
* `test_event_count_is_len_load_events` — parametrised over clean / mid-character /
  between-characters / unparsable-JSON / non-object. **This is the "asserted, not described"
  one.**
* `test_event_count_is_the_index_resume_would_continue_from` — ties the policy to the writer.
* `test_event_count_still_answers_zero_when_the_file_cannot_be_read` — the `except OSError`
  doing the job it is named for (a directory standing where the file belongs).
* `test_event_count_does_not_swallow_a_non_oserror` — the handler stays **narrow**. Widening
  it to `Exception` would "fix" this bug by turning any future reader failure into a silent
  `0`, and `event_count() - 1` would then stamp `-1` into a receipt.

**6 of the 9 are red on pristine `main`.** Green there: the `clean` control, the resume-index
test, and the `OSError` test — all three are anchors, not guards, and I am not implying
otherwise. One caveat on the red list: `test_event_count_does_not_swallow_a_non_oserror` is
red on `main` structurally — `main`'s `event_count` never calls `load_events`, so the
monkeypatch does not reach it — not because `main` swallows a `ValueError`.

**8 mutations of the change, no survivors:** count-physical-lines, ±1, count discarded instead
of events, events+discarded, `strict=True` on the shared scan, widen the handler to
`Exception`, and re-raise instead of returning 0.

`ruff check` / `ruff format` clean on both files; `mypy` clean on `journal.py`.

## Scope and neighbours

One method, one docstring, one test section, one release note. **Full suite not run** — I ran
every test file in the repo that mentions `event_count`: **805 passed**, plus
`tests/unit/core/replay/` and `tests/unit/test_event_journal.py` (100 passed).

`#3955` is open on this same file (`_torn_tail_indices` + `resume`). **No line overlap** — it
adds a module-level helper and edits `resume`; this edits the body of `event_count`. Its own
new helper reasons about the identical `UnicodeDecodeError`/`OSError` shape in a comment, so
the two changes agree rather than collide. It should be fine in either order.


<details>
<summary>AI-assisted</summary>

This patch was written by an autonomous AI agent and no human reviewed the diff. Every number
above is a run on the machine that wrote it rather than an inference: the A/B/C/D table by
executing the two readers against files built from raw bytes, the red list by stashing `src/`
and re-running, the mutation rows by editing the patch and re-running, the timings by
`perf_counter` over a generated 20,000-row journal on this box, and the not-run list is what
this box did not run rather than what was not attempted.

</details>
