### PR TITLE
fix(cli): an unreadable volunteer manifest is a refusal, not a traceback

### DIFF
--- a/src/bernstein/cli/commands/volunteer_cmd.py
+++ b/src/bernstein/cli/commands/volunteer_cmd.py
@@ -82,6 +82,20 @@ def verify_cmd(repo_root: Path, as_json: bool) -> None:
                 path=manifest_path,
             )
             return
+        # Must stay below the FileNotFoundError clause: that is a subclass of
+        # OSError, and above it every project without a manifest would be told
+        # its manifest is unreadable. Its own clause rather than a widening of
+        # the one above, because the two send the reader to different fixes --
+        # "you have not opted in" points a maintainer whose file is chmod 000 at
+        # adding a file they already have.
+        except OSError as exc:
+            _fail(
+                f"the manifest exists but could not be read: {exc.strerror or exc}",
+                field="<unreadable>",
+                as_json=as_json,
+                path=manifest_path,
+            )
+            return
         except VolunteerManifestError as exc:
             _fail(str(exc).split(": ", 1)[-1], field=exc.field, as_json=as_json, path=manifest_path)
             return

--- a/tests/unit/volunteer/test_volunteer_cli.py
+++ b/tests/unit/volunteer/test_volunteer_cli.py
@@ -10,6 +10,7 @@ be allowed to do.
 
 from __future__ import annotations
 
+import errno
 import json
 from typing import TYPE_CHECKING
 
@@ -133,6 +134,151 @@ def test_a_rejection_in_json_mode_is_still_machine_readable(tmp_path: Path) -> N
     payload = json.loads(err)
     assert payload["ok"] is False
     assert payload["field"] == "license"
+
+
+def _make_unreadable(path: Path) -> None:
+    """Take the read permission away, and skip if this process can read it anyway.
+
+    Running as root defeats the mode bits, so the assertions below would pass
+    against a manifest that loaded normally and prove nothing. Checking that the
+    read actually fails is the only thing that makes these tests mean what they
+    say.
+    """
+    path.chmod(0o000)
+    try:
+        path.read_bytes()
+    except OSError:
+        return
+    pytest.skip("this process can read a mode-000 file; the unreadable case is untestable here")
+
+
+def test_an_unreadable_manifest_in_json_mode_still_parses(tmp_path: Path) -> None:
+    """The property that actually broke.
+
+    ``verify`` promises a machine-readable verdict, and three of its four
+    refusal paths deliver one. The fourth raised through Click and printed a
+    traceback at the *same exit code*, so a CI step running
+    ``volunteer verify --json | jq .ok`` could not tell that state from a crash
+    in its own pipe.
+    """
+    manifest = _write(tmp_path, VALID)
+    _make_unreadable(manifest)
+    code, _, err = _run(tmp_path, "--json")
+    assert code == 1
+    payload = json.loads(err)
+    assert payload["ok"] is False
+    assert payload["path"] == str(manifest)
+
+
+def test_an_unreadable_manifest_is_not_reported_as_never_having_opted_in(tmp_path: Path) -> None:
+    """The message has to send the reader at the right fix.
+
+    A maintainer whose manifest is ``chmod 000`` has opted in. Told the project
+    has not, they would go and add a file they already have, and the command
+    that exists to close this loop locally would have sent them the long way
+    round.
+    """
+    manifest = _write(tmp_path, VALID)
+    _make_unreadable(manifest)
+    code, _, err = _run(tmp_path, "--json")
+    assert code == 1
+    payload = json.loads(err)
+    assert payload["field"] == "<unreadable>"
+    assert "opted in" not in payload["error"]
+    assert "could not be read" in payload["error"]
+    # `strerror` rather than the exception: `str(OSError)` carries the filename
+    # and the errno, and the filename is already the `path` key. Interpolating
+    # the whole exception prints the path twice in the human output and puts a
+    # second, differently-quoted copy inside the JSON message.
+    assert str(manifest) not in payload["error"]
+
+
+def test_a_missing_manifest_is_not_reported_as_unreadable(tmp_path: Path) -> None:
+    """The clause order is load-bearing, and nothing else pins it.
+
+    ``FileNotFoundError`` is a subclass of ``OSError``. Catching the wider one
+    first is a one-line edit that compiles, passes every other test in this
+    file, and tells every project without a manifest that its manifest cannot
+    be read.
+    """
+    code, _, err = _run(tmp_path, "--json")
+    assert code == 1
+    payload = json.loads(err)
+    assert payload["field"] == "<file>"
+    assert "opted in" in payload["error"]
+
+
+def test_an_unreadable_manifest_in_human_mode_names_the_fault(tmp_path: Path) -> None:
+    manifest = _write(tmp_path, VALID)
+    _make_unreadable(manifest)
+    code, _, err = _run(tmp_path)
+    assert code == 1
+    assert "Traceback" not in err
+    assert "<unreadable>" in err
+
+
+def test_a_manifest_behind_an_unsearchable_directory_is_a_refusal_too(tmp_path: Path) -> None:
+    """The same failure at the other call site inside the loader.
+
+    ``load_manifest_from_repo`` stats before it reads. ``Path.is_file()``
+    swallows ENOENT and ELOOP but re-raises EACCES, so an unsearchable
+    ``.bernstein/`` escapes from the guard rather than from the read -- a
+    different line, the same OSError, and it must not need its own clause.
+    """
+    manifest = _write(tmp_path, VALID)
+    parent = manifest.parent
+    parent.chmod(0o000)
+    try:
+        try:
+            manifest.read_bytes()
+        except OSError:
+            pass
+        else:
+            pytest.skip("this process can traverse a mode-000 directory")
+        code, _, err = _run(tmp_path, "--json")
+    finally:
+        parent.chmod(0o700)
+    assert code == 1
+    assert json.loads(err)["field"] == "<unreadable>"
+
+
+@pytest.mark.parametrize(
+    ("raised", "expected_tail"),
+    [
+        (OSError(errno.EIO, "Input/output error"), "Input/output error"),
+        (OSError("the mount went away"), "the mount went away"),
+    ],
+)
+def test_any_read_failure_is_a_refusal_and_says_which_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    raised: OSError,
+    expected_tail: str,
+) -> None:
+    """``OSError``, not ``PermissionError``, and the reason has to survive.
+
+    A permission bit is the reachable case on a developer's machine, but it is
+    one member of the class: a manifest on a dropped mount or a failing disk
+    raises a sibling that no test on this box can provoke for real. Narrowing
+    the clause to ``PermissionError`` would restore the traceback for all of
+    them and pass every other test here.
+
+    The second case has no ``strerror`` -- ``OSError`` built from a single
+    argument leaves it ``None`` -- which is what stops the message from
+    rendering the word "None" at a reader.
+    """
+    manifest = _write(tmp_path, VALID)
+
+    def _boom(_self: Path) -> bytes:
+        raise raised
+
+    monkeypatch.setattr("pathlib.Path.read_bytes", _boom)
+    code, _, err = _run(tmp_path, "--json")
+    assert code == 1
+    payload = json.loads(err)
+    assert payload["field"] == "<unreadable>"
+    assert payload["error"].endswith(expected_tail)
+    assert payload["path"] == str(manifest)
 
 
 def test_an_unenforced_field_is_shown_rather_than_swallowed(tmp_path: Path) -> None:


### PR DESCRIPTION
The `volunteer verify` half of the `#4048` review, scoped as you asked: `volunteer_cmd.py` only, one clause, tests for it. `receipt_cmd.py:202` already landed in `23e7f72` on #4051, so nothing here touches it.

**Based on `2c3fba5` (`main`), not on the #4048 → #4051 → #4055 stack.** It shares no file with any of them, so it does not need to wait for that chain to land and does not join the rebase you described. Merge it whenever.

## The defect, measured on pristine `2c3fba5`

| manifest state | `--json` output | exit | parses? |
|---|---|---|---|
| valid | `{"ok": true, …}` | 0 | yes |
| absent | `{"ok": false, "field": "<file>", …}` | 1 | yes |
| invalid `license` | `{"ok": false, "field": "license", …}` | 1 | yes |
| **`chmod 000`** | **`Traceback (most recent call last): … PermissionError: [Errno 13]`** | **1** | **no** |

Same exit code, no object. That is the property you named: `verify --json \| jq .ok` cannot tell it from a crash in its own pipe. The command's own docstring already promises the opposite — *"naming the field at fault rather than raising a traceback at a maintainer who is editing a config file"* — which is why this reads as a bug rather than a widening.

After: `{"ok": false, "path": "…", "field": "<unreadable>", "error": "the manifest exists but could not be read: Permission denied"}`, exit 1.

## Three decisions, and why

**Its own clause, below `FileNotFoundError`.** Your reason, and the ordering is load-bearing in a way nothing else in the file pins: `FileNotFoundError` is a subclass of `OSError`, so hoisting the new clause is a one-line edit that compiles, passes every other test in that file, and tells every project *without* a manifest that its manifest cannot be read. `test_a_missing_manifest_is_not_reported_as_unreadable` is the only thing standing between that edit and `main`.

**`OSError`, not `PermissionError`.** The permission bit is the reachable case on a developer's box; a manifest on a dropped mount or a failing disk raises a sibling nothing here can provoke for real. Driven with a monkeypatched `EIO` so the clause is pinned to the class rather than to one member.

**`exc.strerror or exc`, not `exc`.** `str(OSError)` carries the filename, and the filename is already the report's `path` key — interpolating the exception prints the path twice in the human output and embeds a second, differently-quoted copy inside the JSON message. The `or exc` fallback is there because `OSError("the mount went away")` leaves `strerror` as `None`, and `"… could not be read: None"` is worse than no reason at all. Both halves are a test.

## A second call site the same clause covers

`load_manifest_from_repo` stats before it reads:

```python
if not path.is_file():
    raise FileNotFoundError(…)
return load_manifest(path.read_bytes())
```

`Path.is_file()` swallows only the errnos in `pathlib._IGNORED_ERRNOS`. **`EACCES` is not among them**, so an unsearchable `.bernstein/` — the realistic shape of this on a shared checkout — raises `PermissionError` out of the *guard*, several lines before the read. Measured on `2c3fba5`: also a traceback, also exit 1. One clause covers both, and `test_a_manifest_behind_an_unsearchable_directory_is_a_refusal_too` is there so a future narrowing of the catch to the read site fails.

## Verification

* **24 passed** in `tests/unit/volunteer/test_volunteer_cli.py`. **683 passed** across `tests/unit/volunteer` + `tests/unit/cli`; `tests/unit/test_feature_matrix_drift.py` and `tests/integration/volunteer` green (15 passed / 4 skipped).
* **4 of the 6 new tests are red on unmodified `2c3fba5`** (`PermissionError` escaping through `CliRunner(catch_exceptions=False)`); the two that pass there are the regression guards and are supposed to.
* **8 mutants, 7 killed, 1 equivalent and declared** — table below.
* `ruff check`, `ruff format --check` at **0.14.10**, `typos`, and `mypy` on the changed module: all clean.

| # | mutation | result |
|---|---|---|
| M1 | delete the `except OSError` clause | 6 failed |
| M2 | hoist it above `except FileNotFoundError` | 1 failed |
| M3 | `field="<unreadable>"` → `"<file>"` | 5 failed |
| M4 | message → the opted-in one | 3 failed |
| M5 | `except OSError` → `except PermissionError` | 2 failed |
| M6 | `{exc.strerror or exc}` → `{exc.strerror}` | 1 failed |
| M7 | `{exc.strerror or exc}` → `{exc}` | 1 failed |
| M8 | drop the `return` after `_fail` | **survives — equivalent** |

**M8 is equivalent, not a gap.** `_fail` ends in `raise SystemExit(1)`, so the `return` is unreachable in all four clauses today; `mypy` is clean without it too, so no gate catches it and none can. It is there because the three clauses above it have it, and because it is what keeps the fall-through correct if `_fail` ever stops raising. I am not inventing a test to kill it.

## Two things I measured and did not change

1. **`ELOOP` takes the opposite wrong branch.** A `.bernstein/volunteer.json` symlinked to itself is also a manifest that exists and cannot be read, but `ELOOP` *is* in `_IGNORED_ERRNOS`, so `is_file()` returns `False` and the command reports **"the project has not opted in to volunteer work"** — exit 1, well-formed JSON, and an accurate-looking message about the wrong problem. Distinguishing it needs `manifest.py` to stop conflating "absent" with "unstattable", which is outside the one file you scoped this to. Same for a *directory* at that path, which reports the same thing. Say the word and it is a separate PR against the loader.

2. **The doc's field promise is now one notch looser.** `docs/reference/volunteer-manifest.md` says *"the field name is the one in the table above"*; `<file>` was already outside that table and `<unreadable>` joins it. The angle brackets are the existing convention marking "not a manifest field", so I read this as the doc being imprecise rather than the code being wrong — but it is a one-line clarification if you want it, and I left it out because you scoped this to `volunteer_cmd.py`.

## On #4057

Taking it. Per your note it waits until #4055 is rebased and in, so the arms-versus-pass answer is going on that thread rather than here.
