### PR TITLE
ci: typecheck-ts reports on a queued ref, so it can be required

### DIFF
--- a/.github/workflows/typecheck-ts.yml
+++ b/.github/workflows/typecheck-ts.yml
@@ -34,10 +34,50 @@ name: TypeScript typecheck
 # tsconfigs, or package manifests. It does NOT emit a check named
 # ``CI gate`` -- the canary in ``tests/unit/test_required_check_canary
 # _workflow_yaml.py`` allow-lists exactly two emitters of that string
-# (ci.yml + ci-gate-stub.yml) and rejects a third. Do NOT promote this
-# workflow's job names to required branch-protection contexts while it
-# has no ``merge_group`` trigger: the merge queue would wait forever on
-# a check that never runs on its ephemeral branches.
+# (ci.yml + ci-gate-stub.yml) and rejects a third.
+#
+# Merge queue
+# -----------
+# #4073. ``ci.yml`` paths-ignores ``sdk/typescript/**`` and
+# ``packages/vscode/**``, and ``CI gate`` is the only required context,
+# so nothing required has an opinion about the TypeScript trees: a type
+# error under ``web/`` merges green. That is #4010's shape one directory
+# over, and the fix is the same two steps in the same order. This lane
+# now reports on a queued ref, so branch protection *can* require it. It
+# is not required yet -- that is a repository-settings change, and the
+# ordering matters in one direction only. A required context that cannot
+# report on a queued ref wedges the queue: every entry waits forever for
+# a check that never arrives (docs/operations/merge-queue.md,
+# troubleshooting row 1). Trigger first, requirement second, never the
+# reverse.
+#
+# The paragraph this replaced said "do NOT promote this workflow's job
+# names to required branch-protection contexts while it has no
+# ``merge_group`` trigger". The ban is lifted; the caution it was made
+# of is not, and it is now in the runbook where the person throwing the
+# switch will be looking.
+#
+# What promoting it means here is **four** contexts, not one. The job
+# name is ``typecheck (${{ matrix.package }})`` and the matrix has a
+# cell per TypeScript package, so the lane publishes one check per cell
+# and every one of them has to be listed. Worse, the matrix is not a
+# constant: ``test_every_typescript_package_is_in_the_matrix`` derives
+# it from the tree, so adding a package silently adds an unrequired
+# context and removing one silently strips a required context of its
+# emitter -- a hole and a wedge respectively. The four names are
+# enumerated in the runbook and
+# ``test_queue_reporting_lane_contexts_are_named_in_the_runbook`` fails
+# if the matrix and that list stop agreeing.
+#
+# The ``merge_group`` trigger carries no ``paths`` filter, deliberately.
+# GitHub evaluates ``paths`` / ``paths-ignore`` for ``push``,
+# ``pull_request`` and ``pull_request_target`` only, so copying the
+# filter down from the ``pull_request`` trigger would not filter
+# anything -- it would read as a restriction while being ignored. It
+# would also be the wrong intent: a queue batch stacks several pull
+# requests, so the batch can carry a TypeScript change the entry being
+# tested does not, and a context that reports on only some entries
+# cannot be required at all.
 #
 # Each matrix cell carries its own install command because ``npm ci``
 # aborts rather than resolving a manifest when the package has no
@@ -50,6 +90,7 @@ name: TypeScript typecheck
 # ``--ignore-scripts``; type declarations land on disk either way.
 
 on:
+  merge_group: {}
   pull_request:
     paths:
       - "sdk/typescript/**"

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -71,7 +71,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/static-analysis-extended.yml | static-analysis (extended) | push, schedule, workflow_dispatch | {"cancel-in-progress": "${{ github.event_name == 'pull_request' }}", "group": "static-analysis-extended-${{ github.ref }}"} | 6 |
 | .github/workflows/trufflehog.yml | trufflehog (secret scanning) | pull_request, push, schedule, workflow_dispatch | {"cancel-in-progress": "${{ github.event_name == 'pull_request' }}", "group": "trufflehog-${{ github.ref }}"} | 1 |
 | .github/workflows/trunk-health-slo.yml | Trunk Health SLO | schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "trunk-health-slo"} | 1 |
-| .github/workflows/typecheck-ts.yml | TypeScript typecheck | pull_request, push | {"cancel-in-progress": "true", "group": "typecheck-ts-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
+| .github/workflows/typecheck-ts.yml | TypeScript typecheck | merge_group, pull_request, push | {"cancel-in-progress": "true", "group": "typecheck-ts-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
 | .github/workflows/zizmor.yml | zizmor (workflow static analysis) | pull_request, push, schedule, workflow_dispatch | {"cancel-in-progress": "${{ github.event_name == 'pull_request' }}", "group": "zizmor-${{ github.ref }}"} | 1 |
 
 ## Check Emitters

--- a/docs/operations/merge-queue.md
+++ b/docs/operations/merge-queue.md
@@ -91,6 +91,22 @@ required-context coverage by
 | Context | Emitting workflow | Runs on `merge_group`? | Required? |
 |---------|-------------------|------------------------|-----------|
 | `shipped bundle matches the lockfile` | `spa-bundle-freshness.yml` :: `rebuild` | Yes - `merge_group: {}` | **No - see below** |
+| `typecheck (sdk/typescript)` | `typecheck-ts.yml` :: `typecheck` | Yes - `merge_group: {}` | **No - see below** |
+| `typecheck (packages/vscode)` | `typecheck-ts.yml` :: `typecheck` | Yes - `merge_group: {}` | **No - see below** |
+| `typecheck (web)` | `typecheck-ts.yml` :: `typecheck` | Yes - `merge_group: {}` | **No - see below** |
+| `typecheck (templates/cloudflare-mcp-server)` | `typecheck-ts.yml` :: `typecheck` | Yes - `merge_group: {}` | **No - see below** |
+
+`typecheck-ts` occupies four rows because it publishes four contexts: its
+job is `typecheck (${{ matrix.package }})` and branch protection matches a
+context by its exact rendered string, so requiring "the typecheck lane"
+means listing every cell. The matrix is **derived from the tree** -
+`test_every_typescript_package_is_in_the_matrix` fails if a package that
+declares a `typescript` dependency is missing from it - so this list is not
+a constant. Adding a TypeScript package adds a context nobody required (a
+hole); deleting or renaming one strips a required context of its emitter (a
+wedge). Neither reports as a red check anywhere, so
+`test_queue_reporting_lane_contexts_are_named_in_the_runbook` fails when the
+matrix and this table stop agreeing.
 
 #4010 merged with this lane red. `CI gate` was green, `CI gate` is the only
 required context, so branch protection was satisfied and the queue took the
@@ -114,6 +130,32 @@ Do them in that order, and only while the queue is drained: editing required
 contexts invalidates every in-flight entry, so each one restarts a full-suite
 run. Until both are done the lane is exactly as advisory as it was before -
 the trigger alone changes nothing about whether a red bundle can merge.
+
+#4073 puts `typecheck-ts` in the same state for the same reason, and the two
+flips are the same two flips - with all four contexts from the table above,
+not one. Two things are worth doing before throwing that switch, neither of
+which applies to the bundle gate:
+
+- **Wait for the lane to have reported on a real queued ref at least once.**
+  Nothing here has ever run on a `merge_group` event, and a context that
+  turns out not to arrive wedges the queue rather than blocking the pull
+  request.
+- **Require all four cells or none.** Requiring a subset leaves the
+  unrequired packages in exactly the state #4073 describes, while costing
+  the full four-slot run anyway.
+
+Cost, measured over the 14 most recent runs (56 cells) before #4073, with
+queue wait separated from execution: **execution 16s min, 28s median, 45s
+max per cell**; the cells run in parallel, so a run finishes in a **38s
+median, 45s max**, at **four concurrent slots**. Queue wait is a median of
+3s but reaches **933s**, and that is the number to distrust in the run list:
+the 16-minute run `31953555527` was 933s of waiting for a runner wrapped
+around a 43s job. #4020's rule - a lane that cannot gate a merge should not
+compete for runners with the one that can - is not in tension with either
+trigger for long, because both lanes are on their way to being required,
+which is the case that rule excludes. `typecheck-ts` is nonetheless four
+times the runner cost of the bundle gate, and that is the honest reason to
+finish its flip rather than leave the trigger sitting there indefinitely.
 
 The general rule this came from is locked by
 `test_no_web_triggerable_lane_is_advisory_only`: a lane that can fail on a

--- a/tests/unit/test_merge_queue_gate_coverage_yaml.py
+++ b/tests/unit/test_merge_queue_gate_coverage_yaml.py
@@ -67,6 +67,13 @@ QUEUE_REPORTING_WEB_LANES = {
         "went red behind eleven queue entries. #4028 added the merge_group trigger so that "
         "`shipped bundle matches the lockfile` can be made a required context."
     ),
+    "typecheck-ts.yml": (
+        "`tsc --noEmit` over the TypeScript packages, `web/` among them. #4010's shape one "
+        "directory over: ci.yml paths-ignores the TypeScript trees, `CI gate` is the only "
+        "required context, so a type error under `web/` merges green. #4073 added the "
+        "merge_group trigger. It publishes one context per matrix cell, and the matrix is "
+        "derived from the tree, so all four names are enumerated in the runbook."
+    ),
 }
 
 #: Lanes that can run on a `web/**` change and stay advisory on purpose.
@@ -77,11 +84,6 @@ QUEUE_REPORTING_WEB_LANES = {
 #: an acceptable state. A deferral that has to be typed here, next to the
 #: assertion it suppresses, is one somebody can find and re-decide.
 ADVISORY_BY_DECISION = {
-    "typecheck-ts.yml": (
-        "`tsc --noEmit` over the TypeScript packages, `web/` among them. Same shape as the "
-        "bundle gate and not fixed by #4028, whose scope is one lane; raised on that thread "
-        "rather than folded in silently."
-    ),
     "pr-policy.yml": (
         "Consolidated per-PR policy lane (text hygiene, main-red guard, andon gate, "
         "pre-merge autosync). Its own header already records that none of these is a "
@@ -397,6 +399,213 @@ def test_queue_reporting_web_lanes_can_actually_be_required() -> None:
             f"{name}'s `merge_group` trigger carries a filter ({trigger!r}). `paths` is not evaluated for "
             f"`merge_group` at all, so a filter there is either ignored or a mistake - and a queue batch "
             f"stacks several pull requests, so the batch can carry a `web/**` change the tested entry does not."
+        )
+
+
+#: ``${{ matrix.<key> }}``, tolerating the whitespace GitHub allows.
+_MATRIX_REF = re.compile(r"\$\{\{\s*matrix\.([A-Za-z_][A-Za-z0-9_-]*)\s*\}\}")
+
+
+def _render(template: str, cell: Mapping[str, Any]) -> str:
+    """Substitute one matrix cell into a job name, leaving misses in place."""
+    return _MATRIX_REF.sub(lambda match: str(cell.get(match.group(1), match.group(0))), template)
+
+
+def _published_contexts(doc: Mapping[str, Any]) -> set[str]:
+    """Every check-run name a workflow can publish, as a maintainer must type it.
+
+    Branch protection and the queue ruleset match a context by its exact
+    rendered string, so a matrixed job is not one context - it is one per
+    cell. ``typecheck-ts.yml`` publishes four.
+
+    Total by construction: a name this cannot finish rendering is returned
+    with its ``${{ ... }}`` still in it rather than dropped or raised on.
+    A context nobody can type cannot be required, so leaving the marker in
+    hands the caller something that fails loudly, where discarding it would
+    silently shrink the set the runbook is checked against. Only the
+    ``include`` form is expanded, so converting a lane to a bare-key
+    product matrix fails the same visible way.
+    """
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return set()
+    names: set[str] = set()
+    for key, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        template = job.get("name") or key
+        cells = ((job.get("strategy") or {}).get("matrix") or {}).get("include")
+        if not isinstance(cells, list) or not cells:
+            names.add(template)
+            continue
+        for cell in cells:
+            if not isinstance(cell, Mapping):
+                names.add(template)
+                continue
+            names.add(_render(template, cell))
+    return names
+
+
+#: Heading of the runbook section listing lanes that report on the queue.
+NOT_REQUIRED_YET_HEADING = "### Reports on the queue but is not required yet"
+#: A row of that section's table: context, then ``workflow.yml`` :: ``job``.
+_RUNBOOK_ROW = re.compile(r"^\|\s*`([^`]+)`\s*\|\s*`([^`]+\.yml)`\s*::\s*`[^`]+`\s*\|", re.MULTILINE)
+
+
+def _runbook_contexts(text: str, workflow: str) -> set[str]:
+    """Contexts the runbook's not-required-yet table attributes to a workflow.
+
+    Scoped to that one section: the coverage table above it has a
+    different column count and a different meaning, and matching rows
+    anywhere in the file would fold the two together.
+    """
+    _, _, rest = text.partition(NOT_REQUIRED_YET_HEADING)
+    section = rest.partition("\n### ")[0]
+    return {context for context, emitter in _RUNBOOK_ROW.findall(section) if emitter == workflow}
+
+
+@pytest.mark.parametrize(
+    ("doc", "expected"),
+    [
+        # No `name:` - GitHub falls back to the job key.
+        ({"jobs": {"rebuild": {}}}, {"rebuild"}),
+        (
+            {"jobs": {"rebuild": {"name": "shipped bundle matches the lockfile"}}},
+            {"shipped bundle matches the lockfile"},
+        ),
+        # One cell per context, which is the whole point.
+        (
+            {
+                "jobs": {
+                    "t": {
+                        "name": "typecheck (${{ matrix.package }})",
+                        "strategy": {"matrix": {"include": [{"package": "web"}, {"package": "sdk/typescript"}]}},
+                    }
+                }
+            },
+            {"typecheck (sdk/typescript)", "typecheck (web)"},
+        ),
+        # GitHub tolerates the whitespace; so must the renderer.
+        (
+            {"jobs": {"t": {"name": "x ${{matrix.p}}", "strategy": {"matrix": {"include": [{"p": "1"}]}}}}},
+            {"x 1"},
+        ),
+        # A cell that does not carry the key leaves the marker in, rather
+        # than rendering an empty string that reads like a real context.
+        (
+            {"jobs": {"t": {"name": "x ${{ matrix.p }}", "strategy": {"matrix": {"include": [{"other": "1"}]}}}}},
+            {"x ${{ matrix.p }}"},
+        ),
+        # A bare-key product matrix is not expanded, and says so loudly.
+        (
+            {"jobs": {"t": {"name": "x ${{ matrix.p }}", "strategy": {"matrix": {"p": ["1", "2"]}}}}},
+            {"x ${{ matrix.p }}"},
+        ),
+        # Two cells that render alike collapse: it is one context.
+        (
+            {"jobs": {"t": {"name": "fixed", "strategy": {"matrix": {"include": [{"p": "1"}, {"p": "2"}]}}}}},
+            {"fixed"},
+        ),
+        # Shapes that must not raise.
+        ({}, set()),
+        ({"jobs": None}, set()),
+        ({"jobs": {"t": "not-a-mapping"}}, set()),
+        ({"jobs": {"t": {"name": "n", "strategy": {"matrix": {"include": []}}}}}, {"n"}),
+        ({"jobs": {"t": {"name": "n", "strategy": {"matrix": {"include": ["str"]}}}}}, {"n"}),
+    ],
+)
+def test_published_contexts_renders_one_name_per_cell(doc: dict[str, Any], expected: set[str]) -> None:
+    assert _published_contexts(doc) == expected
+
+
+_RUNBOOK_SAMPLE = f"""\
+| `CI gate` | `ci.yml` :: `ci-gate` | Yes |
+
+{NOT_REQUIRED_YET_HEADING}
+
+| Context | Emitting workflow | Runs on `merge_group`? | Required? |
+|---------|-------------------|------------------------|-----------|
+| `a one` | `w.yml` :: `j` | Yes - `merge_group: {{}}` | **No** |
+| `a two` | `w.yml` :: `j` | Yes - `merge_group: {{}}` | **No** |
+| `b one` | `other.yml` :: `k` | Yes - `merge_group: {{}}` | **No** |
+| `d one` | `typecheck.yml` :: `j` | Yes - `merge_group: {{}}` | **No** |
+
+Prose in the middle of the section, which is not a row. An example of the
+row shape, indented into a block, is documentation and not a claim:
+
+    | `e one` | `w.yml` :: `j` | Yes | **No** |
+
+### Some later section
+
+| `c one` | `w.yml` :: `j` | Yes | **No** |
+"""
+
+
+@pytest.mark.parametrize(
+    ("text", "workflow", "expected"),
+    [
+        (_RUNBOOK_SAMPLE, "w.yml", {"a one", "a two"}),
+        (_RUNBOOK_SAMPLE, "other.yml", {"b one"}),
+        # `check.yml` is a suffix of `typecheck.yml`: the emitter has to
+        # match the whole filename, or one lane inherits another's rows.
+        (_RUNBOOK_SAMPLE, "check.yml", set()),
+        (_RUNBOOK_SAMPLE, "typecheck.yml", {"d one"}),
+        # Named nowhere in the section.
+        (_RUNBOOK_SAMPLE, "absent.yml", set()),
+        # The heading is missing, so the section is empty - not the whole file.
+        ("| `a one` | `w.yml` :: `j` | Yes | **No** |", "w.yml", set()),
+        ("", "w.yml", set()),
+    ],
+)
+def test_runbook_contexts_reads_only_its_own_section(text: str, workflow: str, expected: set[str]) -> None:
+    assert _runbook_contexts(text, workflow) == expected
+
+
+def test_runbook_contexts_stops_at_the_next_heading() -> None:
+    """A row under a later heading is a different claim and must not count.
+
+    The parametrised cases above would still pass if the partition on the
+    next ``###`` were dropped, because `c one` is not in any expectation
+    for another reason. This one fails if it is dropped.
+    """
+    assert "c one" not in _runbook_contexts(_RUNBOOK_SAMPLE, "w.yml")
+
+
+def test_queue_reporting_lane_contexts_are_named_in_the_runbook() -> None:
+    """The runbook must name every context, or the flip is half-done.
+
+    ``QUEUE_REPORTING_WEB_LANES`` promises a maintainer can safely require
+    a lane. That promise is only usable if they know what to type, and for
+    a matrixed lane the answer is one context per cell. ``typecheck-ts``'s
+    matrix is derived from the tree by
+    ``tests/unit/test_typecheck_ts_workflow_yaml.py``, so it is not a
+    constant: adding a TypeScript package adds an unrequired context - a
+    hole - and removing one strips a required context of its emitter,
+    which is a wedge. Both are silent. Pinning the names to the runbook is
+    what makes them loud.
+    """
+    runbook = RUNBOOK.read_text(encoding="utf-8")
+    assert NOT_REQUIRED_YET_HEADING in runbook, (
+        f"{RUNBOOK} no longer has a {NOT_REQUIRED_YET_HEADING!r} section, so this assertion is reading an "
+        f"empty table and checking nothing. Move the section back or repoint the heading."
+    )
+    for name in QUEUE_REPORTING_WEB_LANES:
+        published = set(_published_contexts(_load(WORKFLOWS / name)))
+        assert published, f"{name} declares no jobs, so it publishes no context to require"
+        unrendered = sorted(context for context in published if "${{" in context)
+        assert not unrendered, (
+            f"{name} publishes job names that still contain an expression after matrix expansion: "
+            f"{unrendered}. Branch protection matches a context by its literal rendered string, so a name "
+            f"nobody can type cannot be required - and this lane is listed as requirable."
+        )
+        documented = _runbook_contexts(runbook, name)
+        assert documented == published, (
+            f"{RUNBOOK}'s not-required-yet table and {name} disagree about what it publishes. Missing from "
+            f"the runbook: {sorted(published - documented)} - contexts nobody will know to require, which "
+            f"is the hole #4010 and #4073 are both made of. Listed but no longer emitted: "
+            f"{sorted(documented - published)} - if one of those has already been required, the queue is "
+            f"waiting on a check with no emitter, which is a wedge. Requiring a matrixed lane means "
+            f"listing every cell, and its matrix is derived from the tree rather than fixed."
         )
 
 


### PR DESCRIPTION
Closes #4073.

**Draft on purpose: this is stacked on #4069 and cannot be read against `main` yet.** `QUEUE_REPORTING_WEB_LANES` and `ADVISORY_BY_DECISION` do not exist on `main`, so the diff carries #4069's commit until that lands. My own commit is `28a2ead8d` — one commit, 4 files, +302/−10. When #4069 merges I will rebase and un-draft; if #4069 changes under review this follows it.

## Three things in the brief that did not survive measurement

**1. The guard #4069 added does *not* already fail for this workflow.** The brief's first proof item says to check, so I checked: `pytest tests/unit/test_merge_queue_gate_coverage_yaml.py` on unmodified `5eb151e8d` is **34 passed, 0 failed**. It passes because #4069 recorded `typecheck-ts.yml` in `ADVISORY_BY_DECISION` with a written reason — which is the third of the three states that test offers, and the mechanism behaving exactly as designed. So this is not a fixture change: it is a **bucket move**, `ADVISORY_BY_DECISION` → `QUEUE_REPORTING_WEB_LANES`, and the entry has to stop being a deferral at the same moment the trigger makes it untrue.

What *is* red on pristine, and worth having, is the claim-versus-file arm. Moving the entry without adding the trigger gives:

```
FAILED test_queue_reporting_web_lanes_can_actually_be_required
AssertionError: typecheck-ts.yml is listed as requirable but declares no `merge_group`
trigger. A required context that cannot report on a queued ref wedges the queue.
```

**2. `typecheck-ts.yml:62-65` is not a second gating trigger.** The brief lists it as "(second trigger, same paths)". It is `push: branches: [main]` — it runs *after* `main` has already moved, so it can annotate a type error but never block one. The `merge_group` trigger this PR adds is the first trigger the lane has ever had that can observe a ref before it becomes `main`.

**3. Requiring this lane is four contexts, not one.** The brief says "the context" throughout, and the decision it leaves open is about whether "the context reports on every queue entry or only some". The job is `typecheck (${{ matrix.package }})`, so the lane publishes one check per matrix cell, and branch protection matches by exact rendered string:

| Context |
|---------|
| `typecheck (sdk/typescript)` |
| `typecheck (packages/vscode)` |
| `typecheck (web)` |
| `typecheck (templates/cloudflare-mcp-server)` |

This is the part I think is worth more than the trigger. **That list is not a constant.** `test_every_typescript_package_is_in_the_matrix` derives the matrix from the tree, so:

- **add** a package that declares a `typescript` dependency → a new context nobody required → a **hole**, which is #4010's shape a third time;
- **delete or rename** one → a required context with no emitter → a **wedge**, and the queue waits forever.

Neither reports as a red check anywhere, which is the property that made #4010 expensive. So the four names go in the runbook and `test_queue_reporting_lane_contexts_are_named_in_the_runbook` asserts the matrix and that table agree **by equality**, which is what catches both directions. Simulated on this branch:

```
add a 5th cell     -> FAILED ... Missing from the runbook: ['typecheck (packages/newthing)']
delete a 4th cell  -> FAILED ... Listed but no longer emitted: ['typecheck (packages/vscode)']
```

`spa-bundle-freshness` is checked by the same assertion and already satisfies it — one job, one context, already in the table.

## The decision you left open: unfiltered

`merge_group: {}`, no `paths`. Two independent reasons, and the second is the one that decides it:

- GitHub evaluates `paths` / `paths-ignore` for `push`, `pull_request` and `pull_request_target` only. A filter there is not honoured, so it would read as a restriction while doing nothing — the same class of defect as a comment that has stopped being true.
- It would be the wrong intent even if it worked. A queue batch stacks several pull requests, so the batch can carry a TypeScript change the entry being tested does not. **A context that reports on only some entries cannot be required at all**, which is your own framing, and the unfiltered trigger is what makes the answer "every entry".

This is also already enforced: `test_queue_reporting_web_lanes_can_actually_be_required` rejects a filtered `merge_group` on anything in the requirable bucket.

## Cost, with queue wait separated from execution

14 most recent runs, all four cells each, **56 job records**, from `actions/runs/{id}/jobs` (`created_at` → `started_at` is wait, `started_at` → `completed_at` is execution):

| | min | median | max |
|---|---|---|---|
| execution, per cell | 16s | **28s** | 45s |
| queue wait, per cell | 1s | **3s** | **933s** |
| wall clock per run (slowest cell) | 33s | **38s** | 45s |

The run list is misleading in the same way it was on #4069: run `31953555527` reads as 16 minutes and is **933s of waiting for a runner wrapped around a 43s job**.

Against #4020: its rule is about lanes that compete for runners without being able to gate anything, and it excludes lanes on their way to being required — which this one now is, same as the bundle gate. But I do not want to undersell it. **This is four concurrent slots, not one — four times the bundle gate's runner cost.** That is the honest argument for finishing the flip rather than leaving the trigger parked indefinitely, and I have written it into the runbook rather than only here.

## Not fixed, on purpose

Your out-of-scope line says to list what the predicate finds and offer one follow-up rather than widen. Four lanes remain in `ADVISORY_BY_DECISION`, and I do not think any is the same defect:

- `pr-policy.yml` — its own header already records that none of its checks is required.
- `trufflehog.yml` — advisory as configured; nothing here changed that.
- `pr-observability-summary.yml` — reports behind a `deep-review` label, does not gate.
- `dependabot-auto-merge.yml` — consumes the gate rather than being part of it.

Say the word and I will open one ticket covering the set, but my read is that the predicate is now clean and there is nothing left of this shape. **Nothing else here has been widened.**

## Verification

- **Red on pristine `5eb151e8d`:** 2 assertions (`..._can_actually_be_required`, `..._contexts_are_named_in_the_runbook`). With the trigger applied but the runbook untouched, only the second — which isolates the new guard.
- **822 passed** across every `tests/unit/*yaml*.py` suite plus `test_merge_queue.py`, `test_merge_queue_ruleset_spec.py`, `test_merge_queue_runbook_docs.py`, `test_runbooks.py`, `test_spawner_merge_queue_wiring.py` and `test_web_node_floor.py`. 0 failed.
- `ruff check`, `ruff format --check` clean; `actionlint` clean on the changed workflow. **mypy unchanged at 2 errors** — both pre-existing on this file and both the `doc.get(True, ...)` PyYAML-1.1 dance.
- **16 mutants, 15 killed, 1 declared equivalent.**

On the mutation pass, because two results were only honest after a second look:

- Four survived the first round and **three were defects in my own tests**: `_published_contexts` returned a sorted list nothing pinned the order of (fixed by returning a `set`, since the only caller wanted one); `_runbook_contexts` matched the emitter loosely enough that `check.yml` would have inherited `typecheck.yml`'s rows; and the row regex's line-start anchor was doing nothing, so an indented example row inside prose would have counted as a claim. All three now have cases.
- A fifth "survivor" was **my harness patching the wrong call site** — there are three `if not isinstance(job, dict)` lines in the file and it mutated line 240 instead of 434. Targeted correctly, it dies.
- **The equivalent mutant is `return set()` → `jobs = {}`** on the non-mapping-`jobs` arm. Iterating an empty dict reaches the same result by the same path; there is no input that distinguishes them.
- Three mutants of the guard test's *own* assertions cannot be killed by mutating code, because the assertion is the test. I mutated the **artifact** instead and paired each with the break it exists to catch. Two of them — the unrendered-name check and the heading-present check — turned out to be **redundant with the equality** for the obvious breaks, and are load-bearing only in a narrower case each: a job name nobody can type that somebody *also* pasted verbatim into the runbook, and the section being renamed while the requirable bucket is empty. Both were then killed against those. I would rather say that than call them independent guards.

## What is not in this diff

Both flips, as scoped. Branch protection on `main` and the merge-queue ruleset plus its checked-in mirror, in that order, with the queue drained, **all four contexts or none** — requiring a subset leaves the unrequired packages exactly as they are today while paying the full four-slot cost anyway. And they wait until the lane has reported on a real queued ref at least once, which it never has. All of that is in `merge-queue.md`, next to the bundle gate's.

`docs/operations/ci-topology.md` is regenerated: it lists each workflow's triggers and went stale the moment the trigger landed.
