### PR TITLE
test: stop git housekeeping racing the zero-write assertions

### DIFF
--- a/tests/unit/test_grant_bound_checkpoint.py
+++ b/tests/unit/test_grant_bound_checkpoint.py
@@ -45,6 +45,16 @@ from bernstein.core.security.permissions import AgentPermissions, get_permission
 def _init_git_repo(path: Path) -> None:
     """Initialise a minimal git repo suitable for liveness checks."""
     subprocess.run(["git", "init", "-b", "main"], cwd=path, check=True, capture_output=True)
+    # `git commit` may hand off to background maintenance, which writes
+    # `.git/objects/maintenance.lock` on its own schedule. The zero-write
+    # assertions below snapshot the tree twice and diff it, so a lock file
+    # appearing between the two reads is scored as a write by the code under
+    # test - a red macOS shard with nothing wrong in the product. Switching
+    # the housekeeping off removes the writer rather than filtering its
+    # output, so the assertions still catch a real write anywhere under
+    # `.git/`.
+    subprocess.run(["git", "config", "gc.auto", "0"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "maintenance.auto", "false"], cwd=path, check=True, capture_output=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True, capture_output=True)
     subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True, capture_output=True)
     (path / "README.md").write_text("init\n")


### PR DESCRIPTION
The macOS shard on `681eb997` went red on:

```
FAILED tests/unit/test_grant_bound_checkpoint.py::TestRoleNarrowed::test_zero_writes_on_narrowed_role
Extra items in the right set:
PosixPath('.../test_zero_writes_on_narrowed_r0/.git/objects/maintenance.lock')
```

That single failure put the trunk red-rate at 12% and opened #4091, so the andon gate in `pr-policy` is currently holding every PR in the repo — over a flake with nothing wrong in the product.

**Cause.** The test proves its property by snapshotting the whole tmp tree, running the code under test, and diffing. `git commit` in the fixture can hand off to background maintenance, which writes `.git/objects/maintenance.lock` on its own schedule. A lock file that appears between the two reads is indistinguishable, to the assertion, from a write by the code under test.

**Fix.** The fixture sets `gc.auto=0` and `maintenance.auto=false`. That removes the writer rather than filtering its path out of the snapshot — filtering would have given up the assertion's reach into `.git/`, which is where an over-broad role would write.

`tests/unit/volunteer/test_runner.py` is the only other test that both inits a repo and globs the tree; it globs `.sdd/worktrees/*` alone and cannot see the lock. Verified rather than assumed.

36 passed locally on macOS, which is the platform that failed.