### PR TITLE
fix(security): refuse wrong-typed predicate in verify_result_bundle (#4072)

### DIFF
--- a/src/bernstein/core/security/result_receipt_bundle.py
+++ b/src/bernstein/core/security/result_receipt_bundle.py
@@ -391,8 +391,17 @@ def verify_result_bundle(
         )
 
     statement = env_v.statement
-    predicate = statement.get("predicate", {})
-    raw_bundle = predicate.get("bundle", {})
+    raw_predicate = statement.get("predicate", {})
+    predicate_dict = raw_predicate if isinstance(raw_predicate, dict) else {}
+    if not isinstance(raw_predicate, dict):
+        errors.append(
+            FieldError(
+                "predicate",
+                f"expected an object, got {type(raw_predicate).__name__}",
+            )
+        )
+
+    raw_bundle = predicate_dict.get("bundle", {})
     bundle_dict = raw_bundle if isinstance(raw_bundle, dict) else {}
     if not isinstance(raw_bundle, dict):
         errors.append(

--- a/tests/unit/security/test_result_receipt_bundle.py
+++ b/tests/unit/security/test_result_receipt_bundle.py
@@ -779,3 +779,93 @@ def test_wrong_typed_fields_leave_checked_flags_where_they_were():
     )
     assert v_unasked.prev_digest_checked is False
     assert v_unasked.manifest_digest_checked is False
+
+
+# --------------------------------------------------------------------------- #
+# #4072: a wrong-typed predicate must refuse with a FieldError on "predicate"
+# rather than raising an exception.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("predicate_val", "expected_msg"),
+    [
+        ("x", "expected an object, got str"),
+        (["x"], "expected an object, got list"),
+        (None, "expected an object, got NoneType"),
+        (7, "expected an object, got int"),
+        (True, "expected an object, got bool"),
+        (1.5, "expected an object, got float"),
+        ([], "expected an object, got list"),
+    ],
+    ids=[
+        "predicate-is-str",
+        "predicate-is-list-str",
+        "predicate-is-null",
+        "predicate-is-int",
+        "predicate-is-bool",
+        "predicate-is-float",
+        "predicate-is-empty-list",
+    ],
+)
+def test_wrong_typed_predicate_is_refused_rather_than_raised(predicate_val: Any, expected_msg: str):
+    """Refuse wrong-typed predicate with field-level error rather than raising exception.
+
+    No pytest.raises in this test: the assertion is that verify_result_bundle
+    returns ok=False with FieldError("predicate", ...).
+    """
+    import base64 as b64
+
+    from bernstein.core.security import audit_dsse as ad
+    from bernstein.core.security import result_receipt_bundle as rb
+
+    key = _key()
+    statement = ad.Statement(
+        subjects=[ad.Subject(name="t.json", digest={"sha256": "0" * 64})],
+        predicate_type=rb.RESULT_RECEIPT_PREDICATE_TYPE,
+        predicate=predicate_val,
+    )
+    statement_dict = statement.to_dict()
+    payload = rb.canonical_bytes(statement_dict)
+    sig = key.sign(ad.pae(ad.DSSE_PAYLOAD_TYPE, payload))
+    env = ad.Envelope(
+        payload_type=ad.DSSE_PAYLOAD_TYPE,
+        payload_b64=b64.b64encode(payload).decode(),
+        signatures=[ad.Signature(keyid=ad.keyid_from_public_key(key.public_key()), sig=b64.b64encode(sig).decode())],
+    )
+
+    v = verify_result_bundle(env, key.public_key())
+
+    assert v.ok is False
+    matched_errors = [e for e in v.errors if e.field == "predicate"]
+    assert matched_errors, f"expected field error for predicate, got {v.errors}"
+    assert matched_errors[0].message == expected_msg
+
+
+def test_absent_predicate_keeps_three_error_behavior():
+    """predicate absent keeps its current three-error behaviour: subject.digest.sha256, patch, chain."""
+    import base64 as b64
+
+    from bernstein.core.security import audit_dsse as ad
+    from bernstein.core.security import result_receipt_bundle as rb
+
+    key = _key()
+    statement = ad.Statement(
+        subjects=[ad.Subject(name="t.json", digest={"sha256": "0" * 64})],
+        predicate_type=rb.RESULT_RECEIPT_PREDICATE_TYPE,
+        predicate={},
+    )
+    statement_dict = statement.to_dict()
+    statement_dict.pop("predicate", None)
+    payload = rb.canonical_bytes(statement_dict)
+    sig = key.sign(ad.pae(ad.DSSE_PAYLOAD_TYPE, payload))
+    env = ad.Envelope(
+        payload_type=ad.DSSE_PAYLOAD_TYPE,
+        payload_b64=b64.b64encode(payload).decode(),
+        signatures=[ad.Signature(keyid=ad.keyid_from_public_key(key.public_key()), sig=b64.b64encode(sig).decode())],
+    )
+
+    v = verify_result_bundle(env, key.public_key())
+
+    assert v.ok is False
+    assert [e.field for e in v.errors] == ["subject.digest.sha256", "patch", "chain"]


### PR DESCRIPTION
Closes #4072.

`verify_result_bundle` in `src/bernstein/core/security/result_receipt_bundle.py` read `predicate` from statement using `.get("predicate", {})`. A present predicate holding the wrong type (`str`, `list`, `None`, `int`, `bool`, `float`) caused an `AttributeError` traceback when `.get("bundle", {})` was called on it, instead of returning a `BundleVerification` verdict.

## Changes Made

Implemented a `predicate` type guard ahead of the four field guards added in #4070:
```python
raw_predicate = statement.get("predicate", {})
predicate_dict = raw_predicate if isinstance(raw_predicate, dict) else {}
if not isinstance(raw_predicate, dict):
    errors.append(
        FieldError(
            "predicate",
            f"expected an object, got {type(raw_predicate).__name__}",
        )
    )
```

### Architectural Choice

I chose to **continue execution into downstream field checks against `predicate_dict = {}`** rather than short-circuiting because:
1. It matches the accumulate-everything style of `verify_result_bundle` and the field guards from #4070 (`bundle`, `worker`, `patch`, `gates`, `chain`).
2. It provides callers with a full list of verification findings in a single call.

## Verification
- Added parametrized unit tests in `tests/unit/security/test_result_receipt_bundle.py` covering all 7 wrong-typed predicate shapes from #4072 (`predicate` as `"x"`, `["x"]`, `None`, `7`, `True`, `1.5`, `[]`), asserting a `FieldError("predicate", ...)` on the returned verdict with no `try/except` or `pytest.raises`.
- Verified that an absent `predicate` keeps its 3-error behavior (`subject.digest.sha256`, `patch`, `chain`), proving that absent vs present-but-wrong-typed produce distinct error sets (`['subject.digest.sha256', 'patch', 'chain']` vs `['predicate', 'subject.digest.sha256', 'patch', 'chain']`).
- 50 tests passing in `tests/unit/security/test_result_receipt_bundle.py`.
- `ruff check`, `ruff format --check`, and `mypy` clean.