### PR TITLE
ci: the bundle gate reports on a queued ref, so it can be required

### DIFF
--- a/.github/workflows/spa-bundle-freshness.yml
+++ b/.github/workflows/spa-bundle-freshness.yml
@@ -30,12 +30,35 @@ name: SPA bundle freshness
 # allow-lists exactly two emitters of that string and rejects a third. See
 # docs/operations/ci.md.
 #
-# It also has no ``merge_group`` trigger, so it must not be made a required
-# context as it stands - a required context that cannot report on a queued
-# ref wedges the merge queue (see docs/operations/merge-queue.md). Add the
-# trigger first if branch protection is ever meant to require it.
+# Merge queue
+# -----------
+# This lane reports on a queued ref, so branch protection *can* require it.
+# It is not required yet: that is a repository-settings change, and the
+# ordering matters in one direction only. A required context that cannot
+# report on a queued ref wedges the queue - every entry waits forever for a
+# check that never arrives (docs/operations/merge-queue.md, troubleshooting
+# row 1). Trigger first, requirement second, never the reverse. Until the
+# switch is thrown this lane still only annotates; #4010 is the bill for
+# that state, and #4028 has the two flips that end it.
+#
+# The ``merge_group`` trigger carries no ``paths`` filter, deliberately.
+# GitHub evaluates ``paths`` / ``paths-ignore`` for ``push``,
+# ``pull_request`` and ``pull_request_target`` only, so a filter here would
+# be silently ignored; and a queue batch stacks several pull requests, so
+# the batch can contain a ``web/**`` change even when the entry being tested
+# does not.
+#
+# #4020 took three lanes *out* of the queue on the rule that a lane which
+# cannot gate a merge should not compete for runners with the one that can.
+# That rule is not in tension with this trigger for long - this lane is on
+# its way to being required, which is the case #4020 excludes - and the
+# job is one slot for a median of 28s (14 recent executions: 23s min, 37s
+# max; the multi-minute figures in the run list are queue wait, not
+# execution), against the 16-job matrices and multi-minute scanners #4020
+# removed.
 
 on:
+  merge_group: {}
   pull_request:
     paths:
       - "web/**"

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -65,7 +65,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/sbom.yml | SBOM | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "sbom-${{ github.ref }}"} | 1 |
 | .github/workflows/scorecard.yml | OSSF Scorecard | branch_protection_rule, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "scorecard-${{ github.ref }}"} | 2 |
 | .github/workflows/soc2-evidence-weekly.yml | soc2-evidence-weekly | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "soc2-evidence-${{ github.ref }}"} | 2 |
-| .github/workflows/spa-bundle-freshness.yml | SPA bundle freshness | pull_request, push | {"cancel-in-progress": "true", "group": "spa-bundle-freshness-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
+| .github/workflows/spa-bundle-freshness.yml | SPA bundle freshness | merge_group, pull_request, push | {"cancel-in-progress": "true", "group": "spa-bundle-freshness-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
 | .github/workflows/spiffe-extra-e2e.yml | SPIFFE Extra E2E | pull_request, push, workflow_dispatch | {"cancel-in-progress": "true", "group": "spiffe-extra-e2e-${{ github.ref }}"} | 1 |
 | .github/workflows/stale.yml | Stale cleanup | schedule | {"cancel-in-progress": "false", "group": "stale-${{ github.ref }}"} | 1 |
 | .github/workflows/static-analysis-extended.yml | static-analysis (extended) | push, schedule, workflow_dispatch | {"cancel-in-progress": "${{ github.event_name == 'pull_request' }}", "group": "static-analysis-extended-${{ github.ref }}"} | 6 |

--- a/docs/operations/merge-queue.md
+++ b/docs/operations/merge-queue.md
@@ -86,6 +86,42 @@ queue for every diff the filter excludes. It is locked by
 required-context coverage by
 `tests/unit/test_merge_queue_gate_coverage_yaml.py`.
 
+### Reports on the queue but is not required yet
+
+| Context | Emitting workflow | Runs on `merge_group`? | Required? |
+|---------|-------------------|------------------------|-----------|
+| `shipped bundle matches the lockfile` | `spa-bundle-freshness.yml` :: `rebuild` | Yes - `merge_group: {}` | **No - see below** |
+
+#4010 merged with this lane red. `CI gate` was green, `CI gate` is the only
+required context, so branch protection was satisfied and the queue took the
+entry; `main` went red and the repair landed at the back of an eleven-entry
+queue. The lane could only ever annotate the damage, never prevent it.
+
+#4028 added the trigger, which is the half that has to come first. The lane
+now reports on a queued ref, so the remaining step is safe to take and is
+**two flips, both maintainer-only**:
+
+1. Branch protection on `main`: add `shipped bundle matches the lockfile` to
+   the required-status-checks list. This is what stops the pull request
+   entering the queue.
+2. The merge-queue ruleset: add the same context to
+   `required_status_checks`, in the live ruleset (the `gh api PUT` payload
+   above) **and** in its checked-in mirror
+   `docs/operations/merge-queue-ruleset.json`, which
+   `tests/unit/test_merge_queue_gate_coverage_yaml.py` reads.
+
+Do them in that order, and only while the queue is drained: editing required
+contexts invalidates every in-flight entry, so each one restarts a full-suite
+run. Until both are done the lane is exactly as advisory as it was before -
+the trigger alone changes nothing about whether a red bundle can merge.
+
+The general rule this came from is locked by
+`test_no_web_triggerable_lane_is_advisory_only`: a lane that can fail on a
+`web/**` change is either part of the required gate, on its way to being
+required, or a written-down deferral. The state that produced #4010 - a lane
+whose reason for staying advisory lived in a comment, with nothing failing
+when that reason expired - is the one that is no longer reachable.
+
 ### What the group's CI actually tests
 
 Reporting `CI gate` on the group is necessary but not sufficient: the gate

--- a/tests/unit/test_merge_queue_gate_coverage_yaml.py
+++ b/tests/unit/test_merge_queue_gate_coverage_yaml.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import ast
 import json
 import re
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +46,57 @@ GATE_JOB_KEY = "ci-gate"
 # their truth value changes with `github.event_name`, so they may resolve
 # differently on a queued group than on the pull request.
 EVENT_SHAPE_MARKERS = ("github.event_name", "github.event.pull_request")
+
+# Top-level directory whose change can move the shipped SPA bundle. A
+# `pull_request` lane that can run on a change under it can also fail on
+# one, which is the property #4010 turned into a red `main`.
+WEB_ROOT = "web"
+# A `paths` entry starting with either of these matches any diff, so the
+# lane runs on a `web/**` change too.
+MATCH_ANYTHING = ("*", "**")
+
+#: Lanes that can fail on a `web/**` change and carry an unfiltered
+#: `merge_group` trigger, so branch protection *can* require them.
+#:
+#: A name here is a claim about the file, not an exemption from it:
+#: `test_queue_reporting_web_lanes_can_actually_be_required` re-reads the
+#: workflow and fails if the trigger is missing or filtered.
+QUEUE_REPORTING_WEB_LANES = {
+    "spa-bundle-freshness.yml": (
+        "The bundle gate. #4010 merged with it red because the lane was advisory, and main "
+        "went red behind eleven queue entries. #4028 added the merge_group trigger so that "
+        "`shipped bundle matches the lockfile` can be made a required context."
+    ),
+}
+
+#: Lanes that can run on a `web/**` change and stay advisory on purpose.
+#:
+#: This bucket exists because #4010's bill was for an *unwritten* deferral.
+#: The reason the bundle gate could not be required lived in a comment in
+#: its own header, and nothing failed when the comment stopped describing
+#: an acceptable state. A deferral that has to be typed here, next to the
+#: assertion it suppresses, is one somebody can find and re-decide.
+ADVISORY_BY_DECISION = {
+    "typecheck-ts.yml": (
+        "`tsc --noEmit` over the TypeScript packages, `web/` among them. Same shape as the "
+        "bundle gate and not fixed by #4028, whose scope is one lane; raised on that thread "
+        "rather than folded in silently."
+    ),
+    "pr-policy.yml": (
+        "Consolidated per-PR policy lane (text hygiene, main-red guard, andon gate, "
+        "pre-merge autosync). Its own header already records that none of these is a "
+        "required check."
+    ),
+    "trufflehog.yml": ("Secret scanning. Advisory as configured today; nothing about #4028 changed it."),
+    "pr-observability-summary.yml": (
+        "Posts a summary on the pull request behind a `deep-review` label. It reports, it "
+        "does not gate, so requiring it is not the missing piece."
+    ),
+    "dependabot-auto-merge.yml": (
+        "Automation that merges Dependabot PRs once the required checks pass. It consumes "
+        "the gate rather than being part of it."
+    ),
+}
 
 
 def _load(path: Path) -> dict[str, Any]:
@@ -121,9 +173,283 @@ def queue_required_contexts() -> tuple[str, ...]:
     raise AssertionError("enable payload declares no required_status_checks rule")
 
 
-def _triggers_on_merge_group(doc: dict[str, Any]) -> bool:
+def _triggers(doc: Mapping[Any, Any]) -> dict[str, Any]:
+    """The workflow's trigger mapping, or an empty one if it has none.
+
+    Looked up under both keys because PyYAML 1.1 parses a bare ``on:`` as
+    the boolean ``True``. Unlike ``_on`` this tolerates a workflow with no
+    triggers rather than asserting, because the callers below scan every
+    file in the directory and a malformed one is not their subject.
+    """
     on = doc.get(True, doc.get("on"))
-    return isinstance(on, dict) and "merge_group" in on
+    return on if isinstance(on, dict) else {}
+
+
+def _triggers_on_merge_group(doc: dict[str, Any]) -> bool:
+    return "merge_group" in _triggers(doc)
+
+
+def _names_web(entry: str) -> bool:
+    """Whether a ``paths`` / ``paths-ignore`` entry covers a ``web/`` change."""
+    head = str(entry).lstrip("!").split("/", 1)[0]
+    return head == WEB_ROOT or head in MATCH_ANYTHING
+
+
+def _can_run_on_a_web_change(doc: dict[str, Any]) -> bool:
+    """Whether a ``pull_request`` event over a ``web/**`` diff starts this lane.
+
+    Negated entries are skipped on both sides, which is the conservative
+    direction in each case: an excluded pattern is not read as adding
+    coverage under ``paths``, and not read as removing it under
+    ``paths-ignore``. A lane that lands in scope by mistake has to be
+    written down, which is cheap; one that escapes is the defect.
+    """
+    on = _triggers(doc)
+    if "pull_request" not in on:
+        return False
+    trigger = on.get("pull_request")
+    if not isinstance(trigger, dict):
+        # Bare ``pull_request:`` - every pull request, `web/**` included.
+        return True
+
+    paths = trigger.get("paths")
+    if isinstance(paths, list):
+        return any(_names_web(e) for e in paths if not str(e).startswith("!"))
+
+    ignored = trigger.get("paths-ignore")
+    if isinstance(ignored, list):
+        return not any(_names_web(e) for e in ignored if not str(e).startswith("!"))
+
+    return True
+
+
+def _emits_any(path: Path, doc: dict[str, Any], contexts: tuple[str, ...]) -> bool:
+    """Whether the workflow publishes one of ``contexts`` as a check run.
+
+    Unlike ``test_every_queue_required_context_has_a_merge_group_emitter``
+    this does not care which event the lane runs on: the question here is
+    whether the workflow is part of the required gate at all.
+    """
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return False
+    text = path.read_text(encoding="utf-8")
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        if any(job.get("name") == c or f"--name {c}" in text for c in contexts):
+            return True
+    return False
+
+
+def _web_triggerable_lanes() -> list[Path]:
+    out: list[Path] = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        try:
+            doc = _load(path)
+        except (AssertionError, yaml.YAMLError):
+            continue
+        if _can_run_on_a_web_change(doc):
+            out.append(path)
+    return out
+
+
+# The scan below is only as good as the predicate that feeds it, and the
+# predicate's interesting cases are not all present in the tree on any given
+# day - exactly one workflow uses `paths-ignore` under `pull_request`, and it
+# is exempt for an unrelated reason, so a bug in that branch would change
+# nothing today and everything the moment a second one appeared. These
+# assert the function's behaviour directly rather than through whatever
+# `.github/workflows` happens to contain.
+@pytest.mark.parametrize(
+    ("entry", "expected"),
+    [
+        ("web/**", True),
+        ("web/package-lock.json", True),
+        ("**", True),
+        ("*", True),
+        ("!web/**", True),  # `lstrip` first: callers decide what negation means
+        ("src/**", False),
+        ("docs/**", False),
+        # A prefix, not a path segment. `webhooks/**` is a different tree and
+        # a substring test would wrongly claim the lane guards the bundle.
+        ("webhooks/**", False),
+        ("src/bernstein/gui/static/**", False),
+    ],
+)
+def test_names_web_matches_on_a_path_segment(entry: str, expected: bool) -> None:
+    assert _names_web(entry) is expected
+
+
+@pytest.mark.parametrize(
+    ("trigger", "expected"),
+    [
+        # No `pull_request` trigger at all - not this test's subject.
+        ({"push": {"branches": ["main"]}}, False),
+        # Bare `pull_request:` - runs on every PR, `web/**` among them.
+        ({"pull_request": None}, True),
+        ({"pull_request": {"types": ["opened"]}}, True),
+        # An allow-list decides it.
+        ({"pull_request": {"paths": ["web/**"]}}, True),
+        ({"pull_request": {"paths": ["src/**", "web/**"]}}, True),
+        ({"pull_request": {"paths": ["src/**"]}}, False),
+        # A negated entry is not coverage, so this lane never sees `web/`.
+        ({"pull_request": {"paths": ["!web/**", "src/**"]}}, False),
+        # A deny-list decides it the other way round.
+        ({"pull_request": {"paths-ignore": ["docs/**"]}}, True),
+        ({"pull_request": {"paths-ignore": ["web/**"]}}, False),
+        # A negated deny-list entry re-includes, so coverage stands.
+        ({"pull_request": {"paths-ignore": ["!web/**"]}}, True),
+    ],
+)
+def test_can_run_on_a_web_change_reads_both_filter_shapes(trigger: dict[str, Any], expected: bool) -> None:
+    assert _can_run_on_a_web_change({"on": trigger}) is expected
+
+
+def test_can_run_on_a_web_change_reads_the_yaml_true_key() -> None:
+    """PyYAML 1.1 turns a bare ``on:`` into ``True``; both spellings count."""
+    assert _can_run_on_a_web_change({True: {"pull_request": {"paths": ["web/**"]}}}) is True
+    assert _can_run_on_a_web_change({}) is False
+
+
+def test_emits_any_discriminates(tmp_path: Path) -> None:
+    """The gate-emitter exemption must not wave everything through.
+
+    If this predicate ever answered ``True`` unconditionally, the scan below
+    would pass with an empty allow-list and assert nothing at all.
+    """
+    wf = tmp_path / "w.yml"
+    wf.write_text("jobs:\n  a:\n    name: CI gate\n", encoding="utf-8")
+    assert _emits_any(wf, {"jobs": {"a": {"name": "CI gate"}}}, ("CI gate",)) is True
+    assert _emits_any(wf, {"jobs": {"a": {"name": "something else"}}}, ("CI gate",)) is False
+    assert _emits_any(wf, {}, ("CI gate",)) is False
+
+
+def test_the_bundle_gate_is_not_exempt_as_a_gate_emitter(
+    queue_required_contexts: tuple[str, ...],
+) -> None:
+    """It is accounted for by the allow-list, not by publishing `CI gate`.
+
+    Pins the reason the lane is in the first dict. If it ever started
+    emitting a required context the entry would become dead weight, and
+    worse, the canary in
+    ``tests/unit/test_required_check_canary_workflow_yaml.py`` would already
+    be failing for a different reason.
+    """
+    path = WORKFLOWS / "spa-bundle-freshness.yml"
+    assert _can_run_on_a_web_change(_load(path)) is True
+    assert _emits_any(path, _load(path), queue_required_contexts) is False
+
+
+def test_no_web_triggerable_lane_is_advisory_only(
+    queue_required_contexts: tuple[str, ...],
+) -> None:
+    """Every lane that can fail on a ``web/**`` change is accounted for.
+
+    This is the assertion #4010 did not have. `SPA bundle freshness` went
+    red on that pull request, `CI gate` - the only required context - went
+    green, branch protection was satisfied, and the queue merged it. The
+    lane existed precisely to stop that and could only annotate it.
+
+    A lane in scope has to be one of three things, and the third is the
+    point: part of the required gate, on the way to being required, or a
+    deferral somebody typed out on purpose. What is no longer available is
+    the fourth state, which is where the bundle gate sat - advisory, for a
+    reason recorded only in a comment, with nothing failing when that
+    reason expired.
+    """
+    unaccounted: list[str] = []
+    for path in _web_triggerable_lanes():
+        if path.name in QUEUE_REPORTING_WEB_LANES or path.name in ADVISORY_BY_DECISION:
+            continue
+        if _emits_any(path, _load(path), queue_required_contexts):
+            continue
+        unaccounted.append(path.name)
+
+    assert not unaccounted, (
+        f"these lanes can run - and so can fail - on a `web/**` change, but they neither publish a "
+        f"required context nor appear in QUEUE_REPORTING_WEB_LANES or ADVISORY_BY_DECISION: "
+        f"{sorted(unaccounted)}. That is the #4010 shape: red lane, green gate, merged anyway. Give the "
+        f"lane a `merge_group` trigger and list it in the first dict, or record why it stays advisory in "
+        f"the second."
+    )
+
+
+def test_queue_reporting_web_lanes_can_actually_be_required() -> None:
+    """The allow-list above must not be able to lie about a file.
+
+    Listing a lane in ``QUEUE_REPORTING_WEB_LANES`` is a claim that a
+    maintainer can safely add it to branch protection. If the trigger is
+    absent, or filtered, that claim is false and flipping the switch wedges
+    the queue instead of gating the pull request - the failure mode in
+    ``docs/operations/merge-queue.md``'s troubleshooting table, row 1.
+    """
+    for name, reason in QUEUE_REPORTING_WEB_LANES.items():
+        path = WORKFLOWS / name
+        assert path.is_file(), f"QUEUE_REPORTING_WEB_LANES names {name}, which does not exist"
+        assert reason.strip(), f"{name} needs a reason, not an empty string"
+        trigger = _on(_load(path)).get("merge_group", "__absent__")
+        assert trigger != "__absent__", (
+            f"{name} is listed as requirable but declares no `merge_group` trigger. A required context "
+            f"that cannot report on a queued ref wedges the queue."
+        )
+        assert trigger in (None, {}), (
+            f"{name}'s `merge_group` trigger carries a filter ({trigger!r}). `paths` is not evaluated for "
+            f"`merge_group` at all, so a filter there is either ignored or a mistake - and a queue batch "
+            f"stacks several pull requests, so the batch can carry a `web/**` change the tested entry does not."
+        )
+
+
+def _stale_bucket_entries(bucket: Mapping[str, str], in_scope: set[str]) -> list[str]:
+    """Bucket names that no longer describe a lane the scan looks at.
+
+    Split out from the test so it can be exercised on a bucket that has
+    actually gone stale. Doing it only against the shipped constants would
+    assert nothing until the day one of them rots, which is the day the
+    assertion is supposed to have been protecting something.
+    """
+    return sorted(name for name in bucket if name not in in_scope)
+
+
+@pytest.mark.parametrize(
+    ("bucket", "in_scope", "expected"),
+    [
+        ({"a.yml": "reason"}, {"a.yml"}, []),
+        ({"a.yml": "reason"}, {"a.yml", "b.yml"}, []),
+        # The lane's trigger changed and it left the scan's scope: the entry
+        # is now suppressing an assertion about nothing.
+        ({"a.yml": "reason"}, {"b.yml"}, ["a.yml"]),
+        ({"a.yml": "reason", "b.yml": "reason"}, set(), ["a.yml", "b.yml"]),
+        ({}, {"a.yml"}, []),
+    ],
+)
+def test_stale_bucket_entries_flags_a_lane_that_left_scope(
+    bucket: dict[str, str], in_scope: set[str], expected: list[str]
+) -> None:
+    assert _stale_bucket_entries(bucket, in_scope) == expected
+
+
+def test_lane_buckets_stay_in_sync_with_the_tree() -> None:
+    """Stale entries in either bucket are silent holes, so they are errors."""
+    overlap = set(QUEUE_REPORTING_WEB_LANES) & set(ADVISORY_BY_DECISION)
+    assert not overlap, f"{sorted(overlap)} is both requirable and advisory-by-decision; pick one"
+
+    in_scope = {path.name for path in _web_triggerable_lanes()}
+    for bucket, label in (
+        (QUEUE_REPORTING_WEB_LANES, "QUEUE_REPORTING_WEB_LANES"),
+        (ADVISORY_BY_DECISION, "ADVISORY_BY_DECISION"),
+    ):
+        for name in bucket:
+            assert (WORKFLOWS / name).is_file(), f"{label} names {name}, which does not exist"
+        stale = _stale_bucket_entries(bucket, in_scope)
+        assert not stale, (
+            f"{label} names {stale}, which can no longer run on a `web/**` change. The trigger changed; "
+            f"drop the entry rather than leaving it to suppress an assertion about nothing."
+        )
+
+    for bucket in (QUEUE_REPORTING_WEB_LANES, ADVISORY_BY_DECISION):
+        for name, reason in bucket.items():
+            assert reason.strip(), f"{name} needs a reason, not an empty string"
 
 
 def test_ci_merge_group_trigger_carries_no_filter(ci_doc: dict[str, Any]) -> None:

--- a/tests/unit/test_spa_bundle_freshness_workflow_yaml.py
+++ b/tests/unit/test_spa_bundle_freshness_workflow_yaml.py
@@ -17,9 +17,10 @@ that make it work are pinned here rather than left to review:
   every ``pull_request`` workflow;
 * no job is named ``CI gate``, which the required-check canary allow-lists
   to exactly two workflows;
-* it has no ``merge_group`` trigger, so it must not be a required context -
-  one that cannot report on a queued ref wedges the merge queue. If the
-  trigger is ever added, this test is the place that says so.
+* it triggers on ``merge_group`` with no filter, so it reports on a queued
+  ref and branch protection can require it. Being required is a separate,
+  later, maintainer-only change; this file pins the half that has to come
+  first, because the reverse order wedges the queue.
 """
 
 from __future__ import annotations
@@ -153,13 +154,41 @@ def test_no_job_emits_the_required_check_name() -> None:
     assert "CI gate" not in names, f"{WORKFLOW.name} would post a third `CI gate` check"
 
 
-def test_workflow_is_not_merge_queue_safe_yet() -> None:
-    """No ``merge_group`` trigger, so it must not be made a required context.
+def test_merge_group_trigger_present() -> None:
+    """The gate must report on a queued ref before it can be required.
 
-    If a ``merge_group`` trigger is added, drop this test and add the job to
-    the merge-queue coverage assertions instead.
+    Until #4028 this file asserted the opposite - that no ``merge_group``
+    trigger existed - and its docstring said to replace it with this once
+    the trigger was added. #4010 is why: the lane went red on the pull
+    request, ``CI gate`` stayed green, and the queue merged it because an
+    advisory lane gates nothing.
+
+    Adding the trigger does not make the check required; that is a branch
+    protection change, and it is deliberately the later half. This assertion
+    pins the earlier half, which is the half that has to exist first.
     """
-    assert "merge_group" not in _on(), (
-        "a merge_group trigger means this job can be required - update "
-        "docs/operations/merge-queue.md and the coverage test alongside it"
+    assert "merge_group" in _on(), (
+        "without a `merge_group` trigger this lane cannot report on a queued ref, so it cannot be a "
+        "required context - and while it is not required, a red bundle merges (#4010)"
+    )
+
+
+def test_merge_group_trigger_carries_no_filter() -> None:
+    """The queue runs it on every group, not only ``web/**`` ones.
+
+    Two independent reasons, and either alone is sufficient. ``paths`` and
+    ``paths-ignore`` are evaluated for ``push``, ``pull_request`` and
+    ``pull_request_target`` only - never for ``merge_group`` - so a filter
+    here is silently ignored and reads as a guarantee nobody is honouring.
+    And a queue batch stacks several pull requests, so the batch can carry
+    a ``web/**`` change even when the entry under test does not; filtering
+    on the entry's own diff would let exactly this defect back in.
+
+    Mirrors ``test_ci_merge_group_trigger_carries_no_filter``.
+    """
+    trigger = _on().get("merge_group", "__absent__")
+    assert trigger != "__absent__", "no `merge_group` trigger at all"
+    assert trigger in (None, {}), (
+        f"the `merge_group` trigger carries a filter ({trigger!r}). GitHub does not evaluate `paths` for "
+        "`merge_group`, and a batch can contain a `web/**` change the tested entry does not."
     )


### PR DESCRIPTION
Closes #4028.

This is the **first of the two halves**, and it is inert on its own. The lane now reports on a queued ref; it is still advisory. Nothing here makes a red bundle block a merge — that takes two flips in repository settings, and neither is in this diff:

1. Branch protection on `main`: add `shipped bundle matches the lockfile` to required status checks.
2. The merge-queue ruleset: add the same context to `required_status_checks`, in the live ruleset **and** in the checked-in mirror `docs/operations/merge-queue-ruleset.json`.

Both are written into `merge-queue.md` in this PR so they are not carried in someone's head. Your ordering is the load-bearing part and I have not reversed it: trigger first, requirement second, because a required context that cannot report on a queued ref wedges the queue rather than blocking the PR.

Based on `302b79ae` (`main`, with #4051 and #4055 in it). Touches no file any open PR touches.

---

## Two things in the brief I could not confirm, and one I think you will want to know

### 1. The "precedent to copy" in §4 is inverted

The brief says three workflows already solve this shape with a bare `merge_group: {}`, and names `adapter-contract-drift.yml:32-36`, `mutation-fixed.yml:35-41`, `static-analysis-extended.yml:38-42`.

Those three are the opposite: **#4020 took `merge_group` off all three**, and each now carries a header comment saying why. `ci.yml` is the only workflow in the tree with a `merge_group` trigger.

```
$ grep -ln "^\s*merge_group" .github/workflows/*.yml
.github/workflows/ci.yml
```

So there is no precedent to copy, and the rule I was pointed at is one this PR appears to violate: *a lane that cannot gate a merge should not compete for runners with the one that can.*

I still think the trigger is right, for a reason that is narrow and worth stating rather than glossing: **#4020's rule is about lanes that will never be required.** This one is on its way to being required — that is the whole ticket — so the runner cost is bounded by how long the window between the two halves stays open, not permanent.

And the cost is small. I sampled the last 14 executions of the job:

```
durations(s): [23, 25, 26, 27, 28, 28, 28, 28, 28, 29, 30, 31, 31, 37]
min 23s   median 28s   max 37s
```

One slot for a median of 28 seconds, against the 16-job matrices and multi-minute scanners #4020 removed. Worth flagging that the multi-minute figures in the run list are **queue wait, not execution** — `run_started_at` to `updated_at` on a recent run reads 9.4 minutes for a job that ran for 28 seconds, which is exactly the runner contention #4020 was about, and is an argument for the window being short rather than against the trigger.

If you read that trade differently, the trigger is one line and I will take it back out — but then #4028 cannot be closed, because the trigger is the only thing that makes the requirement safe.

### 2. AC bullet 5 catches two lanes today, not one

The brief expected the new guard to fail on `spa-bundle-freshness.yml` alone before the fix. Running the predicate over the tree, **`typecheck-ts.yml` is in the same shape**: its `pull_request` paths include `web/**`, it is advisory, and `ci.yml` paths-ignores `sdk/typescript/**` and `packages/vscode/**` so the roll-up never covers it. A TS type error under `web/` merges green the same way a stale bundle did.

I have **not** fixed it. #4028's scope is one lane, and folding a second in silently is worse than saying so. It is recorded in the new `ADVISORY_BY_DECISION` bucket with that reason, so it is visible rather than implied. Happy to take it as its own ticket if you want it, but I am not opening one unprompted.

### 3. So the guard has two buckets, not one allow-list

The brief's shape — one allow-list of standalone-required lanes, seeded with this workflow — would have failed on six lanes, not one, once `web/`-triggerable is read as "can run on a `web/**` change" (which includes lanes with no `paths` filter at all: `pr-policy`, `trufflehog`, `pr-observability-summary`, `dependabot-auto-merge`).

Rather than narrow the predicate until only the answer I wanted survived, the guard scans all seven in-scope lanes and requires each to be one of three things:

- publishes a queue-required context (`ci.yml`, derived, not hand-listed);
- `QUEUE_REPORTING_WEB_LANES` — on its way to being required. **A name here is a claim that is re-checked:** `test_queue_reporting_web_lanes_can_actually_be_required` re-reads the workflow and fails if the `merge_group` trigger is missing or filtered, so the entry cannot lie about the file;
- `ADVISORY_BY_DECISION` — a deferral with a written reason.

The fourth state is the one that is now unreachable, and it is the state that produced #4010: advisory, for a reason that lived in a comment in the workflow's own header, with nothing failing when that reason expired.

Current classification:

| lane | how it is accounted for |
|---|---|
| `ci.yml` | emits `CI gate` |
| `spa-bundle-freshness.yml` | requirable (this PR) |
| `typecheck-ts.yml` | advisory by decision — same shape, out of scope, see above |
| `pr-policy.yml` | advisory by decision — its own header already says none of its checks is required |
| `trufflehog.yml` | advisory by decision |
| `pr-observability-summary.yml` | advisory by decision — reports, does not gate |
| `dependabot-auto-merge.yml` | advisory by decision — consumes the gate |

If you would rather the predicate only catch lanes that *name* a web path — two lanes, a much shorter table, and four fewer judgements of mine in the tree — that is a two-line change and I will make it.

---

## The decision in §7: standalone (A), as you recommended

`needs:` only resolves job IDs inside the same workflow file, so folding in means relocating the job body into `ci.yml` or wiring a `workflow_call` edge, and every `workflow_call` in this repo is async post-CI dispatch off `workflow_run`, never a synchronous pre-merge gate. Since #4020 the "no in-repo precedent" part is literally true rather than nearly true.

Standalone does not close the loop by itself, which is the honest counterpoint in your own brief and the reason the two flips are documented rather than assumed.

## Tests

`test_workflow_is_not_merge_queue_safe_yet` asserted the absence of the trigger and its docstring said to replace it once the trigger was added. Replaced, in the same commit, by:

| assertion | file |
|---|---|
| `test_merge_group_trigger_present` | `test_spa_bundle_freshness_workflow_yaml.py` |
| `test_merge_group_trigger_carries_no_filter` | `test_spa_bundle_freshness_workflow_yaml.py` |
| `test_no_web_triggerable_lane_is_advisory_only` | `test_merge_queue_gate_coverage_yaml.py` |
| `test_queue_reporting_web_lanes_can_actually_be_required` | `test_merge_queue_gate_coverage_yaml.py` |
| `test_lane_buckets_stay_in_sync_with_the_tree` | `test_merge_queue_gate_coverage_yaml.py` |

Three of those are red on unmodified `302b79ae`, which is the proof the defect was real.

The predicate is also tested **directly**, on synthetic trigger blocks, not only through whatever `.github/workflows` happens to contain. That is deliberate: exactly one workflow uses `paths-ignore` under `pull_request` and it is exempt for an unrelated reason, so a bug in that branch would change nothing today and everything the moment a second one appeared. Same for `_emits_any` — if it ever answered `True` unconditionally the whole scan would pass with an empty allow-list and assert nothing.

**16 mutants, 0 survivors.** Two survived the first pass and neither was declared equivalent: one was a badly built mutant of mine (the replacement left a non-empty reason string, so it was not testing what it claimed), and the other was real — nothing exercised the "bucket entry has left scope" clause, because killing it needs a bucket that has actually gone stale. Fixed by splitting `_stale_bucket_entries` out and testing it as a total function rather than asserting something invented about the shipped constants.

`320 passed` across the eight adjacent workflow test files. `ruff`, `ruff format`, `typos` clean. `mypy` on the two test files goes **3 errors → 2** — both remaining are pre-existing `_on` helpers I did not touch; the one I removed was by sharing a `_triggers()` helper rather than adding a third copy of the `doc.get(True, doc.get("on"))` dance.

## Two things I checked and deliberately did not change

- **`docs/operations/ci-topology.md` is regenerated** (`scripts/gen_workflow_topology.py`), one line — the trigger list for this workflow. Generated artifact, so it is in the diff rather than left for the heal job.
- **The concurrency group is untouched.** On `merge_group` the `github.event.pull_request.number` side is empty and it falls back to `github.ref`, which for a queued ref is `gh-readonly-queue/main/pr-N-<sha>` — unique per entry, so a queue run cannot cancel another entry's run or the push-to-`main` run. Two runs only share a group if the same ref was re-dispatched, where cancelling the superseded one is correct. `ci.yml` adds `github.sha` to its fallback; this lane does not need it because its fallback ref already carries one.
