### PR TITLE
chore(ci): raise diff-coverage floor to 87%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
-  "diff_coverage_floor_percent": 86,
+  "diff_coverage_floor_percent": 87,
   "head_sha": "6902f699a30d1193a09a99129114af1b08920dfc",
   "line_rate": 0.8384,
   "run_id": "31999416744",
   "total_coverage_percent": 83.84,
-  "updated_at": "2026-08-17T07:34:25+00:00"
+  "updated_at": "2026-08-17T08:04:51+00:00"
 }


### PR DESCRIPTION
Weekly nudge of the LEVEL 1 diff-coverage floor.

The diff-coverage gate in `.github/workflows/ci.yml` reads
`diff_coverage_floor_percent` from `.coverage-baseline.json`.
This PR raises that floor so every subsequent PR must cover a
slightly higher share of its changed lines.

New floor: **87%**.

The gate stays advisory (`continue-on-error`) until an operator
promotes it; see `docs/operations/coverage-ratchet.md` for the
promotion and override procedure. If the increment is too steep
for the current trunk, close this PR - the floor only moves when
the PR merges.

Generated by `.github/workflows/coverage-ratchet-weekly.yml`.