### PR TITLE
fix(security): refuse wrong-typed bundle fields in verify_result_bundle (#4057)

### DIFF
--- a/src/bernstein/core/security/result_receipt_bundle.py
+++ b/src/bernstein/core/security/result_receipt_bundle.py
@@ -392,7 +392,16 @@ def verify_result_bundle(
 
     statement = env_v.statement
     predicate = statement.get("predicate", {})
-    bundle_dict = predicate.get("bundle", {})
+    raw_bundle = predicate.get("bundle", {})
+    bundle_dict = raw_bundle if isinstance(raw_bundle, dict) else {}
+    if not isinstance(raw_bundle, dict):
+        errors.append(
+            FieldError(
+                "bundle",
+                f"expected an object, got {type(raw_bundle).__name__}",
+            )
+        )
+
     subjects = statement.get("subject", [])
     attested_digest = ""
     if subjects and isinstance(subjects[0], dict):
@@ -400,7 +409,7 @@ def verify_result_bundle(
 
     # (2) internal hash consistency: the embedded bundle must reproduce the
     # subject digest byte-for-byte.
-    recomputed = _sha256_hex(canonical_bytes(bundle_dict))
+    recomputed = _sha256_hex(canonical_bytes(raw_bundle))
     if recomputed != attested_digest:
         errors.append(
             FieldError(
@@ -411,7 +420,14 @@ def verify_result_bundle(
 
     # (3) the signer is the worker the bundle names.
     worker = bundle_dict.get("worker", {})
-    if worker.get("keyid") and env_v.keyid and worker["keyid"] != env_v.keyid:
+    if not isinstance(worker, dict):
+        errors.append(
+            FieldError(
+                "worker",
+                f"expected an object, got {type(worker).__name__}",
+            )
+        )
+    elif worker.get("keyid") and env_v.keyid and worker["keyid"] != env_v.keyid:
         errors.append(
             FieldError(
                 "worker.keyid",
@@ -421,28 +437,64 @@ def verify_result_bundle(
 
     # (4) patch integrity.
     patch = bundle_dict.get("patch", "")
-    attested_patch = bundle_dict.get("patch_sha256", "")
-    actual_patch = _sha256_hex(patch.encode("utf-8"))
-    if actual_patch != attested_patch:
+    if not isinstance(patch, str):
         errors.append(
             FieldError(
                 "patch",
-                f"patch hashes to {actual_patch}, bundle attests {attested_patch}",
+                f"expected a string, got {type(patch).__name__}",
             )
         )
-
-    # (5) gate-log integrity, per gate.
-    for index, gate in enumerate(bundle_dict.get("gates", [])):
-        log = gate.get("log", "")
-        attested_log = gate.get("log_sha256", "")
-        actual_log = _sha256_hex(log.encode("utf-8"))
-        if actual_log != attested_log:
+    else:
+        attested_patch = bundle_dict.get("patch_sha256", "")
+        actual_patch = _sha256_hex(patch.encode("utf-8"))
+        if actual_patch != attested_patch:
             errors.append(
                 FieldError(
-                    f"gates[{index}].log",
-                    f"log for {gate.get('command', '?')!r} hashes to {actual_log}, bundle attests {attested_log}",
+                    "patch",
+                    f"patch hashes to {actual_patch}, bundle attests {attested_patch}",
                 )
             )
+
+    # (5) gate-log integrity, per gate.
+    gates = bundle_dict.get("gates", [])
+    if not isinstance(gates, list):
+        errors.append(
+            FieldError(
+                "gates",
+                f"expected a list, got {type(gates).__name__}",
+            )
+        )
+    else:
+        for index, gate in enumerate(gates):
+            if not isinstance(gate, dict):
+                errors.append(
+                    FieldError(
+                        f"gates[{index}]",
+                        f"expected an object, got {type(gate).__name__}",
+                    )
+                )
+            else:
+                log = gate.get("log", "")
+                if not isinstance(log, str):
+                    errors.append(
+                        FieldError(
+                            f"gates[{index}].log",
+                            f"expected a string, got {type(log).__name__}",
+                        )
+                    )
+                else:
+                    attested_log = gate.get("log_sha256", "")
+                    actual_log = _sha256_hex(log.encode("utf-8"))
+                    if actual_log != attested_log:
+                        errors.append(
+                            FieldError(
+                                f"gates[{index}].log",
+                                (
+                                    f"log for {gate.get('command', '?')!r} hashes to {actual_log}, "
+                                    f"bundle attests {attested_log}"
+                                ),
+                            )
+                        )
 
     # (6) chain link shape and, optionally, continuity with a predecessor.
     #

--- a/tests/unit/security/test_result_receipt_bundle.py
+++ b/tests/unit/security/test_result_receipt_bundle.py
@@ -150,7 +150,7 @@ def _sign_dict(key, bundle_dict):
             # ``.get`` rather than ``[...]``: #4050 needs to sign a bundle with
             # no chain key at all, and the predicate mirror of a missing field
             # is the same missing field. Identical for every existing caller.
-            "chain": bundle_dict.get("chain"),
+            "chain": bundle_dict.get("chain") if isinstance(bundle_dict, dict) else None,
         },
     )
     payload = rb.canonical_bytes(statement.to_dict())
@@ -669,3 +669,113 @@ def test_a_real_integer_length_still_verifies():
 
     assert v.ok is True, [str(e) for e in v.errors]
     assert v.prev_digest_checked is True
+
+
+# --------------------------------------------------------------------------- #
+# #4057: wrong-typed fields must refuse with field-level errors rather than
+# raising exceptions.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("mutate_fn", "expected_field", "expected_msg"),
+    [
+        (lambda p, b: ("bundle", "a string"), "bundle", "expected an object, got str"),
+        (lambda p, b: ("bundle", [1, 2]), "bundle", "expected an object, got list"),
+        (lambda p, b: ("bundle", None), "bundle", "expected an object, got NoneType"),
+        (lambda p, b: ("gates", "not a list"), "gates", "expected a list, got str"),
+        (lambda p, b: ("gates", ["a string"]), "gates[0]", "expected an object, got str"),
+        (lambda p, b: ("worker", "not a dict"), "worker", "expected an object, got str"),
+        (lambda p, b: ("patch", 123), "patch", "expected a string, got int"),
+    ],
+    ids=[
+        "bundle-is-str",
+        "bundle-is-list",
+        "bundle-is-null",
+        "gates-is-str",
+        "gates-holds-str",
+        "worker-is-str",
+        "patch-is-int",
+    ],
+)
+def test_wrong_typed_fields_are_refused_rather_than_raised(mutate_fn: Any, expected_field: str, expected_msg: str):
+    """Refuse wrong-typed fields with field-level errors rather than raising exceptions.
+
+    No pytest.raises in this test: the assertion is that verify_result_bundle
+    returns ok=False with the expected field error.
+    """
+    key = _key()
+    bundle_dict = _bundle(key).to_dict()
+    field_to_mutate, new_val = mutate_fn(None, bundle_dict)
+
+    if field_to_mutate == "bundle":
+        env = _sign_dict(key, new_val)
+    else:
+        bundle_dict[field_to_mutate] = new_val
+        env = _sign_dict(key, bundle_dict)
+
+    v = verify_result_bundle(env, key.public_key())
+
+    assert v.ok is False
+    matched_errors = [e for e in v.errors if e.field == expected_field]
+    assert matched_errors, f"expected field error for {expected_field}, got {v.errors}"
+    assert matched_errors[0].message == expected_msg
+
+
+def test_absent_bundle_keeps_three_error_behavior():
+    """bundle absent keeps its current three-error behaviour: subject.digest.sha256, patch, chain."""
+    import base64 as b64
+
+    from bernstein.core.security import audit_dsse as ad
+    from bernstein.core.security import result_receipt_bundle as rb
+
+    key = _key()
+    statement = ad.Statement(
+        subjects=[ad.Subject(name="t.json", digest={"sha256": "0" * 64})],
+        predicate_type=rb.RESULT_RECEIPT_PREDICATE_TYPE,
+        predicate={
+            "schema_version": rb.BUNDLE_SCHEMA_VERSION,
+            "bundle_kind": "result-receipt",
+        },
+    )
+    payload = rb.canonical_bytes(statement.to_dict())
+    sig = key.sign(ad.pae(ad.DSSE_PAYLOAD_TYPE, payload))
+    env = ad.Envelope(
+        payload_type=ad.DSSE_PAYLOAD_TYPE,
+        payload_b64=b64.b64encode(payload).decode(),
+        signatures=[ad.Signature(keyid=ad.keyid_from_public_key(key.public_key()), sig=b64.b64encode(sig).decode())],
+    )
+
+    v = verify_result_bundle(env, key.public_key())
+
+    assert v.ok is False
+    assert [e.field for e in v.errors] == ["subject.digest.sha256", "patch", "chain"]
+
+
+def test_wrong_typed_fields_leave_checked_flags_where_they_were():
+    """Neither manifest_digest_checked nor prev_digest_checked moves as a side effect."""
+    key = _key()
+    manifest = _manifest()
+    first = _bundle(key)
+    successor = _successor(key, first, anchor=first.digest)
+    bundle_dict = bundle_with_manifest_digest(successor, manifest).to_dict()
+    bundle_dict["worker"] = "not a dict"
+
+    v = verify_result_bundle(
+        _sign_dict(key, bundle_dict),
+        key.public_key(),
+        expected_prev_digest=first.digest,
+        expected_manifest_sha256=manifest.digest,
+    )
+
+    assert v.ok is False
+    assert any(e.field == "worker" for e in v.errors)
+    assert v.prev_digest_checked is True
+    assert v.manifest_digest_checked is True
+
+    v_unasked = verify_result_bundle(
+        _sign_dict(key, bundle_dict),
+        key.public_key(),
+    )
+    assert v_unasked.prev_digest_checked is False
+    assert v_unasked.manifest_digest_checked is False


### PR DESCRIPTION
Closes #4057.

`verify_result_bundle` in `src/bernstein/core/security/result_receipt_bundle.py` read `bundle`, `worker`, `patch`, and `gates` using `.get(key, default)`. The default guarded against an absent key, but not against a present key holding the wrong type (`str`, `list`, `None`, `int`), causing `AttributeError` or `TypeError` tracebacks on untrusted third-party bundles instead of returning a field-level verification refusal.

## Changes Made

Implemented four independent `isinstance` type guard arms matching the `chain` guard pattern established in #4055:
- `bundle`: `expected an object, got <type>`
- `worker`: `expected an object, got <type>`
- `patch`: `expected a string, got <type>`
- `gates`: `expected a list, got <type>` for container; `gates[i]` `expected an object, got <type>` for non-dict elements; `gates[i].log` `expected a string, got <type>` for gate logs

### Architectural Choice

I selected **four `isinstance` arms** directly at each site rather than a single shared shape-checking helper because:
1. Four arms allow each site to name its exact JSON field path (`bundle`, `worker`, `patch`, `gates`, `gates[i]`, `gates[i].log`) right where the field is evaluated, maintaining precise field attribution for callers.
2. It collects all field-level errors present across the bundle in a single verification call, matching how `verify_result_bundle` operates.
3. It directly follows the pattern landed for `chain` in #4055 without introducing unnecessary helper indirection.

## Verification
- Added unit tests in `tests/unit/security/test_result_receipt_bundle.py` covering all 7 wrong-typed input shapes from #4057 (`bundle` as `str`/`list`/`null`, `gates` as `str`/holding `str`, `worker` as `str`, `patch` as `int`) with no `try/except` or `pytest.raises` (asserting that `verify_result_bundle` returns `ok=False` with the field error).
- Pinned that `bundle` absent maintains its 3-error behavior (`subject.digest.sha256`, `patch`, `chain`).
- Verified checked flags (`manifest_digest_checked`, `prev_digest_checked`) remain unaffected.
- 42 tests passing in `tests/unit/security/test_result_receipt_bundle.py`.
- `ruff check` and `ruff format --check` clean.