### PR TITLE
fix(security): return a verdict for a non-mapping chain and reject a boolean chain length

### DIFF
--- a/src/bernstein/core/security/result_receipt_bundle.py
+++ b/src/bernstein/core/security/result_receipt_bundle.py
@@ -454,9 +454,18 @@ def verify_result_bundle(
     # is missing outright.
     prev_digest_checked = False
     chain = bundle_dict.get("chain", {})
-    if "anchor" not in chain or "length" not in chain:
+    # The mapping check has to precede the membership test: ``in`` on a str is
+    # substring matching -- ``"anchor and length"`` passes the arm below and
+    # dies at ``.get`` -- and on a non-iterable it raises outright. A wrong
+    # type reports the same field as a missing link: absent, null, and
+    # non-mapping are all "this chain cannot be walked", one name, one fix.
+    if not isinstance(chain, dict):
+        errors.append(FieldError("chain", f"expected a mapping, got {type(chain).__name__}"))
+    elif "anchor" not in chain or "length" not in chain:
         errors.append(FieldError("chain", "missing anchor or length"))
-    elif not isinstance(chain.get("length"), int) or chain["length"] < 1:
+    # bool is an int subclass; ``true`` is not a chain length -- the same call
+    # ``_load_version`` makes about a schema version one module over.
+    elif not isinstance(chain.get("length"), int) or isinstance(chain["length"], bool) or chain["length"] < 1:
         errors.append(FieldError("chain.length", f"invalid length {chain.get('length')!r}"))
     elif expected_prev_digest is not None:
         prev_digest_checked = True

--- a/tests/unit/security/test_result_receipt_bundle.py
+++ b/tests/unit/security/test_result_receipt_bundle.py
@@ -538,3 +538,79 @@ def test_the_flag_defaults_false_for_every_existing_caller():
 
     assert verify_result_bundle(env, key.public_key()).prev_digest_checked is False
     assert BundleVerification(ok=True).prev_digest_checked is False
+
+
+# ---------------------------------------------------------------------------
+# #4054: the chain-shape check returns a verdict for every chain a bundle
+# might carry, and a boolean is not a chain length.
+#
+# A self-signed bundle reaches step 6 with a signature that verifies (trust on
+# first use), so every test here signs its hand-edited bundle with the worker's
+# own key -- exactly the position the CLI operator is in.
+# ---------------------------------------------------------------------------
+
+
+def test_a_non_mapping_chain_is_a_field_level_verdict_not_a_traceback():
+    """The four inputs from the issue, each of which used to raise.
+
+    ``bundle_dict.get("chain", {})`` defends against the key being absent, not
+    against it holding the wrong type -- and the first arm's membership test
+    does not defend either: ``in`` on a string is substring matching, so a
+    chain that literally says ``"anchor and length"`` passes the missing-keys
+    arm and dies at ``.get``. None of these may raise; the contract is a
+    verdict. No try/except here on purpose: a raise must fail the test, not be
+    absorbed by it.
+    """
+    key = _key()
+    pub = key.public_key()
+    first = _bundle(key)
+
+    for label, bad_chain in (
+        ("str with both key names as substrings", "anchor and length"),
+        ("list of the key names", ["anchor", "length"]),
+        ("null", None),
+        ("int", 42),
+    ):
+        bundle_dict = _successor(key, first, anchor=first.digest).to_dict()
+        bundle_dict["chain"] = bad_chain
+        v = verify_result_bundle(_sign_dict(key, bundle_dict), pub, expected_prev_digest=first.digest)
+
+        assert not v.ok, label
+        assert [e.field for e in v.errors] == ["chain"], label
+        # asked, and the anchor was still never looked at -- same state as any
+        # other malformed link, not a new one
+        assert v.prev_digest_checked is False, label
+
+
+def test_a_boolean_chain_length_is_not_a_length():
+    """``isinstance(True, int)`` is True and ``True >= 1``, so ``length: true``
+    used to pass the shape check and the bundle verified ``ok=True``.
+
+    The same rejection ``_load_version`` in ``volunteer/manifest.py`` already
+    makes one module over: bool is an int subclass, so an int slot has to
+    exclude it explicitly.
+    """
+    key = _key()
+    pub = key.public_key()
+    first = _bundle(key)
+
+    bundle_dict = _successor(key, first, anchor=first.digest).to_dict()
+    bundle_dict["chain"]["length"] = True
+    v = verify_result_bundle(_sign_dict(key, bundle_dict), pub, expected_prev_digest=first.digest)
+
+    assert not v.ok
+    assert [e.field for e in v.errors] == ["chain.length"]
+    assert v.prev_digest_checked is False
+
+
+def test_an_int_chain_length_still_verifies():
+    """The fix must not narrow the accepted shape: any int >= 1 stays a length."""
+    key = _key()
+    pub = key.public_key()
+    first = _bundle(key)
+
+    bundle_dict = _successor(key, first, anchor=first.digest, length=3).to_dict()
+    v = verify_result_bundle(_sign_dict(key, bundle_dict), pub, expected_prev_digest=first.digest)
+
+    assert v.ok, v.errors
+    assert v.prev_digest_checked is True


### PR DESCRIPTION
Fixes #4054. Both defects live in the step (6) `elif` chain of `verify_result_bundle`, so they are one change rather than two conflicting ones.

## What was broken

**A non-mapping `chain` raises out of the function.** `bundle_dict.get("chain", {})` defends against the key being absent, not against it holding the wrong type, and the first arm's membership test does not defend either — `in` on a string is substring matching, so `"anchor and length"` passes the missing-keys arm and dies at `chain.get`; a list passes membership and dies the same way; `null`/`42` make `in` itself raise `TypeError`. Reachable from `bernstein receipt verify <bundle>` without `--pubkey` (trust on first use): a self-signed bundle clears the signature step, so the operator got a traceback where the documented behaviour is `✗` and a non-zero exit.

**`{"length": true}` passed the shape check.** `isinstance(True, int)` is `True` and `True >= 1`, so a bundle whose chain length is the JSON boolean `true` verified `ok=True`. Now rejected the same way `_load_version` in `volunteer/manifest.py` already rejects a bool schema version — an inconsistency, not a novel decision.

## Red before, green after

The three new tests in `tests/unit/security/test_result_receipt_bundle.py` were written first and confirmed red against `origin/main` (`65a2831`):

- `test_a_non_mapping_chain_is_a_field_level_verdict_not_a_traceback` — failed with `AttributeError: 'str' object has no attribute 'get'` (no `pytest.raises`, no try/except; a raise fails the test)
- `test_a_boolean_chain_length_is_not_a_length` — failed with `assert not True` (the bundle verified `ok=True`)
- `test_an_int_chain_length_still_verifies` — already passing on `main`, and still passing: the anti-narrowing guard, not a regression test

After the fix all 25 tests in the file pass, the 22 pre-existing ones unchanged.

End-to-end, the CLI scenario from the issue: a self-signed bundle with `chain: "anchor and length"` through `bernstein receipt verify` traced back with `AttributeError` on `main`; with this branch it prints `✗ bundle verification failed: chain: expected a mapping, got str` and exits 1.

## The field-name decision

A **non-mapping `chain` reports the field `chain` — the same name a missing anchor/length already reports.** The type name goes in the message (`expected a mapping, got str`), so nothing is lost, but the field stays one name because a caller reading the error does the same thing next in every case: this bundle's chain link cannot be walked, continuity cannot be established. Absent, `null`, and wrong-type have one remediation, so they get one name — and a distinct name (e.g. `chain.type`) would be a second string every error consumer has to handle for no new action it enables. It also keeps the non-mapping cases inside the set `test_a_malformed_chain_link_does_not_report_continuity_as_checked` already accepts (`["chain"]` or `["chain.length"]`).

`{"length": true}` reports `chain.length`, exactly like `"2"` and `0` already did.

## Out of scope, and why the flags are untouched

The guard is a new first arm; every input for which `chain` is a mapping reaches the same arm it reached before, and `manifest_digest_checked` is set outside step 6 entirely. `test_the_two_checked_flags_are_independent` and `test_the_manifest_flag_is_unaffected_by_a_malformed_chain` pass unchanged. One note for completeness: a bundle with `length: true` that previously slipped *through* the shape check into the continuity arm now lands in the same "malformed link → `prev_digest_checked` stays `False`" state as `length: "2"` always did — that is #4050's established semantics for a link the comparison cannot run on, which is exactly what a boolean length is.

## Checks

- `uv run python scripts/run_tests.py --test-dir tests/unit/security` — 31 files, 0 failed
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run mypy src` — 146 pre-existing errors on `main`, 146 with this branch; none in the touched files (verified by stashing)

Docs: no change needed — the only doc touching this surface is the `FEATURE_MATRIX.md` line ("names the field that diverged"), which this PR makes true for more inputs rather than changing.
