### PR TITLE
fix(scripts): gen_agents_md steps aside when agents-md sync owns AGENTS.md

### DIFF
--- a/docs/playbooks/docs-drift.md
+++ b/docs/playbooks/docs-drift.md
@@ -26,7 +26,7 @@ Drift remediation paths used by the rows below:
 | Remediation token | What it runs |
 |-------------------|--------------|
 | `agents-md-sync` | `uv run bernstein agents-md sync` then `uv run bernstein agents-md verify` |
-| `gen-agents-md` | `uv run python scripts/gen_agents_md.py --update` (legacy detailed module map; do not run if `agents-md-sync` is the active source of truth) |
+| `gen-agents-md` | `uv run python scripts/gen_agents_md.py --update` (legacy detailed module map). Self-guarding since #4019: when `agents-md-sync` is the active source of truth it prints a note and exits 0 without writing. `--force` overrides. |
 | `manual-prose` | Re-read the source-of-truth module and adjust the prose by hand; no script generates this content |
 | `manual-cmd` | The doc lists a CLI command surface; re-run `bernstein <cmd> --help` and reconcile |
 | `gen-benchmarks` | `uv run python scripts/generate_benchmark_docs.py` |

--- a/docs/playbooks/docs-update-sweep.md
+++ b/docs/playbooks/docs-update-sweep.md
@@ -78,7 +78,7 @@ the set of rows the agent reads from `docs-drift.md`.
    | Remediation token | How to apply |
    |-------------------|--------------|
    | `agents-md-sync` | `uv run bernstein agents-md sync` then `uv run bernstein agents-md verify`. Operates only on AGENTS.md, CLAUDE.md, CONVENTIONS.md, `.goosehints`, `.cursor/rules/*.mdc`. |
-   | `gen-agents-md` | `uv run python scripts/gen_agents_md.py --update`. Only run if the row explicitly names this token; never run for rows that name `agents-md-sync`. |
+   | `gen-agents-md` | `uv run python scripts/gen_agents_md.py --update`. Only run if the row explicitly names this token. Since #4019 the script refuses anyway when `agents-md-sync` owns AGENTS.md, so a misrouted run is a no-op rather than 74 deleted rows. |
    | `manual-prose` | Re-read the source-of-truth module(s); edit the doc by hand to reflect current public surface; do not regenerate. |
    | `manual-cmd` | Run `bernstein <cmd> --help` for each CLI surface the doc claims to document; reconcile the listed flags / subcommands by hand. |
    | `gen-benchmarks` | `uv run python scripts/generate_benchmark_docs.py`. |

--- a/scripts/gen_agents_md.py
+++ b/scripts/gen_agents_md.py
@@ -4,6 +4,7 @@ Usage:
     uv run python scripts/gen_agents_md.py --check   # exit 1 if stale
     uv run python scripts/gen_agents_md.py --update  # rewrite module map in place
     uv run python scripts/gen_agents_md.py           # print generated section to stdout
+    ... add --force to either to override the supersession check below
 
 The script scans src/bernstein/ with ast to extract one-line module
 docstrings, groups them by package, then replaces the section of AGENTS.md
@@ -13,8 +14,20 @@ conventions, test patterns, gotchas, etc.) is preserved verbatim.
 
 Note: this is the *legacy detailed* module-map generator. When
 ``bernstein agents-md sync`` is the active source of truth (its verify runs
-in CI), that command owns AGENTS.md end to end - do not run ``--update``
-here, or the module map will diverge from the canonical output.
+in CI), that command owns AGENTS.md end to end and this script steps aside:
+``--check`` and ``--update`` print a note and exit 0 rather than acting.
+
+That guard used to be advice, written down in two playbooks and nowhere the
+reader would meet it. This script called the committed file stale and printed
+a command that removed 74 rows and reddened the docs-drift gate, so following
+its own instruction broke CI (#4019). ``scripts/`` is where somebody goes to
+find out what to run before pushing, and running the ``--check`` variants
+there is the careful behaviour - it should not be the punished one.
+
+``--force`` restores the old strict behaviour for anyone who wants the
+detailed map. Retiring the script is a separate decision: its output is
+ported in ``core/knowledge/agents_md_generator.py`` and two test files still
+pin the legacy contract.
 """
 
 from __future__ import annotations
@@ -316,12 +329,65 @@ def update_agents_md(dry_run: bool = False) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Supersession
+# ---------------------------------------------------------------------------
+
+#: Printed instead of a stale verdict when ``agents-md sync`` owns AGENTS.md.
+SUPERSEDED_NOTE = (
+    "AGENTS.md is managed by `bernstein agents-md sync`, which reports it in sync.\n"
+    "This legacy generator produces a different (smaller) module map; running --update\n"
+    "here would drop the sub-package rows and fail the docs-drift gate.\n"
+    "  To regenerate:           uv run bernstein agents-md sync\n"
+    "  To use this map anyway:  uv run python scripts/gen_agents_md.py --update --force"
+)
+
+
+def agents_md_is_synced() -> bool | None:
+    """Whether ``bernstein agents-md sync`` reports AGENTS.md already in sync.
+
+    ``None`` when that cannot be determined - bernstein not importable, or its
+    internals moved. Undeterminable is deliberately NOT treated as superseded:
+    this script must keep working as a standalone generator in a checkout with
+    no installed package, and going quiet there would trade one wrong verdict
+    for another.
+
+    Only AGENTS.md is consulted. ``agents-md verify`` covers 14 files, but this
+    script writes exactly one, and a drift in ``.goosehints`` is no reason for
+    this generator to change its answer about the file it does own.
+    """
+    try:
+        from bernstein.cli.commands.agents_md_cmd import _generate_sections
+        from bernstein.core.knowledge.agents_md_bridge import render
+    except Exception:
+        return None
+    try:
+        sections, name = _generate_sections(AGENTS_MD.parent, None)
+        expected = render(sections, "canonical", repo_name=name).files.get(AGENTS_MD.name)
+        if expected is None or not AGENTS_MD.is_file():
+            return None
+        # The same normalisation ``agents-md verify`` uses: trailing whitespace
+        # and final-newline variance is not semantically a drift.
+        return AGENTS_MD.read_text(encoding="utf-8").rstrip() == expected.rstrip()
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
 
 def main() -> int:
     args = sys.argv[1:]
+
+    # This generator was superseded by ``bernstein agents-md sync``, which owns
+    # AGENTS.md and produces a LARGER map. Left alone it called the committed
+    # file stale and printed a command that removes 74 rows and reddens the
+    # docs-drift gate - a confident verdict from a tool no longer in a position
+    # to give one (#4019). It steps aside now unless --force says otherwise.
+    if "--force" not in args and agents_md_is_synced() is True:
+        print(SUPERSEDED_NOTE)
+        return 0
 
     if "--update" in args:
         update_agents_md(dry_run=False)
@@ -331,7 +397,7 @@ def main() -> int:
         changed = update_agents_md(dry_run=True)
         if changed:
             print(
-                "AGENTS.md module map is stale. Run:\n  uv run python scripts/gen_agents_md.py --update",
+                "AGENTS.md module map is stale. Run:\n  uv run python scripts/gen_agents_md.py --update --force",
                 file=sys.stderr,
             )
             return 1

--- a/scripts/gen_agents_md.py
+++ b/scripts/gen_agents_md.py
@@ -4,7 +4,7 @@ Usage:
     uv run python scripts/gen_agents_md.py --check   # exit 1 if stale
     uv run python scripts/gen_agents_md.py --update  # rewrite module map in place
     uv run python scripts/gen_agents_md.py           # print generated section to stdout
-    ... add --force to either to override the supersession check below
+    ... add --force to any of them to override the supersession check below
 
 The script scans src/bernstein/ with ast to extract one-line module
 docstrings, groups them by package, then replaces the section of AGENTS.md
@@ -15,7 +15,10 @@ conventions, test patterns, gotchas, etc.) is preserved verbatim.
 Note: this is the *legacy detailed* module-map generator. When
 ``bernstein agents-md sync`` is the active source of truth (its verify runs
 in CI), that command owns AGENTS.md end to end and this script steps aside:
-``--check`` and ``--update`` print a note and exit 0 rather than acting.
+every invocation - ``--check``, ``--update``, and the bare stdout form -
+prints a note and exits 0 rather than acting. The guard is on the script, not
+on a subset of its flags, so there is no spelling of the command that reaches
+a stale verdict or the smaller map by accident.
 
 That guard used to be advice, written down in two playbooks and nowhere the
 reader would meet it. This script called the committed file stale and printed

--- a/tests/unit/test_gen_agents_md_supersession.py
+++ b/tests/unit/test_gen_agents_md_supersession.py
@@ -64,6 +64,16 @@ class TestItStepsAsideRatherThanMisleading:
         assert "bernstein agents-md sync" in out
         assert "--force" in out
 
+    def test_the_bare_stdout_form_steps_aside_too(self) -> None:
+        # The guard sits ahead of the flag dispatch, so the no-argument form is
+        # covered as well. Pinned because the module docstring documents all
+        # three spellings: a doc that named only two would be the same defect
+        # this change fixes, one layer in.
+        proc = run_script()
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "managed by `bernstein agents-md sync`" in proc.stdout
+        assert "## Module map" not in proc.stdout, "the smaller legacy map must not reach stdout unforced"
+
     def test_update_without_force_writes_nothing(self) -> None:
         # The destructive half. --check being safe would be no comfort if the
         # command the old message printed still removed the rows.

--- a/tests/unit/test_gen_agents_md_supersession.py
+++ b/tests/unit/test_gen_agents_md_supersession.py
@@ -1,0 +1,111 @@
+"""The legacy AGENTS.md generator steps aside when `agents-md sync` owns the file (#4019).
+
+`scripts/gen_agents_md.py --check` reported the committed AGENTS.md as stale on a
+clean tree while `bernstein agents-md verify` reported it in sync, and the remedy
+it printed removed 74 rows and reddened the docs-drift gate. `scripts/` is where a
+contributor goes to find out what to run before pushing, so running the `--check`
+variants there is the careful behaviour - and it was the behaviour being punished.
+
+The invariant: **a check that cannot be the authority on an artifact must not
+issue a verdict on it.** `--force` still reaches the legacy behaviour for anyone
+who wants the detailed map, because retiring the script is a separate decision.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "gen_agents_md.py"
+
+
+def load_script() -> ModuleType:
+    """Import the script by path - `scripts/` is not a package."""
+    spec = importlib.util.spec_from_file_location("gen_agents_md_under_test", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_script(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+
+
+class TestItStepsAsideRatherThanMisleading:
+    def test_check_on_a_clean_tree_exits_zero_with_the_note(self) -> None:
+        # The reproduction from the issue, inverted: this used to exit 1 saying
+        # "module map is stale" and hand over a command that breaks the gate.
+        proc = run_script("--check")
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "managed by `bernstein agents-md sync`" in proc.stdout
+        assert "module map is stale" not in proc.stdout + proc.stderr
+
+    def test_the_note_names_both_ways_forward(self) -> None:
+        # A refusal that does not say what to run instead is a dead end on the
+        # one command somebody ran to find out what to run.
+        out = run_script("--check").stdout
+        assert "bernstein agents-md sync" in out
+        assert "--force" in out
+
+    def test_update_without_force_writes_nothing(self) -> None:
+        # The destructive half. --check being safe would be no comfort if the
+        # command the old message printed still removed the rows.
+        before = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        proc = run_script("--update")
+        assert proc.returncode == 0
+        assert (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8") == before
+
+
+class TestForceStillReachesTheLegacyBehaviour:
+    def test_force_bypasses_the_supersession_check(self) -> None:
+        # Retiring the script is a separate decision (its tests still pin the
+        # legacy contract), so the old path has to stay reachable on purpose.
+        proc = run_script("--check", "--force")
+        assert proc.returncode == 1
+        assert "module map is stale" in proc.stderr
+
+    def test_the_forced_remedy_names_force_so_it_does_not_loop(self) -> None:
+        # The old message said `--update` with no --force. Following it now
+        # would hit the supersession guard and do nothing, leaving a reader
+        # running a command that reports stale and then declines to fix it.
+        assert "--update --force" in run_script("--check", "--force").stderr
+
+
+class TestUndeterminableIsNotTreatedAsSuperseded:
+    """The failure mode worth guarding: this script must still work standalone."""
+
+    def test_an_unimportable_bernstein_means_cannot_tell_not_superseded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Silently going quiet in a checkout with no installed package would
+        # trade one wrong verdict for another - a generator that reports
+        # nothing is not more honest than one that reports wrongly.
+        module = load_script()
+        monkeypatch.setitem(sys.modules, "bernstein.core.knowledge.agents_md_bridge", None)
+        assert module.agents_md_is_synced() is None
+
+    def test_a_missing_agents_md_is_cannot_tell(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        module = load_script()
+        monkeypatch.setattr(module, "AGENTS_MD", REPO_ROOT / "does-not-exist.md")
+        assert module.agents_md_is_synced() is None
+
+    def test_on_this_tree_it_reports_synced(self) -> None:
+        # The positive control. Without it, every assertion above would pass
+        # just as well if the helper always returned None - which is exactly
+        # the "reports success without checking" shape this fixes.
+        assert load_script().agents_md_is_synced() is True


### PR DESCRIPTION
Closes #4019. Took the "refuse rather than mislead" option and the starting point you gave.

## The proof you asked for

```
$ uv run python scripts/gen_agents_md.py --check
AGENTS.md is managed by `bernstein agents-md sync`, which reports it in sync.
This legacy generator produces a different (smaller) module map; running --update
here would drop the sub-package rows and fail the docs-drift gate.
  To regenerate:           uv run bernstein agents-md sync
  To use this map anyway:  uv run python scripts/gen_agents_md.py --update --force
exit 0

$ uv run python scripts/gen_agents_md.py --update --force
AGENTS.md updated.          # 74 rows changed — the legacy map, still reachable
```

## Two decisions I made inside the spec, both stated rather than assumed

**`--update` is guarded too, not just `--check`.** The issue is about a misleading verdict, but the verdict was only half the harm — the *command it printed* is what removed the rows. Guarding `--check` alone would leave the destructive path one paste away, and the message a reader had already been given still pointed at it. `--update` without `--force` now prints the same note and writes nothing.

**Undeterminable is not treated as superseded.** `agents_md_is_synced()` returns `bool | None`, and only an explicit `True` steps aside. If bernstein is not importable, or its internals move, the legacy path runs exactly as before. Going quiet in a checkout with no installed package would trade one wrong verdict for another — a generator that reports *nothing* is not more honest than one that reports wrongly, and this script has to keep working standalone. There is a test for each direction, plus a positive control asserting it really does return `True` on this tree, because every other assertion would pass just as well if the helper always returned `None`.

It also consults **AGENTS.md only**, not all 14 files `agents-md verify` covers. This script writes one file, and a drift in `.goosehints` is no reason for it to change its answer about the file it owns.

## One thing I fixed that was not in the spec

The forced remedy string. The old message said `--update` with no `--force`; following it now hits the guard and does nothing — so a reader would run a command that reports stale and then declines to fix it. `--check --force` now prints `--update --force`, and there is a test named for that loop.

## Docs, since they were half the defect

The guard existed — as prose in `docs/playbooks/docs-drift.md:29` and `docs-update-sweep.md:81`. Both were correct and both lived somewhere the reader had no reason to open. They now describe an enforced rule rather than advice, and say a misrouted run is a no-op rather than 74 deleted rows.

I also rewrote the script's own module docstring, which still said "do not run `--update` here" as a warning. Leaving it would have been the same defect one layer in: a doc describing behaviour that had changed underneath it.

## Verification

```
tests/unit/test_gen_agents_md_supersession.py     8 passed   (new)
test_gen_agents_md_split.py
test_agents_md_generator.py                      58 passed   (legacy contract, untouched)
test_context_staleness.py
ruff check / format --check / mypy                clean
bernstein agents-md verify                        OK  all 14 file(s) in sync
scripts/check_docs_drift.py                       No drift detected
```

Out of scope as you set it: the script and its tests are not retired, and `agents_md_generator.py` is untouched.