### PR TITLE
fix(security): let the devops role edit docker-compose.yaml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,6 +269,7 @@ CI parsers implement the `CILogParser` protocol from `core/ci_log_parser.py`:
 ```python
 class CILogParser(Protocol):
     name: str
+
     def parse(self, raw_log: str) -> list[CIFailure]: ...
 ```
 

--- a/community/awesome-bernstein-plugins.md
+++ b/community/awesome-bernstein-plugins.md
@@ -348,6 +348,7 @@ A plugin is a Python class decorated with `@hookimpl`. No base class. No registr
 ```python
 from bernstein.plugins import hookimpl
 
+
 class MyPlugin:
     @hookimpl
     def on_task_completed(self, task_id: str, role: str, result_summary: str) -> None:

--- a/docs/adapters/capability_profiles.md
+++ b/docs/adapters/capability_profiles.md
@@ -132,8 +132,8 @@ presented, and the axes that went unmet:
 try:
     profile = select_profile_for(TaskCapabilityRequirements(vision=True))
 except CapabilityMismatchError as exc:
-    exc.receipt.unmet          # ("vision",)
-    exc.receipt.receipt_hash   # deterministic sha256
+    exc.receipt.unmet  # ("vision",)
+    exc.receipt.receipt_hash  # deterministic sha256
 ```
 
 The receipt hash is deterministic for a given

--- a/docs/adapters/deepseek.md
+++ b/docs/adapters/deepseek.md
@@ -66,9 +66,9 @@ local model:
 from bernstein.adapters.ollama import OllamaAdapter
 
 adapter = OllamaAdapter(
-    base_url="http://10.0.0.5:11434",   # Ollama on a private node
-    eu_residency=True,                   # belt-and-braces; the model
-                                         # alone already pins the guard
+    base_url="http://10.0.0.5:11434",  # Ollama on a private node
+    eu_residency=True,  # belt-and-braces; the model
+    # alone already pins the guard
 )
 ```
 

--- a/docs/architecture/model-routing.md
+++ b/docs/architecture/model-routing.md
@@ -64,13 +64,13 @@ A task is treated as high-stakes when **any** of:
 ```python
 @dataclass
 class CascadeDecision:
-    model: str           # e.g. "sonnet"
-    effort: str          # "low" | "high" | "max"
+    model: str  # e.g. "sonnet"
+    effort: str  # "low" | "high" | "max"
     attempt_number: int  # 0 for first attempt
     is_escalated: bool
-    reason: str          # human-readable explanation
+    reason: str  # human-readable explanation
     estimated_cost_usd: float
-    chain_id: str        # opaque id; pass back to record_and_escalate()
+    chain_id: str  # opaque id; pass back to record_and_escalate()
 ```
 
 `_select_initial_model()` (`cascade_router.py`) decides:
@@ -112,9 +112,9 @@ keeps one `BanditArm` per `(role, model)` pair, recording observations
 (success/failure, cost, latency) over the run. Constants:
 
 ```python
-EPSILON = 0.1            # 10% explore, 90% exploit
-MIN_OBSERVATIONS = 5     # arms trusted only after this many samples
-QUALITY_THRESHOLD = 0.80 # min success_rate to consider an arm
+EPSILON = 0.1  # 10% explore, 90% exploit
+MIN_OBSERVATIONS = 5  # arms trusted only after this many samples
+QUALITY_THRESHOLD = 0.80  # min success_rate to consider an arm
 ```
 
 (`cost.py`.)
@@ -171,11 +171,11 @@ Aggregate stats are computed on demand by
 
 ```python
 {
-  "total_chains": 1247,
-  "total_cost_usd": 412.93,
-  "escalation_overhead_usd": 28.41,
-  "saved_vs_opus_usd": 1153.04,
-  "escalation_rate": 0.073   # 7.3% of chains escalated past tier 0
+    "total_chains": 1247,
+    "total_cost_usd": 412.93,
+    "escalation_overhead_usd": 28.41,
+    "saved_vs_opus_usd": 1153.04,
+    "escalation_rate": 0.073,  # 7.3% of chains escalated past tier 0
 }
 ```
 
@@ -216,9 +216,9 @@ would silently degrade output quality:
 
 ```python
 CAPABILITY_FLOOR: dict[Complexity, int] = {
-    Complexity.HIGH:   _STRENGTH_ORDER["high"],     # only high or very_high
+    Complexity.HIGH: _STRENGTH_ORDER["high"],  # only high or very_high
     Complexity.MEDIUM: _STRENGTH_ORDER["medium"],
-    Complexity.LOW:    _STRENGTH_ORDER["low"],
+    Complexity.LOW: _STRENGTH_ORDER["low"],
 }
 ```
 

--- a/docs/architecture/protocol-negotiation.md
+++ b/docs/architecture/protocol-negotiation.md
@@ -74,8 +74,8 @@ remote = [ProtocolVersion(protocol="mcp", major=1, minor=0, patch=0)]
 
 result = negotiate_version(local, remote)
 if result.success:
-    print(result.negotiated_version.version_string)   # "1.0.0"
-    print(sorted(result.degraded_capabilities))        # capabilities lost vs. local best
+    print(result.negotiated_version.version_string)  # "1.0.0"
+    print(sorted(result.degraded_capabilities))  # capabilities lost vs. local best
 ```
 
 `get_supported_versions(protocol)` returns Bernstein's own hardcoded

--- a/docs/architecture/quality-pipeline.md
+++ b/docs/architecture/quality-pipeline.md
@@ -136,6 +136,7 @@ from pathlib import Path
 from bernstein.core.quality.gate_plugins import GatePlugin
 from bernstein.core.quality.gate_runner import GateResult
 
+
 class NoFooGate(GatePlugin):
     @property
     def name(self) -> str:

--- a/docs/architecture/schema-registry.md
+++ b/docs/architecture/schema-registry.md
@@ -100,19 +100,23 @@ There is no CLI command for this module - it is a plain Python API.
 from bernstein.core.protocols.schema_registry import SchemaRegistry, SchemaVersion
 
 registry = SchemaRegistry()
-registry.register(SchemaVersion(
-    version=1,
-    fields={"name": "str", "priority": "int"},
-    required_fields=frozenset({"name"}),
-))
-registry.register(SchemaVersion(
-    version=2,
-    fields={"name": "str", "priority": "int", "owner": "str"},
-    required_fields=frozenset({"name", "owner"}),
-))
+registry.register(
+    SchemaVersion(
+        version=1,
+        fields={"name": "str", "priority": "int"},
+        required_fields=frozenset({"name"}),
+    )
+)
+registry.register(
+    SchemaVersion(
+        version=2,
+        fields={"name": "str", "priority": "int", "owner": "str"},
+        required_fields=frozenset({"name", "owner"}),
+    )
+)
 
 compat = registry.check_compatibility(1, 2)
-assert not compat.compatible          # "owner" is newly required in v2
+assert not compat.compatible  # "owner" is newly required in v2
 print(compat.breaking_changes)
 
 result = registry.validate_payload({"name": "fix bug"}, version=1)

--- a/docs/architecture/state-persistence.md
+++ b/docs/architecture/state-persistence.md
@@ -62,14 +62,14 @@ Every line is a JSON object representing one orchestrator decision.
 ```python
 @dataclass(frozen=True)
 class WALEntry:
-    seq: int                # 0-based monotonic sequence
-    prev_hash: str          # SHA-256 of previous entry; first is GENESIS_HASH
-    entry_hash: str         # SHA-256 over (seq, prev_hash, timestamp, ...)
-    timestamp: float        # Unix seconds
-    decision_type: str      # e.g. "task_spawn_intent", "task_spawn_confirmed"
+    seq: int  # 0-based monotonic sequence
+    prev_hash: str  # SHA-256 of previous entry; first is GENESIS_HASH
+    entry_hash: str  # SHA-256 over (seq, prev_hash, timestamp, ...)
+    timestamp: float  # Unix seconds
+    decision_type: str  # e.g. "task_spawn_intent", "task_spawn_confirmed"
     inputs: dict[str, Any]  # what we decided on
     output: dict[str, Any]  # the resulting action's primary key(s)
-    actor: str              # which orchestrator component wrote it
+    actor: str  # which orchestrator component wrote it
     committed: bool = True  # False = pre-execution intent
 ```
 

--- a/docs/architecture/subagent-delegation.md
+++ b/docs/architecture/subagent-delegation.md
@@ -48,9 +48,9 @@ structured result into `dispatch_node()` or `delegate_plan()`:
 result = dispatch_node(
     node,
     native_result={"files_changed": ["app.py"]},
-    journal=run_journal,          # optional
-    chain=audit_chain_store,      # optional
-    ledger=spend_ledger,          # optional
+    journal=run_journal,  # optional
+    chain=audit_chain_store,  # optional
+    ledger=spend_ledger,  # optional
     undiscounted_cost_usd=0.02,
     input_tokens=1200,
     output_tokens=340,

--- a/docs/architecture/warm-pool.md
+++ b/docs/architecture/warm-pool.md
@@ -78,7 +78,9 @@ if warm_entry is not None:
     self._warm_pool_entries[session_id] = warm_entry
     logger.info(
         "Using warm pool slot %s for session %s (role=%s)",
-        warm_entry.slot_id, session_id, role,
+        warm_entry.slot_id,
+        session_id,
+        role,
     )
 else:
     spawn_cwd = worktree_mgr.create(session_id)  # cold path

--- a/docs/blog/zero-llm-coordination.md
+++ b/docs/blog/zero-llm-coordination.md
@@ -34,11 +34,8 @@ The Bernstein orchestrator is a priority queue over a dependency graph. Here's t
 ```python
 def get_ready_tasks(tasks: list[Task]) -> list[Task]:
     completed_ids = {t.id for t in tasks if t.status == "done"}
-    return [
-        t for t in tasks
-        if t.status == "open"
-        and all(dep in completed_ids for dep in t.dependencies)
-    ]
+    return [t for t in tasks if t.status == "open" and all(dep in completed_ids for dep in t.dependencies)]
+
 
 def tick(state: OrchestratorState) -> list[Task]:
     ready = get_ready_tasks(state.tasks)

--- a/docs/cloudflare/cloudflare-ai.md
+++ b/docs/cloudflare/cloudflare-ai.md
@@ -46,10 +46,12 @@ All models listed below are free on Workers AI:
 ```python
 from bernstein.core.routing.cloudflare_ai import WorkersAIConfig, WorkersAIProvider
 
-provider = WorkersAIProvider(WorkersAIConfig(
-    account_id="abc123",
-    api_token="cf_token_...",
-))
+provider = WorkersAIProvider(
+    WorkersAIConfig(
+        account_id="abc123",
+        api_token="cf_token_...",
+    )
+)
 
 response = await provider.complete(
     "Decompose this task into 3 subtasks: Add authentication to the API",
@@ -57,10 +59,10 @@ response = await provider.complete(
 )
 
 print(response.text)
-print(response.model)          # "@cf/meta/llama-3.1-70b-instruct"
-print(response.input_tokens)   # token count from API
+print(response.model)  # "@cf/meta/llama-3.1-70b-instruct"
+print(response.input_tokens)  # token count from API
 print(response.output_tokens)
-print(response.is_free)        # True for free-tier models
+print(response.is_free)  # True for free-tier models
 ```
 
 ### Structured JSON output

--- a/docs/cloudflare/cloudflare-analytics.md
+++ b/docs/cloudflare/cloudflare-analytics.md
@@ -64,26 +64,30 @@ from bernstein.core.cost.d1_analytics import (
     UsageEvent,
 )
 
-client = D1AnalyticsClient(D1Config(
-    account_id="abc123",
-    api_token="cf_token_...",
-    database_id="d1-uuid",
-))
+client = D1AnalyticsClient(
+    D1Config(
+        account_id="abc123",
+        api_token="cf_token_...",
+        database_id="d1-uuid",
+    )
+)
 
 # Idempotent; safe to call on every boot.
 await client.initialize_schema()
 
 # Record a single event.
-await client.record_event(UsageEvent(
-    user_id="user-42",
-    event_type="run_start",
-    timestamp=time.time(),
-    model="claude-sonnet-4-6",
-    run_id="run-001",
-    tokens_input=5000,
-    tokens_output=2000,
-    cost_usd=0.045,
-))
+await client.record_event(
+    UsageEvent(
+        user_id="user-42",
+        event_type="run_start",
+        timestamp=time.time(),
+        model="claude-sonnet-4-6",
+        run_id="run-001",
+        tokens_input=5000,
+        tokens_output=2000,
+        cost_usd=0.045,
+    )
+)
 
 # Batch insert (single transaction).
 await client.record_events_batch([event1, event2, event3])

--- a/docs/cloudflare/cloudflare-bridges.md
+++ b/docs/cloudflare/cloudflare-bridges.md
@@ -41,13 +41,15 @@ config = BridgeConfig(
 )
 
 bridge = CloudflareBridge(config)
-status = await bridge.spawn(SpawnRequest(
-    agent_id="agent-001",
-    prompt="Add input validation to all API endpoints",
-    model="sonnet",
-    role="backend",
-    effort="high",
-))
+status = await bridge.spawn(
+    SpawnRequest(
+        agent_id="agent-001",
+        prompt="Add input validation to all API endpoints",
+        model="sonnet",
+        role="backend",
+        effort="high",
+    )
+)
 
 # Poll status
 current = await bridge.status("agent-001")
@@ -136,17 +138,19 @@ config = BridgeConfig(
 bridge = CloudflareWorkflowBridge(config)
 
 # Dispatch a workflow
-status = await bridge.spawn(SpawnRequest(
-    agent_id="task-42",
-    prompt="Refactor the auth module",
-    model="opus",
-    role="architect",
-))
+status = await bridge.spawn(
+    SpawnRequest(
+        agent_id="task-42",
+        prompt="Refactor the auth module",
+        model="opus",
+        role="architect",
+    )
+)
 
 # Check detailed workflow status
 wf_status = await bridge.get_workflow_status("task-42")
-print(wf_status.current_step)   # WorkflowStep.EXECUTE
-print(wf_status.retries_used)   # 0
+print(wf_status.current_step)  # WorkflowStep.EXECUTE
+print(wf_status.retries_used)  # 0
 
 # Approve a workflow waiting at the approval gate
 await bridge.approve("task-42")
@@ -182,10 +186,12 @@ Gives agents the ability to browse web pages, take screenshots, extract content,
 ```python
 from bernstein.bridges.browser_rendering import BrowserConfig, BrowserRenderingBridge
 
-browser = BrowserRenderingBridge(BrowserConfig(
-    account_id="abc123",
-    api_token="cf_token_...",
-))
+browser = BrowserRenderingBridge(
+    BrowserConfig(
+        account_id="abc123",
+        api_token="cf_token_...",
+    )
+)
 
 # Render a page and extract content
 page = await browser.render("https://example.com", screenshot=True)
@@ -254,10 +260,12 @@ Default exclude patterns:
 from pathlib import Path
 from bernstein.bridges.r2_sync import R2Config, R2WorkspaceSync
 
-sync = R2WorkspaceSync(R2Config(
-    account_id="abc123",
-    api_token="cf_token_...",
-))
+sync = R2WorkspaceSync(
+    R2Config(
+        account_id="abc123",
+        api_token="cf_token_...",
+    )
+)
 
 # Upload workspace before agent runs
 manifest = await sync.upload(

--- a/docs/cloudflare/cloudflare-browser-rendering.md
+++ b/docs/cloudflare/cloudflare-browser-rendering.md
@@ -83,10 +83,10 @@ Fetches a fully-rendered page after JavaScript has run.
 
 ```python
 page = await browser.render("https://example.com", full_html=True)
-print(page.title)           # "Example Domain"
-print(page.content[:200])   # extracted text content
-print(len(page.links))      # outbound hrefs
-print(page.html[:500])      # only present if full_html=True
+print(page.title)  # "Example Domain"
+print(page.content[:200])  # extracted text content
+print(len(page.links))  # outbound hrefs
+print(page.html[:500])  # only present if full_html=True
 ```
 
 Returns a `PageResult` with `url`, `title`, `content` (extracted

--- a/docs/cloudflare/cloudflare-mcp.md
+++ b/docs/cloudflare/cloudflare-mcp.md
@@ -123,6 +123,7 @@ app = create_asgi_app(
 
 # Run with uvicorn
 import uvicorn
+
 uvicorn.run(app, host="0.0.0.0", port=8053)
 ```
 

--- a/docs/cloudflare/cloudflare-setup.md
+++ b/docs/cloudflare/cloudflare-setup.md
@@ -82,8 +82,8 @@ config = R2Config(
     account_id="abc123",
     api_token="cf_token_...",
     bucket_name="my-custom-bucket",  # default: "bernstein-workspaces"
-    max_file_size_mb=50,             # skip files larger than this
-    exclude_patterns=(               # default exclusions
+    max_file_size_mb=50,  # skip files larger than this
+    exclude_patterns=(  # default exclusions
         ".git",
         "__pycache__",
         "node_modules",

--- a/docs/compliance/lineage-export.md
+++ b/docs/compliance/lineage-export.md
@@ -189,7 +189,9 @@ critical path:
 
 ```python
 from bernstein.core.persistence.lineage import (
-    LineageReader, canonical_record_bytes, decode_signature,
+    LineageReader,
+    canonical_record_bytes,
+    decode_signature,
 )
 from bernstein.core.persistence.lineage_signer import (
     Ed25519PublicKeyVerifier,

--- a/docs/compliance/regulatory-lineage.md
+++ b/docs/compliance/regulatory-lineage.md
@@ -135,7 +135,9 @@ A customer auditor with only the public key and the WAL files runs:
 
 ```python
 from bernstein.core.persistence.lineage import (
-    LineageReader, canonical_record_bytes, decode_signature,
+    LineageReader,
+    canonical_record_bytes,
+    decode_signature,
 )
 from bernstein.core.persistence.lineage_signer import (
     Ed25519PublicKeyVerifier,

--- a/docs/concepts/abstracted-code-review.md
+++ b/docs/concepts/abstracted-code-review.md
@@ -39,7 +39,8 @@ Programmatic API for custom tooling:
 
 ```python
 from bernstein.core.quality.review_pipeline.abstract_diff import (
-    summarize_diff, pseudo_for_function,
+    summarize_diff,
+    pseudo_for_function,
 )
 
 # summarize_diff is async and returns one IntentSummary per file

--- a/docs/concepts/ast-aware-chunking.md
+++ b/docs/concepts/ast-aware-chunking.md
@@ -32,8 +32,8 @@ chunks = chunk_for_review(
     budget_tokens=4_000,
 )
 for chunk in chunks:
-    print(chunk.header)        # symbols included in this chunk
-    print(chunk.text)          # full Python source, never split mid-body
+    print(chunk.header)  # symbols included in this chunk
+    print(chunk.text)  # full Python source, never split mid-body
 ```
 
 Each `ReviewChunk` carries the symbol header (function or class names

--- a/docs/concepts/feature-contract.md
+++ b/docs/concepts/feature-contract.md
@@ -53,7 +53,7 @@ Load and verify the contract programmatically:
 from bernstein.core.planning.feature_contract import FeatureContract
 from bernstein.core.planning.spec_assertions import verify_contract
 
-contract = FeatureContract.load()              # raises on tampering
+contract = FeatureContract.load()  # raises on tampering
 extraction, results = verify_contract(apply=True)  # run checks, flip passes
 ```
 

--- a/docs/concepts/fingerprint-memoization.md
+++ b/docs/concepts/fingerprint-memoization.md
@@ -28,10 +28,12 @@ recompute and depends only on its arguments:
 ```python
 from pathlib import Path
 from bernstein.core.persistence.fingerprint import (
-    default_store, memoize_persistent,
+    default_store,
+    memoize_persistent,
 )
 
 store = default_store(Path("."))  # rooted at .sdd/runtime/memo
+
 
 @memoize_persistent(store, site="embed")
 def embed_chunk(chunk_text: str, embedder_id: str) -> list[float]:
@@ -63,6 +65,7 @@ Name the delegated code with `depends_on`:
 
 ```python
 from bernstein.core.knowledge import ast_symbol_graph
+
 
 @memoize_persistent(store, site="knowledge_graph", depends_on=(ast_symbol_graph,))
 def _extract_symbols_for_memo(*, file_sha: str, rel_path: str, abs_path: str):

--- a/docs/concepts/schema-validation-retry.md
+++ b/docs/concepts/schema-validation-retry.md
@@ -26,23 +26,28 @@ from bernstein.core.tasks.schema_retry import (
 )
 from pydantic import BaseModel
 
+
 class PlannerOutput(BaseModel):
     tasks: list[str]
     rationale: str
 
+
 ctx = SchemaRetryContext()
+
 
 def validate(raw: str) -> PlannerOutput:
     # raise ValueError on bad input; the retry loop catches it
     return PlannerOutput.model_validate_json(raw)
 
+
 def ask_again(prompt_with_errors: str) -> str:
     # call your spawned agent / model with the augmented prompt
     return run_agent(prompt_with_errors)
 
+
 result = validate_with_retry(
-    raw_text,             # initial_response (positional)
-    validate,             # parses-or-raises ValueError
+    raw_text,  # initial_response (positional)
+    validate,  # parses-or-raises ValueError
     ctx,
     ask_again=ask_again,
     max_attempts=3,

--- a/docs/concepts/spec-as-test.md
+++ b/docs/concepts/spec-as-test.md
@@ -52,7 +52,9 @@ You can emit the assertions as a real pytest file for CI:
 ```python
 from pathlib import Path
 from bernstein.core.planning.spec_assertions import (
-    load_contract, extract_assertions, assertions_to_pytest,
+    load_contract,
+    extract_assertions,
+    assertions_to_pytest,
 )
 
 contract = load_contract()

--- a/docs/contributing/hooks.md
+++ b/docs/contributing/hooks.md
@@ -210,10 +210,14 @@ import sys
 payload = json.loads(sys.stdin.read())
 duration_ms = payload["data"].get("duration_ms", 0)
 
-print(json.dumps({
-    "decision": "annotate",
-    "data": {"billing_unit_cost": duration_ms * 0.0001},
-}))
+print(
+    json.dumps(
+        {
+            "decision": "annotate",
+            "data": {"billing_unit_cost": duration_ms * 0.0001},
+        }
+    )
+)
 ```
 
 Place this at `.bernstein/hooks/postToolUse.py`, mark it executable,

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -259,8 +259,7 @@ import pytest
 
 
 @pytest.mark.allow_network  # justification: probes the real X endpoint; see #NNNN
-def test_live_thing() -> None:
-    ...
+def test_live_thing() -> None: ...
 ```
 
 The marker is registered in `pyproject.toml` (`--strict-markers` is on, so an

--- a/docs/decisions/003-self-evolution.md
+++ b/docs/decisions/003-self-evolution.md
@@ -333,7 +333,7 @@ coordinator = EvolutionCoordinator(
         evaluation_interval_minutes=30,
         min_tasks_for_evaluation=5,
         auto_execute_low_priority=False,
-    )
+    ),
 )
 
 coordinator.start()  # Background evaluation loop

--- a/docs/decisions/007-pluggy-plugin-system.md
+++ b/docs/decisions/007-pluggy-plugin-system.md
@@ -67,9 +67,10 @@ class EventEmitter:
 ```python
 import importlib.metadata
 
+
 def load_plugins() -> list[Any]:
     plugins = []
-    for ep in importlib.metadata.entry_points(group='bernstein.plugins'):
+    for ep in importlib.metadata.entry_points(group="bernstein.plugins"):
         plugin_class = ep.load()
         plugins.append(plugin_class())
     return plugins
@@ -135,6 +136,7 @@ def _safe_call(self, hook_name: str, **kwargs) -> None:
 
 ```python
 # src/bernstein/plugins/hookspecs.py
+
 
 class BernsteinSpec:
     @hookspec

--- a/docs/decisions/008-click-for-cli.md
+++ b/docs/decisions/008-click-for-cli.md
@@ -30,13 +30,13 @@ framework.**
 ```python
 import argparse
 
-parser = argparse.ArgumentParser(description='Bernstein orchestrator')
-subparsers = parser.add_subparsers(dest='command')
+parser = argparse.ArgumentParser(description="Bernstein orchestrator")
+subparsers = parser.add_subparsers(dest="command")
 
-run_parser = subparsers.add_parser('run', help='Start orchestration')
-run_parser.add_argument('plan', nargs='?', help='Plan file')
-run_parser.add_argument('--goal', help='High-level goal for planner')
-run_parser.add_argument('--max-agents', type=int, default=3)
+run_parser = subparsers.add_parser("run", help="Start orchestration")
+run_parser.add_argument("plan", nargs="?", help="Plan file")
+run_parser.add_argument("--goal", help="High-level goal for planner")
+run_parser.add_argument("--max-agents", type=int, default=3)
 ```
 
 **Pros**: Zero dependencies. Everyone knows it.
@@ -62,6 +62,7 @@ Typer builds on Click but uses Python type annotations as the command interface:
 import typer
 
 app = typer.Typer()
+
 
 @app.command()
 def run(
@@ -99,16 +100,19 @@ of Typer-specific idioms.
 ```python
 import click
 
+
 @click.group()
 @click.version_option()
 def cli() -> None:
     """Bernstein - multi-agent orchestration for CLI coding agents."""
 
+
 @cli.command()
-@click.argument('plan', required=False)
-@click.option('--goal', help='High-level goal for the planner')
-@click.option('--max-agents', default=3, show_default=True,
-              envvar='BERNSTEIN_MAX_AGENTS', help='Maximum parallel agents')
+@click.argument("plan", required=False)
+@click.option("--goal", help="High-level goal for the planner")
+@click.option(
+    "--max-agents", default=3, show_default=True, envvar="BERNSTEIN_MAX_AGENTS", help="Maximum parallel agents"
+)
 def run(plan: str | None, goal: str | None, max_agents: int) -> None:
     """Start the orchestrator. Provide a PLAN file or --goal."""
     ...
@@ -132,10 +136,11 @@ def run(plan: str | None, goal: str | None, max_agents: int) -> None:
    straightforward without sys.argv manipulation:
    ```python
    from click.testing import CliRunner
-   
+
+
    def test_run_command():
        runner = CliRunner()
-       result = runner.invoke(run, ['plans/test.yaml', '--max-agents', '2'])
+       result = runner.invoke(run, ["plans/test.yaml", "--max-agents", "2"])
        assert result.exit_code == 0
    ```
 

--- a/docs/eval/ab-runner.md
+++ b/docs/eval/ab-runner.md
@@ -37,13 +37,16 @@ tasks = [
     Task(task_id="t-002", input={"diff": "..."}, expected="block"),
 ]
 
+
 def my_executor(variant, task):
     # Synthetic in tests; live adapter call in production
     return {"verdict": "approve"}
 
+
 def my_scorer(result, task):
     # Returns a float in [0.0, 1.0]
     return 1.0 if result["verdict"] == task.expected else 0.0
+
 
 comparison = run_ab(
     variants=variants,
@@ -54,6 +57,7 @@ comparison = run_ab(
 
 # Comparison serialises deterministically
 import json
+
 artefact = json.dumps(comparison.to_dict(), sort_keys=True, indent=2)
 ```
 

--- a/docs/eval/bench.md
+++ b/docs/eval/bench.md
@@ -232,16 +232,18 @@ print(result.report())
 
 # Project to leaderboard
 lb = Leaderboard(suite_hash=suite.suite_hash, suite_version=suite.version)
-lb.add_entry(LeaderboardEntry(
-    bundle_hash=bundle.bundle_hash(),
-    suite_hash=bundle.suite_hash,
-    suite_version=bundle.suite_version,
-    overall_score=bundle.overall_score,
-    pass_rate=bundle.pass_rate,
-    num_tasks=len(bundle.task_results),
-    submitted_at=bundle.submitted_at,
-    bundle_path="bundles/my-bundle.json",
-))
+lb.add_entry(
+    LeaderboardEntry(
+        bundle_hash=bundle.bundle_hash(),
+        suite_hash=bundle.suite_hash,
+        suite_version=bundle.suite_version,
+        overall_score=bundle.overall_score,
+        pass_rate=bundle.pass_rate,
+        num_tasks=len(bundle.task_results),
+        submitted_at=bundle.submitted_at,
+        bundle_path="bundles/my-bundle.json",
+    )
+)
 print(lb.to_markdown())
 ```
 

--- a/docs/eval/reliability.md
+++ b/docs/eval/reliability.md
@@ -206,7 +206,7 @@ receipt = StubReliabilitySigner().sign(runner.run())
 print(f"pass^5 floor: {receipt.pass_caret_k:.2%}  pass@1: {receipt.pass_at_1:.2%}")
 
 verifier = ReliabilityVerifier(suite=suite, adapter=adapter)
-print(verifier.verify(receipt).report())     # overall: MATCH
+print(verifier.verify(receipt).report())  # overall: MATCH
 
 print(reliability_check(receipt, suite, adapter).report())  # reliability-check: PASS
 ```

--- a/docs/eval/trajectory-receipts.md
+++ b/docs/eval/trajectory-receipts.md
@@ -172,7 +172,7 @@ from bernstein.eval.trajectory_receipt_projection import (
 )
 
 # Operator: emit and project
-sk = Ed25519PrivateKey.generate()   # or load from key store
+sk = Ed25519PrivateKey.generate()  # or load from key store
 receipt = build_trajectory_receipt(...)
 projection = project_trajectory_receipt(receipt, signing_key=sk)
 
@@ -183,7 +183,7 @@ projection = project_trajectory_receipt(receipt, signing_key=sk)
 # Reviewer: verify with only the public key
 receipt_hash = verify_cose_projection_bytes(
     projection.cose_bytes,
-    public_key=sk.public_key(),   # from published JWK / key server
+    public_key=sk.public_key(),  # from published JWK / key server
 )
 # receipt_hash == receipt.receipt_hash → fetch receipt, run verify
 ```

--- a/docs/eval/yaml-harness.md
+++ b/docs/eval/yaml-harness.md
@@ -173,7 +173,7 @@ from pathlib import Path
 from bernstein.eval.yaml_runner import YAMLRunner, load_spec, save_report
 
 spec = load_spec(Path("eval/specs/my-suite.yaml"))
-runner = YAMLRunner()                      # default: deterministic mock
+runner = YAMLRunner()  # default: deterministic mock
 report = runner.run(spec, base_dir=Path("eval/specs"))
 json_path, md_path = save_report(report, state_dir=Path(".sdd"))
 

--- a/docs/integrations/hook-system.md
+++ b/docs/integrations/hook-system.md
@@ -60,8 +60,8 @@ Event types are defined in `bernstein.core.config.hook_events`:
 from bernstein.core.config.hook_events import HookEvent
 
 # Available events:
-HookEvent.TASK_COMPLETED   # "task.completed"
-HookEvent.AGENT_KILLED     # "agent.killed"
+HookEvent.TASK_COMPLETED  # "task.completed"
+HookEvent.AGENT_KILLED  # "agent.killed"
 # ... see full list in hook_events.py
 ```
 
@@ -210,6 +210,7 @@ import urllib.request
 
 SLACK_WEBHOOK = "https://hooks.slack.com/services/T.../B.../..."
 
+
 def main() -> None:
     event = json.load(sys.stdin)
     data = event["data"]
@@ -239,6 +240,7 @@ def main() -> None:
     )
     urllib.request.urlopen(req)
 
+
 if __name__ == "__main__":
     main()
 ```
@@ -251,6 +253,7 @@ if __name__ == "__main__":
 
 import json
 import sys
+
 
 def main() -> int:
     event = json.load(sys.stdin)
@@ -268,6 +271,7 @@ def main() -> int:
         return 1
 
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())
@@ -289,16 +293,12 @@ For blocking hooks, verify they return the correct exit code:
 import json
 import subprocess
 
+
 def test_validate_task_blocks_missing_scope() -> None:
-    payload = json.dumps({
-        "event": "task.created",
-        "timestamp": 1712345678.0,
-        "data": {"task_id": "t1", "goal": "Short"}
-    })
-    result = subprocess.run(
-        ["python", "scripts/validate_task.py"],
-        input=payload, capture_output=True, text=True
+    payload = json.dumps(
+        {"event": "task.created", "timestamp": 1712345678.0, "data": {"task_id": "t1", "goal": "Short"}}
     )
+    result = subprocess.run(["python", "scripts/validate_task.py"], input=payload, capture_output=True, text=True)
     assert result.returncode == 1  # blocked
 ```
 

--- a/docs/integrations/plugin-sdk.md
+++ b/docs/integrations/plugin-sdk.md
@@ -56,6 +56,7 @@ A plugin is a Python class whose methods are decorated with `@hookimpl`.
 ```python
 from bernstein.plugins import hookimpl
 
+
 class MyPlugin:
     @hookimpl
     def on_task_completed(self, task_id: str, role: str, result_summary: str) -> None:
@@ -201,6 +202,7 @@ lifecycle event to stdout; useful as a starting template.
 ```python
 from bernstein.plugins import hookimpl
 
+
 class LoggingPlugin:
     """Prints all lifecycle events to stdout."""
 
@@ -281,24 +283,30 @@ class SlackNotifier:
     @hookimpl
     def on_task_failed(self, task_id: str, role: str, error: str) -> None:
         """Alert on task failure - highest-signal event for on-call."""
-        self._post({
-            "text": f":red_circle: *Task failed* `{task_id}` (role: `{role}`)\n```{error[:500]}```",
-        })
+        self._post(
+            {
+                "text": f":red_circle: *Task failed* `{task_id}` (role: `{role}`)\n```{error[:500]}```",
+            }
+        )
 
     @hookimpl
     def on_task_completed(self, task_id: str, role: str, result_summary: str) -> None:
         """Optional: notify on completion (disable if too noisy)."""
-        self._post({
-            "text": f":white_check_mark: Task `{task_id}` completed by `{role}`: {result_summary[:200]}",
-        })
+        self._post(
+            {
+                "text": f":white_check_mark: Task `{task_id}` completed by `{role}`: {result_summary[:200]}",
+            }
+        )
 
     @hookimpl
     def on_evolve_proposal(self, proposal_id: str, title: str, verdict: str) -> None:
         """Notify when an evolution proposal is accepted or rejected."""
         emoji = ":tada:" if verdict == "accepted" else ":no_entry_sign:"
-        self._post({
-            "text": f"{emoji} Evolution proposal `{proposal_id}` *{verdict}*: {title}",
-        })
+        self._post(
+            {
+                "text": f"{emoji} Evolution proposal `{proposal_id}` *{verdict}*: {title}",
+            }
+        )
 
     def _post(self, payload: dict[str, Any]) -> None:
         """Dispatch a Slack webhook call on a background daemon thread."""
@@ -310,7 +318,8 @@ class SlackNotifier:
             try:
                 data = json.dumps(payload).encode()
                 req = urllib.request.Request(
-                    url, data=data,
+                    url,
+                    data=data,
                     headers={"Content-Type": "application/json"},
                     method="POST",
                 )
@@ -373,28 +382,40 @@ class DiscordNotifier:
 
     @hookimpl
     def on_task_failed(self, task_id: str, role: str, error: str) -> None:
-        self._post(embeds=[{
-            "title": f"Task Failed: {task_id}",
-            "description": f"**Role:** `{role}`\n```{error[:800]}```",
-            "color": 0xED4245,  # Discord red
-        }])
+        self._post(
+            embeds=[
+                {
+                    "title": f"Task Failed: {task_id}",
+                    "description": f"**Role:** `{role}`\n```{error[:800]}```",
+                    "color": 0xED4245,  # Discord red
+                }
+            ]
+        )
 
     @hookimpl
     def on_task_completed(self, task_id: str, role: str, result_summary: str) -> None:
-        self._post(embeds=[{
-            "title": f"Task Completed: {task_id}",
-            "description": f"**Role:** `{role}`\n{result_summary[:400]}",
-            "color": 0x57F287,  # Discord green
-        }])
+        self._post(
+            embeds=[
+                {
+                    "title": f"Task Completed: {task_id}",
+                    "description": f"**Role:** `{role}`\n{result_summary[:400]}",
+                    "color": 0x57F287,  # Discord green
+                }
+            ]
+        )
 
     @hookimpl
     def on_evolve_proposal(self, proposal_id: str, title: str, verdict: str) -> None:
         color = 0x57F287 if verdict == "accepted" else 0xED4245
-        self._post(embeds=[{
-            "title": f"Evolution Proposal {verdict.title()}: {title}",
-            "description": f"Proposal ID: `{proposal_id}`",
-            "color": color,
-        }])
+        self._post(
+            embeds=[
+                {
+                    "title": f"Evolution Proposal {verdict.title()}: {title}",
+                    "description": f"Proposal ID: `{proposal_id}`",
+                    "color": color,
+                }
+            ]
+        )
 
     def _post(self, embeds: list[dict[str, Any]]) -> None:
         """Dispatch Discord webhook on a background daemon thread."""
@@ -407,7 +428,8 @@ class DiscordNotifier:
             try:
                 data = json.dumps(payload).encode()
                 req = urllib.request.Request(
-                    url, data=data,
+                    url,
+                    data=data,
                     headers={"Content-Type": "application/json"},
                     method="POST",
                 )
@@ -577,14 +599,20 @@ class SecurityScanGate:
         if not passed:
             log.warning(
                 "SecurityScanGate: scan failed after task %s (%s):\n%s",
-                task_id, role, output[:500],
+                task_id,
+                role,
+                output[:500],
             )
 
     def _run_scan(self) -> tuple[bool, str]:
         try:
             proc = subprocess.run(
-                self._command, shell=True, cwd=self._workdir,
-                capture_output=True, text=True, timeout=self._timeout_s,
+                self._command,
+                shell=True,
+                cwd=self._workdir,
+                capture_output=True,
+                text=True,
+                timeout=self._timeout_s,
             )
             out = (proc.stdout + proc.stderr).strip()
             if len(out) > 2000:
@@ -878,7 +906,11 @@ providers:
 
 ```python
 from bernstein.core.router import (
-    TierAwareRouter, ProviderConfig, ModelConfig, Tier, get_default_router,
+    TierAwareRouter,
+    ProviderConfig,
+    ModelConfig,
+    Tier,
+    get_default_router,
 )
 
 router = get_default_router()
@@ -937,6 +969,7 @@ starting the orchestrator.
 ```python
 from bernstein.plugins.manager import PluginManager
 from my_package.hooks import SlackNotifier
+
 
 def test_slack_notifier_on_failure(monkeypatch, capsys):
     calls = []

--- a/docs/lineage/artifacts.md
+++ b/docs/lineage/artifacts.md
@@ -62,7 +62,7 @@ from bernstein.core.lineage.artifact_uri import external_reference_content_hash
 
 content_hash = external_reference_content_hash(
     "pkg://pypi/bernstein/3.9.0",
-    digest="sha256:" + archive_sha256,      # the package archive
+    digest="sha256:" + archive_sha256,  # the package archive
 )
 ```
 
@@ -74,7 +74,7 @@ too, so the content address changes when the extraction changes:
 content_hash = external_reference_content_hash(
     "doc://example.test/lineage",
     digest="sha256:" + page_sha256,
-    extractor="html-readability@2.4.1",     # stable "id@version", passed deliberately
+    extractor="html-readability@2.4.1",  # stable "id@version", passed deliberately
 )
 ```
 

--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -59,9 +59,9 @@ client validated against.
 
 ```python
 session = MCPClientSession(RemoteServerConfig(name="github", url="https://..."))
-await session.connect()           # discovers + digests the manifest
-await session.call_tool("create_issue", {...})   # ok: declared
-await session.call_tool("rm_minus_rf", {...})     # raises MCPCapabilityMissing
+await session.connect()  # discovers + digests the manifest
+await session.call_tool("create_issue", {...})  # ok: declared
+await session.call_tool("rm_minus_rf", {...})  # raises MCPCapabilityMissing
 ```
 
 `MCPCapabilityMissing` subclasses `MCPToolNotFoundError`, so callers that
@@ -90,6 +90,7 @@ def stream_factory(resume_from, idempotency_key):
     # resume_from is the last checkpoint token, or None on first attempt.
     return transport.open_stream(resume_from=resume_from, idem=idempotency_key)
 
+
 result = await session.call_tool_streaming("long_query", {...}, stream_factory=stream_factory)
 ```
 
@@ -108,10 +109,8 @@ partial output.
 
 ```python
 handle = StreamedToolCall(server_name="github", tool_name="long_query")
-task = asyncio.create_task(
-    session.call_tool_streaming("long_query", {...}, stream_factory=f, handle=handle)
-)
-handle.cancel()              # cooperative; partial output is preserved
+task = asyncio.create_task(session.call_tool_streaming("long_query", {...}, stream_factory=f, handle=handle))
+handle.cancel()  # cooperative; partial output is preserved
 result = await task
 assert result.metadata["cancelled"] is True
 ```
@@ -134,8 +133,8 @@ manager = MCPClientManager(cost_meter=meter, task_id="task-42")
 await manager.connect(config)
 await manager.call_tool("github", "search", {...}, cost_usd=0.02)
 
-manager.server_cost("github")   # 0.02
-manager.task_cost()             # total across all servers for task-42
+manager.server_cost("github")  # 0.02
+manager.task_cost()  # total across all servers for task-42
 ```
 
 Negative costs are clamped to zero so a misreporting server cannot corrupt

--- a/docs/operations/MODEL_POLICY.md
+++ b/docs/operations/MODEL_POLICY.md
@@ -98,10 +98,7 @@ router = TierAwareRouter()
 router.register_provider(ProviderConfig(...))  # ... 10 providers
 
 # Apply policy
-policy = ModelPolicy(
-    denied_providers=["openai", "cohere"],
-    prefer="anthropic"
-)
+policy = ModelPolicy(denied_providers=["openai", "cohere"], prefer="anthropic")
 router.state.model_policy = policy
 
 # Router now respects the policy
@@ -222,10 +219,7 @@ model_policy:
 from bernstein.core.routing.router import ModelPolicy, TierAwareRouter
 
 # Create policy
-policy = ModelPolicy(
-    allowed_providers=["anthropic"],
-    prefer="anthropic"
-)
+policy = ModelPolicy(allowed_providers=["anthropic"], prefer="anthropic")
 
 # Validate
 issues = policy.validate()
@@ -300,10 +294,7 @@ The router validates the policy when it initializes and logs warnings if there a
 If the preferred provider is unavailable (rate-limited, down), the router falls back to the next best allowed provider.
 
 ```python
-policy = ModelPolicy(
-    allowed_providers=["anthropic", "ollama"],
-    prefer="anthropic"
-)
+policy = ModelPolicy(allowed_providers=["anthropic", "ollama"], prefer="anthropic")
 
 # If anthropic is down → fallback to ollama
 # If ollama is also down → no provider available → error

--- a/docs/operations/datasources.md
+++ b/docs/operations/datasources.md
@@ -228,9 +228,9 @@ connection = DataSourceConnection(id="sales", driver="sqlite", dsn="/var/data/sa
 driver = build_sqlite_query_driver(sdd_dir, connection)
 
 run = driver.run("SELECT region, SUM(amount) FROM orders GROUP BY region")
-run.schema_digest      # the schema snapshot the result was derived against
-run.result_hash        # sha256 over the canonical (explicitly ordered) bytes
-run.receipt            # the signed DataOpsReceipt; verifies offline
+run.schema_digest  # the schema snapshot the result was derived against
+run.result_hash  # sha256 over the canonical (explicitly ordered) bytes
+run.receipt  # the signed DataOpsReceipt; verifies offline
 ```
 
 ### Schema drift is a typed refusal
@@ -242,11 +242,10 @@ when the live schema no longer matches — *before* executing the query:
 from bernstein.core.datasources.errors import SchemaDrift
 
 try:
-    driver.run("SELECT region, SUM(amount) FROM orders GROUP BY region",
-               expected_schema=recorded_snapshot)
+    driver.run("SELECT region, SUM(amount) FROM orders GROUP BY region", expected_schema=recorded_snapshot)
 except SchemaDrift as drift:
-    drift.changed_object_names   # e.g. ('orders',)
-    drift.drifts[0].describe()   # "changed table 'orders': added columns 'discount'"
+    drift.changed_object_names  # e.g. ('orders',)
+    drift.drifts[0].describe()  # "changed table 'orders': added columns 'discount'"
 ```
 
 The verdict names the changed objects (added / removed / changed, with

--- a/docs/operations/deployment-guide.md
+++ b/docs/operations/deployment-guide.md
@@ -1125,9 +1125,9 @@ green_path = deploy.prepare_green("2.1.0")
 
 # 3. Check health
 if deploy.health_check():
-    deploy.switch_traffic()   # symlink: .sdd/ → .sdd-green/
+    deploy.switch_traffic()  # symlink: .sdd/ → .sdd-green/
 else:
-    deploy.rollback()         # stays on blue; green is discarded
+    deploy.rollback()  # stays on blue; green is discarded
 ```
 
 ### Upgrade procedure (bare metal)
@@ -1159,10 +1159,10 @@ kill $(cat .sdd-blue/runtime/server.pid)
 
 ```python
 status = deploy.status()
-print(status.active)         # "blue" or "green"
-print(status.blue_version)   # "2.0.0"
+print(status.active)  # "blue" or "green"
+print(status.blue_version)  # "2.0.0"
 print(status.green_version)  # "2.1.0"
-print(status.healthy)        # True / False
+print(status.healthy)  # True / False
 ```
 
 ---

--- a/docs/operations/env-isolation.md
+++ b/docs/operations/env-isolation.md
@@ -130,7 +130,7 @@ To add a variable for one adapter only, edit that adapter's call site
 filtered = build_filtered_env(
     extra_keys=[
         "ANTHROPIC_API_KEY",
-        "ANTHROPIC_BEDROCK_BASE_URL",   # new
+        "ANTHROPIC_BEDROCK_BASE_URL",  # new
     ]
 )
 ```

--- a/docs/operations/observability-overview.md
+++ b/docs/operations/observability-overview.md
@@ -166,9 +166,7 @@ Environment variables (`apm_integration.py:29-37`):
 Setup is one of:
 
 ```python
-from bernstein.core.observability.apm_integration import (
-    auto_configure_apm, configure_datadog
-)
+from bernstein.core.observability.apm_integration import auto_configure_apm, configure_datadog
 
 # Auto-pick whatever is available based on env vars
 auto_configure_apm()
@@ -194,9 +192,7 @@ tracer, meter, span context manager, and named presets for common
 backends (`telemetry.py:1-22`).
 
 ```python
-from bernstein.core.observability.telemetry import (
-    init_telemetry_from_preset, init_telemetry, start_span
-)
+from bernstein.core.observability.telemetry import init_telemetry_from_preset, init_telemetry, start_span
 
 # Built-in presets (telemetry.py:86-100): "jaeger", "grafana", "datadog",
 # "zipkin", "console", and more. Each preset hardcodes endpoint, protocol,

--- a/docs/operations/odata.md
+++ b/docs/operations/odata.md
@@ -137,7 +137,7 @@ connection = OdataConnection(
     entity_set="Orders",
     timestamp_property="LastChangeDateTime",
     key_properties=("OrderID",),
-    prefer_delta=True,              # probe for delta; fall back to watermark
+    prefer_delta=True,  # probe for delta; fall back to watermark
     rate_limit_min_interval_s=1.0,  # respect a documented per-API minimum
     auth=OdataAuth(kind="bearer", token_env="ERP_TOKEN"),
     name="erp_orders",
@@ -149,7 +149,7 @@ source = OdataPollSource(connection)
 # 1. Poll -> one TriggerEvent per changed order.
 result = source.poll(load_cursor(cursor_path))
 for event in result.events:
-    seed_task_from(event)         # your normal trigger -> task path
+    seed_task_from(event)  # your normal trigger -> task path
 
 # 2. Persist the advanced cursor so a restart resumes byte-identically.
 save_cursor(cursor_path, result.cursor)

--- a/docs/operations/trigger-sources.md
+++ b/docs/operations/trigger-sources.md
@@ -9,7 +9,7 @@ normalized shape instead of against N different payload formats.
 ```python
 @dataclass
 class TriggerEvent:
-    source: str                       # "github", "slack", "schedule", ...
+    source: str  # "github", "slack", "schedule", ...
     timestamp: float
     raw_payload: dict[str, Any]
     repo: str = ""

--- a/docs/operations/tui-keybindings.md
+++ b/docs/operations/tui-keybindings.md
@@ -55,10 +55,10 @@ calling `resolve_all_bindings()`, which merges the three layers above:
 # src/bernstein/tui/app.py
 from bernstein.tui.keybinding_config import resolve_all_bindings as _resolve_all_bindings
 
+
 def _build_app_bindings() -> list[BindingType]:
     bindings = [
-        Binding(e.key, e.action, e.description, show=e.show, priority=e.priority)
-        for e in _resolve_all_bindings()
+        Binding(e.key, e.action, e.description, show=e.show, priority=e.priority) for e in _resolve_all_bindings()
     ]
     ...
 ```

--- a/docs/orchestration/bulletin-board.md
+++ b/docs/orchestration/bulletin-board.md
@@ -17,7 +17,7 @@ class BulletinMessage:
     agent_id: str
     type: Literal["alert", "blocker", "finding", "status", "dependency"]
     content: str
-    timestamp: float = 0.0   # auto-filled on post() if left as 0
+    timestamp: float = 0.0  # auto-filled on post() if left as 0
     cell_id: str | None = None
 ```
 
@@ -49,7 +49,7 @@ from bernstein.core.communication.bulletin import BulletinBoard, BulletinMessage
 board = BulletinBoard()
 board.post(BulletinMessage(agent_id="qa-1", type="status", content="ran full suite, 2 failures"))
 
-recent = board.read_since(0.0)          # everything
+recent = board.read_since(0.0)  # everything
 blockers = board.read_by_type("blocker")
 cell_msgs = board.read_by_cell("cell-2")
 ```

--- a/docs/orchestration/federation.md
+++ b/docs/orchestration/federation.md
@@ -99,9 +99,7 @@ dispatcher = FederationDispatcher(
     role="backend",
     audit_sink=lambda record: write_audit_record(record, Path(".sdd")),
 )
-dispatcher.comment(
-    "github_projects", "42", "linked from LIN-1", from_tracker="linear"
-)
+dispatcher.comment("github_projects", "42", "linked from LIN-1", from_tracker="linear")
 ```
 
 The dispatcher routes the comment to the correct adapter, records the

--- a/docs/orchestration/research-activity.md
+++ b/docs/orchestration/research-activity.md
@@ -47,6 +47,7 @@ from bernstein.core.orchestration.research_worker import (
 
 worker = ResearchWorker(store=store, budget=ResearchBudget(max_fetches=8))
 
+
 def synthesise(query, fetched):
     # The opaque, stochastic step (a model in production). It drafts claims and
     # the spans they quote; the worker binds each span to the fetched page hash.
@@ -57,10 +58,11 @@ def synthesise(query, fetched):
         ),
     ]
 
+
 run = worker.run(
     query="what changed in 3.13",
     sources=["https://example/a", "https://example/b"],
-    fetch_fn=fetch_bytes,       # retrieves the exact page bytes
+    fetch_fn=fetch_bytes,  # retrieves the exact page bytes
     synthesise=synthesise,
 )
 dispatch_activity(run.result, stage_id="research-0", journal=journal, chain=chain)

--- a/docs/orchestration/tracker-pipeline.md
+++ b/docs/orchestration/tracker-pipeline.md
@@ -261,8 +261,8 @@ raw = {
 # bernstein.core.trackers.contract for the adapter contract.
 pipeline = build_pipeline_from_yaml(
     raw,
-    trackers=trackers,        # mapping name -> AbstractTrackerAdapter
-    dispatcher=dispatcher,    # supplies role execution
+    trackers=trackers,  # mapping name -> AbstractTrackerAdapter
+    dispatcher=dispatcher,  # supplies role execution
     state_root=Path(".sdd"),
     hook_registry=HookRegistry(),
 )

--- a/docs/orchestration/worker-coordination.md
+++ b/docs/orchestration/worker-coordination.md
@@ -154,7 +154,7 @@ from bernstein.core.communication.task_mailbox import TaskMailbox, verify_agains
 from bernstein.core.security.audit_chain import AuditChainStore
 
 mailbox = TaskMailbox(runtime_dir / "mailbox.jsonl", hmac_key=key, identity_dir=identity_dir)
-ok, problems = mailbox.verify()                      # chain + signatures
+ok, problems = mailbox.verify()  # chain + signatures
 ok, problems = verify_against_chain(mailbox, chain)  # journal == chain-attested log
 ```
 
@@ -226,7 +226,7 @@ from bernstein.core.communication.signal_actions import ClearanceGateCoordinator
 coordinator = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=chain)
 board.set_post_hook(
     coordinator.materialize,
-    outbox_path=Path(".sdd/runtime/signal_outbox.jsonl"),   # durable retry queue
+    outbox_path=Path(".sdd/runtime/signal_outbox.jsonl"),  # durable retry queue
 )
 # ... later, when the blocker is fixed:
 coordinator.resolve(clearance_task_id, resolver="operator:alex")

--- a/docs/planning/spec-quality-gate.md
+++ b/docs/planning/spec-quality-gate.md
@@ -84,6 +84,7 @@ callable:
 ```python
 from bernstein.core.planning.spec_quality import Rule, RuleResult
 
+
 def _check(spec_text, workspace_root):
     if "stakeholder" not in spec_text.lower():
         return RuleResult(
@@ -93,6 +94,7 @@ def _check(spec_text, workspace_root):
             hint="Add a 'Stakeholder' heading or sentence.",
         )
     return RuleResult(rule_id="stakeholder_named", passed=True)
+
 
 def factory() -> Rule:
     return Rule(

--- a/docs/protocols/tool-search.md
+++ b/docs/protocols/tool-search.md
@@ -50,7 +50,8 @@ To inspect the search engine directly:
 
 ```python
 from bernstein.core.protocols.mcp.mcp_tool_search import (
-    ToolCatalog, ToolSearchEngine,
+    ToolCatalog,
+    ToolSearchEngine,
 )
 
 catalog = ToolCatalog.from_registered_servers()

--- a/docs/quality/consensus-scoring.md
+++ b/docs/quality/consensus-scoring.md
@@ -33,13 +33,14 @@ class Evidence:
     snippet: str = ""
     symbol: str = ""
 
+
 @dataclass(frozen=True)
 class NormalizedFinding:
-    bot: str                 # e.g. "coderabbit", "sourcery", "gh-advanced-security"
-    finding_id: str          # bot-local id, audit only (not part of dedup key)
-    severity: Severity       # info | low | medium | high | critical
-    category: str            # coarse class: security | perf | style | ...
-    title: str               # short title, used for fuzzy dedup + display
+    bot: str  # e.g. "coderabbit", "sourcery", "gh-advanced-security"
+    finding_id: str  # bot-local id, audit only (not part of dedup key)
+    severity: Severity  # info | low | medium | high | critical
+    category: str  # coarse class: security | perf | style | ...
+    title: str  # short title, used for fuzzy dedup + display
     evidence: Evidence
     confidence: float = 1.0  # bot self-reported, [0.0, 1.0]
 ```

--- a/docs/quality/empirical-confidence.md
+++ b/docs/quality/empirical-confidence.md
@@ -21,10 +21,10 @@ Return type:
 ```python
 @dataclass(frozen=True)
 class Confidence:
-    value: float | None        # mean outcome in [0,1], or None
-    samples: int               # total recorded rows
-    insufficient_data: bool    # True when samples < min_samples
-    min_samples: int           # threshold used for this query
+    value: float | None  # mean outcome in [0,1], or None
+    samples: int  # total recorded rows
+    insufficient_data: bool  # True when samples < min_samples
+    min_samples: int  # threshold used for this query
 ```
 
 ## Storage

--- a/docs/reference/volunteer-manifest.md
+++ b/docs/reference/volunteer-manifest.md
@@ -214,7 +214,7 @@ to vendor dependencies.
 from bernstein.core.volunteer import load_manifest_from_repo
 
 manifest = load_manifest_from_repo(repo_root)
-print(manifest.digest)          # the value a receipt carries as manifest_sha256
+print(manifest.digest)  # the value a receipt carries as manifest_sha256
 print([str(g) for g in manifest.gates])
 ```
 

--- a/docs/security/audit-multitenant.md
+++ b/docs/security/audit-multitenant.md
@@ -299,7 +299,7 @@ trust = load_trusted_tsa_certs(Path("path/to/freetsa-bundle.pem"))
 result = verify_tenant_slice(
     Path("path/to/bundle.json"),
     key=key,
-    rfc3161_trusted_tsa_certs=trust,            # opt-in
+    rfc3161_trusted_tsa_certs=trust,  # opt-in
     head_signature_trusted_jwk={"kty": "OKP", "crv": "Ed25519", "x": "..."},
 )
 if not result.ok:

--- a/docs/security/capability-matrix.md
+++ b/docs/security/capability-matrix.md
@@ -71,15 +71,18 @@ Programmatically:
 
 ```python
 from bernstein.core.security.capability_matrix import (
-    CapabilityRegistry, Capability,
+    CapabilityRegistry,
+    Capability,
 )
 
 registry = CapabilityRegistry.load_default()
-decision = registry.evaluate_chain([
-    "read_file",
-    "web_fetch",
-    "gh.issue_comment",
-])
+decision = registry.evaluate_chain(
+    [
+        "read_file",
+        "web_fetch",
+        "gh.issue_comment",
+    ]
+)
 assert decision.kind == "DENY-trifecta"
 print(decision.reason)
 ```

--- a/docs/security/mcp-signing.md
+++ b/docs/security/mcp-signing.md
@@ -112,7 +112,8 @@ findings.
 
 ```python
 from bernstein.core.protocols.mcp.mcp_signing_policy import (
-    MCPSigningPolicy, enforce_mcp_server_load,
+    MCPSigningPolicy,
+    enforce_mcp_server_load,
 )
 
 policy = MCPSigningPolicy(

--- a/docs/security/owasp-asi.md
+++ b/docs/security/owasp-asi.md
@@ -53,9 +53,9 @@ The toggle is read by `is_owasp_asi_enabled()` and consulted by
 ```python
 from bernstein.core.security.guardrail_pipeline import GuardrailPipeline
 
-pipeline = GuardrailPipeline.default()                  # respects env
+pipeline = GuardrailPipeline.default()  # respects env
 pipeline = GuardrailPipeline.default(enable_owasp_asi=True)  # force on
-pipeline = GuardrailPipeline.default(enable_owasp_asi=False) # force off
+pipeline = GuardrailPipeline.default(enable_owasp_asi=False)  # force off
 ```
 
 Detector load failures are caught and logged; the pipeline keeps
@@ -120,7 +120,8 @@ permission graph, audit chain) - it is not a replacement for them.
 
 ```python
 from bernstein.core.security.owasp_asi_detectors import (
-    OwaspAsiGuardrail, DEFAULT_DETECTORS,
+    OwaspAsiGuardrail,
+    DEFAULT_DETECTORS,
 )
 
 custom = OwaspAsiGuardrail(

--- a/docs/security/promptware.md
+++ b/docs/security/promptware.md
@@ -57,6 +57,7 @@ registered with `HookRegistry.register_callable`) can react and raise
 ```python
 from bernstein.core.lifecycle.hooks import HookFailure, LifecycleContext, LifecycleEvent
 
+
 def abort_on_promptware(ctx: LifecycleContext) -> None:
     if ctx.data.get("promptware_abort"):
         raise HookFailure(
@@ -65,6 +66,7 @@ def abort_on_promptware(ctx: LifecycleContext) -> None:
             exit_code=1,
             stderr="promptware detected; refusing to spawn next agent",
         )
+
 
 registry.register_callable(LifecycleEvent.POST_TASK, abort_on_promptware)
 ```

--- a/docs/security/secrets-broker.md
+++ b/docs/security/secrets-broker.md
@@ -83,6 +83,7 @@ item with:
 
 ```python
 import keyring
+
 keyring.set_password("bernstein", "ANTHROPIC_API_KEY", "sk-ant-...")
 ```
 

--- a/docs/security/security-hardening.md
+++ b/docs/security/security-hardening.md
@@ -253,7 +253,7 @@ Denied paths always override allowed paths.
 | `frontend`  | `src/*`, `tests/*`, `docs/*`, `public/*`, `static/*`, `package.json` | `.github/*`, `.sdd/*`, `templates/roles/*` |
 | `qa`        | `tests/*`, `src/*`, `docs/*`, `scripts/*`                   | `.github/*`, `.sdd/*`, `templates/roles/*` |
 | `security`  | `src/*`, `tests/*`, `.github/workflows/*`, `docs/*`, `scripts/*` | `.sdd/*`, `templates/roles/*`          |
-| `devops`    | `.github/*`, `Dockerfile`, `docker-compose.yml`, `scripts/*`, `Makefile` | `.sdd/*`, `src/*`, `templates/roles/*` |
+| `devops`    | `.github/*`, `Dockerfile`, `docker-compose.yaml`, `docker-compose.yml`, `scripts/*`, `Makefile` | `.sdd/*`, `src/*`, `templates/roles/*` |
 | `docs`      | `docs/*`, `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`   | `.github/*`, `.sdd/*`, `src/*`, `tests/*`, `templates/roles/*` |
 | `manager`   | `docs/*`, `.sdd/backlog/*`, `plans/*`                       | `src/*`, `tests/*`, `.github/*`          |
 | `architect` | `src/*`, `tests/*`, `docs/*`, `scripts/*`                   | `.github/*`, `.sdd/*`, `templates/roles/*` |

--- a/docs/testing/cluster-e2e-harness.md
+++ b/docs/testing/cluster-e2e-harness.md
@@ -32,7 +32,7 @@ yields a `ClusterHandle`:
 def test_worker_crash_mid_task(two_node_cluster):
     handle = two_node_cluster
     task_id = handle.submit_task(role="backend", goal="...")
-    handle.kill_worker()                         # SIGKILL
+    handle.kill_worker()  # SIGKILL
     handle.wait_for_node_status("offline", timeout=15)
     handle.restart_worker()
     handle.wait_for_task_completion(task_id, timeout=60)

--- a/docs/trackers/contract.md
+++ b/docs/trackers/contract.md
@@ -91,8 +91,7 @@ class AcmeTracker(AbstractTrackerAdapter):
         body: str,
         *,
         idempotency_key: str | None = None,
-    ) -> CommentResult:
-        ...
+    ) -> CommentResult: ...
 
     def transition(
         self,
@@ -101,8 +100,7 @@ class AcmeTracker(AbstractTrackerAdapter):
         *,
         idempotency_key: str | None = None,
         etag: str | None = None,
-    ) -> TransitionResult:
-        ...
+    ) -> TransitionResult: ...
 ```
 
 ## Shipping the adapter as a plugin

--- a/examples/plugins/custom-adapter/README.md
+++ b/examples/plugins/custom-adapter/README.md
@@ -34,9 +34,12 @@ same event types it would in production.
 
 ```python
 from custom_adapter import ClaudeMockAdapter
-adapter = ClaudeMockAdapter(canned_responses={
-    "fix the bug": "I patched src/foo.py.",
-})
+
+adapter = ClaudeMockAdapter(
+    canned_responses={
+        "fix the bug": "I patched src/foo.py.",
+    }
+)
 ```
 
 bernstein instantiates the adapter without arguments by default; pass
@@ -46,6 +49,7 @@ relying on entry-point discovery:
 ```python
 from bernstein.adapters.registry import register_adapter
 from custom_adapter import ClaudeMockAdapter
+
 register_adapter("claude_mock", ClaudeMockAdapter(canned_responses={...}))
 ```
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -40,8 +40,8 @@ with BernsteinClient("http://127.0.0.1:8052") as client:
 from bernstein_sdk.state_map import JiraToBernstein, BernsteinToJira
 from bernstein_sdk.models import TaskStatus
 
-status = JiraToBernstein.map("In Progress")   # → TaskStatus.IN_PROGRESS
-label  = BernsteinToJira.map(TaskStatus.DONE) # → "Done"
+status = JiraToBernstein.map("In Progress")  # → TaskStatus.IN_PROGRESS
+label = BernsteinToJira.map(TaskStatus.DONE)  # → "Done"
 ```
 
 ## Async client

--- a/src/bernstein/core/security/permissions.py
+++ b/src/bernstein/core/security/permissions.py
@@ -170,7 +170,16 @@ DEFAULT_ROLE_PERMISSIONS: dict[str, AgentPermissions] = {
         denied_paths=(_PATTERN_SDD, _PATTERN_ROLES),
     ),
     "devops": AgentPermissions(
-        allowed_paths=(_PATTERN_GITHUB, "Dockerfile", "docker-compose.yml", _PATTERN_SCRIPTS, "Makefile"),
+        allowed_paths=(
+            _PATTERN_GITHUB,
+            "Dockerfile",
+            # Both spellings occur in the wild; listed literally rather than as a
+            # glob because fnmatch's ``*`` also crosses ``/``.
+            "docker-compose.yaml",
+            "docker-compose.yml",
+            _PATTERN_SCRIPTS,
+            "Makefile",
+        ),
         denied_paths=(_PATTERN_SDD, _PATTERN_SRC, _PATTERN_ROLES),
     ),
     "docs": AgentPermissions(

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from bernstein.core.permissions import (
     DEFAULT_ROLE_PERMISSIONS,
     AgentPermissions,
@@ -303,6 +304,12 @@ class TestDefaultRoleMatrix:
     def test_devops_cannot_edit_src(self) -> None:
         perms = DEFAULT_ROLE_PERMISSIONS["devops"]
         assert not is_path_allowed("src/foo.py", perms)
+
+    @pytest.mark.parametrize("compose_file", ["docker-compose.yaml", "docker-compose.yml"])
+    def test_devops_can_edit_compose_file(self, compose_file: str) -> None:
+        # Both spellings are in the wild; the file at this repo root is .yaml.
+        perms = DEFAULT_ROLE_PERMISSIONS["devops"]
+        assert is_path_allowed(compose_file, perms)
 
     def test_manager_cannot_edit_src(self) -> None:
         perms = DEFAULT_ROLE_PERMISSIONS["manager"]


### PR DESCRIPTION
## Problem

`DEFAULT_ROLE_PERMISSIONS["devops"]` allowed the literal `docker-compose.yml`, but the compose file at the repo root is `docker-compose.yaml`.

`path_matches_any()` does a plain `fnmatch.fnmatch(filepath, pattern)` with no extension normalisation, so the pattern never matched the real path. The devops allow-list is non-empty, so a path matching none of its patterns is denied. Net effect: a devops agent could not modify the project's compose file at all.

Reproduced before the fix:

```
docker-compose.yaml   -> False
docker-compose.yml    -> True
Dockerfile            -> True
Makefile              -> True
.github/workflows/ci.yml -> True
```

## Fix

Allow both spellings. Two literals rather than one glob: `fnmatch`'s `*` also crosses `/`, so a leading-wildcard pattern such as `docker-compose*.y*ml` would widen the allow-list to nested paths — unwanted in a security allow-list.

Also refreshes the role matrix in `docs/security/security-hardening.md`, which mirrored the stale filename.

## Tests

New parametrised case in `TestDefaultRoleMatrix` covering both extensions. It fails on `main` (`docker-compose.yaml` → `AssertionError: assert False`) and passes with the fix.

```
tests/unit/test_permissions.py ............................. 45 passed
```

Also green across every test module importing the permissions matrix (`test_path_traversal`, `test_agent_trust`, `test_grant_bound_checkpoint`, `test_security_posture`, `test_permissions`) — 191 passed — plus the adjacent permission/guardrail suites (142 passed). `ruff check`, `ruff format --check`, and `mypy` clean on the changed files.

## Scope check

Grepped the rest of the tree for the same stale assumption. Remaining `docker-compose.yml` references are all legitimate: `examples/cluster/cloudflared/docker-compose.yml` really is a `.yml` file, `plans/templates/fullstack.yaml` describes a file the plan itself creates, and the `test_data_generators.py` entry is a synthetic filename in an unrelated fixture.
