### PR TITLE
fix(volunteer): "absent" and "unstattable" are different answers

### DIFF
--- a/src/bernstein/core/volunteer/manifest.py
+++ b/src/bernstein/core/volunteer/manifest.py
@@ -70,8 +70,10 @@ along with everything else.
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
+import stat
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -335,16 +337,68 @@ def load_manifest(source: str | bytes) -> VolunteerManifest:
     )
 
 
+def _not_a_regular_file(mode: int) -> str:
+    """Name the shape found at the manifest path, for the refusal message."""
+    if stat.S_ISDIR(mode):
+        return "a directory"
+    if stat.S_ISFIFO(mode):
+        return "a fifo"
+    if stat.S_ISSOCK(mode):
+        return "a socket"
+    if stat.S_ISBLK(mode) or stat.S_ISCHR(mode):
+        return "a device file"
+    return "of an unrecognised type"
+
+
 def load_manifest_from_repo(repo_root: Path) -> VolunteerManifest:
     """Load ``.bernstein/volunteer.json`` from a checked-out repository.
 
+    "The project has not opted in" is a claim about the *project*, so it is
+    made only when nothing exists at the path at all.  Every other filesystem
+    state -- a symlink loop, a directory, an unreadable file, a
+    ``.bernstein`` that is itself a regular file -- is a manifest that exists
+    and could not be read, and raises :class:`OSError` instead, which is what
+    lets a caller tell the two apart (#4064).
+
+    :meth:`Path.is_file` could not make that distinction.  It swallows every
+    errno in ``pathlib._IGNORED_ERRNOS`` -- ``ENOENT``, ``ENOTDIR``, ``EBADF``,
+    ``ELOOP`` -- and answers ``False`` for anything that is not a regular file,
+    so five states arrived at one message asserting something false about the
+    project.  That is worse than a traceback: exit 1 and a well-formed
+    ``"the project has not opted in"`` sends a maintainer whose file is a
+    broken symlink off to add a file they already have.
+
+    The synthesised errors carry ``EINVAL`` deliberately.  ``ENOENT`` is the
+    errno that describes a dangling symlink, but ``OSError(ENOENT, ...)``
+    *constructs a* :class:`FileNotFoundError` -- the errno-to-subclass map runs
+    in ``OSError.__new__`` -- which would reintroduce this bug through the fix
+    for it.
+
     Raises:
-        FileNotFoundError: The project has not opted in.
-        VolunteerManifestError: The manifest exists but does not validate.
+        FileNotFoundError: Nothing exists at the path; the project has not
+            opted in.
+        OSError: Something exists at the path and is not a readable regular
+            file.
+        VolunteerManifestError: The manifest was read but does not validate.
     """
     path = repo_root / VOLUNTEER_MANIFEST_PATH
-    if not path.is_file():
-        raise FileNotFoundError(f"{path} does not exist; the project has not opted in to volunteer work")
+    absent = f"{path} does not exist; the project has not opted in to volunteer work"
+    try:
+        mode = path.stat().st_mode
+    except FileNotFoundError as exc:
+        # ENOENT from stat() is ambiguous: either nothing is at the path, or a
+        # symlink is and its target is gone.  lstat separates them, and only
+        # the first is a project that never opted in.  An lstat that fails for
+        # any other reason propagates, because that is not an absence either.
+        try:
+            path.lstat()
+        except FileNotFoundError:
+            raise FileNotFoundError(absent) from exc
+        raise OSError(errno.EINVAL, "the symbolic link has no target", str(path)) from exc
+    if not stat.S_ISREG(mode):
+        # Refused before the open() rather than after: a fifo at this path
+        # would otherwise block the read until someone wrote to it.
+        raise OSError(errno.EINVAL, f"it is {_not_a_regular_file(mode)}, not a regular file", str(path))
     return load_manifest(path.read_bytes())
 
 

--- a/tests/unit/volunteer/test_volunteer_cli.py
+++ b/tests/unit/volunteer/test_volunteer_cli.py
@@ -243,6 +243,43 @@ def test_a_manifest_behind_an_unsearchable_directory_is_a_refusal_too(tmp_path: 
 
 
 @pytest.mark.parametrize(
+    ("kind", "expected_tail"),
+    [
+        ("symlink loop", "Too many levels of symbolic links"),
+        ("directory", "it is a directory, not a regular file"),
+        ("dangling symlink", "the symbolic link has no target"),
+    ],
+)
+def test_a_manifest_that_is_not_a_readable_file_is_unreadable_not_missing(
+    tmp_path: Path,
+    kind: str,
+    expected_tail: str,
+) -> None:
+    """The states ``is_file()`` used to fold into "you have not opted in" (#4064).
+
+    Fixed in the loader rather than here, so this test asserts that no clause
+    in this command had to change: the ``OSError`` arm added for a mode-000
+    manifest already carries all three, and the ``<file>`` verdict is left
+    saying the one thing it can still prove.
+    """
+    path = tmp_path / VOLUNTEER_MANIFEST_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if kind == "symlink loop":
+        path.symlink_to("volunteer.json")
+    elif kind == "dangling symlink":
+        path.symlink_to("no-such-file.json")
+    else:
+        path.mkdir()
+
+    code, _, err = _run(tmp_path, "--json")
+
+    assert code == 1
+    payload = json.loads(err)
+    assert payload["field"] == "<unreadable>"
+    assert payload["error"] == f"the manifest exists but could not be read: {expected_tail}"
+
+
+@pytest.mark.parametrize(
     ("raised", "expected_tail"),
     [
         (OSError(errno.EIO, "Input/output error"), "Input/output error"),

--- a/tests/unit/volunteer/test_volunteer_manifest.py
+++ b/tests/unit/volunteer/test_volunteer_manifest.py
@@ -11,9 +11,13 @@ policy differs, every downstream verification is theatre.
 
 from __future__ import annotations
 
+import errno
 import json
+import os
 import re
+import socket
 import warnings
+from contextlib import closing
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +30,7 @@ from bernstein.core.volunteer.manifest import (
     GateCommand,
     UnenforcedManifestFieldWarning,
     VolunteerManifestError,
+    _not_a_regular_file,
     canonical_manifest_bytes,
     load_manifest,
     load_manifest_from_repo,
@@ -117,6 +122,210 @@ def test_absent_manifest_is_not_opted_in_rather_than_invalid(tmp_path: Any) -> N
     """A project that never opted in must not read as a project that failed."""
     with pytest.raises(FileNotFoundError):
         load_manifest_from_repo(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Absent is not the same as unstattable (#4064)
+#
+# ``Path.is_file()`` answered one ``False`` for five different filesystem
+# states, so the loader told a maintainer whose manifest is a broken symlink
+# that their project had not opted in -- exit 1, well-formed, and false in the
+# field a caller routes on.  ``FileNotFoundError`` is now reserved for the one
+# state that claim is true of; everything else is an ``OSError`` the CLI
+# already renders as ``<unreadable>``.
+# ---------------------------------------------------------------------------
+
+
+def _manifest_dir(root: Path) -> Path:
+    directory = root / ".bernstein"
+    directory.mkdir(exist_ok=True)
+    return directory
+
+
+def _shape(root: Path, kind: str) -> None:
+    """Put `kind` at the manifest path, for the states a stat can end in."""
+    path = _manifest_dir(root) / "volunteer.json"
+    if kind == "symlink loop":
+        path.symlink_to("volunteer.json")
+    elif kind == "dangling symlink":
+        path.symlink_to("no-such-file.json")
+    elif kind == "directory":
+        path.mkdir()
+    elif kind == "fifo":
+        os.mkfifo(path)
+    elif kind == "socket":
+        with closing(socket.socket(socket.AF_UNIX)) as sock:
+            sock.bind(str(path))
+    elif kind == "device":
+        path.symlink_to("/dev/null")
+    else:  # pragma: no cover - a typo in a parametrisation, not a state
+        raise AssertionError(kind)
+
+
+@pytest.mark.parametrize(
+    "kind",
+    ["symlink loop", "dangling symlink", "directory", "fifo", "socket", "device"],
+)
+def test_something_at_the_manifest_path_is_never_reported_as_not_opted_in(tmp_path: Path, kind: str) -> None:
+    """Every state below is a manifest that exists and cannot be read.
+
+    The assertion that matters is the negative one.  ``FileNotFoundError`` is
+    an ``OSError``, so a clause catching the base class would pass a weaker
+    test while the CLI still printed "the project has not opted in" -- that
+    message is chosen by the *type*, not by the text.
+    """
+    _shape(tmp_path, kind)
+
+    with pytest.raises(OSError) as caught:
+        load_manifest_from_repo(tmp_path)
+
+    assert not isinstance(caught.value, FileNotFoundError)
+    assert "opted in" not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected"),
+    [
+        ("directory", "it is a directory, not a regular file"),
+        ("fifo", "it is a fifo, not a regular file"),
+        ("socket", "it is a socket, not a regular file"),
+        ("device", "it is a device file, not a regular file"),
+        ("dangling symlink", "the symbolic link has no target"),
+    ],
+)
+def test_the_refusal_names_the_shape_that_was_found(tmp_path: Path, kind: str, expected: str) -> None:
+    """A refusal without a reason sends the reader back to guessing.
+
+    The CLI prints ``exc.strerror``, so these phrases are the whole of what a
+    maintainer sees; they have to name the shape rather than restate the path,
+    which the report already carries as its own key.
+    """
+    _shape(tmp_path, kind)
+
+    with pytest.raises(OSError) as caught:
+        load_manifest_from_repo(tmp_path)
+
+    assert caught.value.strerror == expected
+
+
+def test_a_fifo_is_refused_before_the_open_rather_than_after(tmp_path: Path) -> None:
+    """Reaching ``read_bytes()`` on a fifo blocks until somebody writes to it.
+
+    ``is_file()`` happened to prevent that by answering ``False``; the stat
+    that replaced it has to keep the property deliberately.  This test hanging
+    rather than failing is the symptom.
+    """
+    _shape(tmp_path, "fifo")
+
+    with pytest.raises(OSError, match="not a regular file"):
+        load_manifest_from_repo(tmp_path)
+
+
+def test_a_manifest_that_cannot_be_stat_ed_keeps_the_reason_from_the_kernel(tmp_path: Path) -> None:
+    """A permission failure must not be relabelled as a broken link.
+
+    The ``ENOENT`` arm exists to separate "nothing there" from "symlink with no
+    target".  Widening its ``except`` to ``OSError`` would route every stat
+    failure through it, and ``lstat`` succeeds on a mode-000 file, so the
+    refusal would come back naming a symlink that is not there.
+    """
+    path = _manifest_dir(tmp_path) / "volunteer.json"
+    path.write_text(_manifest(), encoding="utf-8")
+    path.chmod(0o000)
+    try:
+        path.read_bytes()
+    except OSError:
+        pass
+    else:  # pragma: no cover - depends on the runner's privileges
+        pytest.skip("this process can read a mode-000 file")
+    finally:
+        path.chmod(0o600)
+
+    path.chmod(0o000)
+    try:
+        with pytest.raises(PermissionError) as caught:
+            load_manifest_from_repo(tmp_path)
+    finally:
+        path.chmod(0o600)
+
+    assert caught.value.strerror == "Permission denied"
+
+
+def test_an_entry_that_disappears_mid_check_is_absent_rather_than_a_broken_link(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``stat`` and ``lstat`` are two syscalls and a file can vanish between them.
+
+    Neither call is wrong when that happens, and the answer is the honest one:
+    nothing is at the path now.  Without the second ``FileNotFoundError`` arm
+    the race would be reported as a symlink whose target is missing.
+    """
+    (tmp_path / VOLUNTEER_MANIFEST_PATH).parent.mkdir(parents=True)
+    (tmp_path / VOLUNTEER_MANIFEST_PATH).write_text(_manifest(), encoding="utf-8")
+
+    def _vanished(self: Path, *args: Any, **kwargs: Any) -> Any:
+        raise FileNotFoundError(errno.ENOENT, "No such file or directory", str(self))
+
+    monkeypatch.setattr(Path, "stat", _vanished)
+    monkeypatch.setattr(Path, "lstat", _vanished)
+
+    with pytest.raises(FileNotFoundError, match="opted in"):
+        load_manifest_from_repo(tmp_path)
+
+
+def test_only_a_missing_entry_ends_the_ambiguity_as_an_absence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The inner ``except`` is ``FileNotFoundError`` for a reason, not for symmetry.
+
+    An ``lstat`` that fails some other way has not established that the path is
+    empty, so it must propagate.  Widened to ``OSError`` this reads a failure
+    it cannot interpret as proof the project never opted in -- the same
+    substitution the whole change exists to undo, one level down.
+    """
+    (tmp_path / VOLUNTEER_MANIFEST_PATH).parent.mkdir(parents=True)
+
+    def _gone(self: Path, *args: Any, **kwargs: Any) -> Any:
+        raise FileNotFoundError(errno.ENOENT, "No such file or directory", str(self))
+
+    def _refused(self: Path, *args: Any, **kwargs: Any) -> Any:
+        raise PermissionError(errno.EACCES, "Permission denied", str(self))
+
+    monkeypatch.setattr(Path, "stat", _gone)
+    monkeypatch.setattr(Path, "lstat", _refused)
+
+    with pytest.raises(PermissionError):
+        load_manifest_from_repo(tmp_path)
+
+
+def test_a_shape_this_platform_has_no_name_for_still_gets_a_message() -> None:
+    """The fallback arm is portability, not decoration.
+
+    Linux exhausts the file types above it, so nothing a stat returns here
+    reaches this line -- but ``S_IFMT`` is not a closed set across platforms
+    (Solaris doors, BSD whiteouts), and the arm is what keeps such a mode from
+    rendering as an empty phrase inside "it is , not a regular file".  Asserted
+    against the helper directly, because the claim is about a total function
+    rather than about anything this kernel can produce.
+    """
+    assert _not_a_regular_file(0) == "of an unrecognised type"
+
+
+def test_bernstein_itself_being_a_file_is_unreadable_rather_than_absent(tmp_path: Path) -> None:
+    """``ENOTDIR`` is in ``_IGNORED_ERRNOS`` too, so ``is_file()`` hid this one.
+
+    A regular file named ``.bernstein`` is a plausible mistake and the kernel's
+    own wording says exactly what went wrong.
+    """
+    (tmp_path / ".bernstein").write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(NotADirectoryError) as caught:
+        load_manifest_from_repo(tmp_path)
+
+    assert not isinstance(caught.value, FileNotFoundError)
+    assert caught.value.strerror == "Not a directory"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/volunteer/test_volunteer_manifest.py
+++ b/tests/unit/volunteer/test_volunteer_manifest.py
@@ -154,8 +154,20 @@ def _shape(root: Path, kind: str) -> None:
     elif kind == "fifo":
         os.mkfifo(path)
     elif kind == "socket":
-        with closing(socket.socket(socket.AF_UNIX)) as sock:
-            sock.bind(str(path))
+        # Bind from inside the directory, by bare name. `sun_path` is 104 bytes
+        # on macOS and 108 on Linux, and pytest's `tmp_path` under
+        # /var/folders/<...>/pytest-of-<user>/pytest-N/<test-name>N/ already
+        # spends most of that before ".bernstein/volunteer.json" is appended --
+        # so binding the absolute path raises "AF_UNIX path too long" on macOS
+        # while passing on CI. A relative bind is the same socket at the same
+        # place and does not depend on how deep the tmpdir happens to be.
+        previous = Path.cwd()
+        os.chdir(path.parent)
+        try:
+            with closing(socket.socket(socket.AF_UNIX)) as sock:
+                sock.bind(path.name)
+        finally:
+            os.chdir(previous)
     elif kind == "device":
         path.symlink_to("/dev/null")
     else:  # pragma: no cover - a typo in a parametrisation, not a state


### PR DESCRIPTION
Closes #4064 — the `ELOOP` finding you asked me to split out of #4058: *"it needs `manifest.py` to stop conflating 'absent' with 'unstattable', which is the loader, not the command. Open it against the loader whenever suits."*

**Based on `1990dbca9` (`main`, with #4058 in it), not on the #4048 → #4051 → #4055 stack.** It shares no file with any of them.

**One ordering constraint, and I would rather state it than have it found: do not merge this before #4051.** Measured below — it is four lines of `receipt_cmd.py` that #4051 already fixes, and #4051 is at queue position 1, so the constraint costs nothing.

## The defect, measured on `1990dbca9`

`Path.is_file()` swallows every errno in `pathlib._IGNORED_ERRNOS` — `ENOENT`, `ENOTDIR`, `EBADF`, `ELOOP` — and returns `False` for anything that is not a regular file. So the loader answered one `FileNotFoundError`, carrying a claim about the *project*, for five different claims about the *filesystem*:

| state at `.bernstein/volunteer.json` | before | after |
|---|---|---|
| absent | `<file>` — has not opted in | unchanged |
| **symlink loop** | **`<file>` — has not opted in** | `<unreadable>` — `Too many levels of symbolic links` |
| **a directory** | **`<file>` — has not opted in** | `<unreadable>` — `it is a directory, not a regular file` |
| **dangling symlink** | **`<file>` — has not opted in** | `<unreadable>` — `the symbolic link has no target` |
| **`.bernstein` is a regular file** | **`<file>` — has not opted in** | `<unreadable>` — `Not a directory` |
| `chmod 000` / unsearchable parent | `<unreadable>` (#4058) | unchanged |
| fifo, socket, device file | `<file>` — has not opted in | `<unreadable>`, shape named |

Exit 1 and well-formed JSON in every row, before and after. That is what makes the old behaviour worse than the traceback #4058 fixed: `"the project has not opted in to volunteer work"` sends a maintainer whose file is a broken symlink off to add a file they already have — your own argument from the #4048 review, one level down.

**No clause in `volunteer_cmd.py` changed.** The `OSError` arm added by #4058 already carries all seven new rows. That is the argument for fixing it in the loader rather than in the command, and the CLI test added here asserts exactly that.

## Three things in the diff that are decisions rather than typing

**`EINVAL`, not the errno that actually describes the failure.** `ENOENT` is the right errno for a dangling symlink, and `OSError(errno.ENOENT, …)` **constructs a `FileNotFoundError`** — the errno-to-subclass map runs in `OSError.__new__`:

```
ENOENT   -> FileNotFoundError      EINVAL   -> OSError
EISDIR   -> IsADirectoryError      ELOOP    -> OSError
ENOTDIR  -> NotADirectoryError     EACCES   -> PermissionError
```

The obvious spelling reintroduces this bug through the fix for it. Same reason the directory case is not raised as `IsADirectoryError`: it is correct, it is an `OSError`, and it would invite the `ENOENT` version of the same edit later. The docstring says so at the raise.

**`stat` then `lstat`, in that order, and the inner `except` is narrow.** `ENOENT` from `stat()` is ambiguous — nothing there, or a symlink whose target is gone — and only the first is a project that never opted in. An `lstat` that fails some *other* way has not established the path is empty, so it propagates; widening that inner `except` to `OSError` reads an uninterpretable failure as proof of absence, which is the same substitution the PR exists to undo. `lstat` succeeds on a mode-000 file, so the widened version answers a permission failure with `the symbolic link has no target`. Both pinned (M2).

**The `S_ISREG` check is before the `open()`, not after.** `read_bytes()` on a fifo blocks until somebody writes to it. `is_file()` prevented that by accident; the stat that replaced it has to do it on purpose. `test_a_fifo_is_refused_before_the_open_rather_than_after` hangs rather than fails when that ordering is lost — M5 below took 63s against a 60s timeout instead of the ~3s the other mutants take, which is that test doing its job.

## The `receipt_cmd.py` interaction, measured both ways

`receipt_cmd.py:202` on `main` is `except (FileNotFoundError, VolunteerManifestError)`. `receipt create --manifest-repo` against each state, on `main` and on this branch:

```
                 main                                    this branch
absent           ✗ …has not opted in                     ✗ …has not opted in
ELOOP            ✗ …has not opted in   <- false          PermissionError-shaped traceback
directory        ✗ …has not opted in   <- false          traceback
chmod 000        traceback             <- pre-existing   traceback
```

So this branch trades two false refusals for two tracebacks at that call site, and leaves the third alone. **#4051's `OSError` widening closes all three.** I did not fold that one-line widening in here because it is the same line #4051 changes and would conflict with a PR already in the queue. Hence: after #4051. If you would rather have it standalone I can rebase this onto #4051's branch instead — your call, and it is a one-command difference.

## Tests

**16 new tests, 14 of them red on unmodified `1990dbca9`.** The two that pass there are regression guards and are supposed to: the mode-000 refusal must keep the kernel's own reason, and the vanished-mid-check race must stay an absence.

`708 passed / 4 skipped` across `tests/unit/volunteer`, `tests/unit/cli` and `tests/integration/volunteer`. `ruff` 0.14.10, `ruff format`, `typos` clean. `mypy` on the changed source is clean; `mypy` over the two test files reports one pre-existing `"Command" has no attribute "commands"` at `test_volunteer_cli.py:369` — the same error at line 332 on pristine `main` before these 37 lines shifted it, so it is not this branch's. Full `run_tests.py` sweep not run.

**12 mutants, 0 survivors.**

| | mutation | killed by |
|---|---|---|
| M1 | outer `except FileNotFoundError` → `OSError` | the mode-000 reason test |
| M2 | inner `except FileNotFoundError` → `OSError` | `…only_a_missing_entry_ends_the_ambiguity_as_an_absence` |
| M3 | broken-link `EINVAL` → `ENOENT` | `…never_reported_as_not_opted_in[dangling symlink]` |
| M4 | not-regular `EINVAL` → `ENOENT` | same, `[directory]` |
| M5 | `S_ISREG` guard dropped | the fifo test, by timing out |
| M6 | `lstat()` → `stat()` in the split | `[dangling symlink]` |
| M7 | the two `ENOENT` arms swapped | absent → reported as a broken link |
| M8–M11 | each shape arm dropped / `S_ISCHR` dropped | `…names_the_shape_that_was_found` |
| M12 | unreachable fallback relabelled | direct assertion on the helper |

M12 is the one worth a sentence, since it is the shape you and I both called equivalent on #4058's M8. It is **not** equivalent here: Linux exhausts the types above it, but `S_IFMT` is not a closed set across platforms, and without the arm such a mode renders as `it is , not a regular file`. So it is pinned by asserting on `_not_a_regular_file(0)` directly — a claim about a total function, not an invented claim about anything this kernel can produce.

## Measured while writing this, not fixed, filed in #4064

`load_manifest_from_repo` follows a symlink out of the checkout, so **`manifest_digest` is not a function of the commit**. One repo, one commit, one symlink at the manifest path pointing at a host file:

```
digest a74c287bfaa92c1d   gates ['pytest -q']
(the host file is edited; nothing in the repo changes)
digest d73a3ab7cbb54c6a   gates ['true']
```

The module docstring's central claim is that a maintainer *"recomputes it from the manifest at the commit the submission names"*. It is not a forged match — a maintainer recomputing from a clean checkout gets a mismatch and refuses — so it surfaces as an unexplained mismatch rather than a bypass. But `receipt create --manifest-repo` will bind a receipt to a policy that is not in the commit and say nothing. Left out because the fix is a scope decision (refuse symlinks, or resolve and check containment) rather than a clause, and this PR is one clause. Yours to direct if you want it.
