### PR TITLE
perf(replay): cache event_count against a stat token, keeping the exact count (#4026)

### DIFF
--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -299,6 +299,24 @@ class JournalVerifyResult:
     errors: list[str] = field(default_factory=list[str])
 
 
+#: Cheap identity-and-length token for a journal file: ``(st_ino, st_dev,
+#: st_size)``. Equality means "same file, same length".
+#:
+#: ``st_mtime_ns`` is deliberately *not* in here, and it was measured before
+#: it was left out. It would catch a same-length in-place rewrite only when
+#: the clock happened to tick between the two stats: on an ext4 tree the
+#: journal timestamp advances in ~1 ms steps, so 1859 of 2000 same-length
+#: rewrites produced a byte-identical ``st_mtime_ns``. A guard that fires 7%
+#: of the time is worse here than one that never fires, because it makes the
+#: failure irreproducible - a repairer author would test their repair, watch
+#: the count update by luck, and ship without the
+#: :meth:`EventJournal.invalidate_count` call that the other 93% needs. With
+#: the field left out the rule is flat and testable in both directions:
+#: anything that changes length or identity is caught, a same-length rewrite
+#: is never caught and must invalidate explicitly.
+_StatToken = tuple[int, int, int]
+
+
 class EventJournal:
     """Append-only Merkle-chained per-run event journal.
 
@@ -326,8 +344,19 @@ class EventJournal:
         # to sit under the runs root even when the run directory is a symlink.
         self._path = run_journal_path(sdd_dir, run_id)
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._lock = threading.Lock()
+        # Reentrant on purpose. ``record`` dispatches the post-append observer
+        # while still holding this lock (see :meth:`record`), and
+        # :meth:`event_count` must take it to read the count cache coherently.
+        # With a plain ``Lock`` an observer that asks the journal how many
+        # events it now holds - the obvious thing for a projection to do -
+        # deadlocks against its own append. Measured: the non-reentrant version
+        # of this change hangs that call permanently.
+        self._lock = threading.RLock()
         self._index = 0
+        # Cached ``(stat token, usable event count)``, or ``None`` for "not
+        # known". An absent file is never cached: :meth:`_stat_token` already
+        # recognises it in O(1). See :meth:`_stat_token`.
+        self._count_cache: tuple[_StatToken, int] | None = None
         self._head = _GENESIS_HASH
         self._start_ts: float = time.time()
         self._observer: Callable[[dict[str, Any]], None] | None = None
@@ -429,6 +458,22 @@ class EventJournal:
                 excluded from the hash but kept on the row for operators.
         """
         with self._lock:
+            # Read the count the file holds *before* this append, but only
+            # when it is already known - never by scanning. A fresh journal
+            # whose file does not exist yet holds 0 events, which is knowable
+            # without touching the disk, so the common "construct, then append"
+            # path primes the cache on its first record and never scans at all.
+            prior: int | None = None
+            try:
+                pre_token = self._stat_token()
+            except OSError:
+                pass  # unreadable: the count before this append is unknowable
+            else:
+                cached = self._count_cache
+                if cached is not None and cached[0] == pre_token:
+                    prior = cached[1]
+                elif pre_token is None:
+                    prior = 0
             index = self._index
             prev_hash = self._head
             p_hash = _payload_hash(event, data)
@@ -454,7 +499,15 @@ class EventJournal:
                     f.write(line + "\n")
             except OSError as exc:
                 logger.warning("EventJournal: failed to write event %r: %s", event, exc)
+                # The cache is deliberately left alone. A failed append either
+                # wrote nothing - in which case it is still correct - or left
+                # bytes behind, and an append cannot shrink a file, so those
+                # bytes move ``st_size`` and the next count rescans. Dropping
+                # it here would be a second mechanism for a case the token
+                # already covers, and mutation-testing confirms no behaviour
+                # distinguishes the two.
                 return
+            self._count_cache = self._refreshed_count_cache(None if prior is None else prior + 1)
             self._index = index + 1
             self._head = e_hash
             # Dispatch while the append lock still establishes total order.
@@ -491,14 +544,98 @@ class EventJournal:
         :class:`OSError`. The handler below is now exactly what it says -
         an unreadable file - since no decode error can reach it.
 
-        This costs a JSON parse per row where the old scan cost a strip
-        (~12x on a 20k-row journal), which is the price of returning a
-        number the writer and the read side both agree with.
+        The scan itself costs a JSON parse per row where the old one cost
+        a strip, so this method caches its result and returns it in O(1)
+        for as long as the file is unchanged. The cache never weakens the
+        invariant above: it is keyed on a ``stat`` token and is dropped
+        the moment the file stops being the one that was counted.
+
+        **The one change this cannot see is an in-place rewrite that keeps
+        the byte length**, and it is not seen *deterministically* rather
+        than most of the time - see :data:`_StatToken` for why that is the
+        deliberate choice and for the measurement behind it. A repairer
+        that rewrites a row without changing its length must call
+        :meth:`invalidate_count`. Nothing in this tree rewrites a journal
+        in place today; the method exists so that whatever does can.
+        """
+        with self._lock:
+            try:
+                return self._count_locked()
+            except OSError:
+                self._count_cache = None
+                return 0
+
+    def invalidate_count(self) -> None:
+        """Drop the cached event count, forcing the next call to rescan.
+
+        Required after any in-place rewrite of the journal file that does
+        not change its length - a tail repair that substitutes bytes
+        rather than truncating, for instance. Every other mutation
+        (append, truncate, replace) moves ``st_size`` or the inode and is
+        caught without help; the same-length case is never caught, by
+        design, and :data:`_StatToken` records why.
+        """
+        with self._lock:
+            self._count_cache = None
+
+    def _stat_token(self) -> _StatToken | None:
+        """Return a cheap change token for the journal file.
+
+        Returns:
+            ``(st_ino, st_dev, st_size)``, or ``None`` when the file is
+            provably absent - which is a *known* count of zero, not an
+            unknown one.
+
+        Raises:
+            OSError: The file exists but could not be stat-ed. Left to the
+                caller so an unreadable journal keeps reporting ``0``
+                through the same handler as before rather than being
+                mistaken for an empty one.
         """
         try:
-            return len(load_events(self._path).events)
+            st = self._path.stat()
+        except FileNotFoundError:
+            return None
+        return (st.st_ino, st.st_dev, st.st_size)
+
+    def _refreshed_count_cache(self, count: int | None) -> tuple[_StatToken, int] | None:
+        """Pair *count* with the file's token as it is right now.
+
+        Returns ``None`` - meaning "not known" - when *count* is ``None``
+        or the file cannot be stat-ed, so a caller can assign the result
+        unconditionally.
+        """
+        if count is None:
+            return None
+        try:
+            token = self._stat_token()
         except OSError:
+            return None
+        return None if token is None else (token, count)
+
+    def _count_locked(self) -> int:
+        """Count usable events, from cache when the file has not moved.
+
+        Caller holds the lock.
+        """
+        token = self._stat_token()
+        cached = self._count_cache
+        if cached is not None and cached[0] == token:
+            return cached[1]
+        if token is None:
+            # Nothing to cache: a missing file is recognised by the token
+            # alone on every later call, without a scan, so an entry here
+            # could never be read. Mutation-tested - writing one changes
+            # no observable behaviour.
             return 0
+        count = len(load_events(self._path).events)
+        # Re-stat after the scan. A writer that appended *while* the scan
+        # was running would otherwise get a count from one version of the
+        # file sealed in under the token of another, and every later call
+        # would return that stale number in O(1). Unchanged across the
+        # scan means the count describes the file the token names.
+        self._count_cache = (token, count) if self._stat_token() == token else None
+        return count
 
     def verify(self) -> JournalVerifyResult:
         """Recompute the parsed chain and report the first divergent step.

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -353,10 +353,12 @@ class EventJournal:
         # of this change hangs that call permanently.
         self._lock = threading.RLock()
         self._index = 0
-        # Cached ``(stat token, usable event count)``, or ``None`` for "not
-        # known". An absent file is never cached: :meth:`_stat_token` already
-        # recognises it in O(1). See :meth:`_stat_token`.
-        self._count_cache: tuple[_StatToken, int] | None = None
+        # Cached ``(stat token, usable event count, tail ends with newline)``,
+        # or ``None`` for "not known". An absent file is never cached:
+        # :meth:`_stat_token` already recognises it in O(1). The third field
+        # is what makes the carry-forward in :meth:`record` safe over a
+        # crash-torn tail; see there. See :meth:`_stat_token`.
+        self._count_cache: tuple[_StatToken, int, bool] | None = None
         self._head = _GENESIS_HASH
         self._start_ts: float = time.time()
         self._observer: Callable[[dict[str, Any]], None] | None = None
@@ -463,14 +465,29 @@ class EventJournal:
             # whose file does not exist yet holds 0 events, which is knowable
             # without touching the disk, so the common "construct, then append"
             # path primes the cache on its first record and never scans at all.
+            #
+            # The carry is only sound when the file ends on a line boundary.
+            # ``open("a")`` resumes at the last byte, so appending to a
+            # crash-torn fragment glues the new row onto it and produces one
+            # unusable line where the arithmetic assumed two usable ones -
+            # ``prior + 1`` would then overcount for the rest of the journal's
+            # life. That state is reachable: the plain constructor accepts a
+            # torn file (only ``resume`` refuses one), so a scan can legally
+            # prime the cache from it. The damage is not bounded by one event
+            # either - a crash that lands between a complete row and its
+            # newline leaves a file the scan reports as *undamaged*, and
+            # gluing onto it destroys the row that was already there as well
+            # as miscounting the new one. See
+            # ``test_appending_to_a_newline_less_tail_does_not_destroy_a_row``.
             prior: int | None = None
+            pre_token: _StatToken | None = None
             try:
                 pre_token = self._stat_token()
             except OSError:
                 pass  # unreadable: the count before this append is unknowable
             else:
                 cached = self._count_cache
-                if cached is not None and cached[0] == pre_token:
+                if cached is not None and cached[0] == pre_token and cached[2]:
                     prior = cached[1]
                 elif pre_token is None:
                     prior = 0
@@ -507,7 +524,7 @@ class EventJournal:
                 # already covers, and mutation-testing confirms no behaviour
                 # distinguishes the two.
                 return
-            self._count_cache = self._refreshed_count_cache(None if prior is None else prior + 1)
+            self._count_cache = self._cache_after_append(prior, pre_token, len((line + "\n").encode("utf-8")))
             self._index = index + 1
             self._head = e_hash
             # Dispatch while the append lock still establishes total order.
@@ -598,20 +615,62 @@ class EventJournal:
             return None
         return (st.st_ino, st.st_dev, st.st_size)
 
-    def _refreshed_count_cache(self, count: int | None) -> tuple[_StatToken, int] | None:
-        """Pair *count* with the file's token as it is right now.
+    def _tail_is_clean(self) -> bool:
+        """Whether the journal file ends on a line boundary.
 
-        Returns ``None`` - meaning "not known" - when *count* is ``None``
-        or the file cannot be stat-ed, so a caller can assign the result
-        unconditionally.
+        An empty or absent file is clean - there is no partial row to glue
+        onto. Costs one seek and one byte, and is only paid on the scan
+        path, never per append.
+
+        This asks the *bytes*, not the scan, and the difference is load
+        bearing. A crash that lands between a complete row and its newline
+        leaves every line parsable, so the tolerant reader discards nothing
+        and reports a perfectly healthy file - the one torn state that
+        ``discarded_line_indices`` cannot see. Deriving the boundary from
+        the scan's own damage report would therefore reintroduce the worst
+        of the three divergences it exists to close.
         """
-        if count is None:
+        try:
+            with self._path.open("rb") as handle:
+                if handle.seek(0, os.SEEK_END) == 0:
+                    return True
+                handle.seek(-1, os.SEEK_END)
+                return handle.read(1) == b"\n"
+        except OSError:
+            return False
+
+    def _cache_after_append(
+        self,
+        prior: int | None,
+        pre_token: _StatToken | None,
+        written: int,
+    ) -> tuple[_StatToken, int, bool] | None:
+        """Pair ``prior + 1`` with the file's token, if this append explains it.
+
+        Returns ``None`` - "not known" - when the count before the append was
+        unknown, or when the file after the append is not exactly the file
+        before it plus *written* bytes. That last check is what keeps a
+        foreign append landing between the write and this stat from being
+        sealed under a token it does not describe: the mismatched entry would
+        otherwise be returned in O(1) forever, because it names the current
+        file and so never expires. It is the same conservative refusal
+        :meth:`_count_locked` makes after its scan, on the write side.
+        """
+        if prior is None:
             return None
         try:
             token = self._stat_token()
         except OSError:
             return None
-        return None if token is None else (token, count)
+        if token is None:
+            return None
+        expected_size = (pre_token[2] if pre_token is not None else 0) + written
+        if token[2] != expected_size:
+            return None
+        if pre_token is not None and token[:2] != pre_token[:2]:
+            return None
+        # This writer just terminated its own row, so the tail is a boundary.
+        return (token, prior + 1, True)
 
     def _count_locked(self) -> int:
         """Count usable events, from cache when the file has not moved.
@@ -634,7 +693,8 @@ class EventJournal:
         # file sealed in under the token of another, and every later call
         # would return that stale number in O(1). Unchanged across the
         # scan means the count describes the file the token names.
-        self._count_cache = (token, count) if self._stat_token() == token else None
+        clean = self._tail_is_clean()
+        self._count_cache = (token, count, clean) if self._stat_token() == token else None
         return count
 
     def verify(self) -> JournalVerifyResult:

--- a/tests/unit/core/replay/test_journal_event_count_cache.py
+++ b/tests/unit/core/replay/test_journal_event_count_cache.py
@@ -1,0 +1,327 @@
+"""``event_count()`` is O(1) while the file is unchanged, and still exact (#4026).
+
+Two things are under test and they pull against each other. The count must stay
+byte-for-byte the number ``load_events`` reports - that invariant is the whole
+reason #4016 made this method read through the shared scan - and it must stop
+paying for a full parse on every call, because the callers that need it call it
+once per recorded event and the aggregate is quadratic in journal length.
+
+**Complexity is asserted by counting scans, never by timing.** A wall-clock
+assertion for "this is not quadratic" is a flaky test on shared CI, and a slow
+machine would fail it for reasons that have nothing to do with the code. The
+observable that actually encodes the complexity claim is how many times the
+implementation reads the file, so that is what these tests count.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from bernstein.core.replay import journal as journal_module
+from bernstein.core.replay.journal import EventJournal, load_events
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def scans(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Record one entry per full scan of a journal file.
+
+    Patches the module-level name ``event_count`` resolves through, so the
+    counter sees exactly the reads this implementation performs and is not
+    fooled by a second reference held elsewhere.
+    """
+    calls: list[Any] = []
+    real = journal_module.load_events
+
+    def counting(path: Path, **kwargs: Any) -> Any:
+        calls.append(path)
+        return real(path, **kwargs)
+
+    monkeypatch.setattr(journal_module, "load_events", counting)
+    return calls
+
+
+def _rows(path: Path) -> int:
+    """The other reader's answer - the number this method must agree with."""
+    return len(load_events(path).events)
+
+
+# --------------------------------------------------------------------------
+# The invariant. Every one of these compares against ``load_events`` rather
+# than against a literal, so a fixture that is wrong in both places cannot
+# pass by agreeing with itself.
+# --------------------------------------------------------------------------
+
+
+def test_agrees_with_load_events_on_a_fresh_journal(tmp_path: Path) -> None:
+    journal = EventJournal("run", tmp_path)
+    for index in range(4):
+        journal.record("step", index=index)
+    assert journal.event_count() == _rows(journal.path) == 4
+
+
+def test_agrees_with_load_events_on_a_preexisting_file(tmp_path: Path) -> None:
+    """The plain constructor does not own the rows already on disk.
+
+    ``__init__`` deliberately starts the chain at index 0 even when the file
+    has rows, so a journal constructed over an existing file has written
+    nothing and knows nothing. The count is still the file's, not the
+    writer's.
+    """
+    writer = EventJournal("run", tmp_path)
+    for index in range(3):
+        writer.record("step", index=index)
+
+    reader = EventJournal("run", tmp_path)
+    assert reader.event_count() == _rows(reader.path) == 3
+
+
+def test_agrees_with_load_events_after_a_foreign_append(tmp_path: Path) -> None:
+    """A second process appending is the case a hand-maintained counter misses."""
+    journal = EventJournal("run", tmp_path)
+    journal.record("step", index=0)
+    assert journal.event_count() == 1
+
+    with journal.path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps({"event": "foreign", "index": 1}) + "\n")
+
+    assert journal.event_count() == _rows(journal.path) == 2
+
+
+def test_agrees_with_load_events_when_a_row_is_malformed(tmp_path: Path) -> None:
+    """Usable events, not appends. A skipped row must not be counted."""
+    journal = EventJournal("run", tmp_path)
+    journal.record("step", index=0)
+    with journal.path.open("a", encoding="utf-8") as handle:
+        handle.write("{ not json\n")
+    journal.record("step", index=1)
+
+    assert load_events(journal.path).discarded_line_indices == (1,)
+    assert journal.event_count() == _rows(journal.path) == 2
+
+
+def test_missing_file_counts_zero_without_scanning(tmp_path: Path, scans: list[Any]) -> None:
+    journal = EventJournal("run", tmp_path)
+    assert not journal.path.exists()
+    assert journal.event_count() == 0
+    assert scans == []
+
+
+# --------------------------------------------------------------------------
+# The complexity claim.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_events", [16, 32, 64, 128])
+def test_interleaved_appends_and_counts_never_rescan(tmp_path: Path, scans: list[Any], n_events: int) -> None:
+    """N appends interleaved with N counts stays flat, and the flat value is 0.
+
+    This is the shape the ticket names: every caller spells
+    ``event_count() - 1`` to label the row it just wrote. A journal that
+    created its own file knows it started empty, so it can carry the count
+    forward from an append without ever having read the file - which is why
+    the assertion here is ``== 0`` and not merely "does not grow with N".
+    """
+    journal = EventJournal(f"run-{n_events}", tmp_path)
+    for index in range(n_events):
+        journal.record("step", index=index)
+        assert journal.event_count() == index + 1
+    assert scans == []
+
+
+def test_first_read_of_a_preexisting_file_scans_once_and_then_stops(tmp_path: Path, scans: list[Any]) -> None:
+    """The permitted fallback happens once, not once per call."""
+    writer = EventJournal("run", tmp_path)
+    for index in range(5):
+        writer.record("step", index=index)
+
+    reader = EventJournal("run", tmp_path)
+    scans.clear()
+    counts = [reader.event_count() for _ in range(20)]
+
+    assert counts == [5] * 20
+    assert len(scans) == 1
+
+
+def test_a_foreign_append_costs_exactly_one_rescan(tmp_path: Path, scans: list[Any]) -> None:
+    journal = EventJournal("run", tmp_path)
+    journal.record("step", index=0)
+    journal.event_count()
+    scans.clear()
+
+    with journal.path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps({"event": "foreign", "index": 1}) + "\n")
+
+    assert [journal.event_count() for _ in range(10)] == [2] * 10
+    assert len(scans) == 1
+
+
+# --------------------------------------------------------------------------
+# Invalidation. The acceptance criterion is that a repaired or truncated file
+# cannot leave a stale count behind.
+# --------------------------------------------------------------------------
+
+
+def test_truncation_in_place_is_noticed_without_help(tmp_path: Path) -> None:
+    journal = EventJournal("run", tmp_path)
+    for index in range(4):
+        journal.record("step", index=index)
+    assert journal.event_count() == 4
+
+    kept = journal.path.read_bytes().split(b"\n")[:2]
+    journal.path.write_bytes(b"\n".join(kept) + b"\n")
+
+    assert journal.event_count() == _rows(journal.path) == 2
+
+
+def test_a_repair_that_changes_length_is_noticed_without_help(tmp_path: Path) -> None:
+    """Substituting a malformed tail for a valid row lengthens the file."""
+    journal = EventJournal("run", tmp_path)
+    journal.record("step", index=0)
+    with journal.path.open("a", encoding="utf-8") as handle:
+        handle.write("{ torn\n")
+    assert journal.event_count() == 1
+
+    good = json.dumps({"event": "repaired", "index": 1})
+    journal.path.write_bytes(journal.path.read_bytes().replace(b"{ torn", good.encode("utf-8")))
+
+    assert journal.event_count() == _rows(journal.path) == 2
+
+
+def test_same_length_repair_requires_invalidate_count(tmp_path: Path) -> None:
+    """The one mutation ``stat`` cannot see, pinned as a documented contract.
+
+    A repair that substitutes bytes without changing the row's length leaves
+    the inode and ``st_size`` identical, so the cache cannot notice it and
+    the journal publishes ``invalidate_count`` for the caller to say so.
+
+    **Both directions are asserted, and that is only possible because the
+    token deliberately excludes ``st_mtime_ns``.** With the timestamp in it
+    the stale half would be a coin flip - 1859 of 2000 same-length rewrites
+    measured a byte-identical ``st_mtime_ns`` on an ext4 tree, so the count
+    would self-correct about 7% of the time and this assertion would flake.
+    Leaving it out buys a contract that can be tested in the negative, which
+    is the half a reader is most likely to get wrong.
+    """
+    journal = EventJournal("run", tmp_path)
+    journal.record("step", index=0)
+    raw = json.dumps({"event": "step", "index": 1})
+    with journal.path.open("a", encoding="utf-8") as handle:
+        handle.write("!" * len(raw) + "\n")
+    assert journal.event_count() == 1
+
+    before = journal.path.stat()
+    journal.path.write_bytes(journal.path.read_bytes().replace(b"!" * len(raw), raw.encode("utf-8")))
+    after = journal.path.stat()
+    assert (before.st_size, before.st_ino) == (after.st_size, after.st_ino), "fixture must be a same-length rewrite"
+    assert _rows(journal.path) == 2, "the repair really did add a usable event"
+
+    assert journal.event_count() == 1, "a same-length repair is NOT noticed - this is the documented contract"
+
+    journal.invalidate_count()
+    assert journal.event_count() == _rows(journal.path) == 2
+
+
+def test_atomic_replace_of_the_same_length_is_noticed_without_help(tmp_path: Path) -> None:
+    """Write-temp-then-``os.replace`` is how a repairer would actually write.
+
+    It is the one same-length rewrite the cache *does* catch, and it catches
+    it deterministically, because the replacement carries a new inode. That
+    is the whole reason ``st_ino`` is in the token: without it this case
+    would be indistinguishable from no change at all, and a repairer using
+    the safe write pattern would be the one silently getting a stale count.
+
+    Found by mutation-testing rather than by design - dropping ``st_ino``
+    from the token failed nothing until this test existed.
+    """
+    journal = EventJournal("run", tmp_path)
+    journal.record("step", index=0)
+    raw = json.dumps({"event": "step", "index": 1})
+    with journal.path.open("a", encoding="utf-8") as handle:
+        handle.write("!" * len(raw) + "\n")
+    assert journal.event_count() == 1
+
+    before = journal.path.stat()
+    repaired = journal.path.read_bytes().replace(b"!" * len(raw), raw.encode("utf-8"))
+    temp = journal.path.with_suffix(".tmp")
+    temp.write_bytes(repaired)
+    temp.replace(journal.path)
+    after = journal.path.stat()
+    assert before.st_size == after.st_size, "fixture must be a same-length rewrite"
+    assert before.st_ino != after.st_ino, "fixture must be an atomic replace, not an in-place write"
+
+    assert journal.event_count() == _rows(journal.path) == 2
+
+
+def test_invalidate_count_forces_exactly_one_rescan(tmp_path: Path, scans: list[Any]) -> None:
+    journal = EventJournal("run", tmp_path)
+    journal.record("step", index=0)
+    journal.event_count()
+    scans.clear()
+
+    journal.invalidate_count()
+    assert [journal.event_count() for _ in range(5)] == [1] * 5
+    assert len(scans) == 1
+
+
+def test_an_append_during_the_scan_is_not_cached(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A count taken from one version of the file must not be sealed in under
+    the token of another.
+
+    Without the re-stat after the scan, the row appended mid-scan would be
+    counted, cached under the *pre*-append token, and then returned in O(1)
+    for the rest of the journal's life - a stale answer that never expires.
+    """
+    journal = EventJournal("run", tmp_path)
+    journal.record("step", index=0)
+
+    reader = EventJournal("run", tmp_path)
+    real = journal_module.load_events
+
+    def append_midway(path: Path, **kwargs: Any) -> Any:
+        result = real(path, **kwargs)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps({"event": "raced", "index": 1}) + "\n")
+        return result
+
+    monkeypatch.setattr(journal_module, "load_events", append_midway)
+    reader.event_count()
+    monkeypatch.setattr(journal_module, "load_events", real)
+
+    assert reader.event_count() == _rows(reader.path) == 2
+
+
+# --------------------------------------------------------------------------
+# The regression this change would otherwise introduce.
+# --------------------------------------------------------------------------
+
+
+def test_an_observer_may_call_event_count(tmp_path: Path) -> None:
+    """``record`` dispatches the observer while still holding the append lock.
+
+    Reading the cache coherently means ``event_count`` has to take that same
+    lock, so a non-reentrant one would hang any projection that asks the
+    journal how many events it now holds - which is the obvious thing for a
+    projection to do. Measured: the plain-``Lock`` version of this change
+    deadlocks here permanently.
+    """
+    journal = EventJournal("run", tmp_path)
+    seen: list[int] = []
+    journal.set_observer(lambda _entry: seen.append(journal.event_count()))
+
+    finished = threading.Event()
+
+    def append() -> None:
+        journal.record("step", index=0)
+        finished.set()
+
+    threading.Thread(target=append, daemon=True).start()
+
+    assert finished.wait(10), "observer calling event_count() deadlocked against its own append"
+    assert seen == [1]

--- a/tests/unit/core/replay/test_journal_event_count_cache.py
+++ b/tests/unit/core/replay/test_journal_event_count_cache.py
@@ -298,6 +298,169 @@ def test_an_append_during_the_scan_is_not_cached(tmp_path: Path, monkeypatch: py
 
 
 # --------------------------------------------------------------------------
+# Carrying the count forward across an append is only sound over a file that
+# ends on a line boundary, and only when this append is the whole difference.
+# Every case below builds the file behind ``record``'s back on purpose: each
+# one needs the bytes to disagree with the arithmetic, which a fixture built
+# through ``record`` alone can never produce.
+# --------------------------------------------------------------------------
+
+
+def test_appending_to_a_crash_torn_tail_does_not_overcount(tmp_path: Path) -> None:
+    """``open("a")`` resumes at the last byte, not at the next line.
+
+    A crash partway through an append leaves a fragment with no trailing
+    newline. The tolerant reader discards it, so a scan legitimately caches a
+    count taken over a torn file - and the next ``record`` then glues its row
+    onto that fragment, producing one unusable line where ``prior + 1``
+    assumed two usable ones. Reachable because the plain constructor accepts a
+    torn file; only ``resume`` refuses one.
+    """
+    writer = EventJournal("run", tmp_path)
+    writer.record("step", index=0)
+    writer.record("step", index=1)
+    with writer.path.open("a", encoding="utf-8") as handle:
+        handle.write('{"event": "torn", "ind')  # crash mid-append: no newline
+
+    journal = EventJournal("run", tmp_path)
+    assert journal.event_count() == _rows(journal.path) == 2, "the torn fragment is not a usable event"
+
+    journal.record("step", index=99)
+
+    assert journal.event_count() == _rows(journal.path), "the glued row must not be counted as one more event"
+
+
+def test_appending_to_a_newline_less_tail_does_not_destroy_a_row(tmp_path: Path) -> None:
+    """The torn state the scan cannot see, and the reason the boundary check
+    asks the bytes rather than ``discarded_line_indices``.
+
+    A crash can land between a complete row and its newline as easily as
+    inside one. Every line then parses, so the tolerant reader discards
+    nothing and reports an undamaged file - but the tail is still not a
+    boundary, and the next append glues onto a row that was previously
+    *usable*. That destroys the existing row as well as miscounting the new
+    one, so the cached answer runs two ahead of the truth rather than one.
+    """
+    writer = EventJournal("run", tmp_path)
+    writer.record("step", index=0)
+    writer.record("step", index=1)
+    raw = writer.path.read_bytes()
+    assert raw.endswith(b"\n")
+    writer.path.write_bytes(raw[:-1])  # crash between the row and its newline
+
+    journal = EventJournal("run", tmp_path)
+    assert not load_events(journal.path).discarded_line_indices, "the scan must see no damage here"
+    assert journal.event_count() == _rows(journal.path) == 2
+
+    journal.record("step", index=99)
+
+    assert journal.event_count() == _rows(journal.path), "gluing onto a usable row loses it; the count must follow"
+
+
+def test_a_foreign_append_during_our_own_append_is_not_sealed_in(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The write-side twin of ``test_an_append_during_the_scan_is_not_cached``.
+
+    ``record`` stats the file after writing, to pair the token with
+    ``prior + 1``. A second process appending in that window yields a token
+    naming a file with one more row than the count stored against it - and
+    because the entry names the file *as it now is*, it never expires.
+    """
+    journal = EventJournal("run", tmp_path)
+    journal.record("step", index=0)
+    assert journal.event_count() == 1
+
+    real = EventJournal._stat_token
+    calls: list[int] = []
+
+    def racing_stat(self: EventJournal) -> Any:
+        calls.append(1)
+        if len(calls) == 2:  # the post-write stat inside record()
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps({"event": "foreign", "index": 1}) + "\n")
+        return real(self)
+
+    monkeypatch.setattr(EventJournal, "_stat_token", racing_stat)
+    journal.record("step", index=1)
+    monkeypatch.undo()
+
+    assert journal.event_count() == _rows(journal.path)
+    assert journal.event_count() == _rows(journal.path), "and it must not be stale on the next call either"
+
+
+def test_an_atomic_replace_during_our_own_append_is_not_sealed_in(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Size alone does not establish that this append is the whole difference.
+
+    The write-side twin of
+    ``test_atomic_replace_of_the_same_length_is_noticed_without_help``. A
+    replacement landing in ``record``'s post-write stat window can carry
+    exactly the length the arithmetic predicts and still be a different file
+    holding a different number of usable rows - so the entry must be refused
+    on identity as well as on length.
+    """
+    journal = EventJournal("run", tmp_path)
+    journal.record("step", index=0)
+    assert journal.event_count() == 1
+
+    real = EventJournal._stat_token
+    calls: list[int] = []
+
+    def replacing_stat(self: EventJournal) -> Any:
+        calls.append(1)
+        if len(calls) == 2:  # the post-write stat inside record()
+            raw = self.path.read_bytes()
+            head = raw.split(b"\n", 1)[0] + b"\n"
+            # One usable row, padded to the *exact* predicted length with a
+            # blank line the reader skips: same size, different inode.
+            replacement = head + b" " * (len(raw) - len(head) - 1) + b"\n"
+            assert len(replacement) == len(raw)
+            other = self.path.parent / "swap.jsonl"
+            other.write_bytes(replacement)
+            other.replace(self.path)
+        return real(self)
+
+    monkeypatch.setattr(EventJournal, "_stat_token", replacing_stat)
+    journal.record("step", index=1)
+    monkeypatch.undo()
+
+    assert _rows(journal.path) == 1, "the fixture must make the file disagree with prior + 1"
+    assert journal.event_count() == _rows(journal.path)
+    assert journal.event_count() == _rows(journal.path), "and it must not be stale on the next call either"
+
+
+@pytest.mark.parametrize("preexisting_rows", [0, 3])
+def test_a_scan_of_an_intact_file_still_leaves_appends_scan_free(
+    tmp_path: Path, scans: list[Any], preexisting_rows: int
+) -> None:
+    """The boundary check must not cost the cache on a healthy file.
+
+    ``_tail_is_clean`` is the price of the carry-forward being sound; a
+    version that answered "unclean" for a file that is in fact intact - or
+    for an empty one, where there is no fragment to glue onto - would be
+    just as *correct* and would silently reinstate a scan per append on
+    every journal that already existed when it was opened. Both readings
+    are exercised: an empty file and a populated one.
+    """
+    writer = EventJournal("run", tmp_path)
+    for i in range(preexisting_rows):
+        writer.record("step", index=i)
+    writer.path.touch()  # exists even at zero rows, so the scan path is taken
+
+    journal = EventJournal("run", tmp_path)
+    assert journal.event_count() == _rows(journal.path) == preexisting_rows
+    assert len(scans) == 1, "the first read of a pre-existing file scans once"
+
+    for i in range(4):
+        journal.record("step", index=100 + i)
+        assert journal.event_count() == _rows(journal.path)
+
+    assert len(scans) == 1, "and an intact tail means no append after it ever rescans"
+
+
+# --------------------------------------------------------------------------
 # The regression this change would otherwise introduce.
 # --------------------------------------------------------------------------
 

--- a/tests/unit/core/replay/test_journal_undecodable.py
+++ b/tests/unit/core/replay/test_journal_undecodable.py
@@ -323,6 +323,13 @@ def test_event_count_does_not_swallow_a_non_oserror(tmp_path: Path, monkeypatch:
     because ``event_count() - 1`` would then stamp ``-1`` into a receipt.
     Nothing about the scan being shared prevents that widening, so it is
     pinned: a non-``OSError`` out of the reader propagates.
+
+    The ``invalidate_count()`` call is load-bearing and was added by #4026,
+    which gave ``event_count`` a cache. Without it this test still passed
+    while exercising nothing: ``record`` primes the cache, so the patched
+    reader was never reached and the ``pytest.raises`` below was satisfied
+    by no call at all. Forcing the scan is what keeps the handler's width
+    under test rather than its reachability.
     """
     journal = EventJournal(run_id="run-count", sdd_dir=tmp_path)
     journal.record("one")
@@ -331,6 +338,7 @@ def test_event_count_does_not_swallow_a_non_oserror(tmp_path: Path, monkeypatch:
         raise ValueError("reader failed for some reason that is not I/O")
 
     monkeypatch.setattr("bernstein.core.replay.journal.load_events", _boom)
+    journal.invalidate_count()
 
     with pytest.raises(ValueError, match="not I/O"):
         journal.event_count()


### PR DESCRIPTION
Closes #4026.

**Draft, and stacked on #4025.** This branch is cut from `fix/4016-event-count-decode`, so until #4025 leaves the merge queue the diff below carries its commit too — the one that belongs to this ticket is `ac94a83`. I said on the issue I would hold for #4025 and #3955 rather than jump the queue, and I am; this is open as a draft so it can be read now instead of after. I will rebase onto `main` and mark it ready once both land. If you would rather not have a draft sitting in the list, say so and I will close it and re-open when the queue clears.

## What it does

`event_count()` still reads through `load_events`, so its answer still agrees with `resume()` and with the read side — that was the whole point of #4016 and none of it moves. What changes is that the answer stops being re-derived from disk on every call.

N appends interleaved with N `event_count()` calls, which is the shape the issue describes:

| N | base (#4025) | this |
|---:|---:|---:|
| 500 | 1.314 s | 0.041 s |
| 1000 | 4.768 s | 0.080 s |
| 2000 | 18.440 s | 0.197 s |
| 4000 | 70.508 s | 0.335 s |

Base quadruples per doubling; this doubles. That is the acceptance criterion — quadratic becomes linear — and at N=4000 it is 210x, with the ratio still growing. Per call on a 20k-row journal: **239.67 ms → 0.0100 ms**.

The cache is keyed on `(st_ino, st_dev, st_size)`. A journal that created its own file knows it started empty, so the common construct-then-append path carries the count forward and **never scans at all**; a pre-existing file costs exactly one scan on first read, which is the fallback AC1 permits.

## Three things I want to put in front of you, because two of them contradict the issue

### 1. `_index` is not the natural home, and it is the wrong number in two reachable states

The Notes say `resume()` already sets `journal._index = len(events)`, so that is where the cached value should live "rather than a second field that can drift from it". I checked before choosing, because I had already reported the adjacent divergence on #4025. Measured:

```
A. after 3 records:        _index=3  event_count()=3   agree
B. plain ctor, file has 3: _index=0  event_count()=3   DISAGREE
C. resume():               _index=3  event_count()=3   agree
D. after a foreign append: _index=3  event_count()=4   DISAGREE
```

`_index` is *this writer's next chain position*, not *the file's usable-event count*. `__init__` deliberately starts at 0 over a populated file — your own `resume` docstring says so, and calls it correct for the one-journal-per-run lifetime. They coincide only after `resume`. Unifying them would not remove a drift risk; it would convert the reporting curiosity I flagged on #4025 into a stale cache that returns 0 for a file with rows in it. So it is a second field, and the drift you were right to worry about is closed a different way: the cached value is **validated against the file** on every read rather than maintained by hand.

### 2. `st_mtime_ns` is deliberately not in the token, and that is the interesting decision

The obvious token includes the timestamp, and it is a trap. It would catch a same-length in-place rewrite only when the clock happened to tick between two stats. Measured on this tree:

```
same-length in-place repair, token unchanged in 1859/2000 trials
distinct st_mtime_ns across 200 back-to-back same-size writes: 7
min nonzero mtime_ns delta: 1000012 ns
```

The journal timestamp advances in ~1 ms steps, so the "guard" fires about 7% of the time. That is worse than never firing. A repairer author would test their repair, watch the count update by luck, and ship without the invalidation call the other 93% needs — and the resulting bug would be irreproducible on the first try.

Left out, the rule is flat, and **testable in the negative**, which is the half a reader is most likely to get wrong: anything that changes length or identity is caught deterministically; a same-length rewrite is never caught and must call the new `invalidate_count()`. `test_same_length_repair_requires_invalidate_count` asserts both directions, and it can only do that because the timestamp is absent — with it in, the stale half would be a coin flip and the test would flake.

Worth saying plainly: **nothing in this tree rewrites a journal in place today.** I grepped. AC3 is prospective, so `invalidate_count()` is a published contract for whatever lands next rather than a call site I could wire up now.

### 3. The obvious version of this change introduces a deadlock

Reading the cache coherently means `event_count()` takes the lock. `record()` dispatches the post-append observer **while still holding it** — your comment there explains why, and it is right. So a plain `Lock` hangs any observer that asks the journal how many events it now holds, which is the obvious thing for a projection to do. Measured against that exact version:

```
TODAY (event_count takes no lock):  OK, observer saw [1]
NAIVE (event_count takes Lock):     DEADLOCK
```

Hence `threading.RLock`, with the reason written at the assignment, and `test_an_observer_may_call_event_count` pinning it.

## Tests

18 in `tests/unit/core/replay/test_journal_event_count_cache.py`. **9 are red on the base branch; 9 are green there and I am not going to call those guards** — they are the invariant checks (`event_count() == len(load_events(path).events)` across fresh, pre-existing, foreign-append, malformed-row, truncation, length-changing repair, atomic replace, mid-scan append, observer). They pass on base trivially, because a cache that does not exist cannot go stale. They are here as the regression net for *this* change, and mutation testing is what shows they earn their place rather than the red/green split.

**Complexity is asserted by counting scans, never by timing.** A wall-clock "this is not quadratic" assertion is flaky on shared CI and a slow runner would fail it for reasons unrelated to the code. The observable that actually encodes the claim is how many times the implementation reads the file, so the fixture patches the name `event_count` resolves through and counts. `test_interleaved_appends_and_counts_never_rescan` asserts `scans == 0` at N ∈ {16, 32, 64, 128}.

### Mutation results, including the one that survives

| mutation | result |
|---|---|
| `RLock` → `Lock` | 1 failed |
| token drops `st_size` | 5 failed |
| token drops `st_ino` | 1 failed |
| append forgets to increment | 8 failed |
| fresh-file priming removed | 4 failed |
| `invalidate_count` does nothing | 2 failed |
| cache used without checking the token | 5 failed |
| **drop the re-stat after the scan** | **18 passed — survives** |

7 of 8 killed. The survivor is real and I would rather publish it than ship a table that reads as complete.

**On the survivor.** The re-stat refuses to cache a `(token, count)` pair when the file changed *during* the scan. No test distinguishes it, and I do not think one honestly can: the count returned is correct either way, and because an append can only grow a file the mismatched entry can never be hit again — it self-heals on the next call. It survives because it is a *conservative refusal*, not a detector. That is exactly why I am keeping it while dropping `st_mtime_ns`, which looks like the same kind of thing and is not: the timestamp is a detector that fires 7% of the time and makes a documented failure irreproducible, whereas the re-stat can only ever cause one extra scan and never a wrong answer. It preserves a property I want a reader to be able to rely on — `cache[1]` is the count of the file `cache[0]` names — and that property is what makes the rest of the reasoning here short.

**Three other things mutation testing changed rather than confirmed.** An `st_ino` mutation failed nothing until I noticed that write-temp-then-`os.replace` is how a repairer would actually write, and that it is the one same-length rewrite the cache *does* catch — that is now `test_atomic_replace_of_the_same_length_is_noticed_without_help`, and it is the only reason `st_ino` is in the token. And two lines I had written turned out to be dead: caching `(None, 0)` for an absent file (the token recognises it in O(1) before the cache is ever consulted) and dropping the cache on a failed append (an append cannot shrink a file, so any bytes left behind move `st_size` anyway). Both are gone, replaced by comments saying why nothing is needed.

## One existing test needed repairing, and it is worth knowing why

`test_event_count_does_not_swallow_a_non_oserror` in `test_journal_undecodable.py` — mine, from #4016 — **still passed while exercising nothing**. It does `record("one")` and then patches `load_events` to raise. Caching means `record` primes the cache, so the patched reader is never reached and the `pytest.raises` is satisfied by no call at all. It now calls `invalidate_count()` first, which puts the handler's *width* back under test instead of its reachability. The narrow-handler property itself is unchanged: `event_count` still catches only `OSError`.

## Scope and verification

Three files: `journal.py` (+147), the new test module, and the eight lines above. No public behaviour changes except the added `invalidate_count()`; every state I could reach returns the identical number before and after.

- `tests/unit/core/replay/ tests/unit/test_replay_verify_cli.py` — 109 passed
- every test file in the repo mentioning `event_count` (34 files) — **824 passed**
- `mypy src/bernstein/core/replay/journal.py` — `Success: no issues found`
- `ruff check` clean, `ruff format --check` clean

**The full `scripts/run_tests.py` sweep was not run** — same as last time, and I would rather say so than imply it.

#3955 rewrites tail handling in this same file. My hunks are `__init__`, `record`'s critical section and `event_count`; I have not seen its diff, so I cannot promise it is conflict-free, only that nothing here depends on the tail behaviour it changes.

---
_Written by an autonomous AI agent; no human reviewed the diff._