### PR TITLE
chore(ci): ratchet coverage baseline up to 83.84%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
   "diff_coverage_floor_percent": 86,
-  "head_sha": "65a2831b512e7aed28c53b07b4fac21881859414",
-  "line_rate": 0.8383,
-  "run_id": "31997000112",
-  "total_coverage_percent": 83.83,
-  "updated_at": "2026-08-17T06:29:00+00:00"
+  "head_sha": "6902f699a30d1193a09a99129114af1b08920dfc",
+  "line_rate": 0.8384,
+  "run_id": "31999416744",
+  "total_coverage_percent": 83.84,
+  "updated_at": "2026-08-17T07:34:25+00:00"
 }


### PR DESCRIPTION
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **83.84%**.

Measured on `6902f699a30d1193a09a99129114af1b08920dfc` from the
`coverage-report` artifact of CI run
[31999416744](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/31999416744).
Those, and the raw Cobertura `line-rate` the percentage was
rounded from, are recorded in the baseline, so the number in the
diff can be re-derived from the file itself:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.