### PR TITLE
refactor(security): derive the token_type allowlist from its Literal

### DIFF
--- a/src/bernstein/core/agents/agent_identity.py
+++ b/src/bernstein/core/agents/agent_identity.py
@@ -16,7 +16,7 @@ import secrets
 import time
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Final, Literal, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, cast, get_args
 
 from bernstein.core.auth import create_jwt, verify_jwt
 from bernstein.core.path_scope import ScopePatternError, validate_repo_relative_pattern
@@ -154,10 +154,19 @@ def permissions_for_role(role: str) -> frozenset[str]:
 # former is a pre-field record; see :func:`_credential_tenant_id`.
 _TENANT_KEY_ABSENT: Final[object] = object()
 
-# The two kinds a credential may declare, kept beside the ``token_type``
-# annotation on :class:`AgentCredential` so the deserialiser and the type
-# cannot drift apart; see :func:`_credential_token_type`.
-_CREDENTIAL_TOKEN_TYPES: Final[frozenset[str]] = frozenset({"opaque", "jwt"})
+#: The kinds a credential may declare.  ``opaque`` is verified against the
+#: stored token hash alone; ``jwt`` additionally has its claims checked
+#: against the identity, so which one a record says decides which validation
+#: it gets (see :func:`_credential_token_type`).
+TokenType = Literal["opaque", "jwt"]
+
+#: The runtime spelling of :data:`TokenType`, derived from it rather than
+#: restated.  A hand-written copy is one edit away from admitting less than
+#: the type permits: adding a kind means touching the annotation, which is
+#: where the type lives, and a stale allowlist then refuses a kind that
+#: type-checks clean.  Deriving it makes that unreachable rather than
+#: discouraged, which is what the comment here used to claim (#4015).
+_CREDENTIAL_TOKEN_TYPES: Final[tuple[TokenType, ...]] = get_args(TokenType)
 
 
 def _string_list(raw: Any, field: str) -> list[str]:
@@ -278,7 +287,7 @@ def _credential_tenant_id(raw: Any) -> str:
     return normalize_tenant_id(raw)
 
 
-def _credential_token_type(raw: Any) -> Literal["opaque", "jwt"]:
+def _credential_token_type(raw: Any) -> TokenType:
     """Return the token kind a persisted credential declares.
 
     ``token_type`` selects which validation a token gets: ``_validate_jwt_claims``
@@ -318,10 +327,10 @@ def _credential_token_type(raw: Any) -> Literal["opaque", "jwt"]:
 
     Raises:
         ValueError: The record carries a ``token_type`` outside
-            ``Literal["opaque", "jwt"]``.
+            :data:`TokenType`.
     """
     if isinstance(raw, str) and raw in _CREDENTIAL_TOKEN_TYPES:
-        return cast('Literal["opaque", "jwt"]', raw)
+        return cast("TokenType", raw)
     raise ValueError(f"credential token_type must be one of {sorted(_CREDENTIAL_TOKEN_TYPES)}, got {raw!r}")
 
 
@@ -337,7 +346,7 @@ class AgentCredential:
     created_at: float = field(default_factory=time.time)
     expires_at: float = 0.0  # 0 = no expiry (session-scoped)
     revoked: bool = False
-    token_type: Literal["opaque", "jwt"] = "opaque"
+    token_type: TokenType = "opaque"
     algorithm: str = "HS256"
     jti: str = ""
     tenant_id: str = "default"

--- a/tests/unit/test_agent_identity.py
+++ b/tests/unit/test_agent_identity.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, get_args, get_type_hints
 
 import pytest
 from bernstein.core.agent_identity import (
+    _CREDENTIAL_TOKEN_TYPES,
     AgentCredential,
     AgentIdentity,
     AgentIdentityStatus,
     AgentIdentityStore,
     IdentityAuditEvent,
+    TokenType,
     _hash_token,
     permissions_for_role,
 )
@@ -506,6 +508,55 @@ class TestAgentCredentialTokenTypeDeserialization:
 
         assert store.authenticate(token) is None
         assert [found.id for found in store.list_identities()] == []
+
+
+class TestTokenTypeAllowlistIsDerivedNotRestated:
+    """The allowlist and the annotation are one source of truth, not two.
+
+    The refactor these tests guard (#4015) replaced a hand-written
+    ``frozenset`` with :func:`typing.get_args` over :data:`TokenType`. The
+    behaviour is unchanged, so the deserialisation tests above cannot tell
+    the two apart - they pass either way. What is new is the *property*, and
+    a property nothing asserts is one refactor away from being lost again.
+
+    The failure being pinned is quiet: restate the pair on the annotation,
+    add a kind there, and the type permits a value the boundary refuses.
+    Nothing raises, mypy stays green, and the disagreement only surfaces at
+    the far end of a stack trace.
+    """
+
+    def test_the_runtime_allowlist_comes_from_the_type(self) -> None:
+        """A hand-written copy would satisfy today and drift tomorrow."""
+        assert tuple(_CREDENTIAL_TOKEN_TYPES) == get_args(TokenType)
+
+    def test_the_field_annotation_denotes_the_same_type(self) -> None:
+        """The field and the allowlist must not come to permit different sets.
+
+        Worth being exact about what this catches, since ``Literal`` interns
+        its instances: a field that spells the same two values out again *is*
+        :data:`TokenType`, and this passes. That is not a gap - an identical
+        restatement denotes the same type and cannot disagree with it.
+
+        What it catches is the edit that matters. Add a kind to the field and
+        not to :data:`TokenType` and the annotations are different objects,
+        so this fails - which is the case where the type permits a value the
+        boundary refuses.
+        """
+        annotation = get_type_hints(AgentCredential)["token_type"]
+
+        assert annotation is TokenType
+
+    def test_every_declared_kind_is_admitted(self) -> None:
+        """Whatever the type permits, the boundary accepts - by construction.
+
+        Parametrising over ``get_args`` rather than a written-out list is the
+        point: a kind added to :data:`TokenType` is covered here the moment
+        it exists, without anyone remembering to extend this test.
+        """
+        for kind in get_args(TokenType):
+            credential = AgentCredential.from_dict({"token_hash": "abc", "token_type": kind})
+
+            assert credential.token_type == kind
 
 
 class TestCorruptIdentityDoesNotBreakAuthentication:


### PR DESCRIPTION
Closes #4015. Follow-up to the review on #4006, filed there and taken here.

### What changed

The pair was written out five times; it is written once now.

```python
TokenType = Literal["opaque", "jwt"]
_CREDENTIAL_TOKEN_TYPES: Final[tuple[TokenType, ...]] = get_args(TokenType)
```

The return annotation, the docstring reference, the field annotation and the
`cast` all name `TokenType`, so the stringly-typed
`cast('Literal["opaque", "jwt"]', raw)` is gone with them.

Adding a kind is one edit, and the allowlist follows it rather than needing to
be remembered.

### No behaviour change

Same values admitted, same refused, same message shape. The #4006
deserialisation tests are untouched and still pass — that is the evidence,
rather than my saying so. `AgentCredential.from_dict` is byte-for-byte
identical; only what `_CREDENTIAL_TOKEN_TYPES` is built from moved.

### The tests pin the property, not today's behaviour

The existing tests cannot tell a derived allowlist from a hand-written one —
they pass either way, which is exactly why this needs its own. Reintroducing
the second source of truth fails `test_the_runtime_allowlist_comes_from_the_type`;
diverging the field annotation fails `test_the_field_annotation_denotes_the_same_type`.
I checked both by making those edits rather than assuming.

`test_every_declared_kind_is_admitted` parametrises over `get_args(TokenType)`
rather than a written-out list, so a kind added later is covered the moment it
exists.

**One thing worth flagging, because the docstring says it and I nearly did not
notice it.** `Literal` interns its instances, so a field that spells the same
two values out again *is* `TokenType` and the annotation test passes. That is
not a gap — an identical restatement denotes the same type and cannot disagree
with it — but the test's first docstring claimed to catch "restating", which it
does not. It now says what it catches: a *divergent* annotation is a different
object and fails, which is the case where the type permits a value the boundary
refuses. Flagging it since claiming more than a test does is the thing this
whole issue is about.

### Verification

| gate | result |
| --- | --- |
| `test_agent_identity.py` + `_jwt` + `_v1_migration` + `_card` + `test_auth_middleware.py` | 194 passed |
| the three new tests, against a reintroduced hand-written allowlist | fail as intended |
| `mypy src/bernstein/core/agents/agent_identity.py` | `Success: no issues found` |
| `ruff check` | clean |
| `ruff format --check` | clean |

The full `scripts/run_tests.py` sweep was not run — process-per-file over 2000+
tests on this machine. Do not read the above as a green whole suite.

One local note in case it matters to a reviewer on Windows: `ruff format --check`
reports these files as needing reformatting in my working tree because
`core.autocrlf=true` checks them out CRLF. `git ls-files --eol` shows `i/lf` for
both, and the same content formats clean once normalised, so CI sees LF. Nothing
to do; recording it so the next Windows contributor does not chase it.
