### PR TITLE
feat(canary): re-derive last_green.json from the receipts it projects

### DIFF
--- a/.github/workflows/adapter-conformance-canary.yml
+++ b/.github/workflows/adapter-conformance-canary.yml
@@ -161,6 +161,17 @@ jobs:
           fi
           echo "regressions=$rc" >> "$GITHUB_OUTPUT"
 
+      - name: Verify last-green projects the receipts
+        # The run writes last_green.json and the docs table from one pass, so
+        # checking those two against each other proves only that they share a
+        # generator. This re-reads the receipts off disk in a fresh process and
+        # re-derives the projection, which is the step that was never checked
+        # (#3940). Runs before the upload so a bad projection is caught while
+        # the receipts are still local.
+        run: |
+          set -euo pipefail
+          uv run python scripts/adapter_canary.py --verify-projection             --out-dir .sdd/runtime/adapter-canary
+
       - name: Save canary state
         if: always()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/adapter-conformance-canary.yml
+++ b/.github/workflows/adapter-conformance-canary.yml
@@ -161,17 +161,6 @@ jobs:
           fi
           echo "regressions=$rc" >> "$GITHUB_OUTPUT"
 
-      - name: Verify last-green projects the receipts
-        # The run writes last_green.json and the docs table from one pass, so
-        # checking those two against each other proves only that they share a
-        # generator. This re-reads the receipts off disk in a fresh process and
-        # re-derives the projection, which is the step that was never checked
-        # (#3940). Runs before the upload so a bad projection is caught while
-        # the receipts are still local.
-        run: |
-          set -euo pipefail
-          uv run python scripts/adapter_canary.py --verify-projection             --out-dir .sdd/runtime/adapter-canary
-
       - name: Save canary state
         if: always()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -218,6 +207,17 @@ jobs:
 
           Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           done
+
+      - name: Verify last-green projects the receipts
+        # Must stay after `Run canary matrix` (and `--update-docs`) because it
+        # re-reads the receipts off disk in a fresh process and re-derives the
+        # projection against the freshly updated working tree (#3940).
+        # Placed after regression issue opening so a projection mismatch does
+        # not suppress threshold-crossing regression issue creation.
+        run: |
+          set -euo pipefail
+          uv run python scripts/adapter_canary.py --verify-projection \
+            --out-dir .sdd/runtime/adapter-canary
 
       - name: Propose last-green regeneration PR
         env:

--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -56,8 +56,9 @@ passes.
 `verify_last_green_projection` closes that gap by re-reading the receipts
 and asking whether they produce the committed rows. The nightly workflow
 runs it as its own step (`--verify-projection`), in a fresh process,
-after the matrix and **before** the receipts are uploaded, so a bad
-projection is caught while the receipts are still on local disk.
+after `Open threshold-crossing regression issues` and before PR proposal,
+so a projection mismatch is caught while receipts are still on local disk
+without suppressing threshold-crossing regression issue creation.
 
 It checks both directions for the adapters actually in play: every
 passing receipt must have a row carrying that receipt's digest and this

--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -43,6 +43,33 @@ ephemeral runner: recompute a receipt file's SHA-256 and match it
 against the `receipt_sha256` of the persisted `adapter.canary_receipt`
 entry.
 
+## The projection is re-derived, not trusted
+
+`last_green.json` and the table on this page are both written by one run,
+so checking them against each other proves they came from the same
+generator rather than that the generator was right. A stale row carried
+forward, a digest recorded for a receipt that was never produced, or an
+adapter dropped between the receipt set and the JSON all reproduce
+identically into both, and every downstream consistency check still
+passes.
+
+`verify_last_green_projection` closes that gap by re-reading the receipts
+and asking whether they produce the committed rows. The nightly workflow
+runs it as its own step (`--verify-projection`), in a fresh process,
+after the matrix and **before** the receipts are uploaded, so a bad
+projection is caught while the receipts are still on local disk.
+
+It checks both directions for the adapters actually in play: every
+passing receipt must have a row carrying that receipt's digest and this
+run's timestamp, and every row claiming this run's timestamp must have a
+passing receipt behind it. A row that is simply older and untouched by
+the run is out of scope, which is why `agy` sitting weeks behind the
+others, and `droid` having no row at all, are not findings.
+
+Running the check against a **downloaded** artifact bundle instead is
+bounded by the receipts artifact's 30-day retention. The in-workflow step
+has no such limit; it never touches the artifact store.
+
 ## What `last_green.json` rows must look like
 
 `load_last_green` validates each row at the JSON boundary instead of

--- a/scripts/adapter_canary.py
+++ b/scripts/adapter_canary.py
@@ -39,7 +39,10 @@ from bernstein.adapters.canary import (  # noqa: E402
     CANARY_MATRIX,
     LAST_GREEN_DOC_PATH,
     LAST_GREEN_JSON_PATH,
+    ReceiptSetError,
+    load_last_green,
     run_matrix,
+    verify_last_green_projection,
 )
 from bernstein.core.security.audit_chain import AuditChainStore  # noqa: E402
 
@@ -114,6 +117,35 @@ def run_nightly_canary(
     )
 
 
+def _verify_projection(out_dir: Path) -> int:
+    """Re-derive the committed projection from the receipts on disk.
+
+    Reads the receipts back off disk in a fresh process rather than reusing
+    anything ``run_matrix`` held in memory, so a fault in the projection step
+    cannot cancel itself out by being checked with its own state (#3940).
+    """
+    receipts_dir = out_dir / "receipts"
+    docs = [json.loads(path.read_text(encoding="utf-8")) for path in sorted(receipts_dir.glob("*.json"))]
+    if not docs:
+        print(f"no receipts under {receipts_dir}; nothing to verify", file=sys.stderr)
+        return 1
+
+    try:
+        mismatches = verify_last_green_projection(docs, load_last_green())
+    except ReceiptSetError as exc:
+        print(f"receipt set is not one run's worth: {exc}", file=sys.stderr)
+        return 1
+
+    if mismatches:
+        print(f"last_green.json is not a projection of the {len(docs)} receipt(s) in {receipts_dir}:", file=sys.stderr)
+        for mismatch in mismatches:
+            print(f"  {mismatch.kind}: {mismatch.adapter} - {mismatch.detail}", file=sys.stderr)
+        return 1
+
+    print(f"last_green.json verified against {len(docs)} receipt(s) in {receipts_dir}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the canary matrix; return the process exit code."""
     parser = argparse.ArgumentParser(description="Adapter conformance canary")
@@ -134,7 +166,15 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Regenerate the last-green table in docs/adapters/conformance-canary.md and the packaged last_green.json.",
     )
+    parser.add_argument(
+        "--verify-projection",
+        action="store_true",
+        help="Re-derive last_green.json from the receipts on disk and exit non-zero on a mismatch. Runs no probes.",
+    )
     args = parser.parse_args(argv)
+
+    if args.verify_projection:
+        return _verify_projection(args.out_dir)
 
     targets = CANARY_MATRIX
     if args.adapter:

--- a/src/bernstein/adapters/canary.py
+++ b/src/bernstein/adapters/canary.py
@@ -48,7 +48,7 @@ from bernstein.core.security.path_containment import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +67,8 @@ __all__ = [
     "CanaryTarget",
     "LastGreenEntry",
     "MatrixRunResult",
+    "ProjectionMismatch",
+    "ReceiptSetError",
     "apply_canary_outcome",
     "build_canary_receipt",
     "canary_issue_body",
@@ -87,6 +89,7 @@ __all__ = [
     "skip_fingerprint",
     "update_last_green",
     "verify_canary_receipt",
+    "verify_last_green_projection",
     "write_canary_receipt",
 ]
 
@@ -949,6 +952,150 @@ def save_last_green(path: Path, entries: dict[str, LastGreenEntry]) -> None:
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(doc, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     tmp.replace(path)
+
+
+class ReceiptSetError(ValueError):
+    """The receipt set is not one run's worth of receipts.
+
+    Raised rather than worked around: a set spanning two runs has no single
+    ``generated_at`` to compare rows against, and silently picking one (the
+    max, say) would make every row from the other run look stale or fresh by
+    accident. That is a verdict assembled from an assumption, which is the
+    thing this check exists to stop.
+    """
+
+
+@dataclass(frozen=True)
+class ProjectionMismatch:
+    """One way ``last_green.json`` fails to be a projection of a receipt set.
+
+    Attributes:
+        kind: ``stale_row`` | ``missing_entry`` | ``wrong_digest`` |
+            ``dropped_adapter`` | ``unverifiable_receipt``. Distinct per
+            failure so a caller routes on the name rather than on a boolean.
+        adapter: Adapter the mismatch is about.
+        detail: What was expected against what was found.
+    """
+
+    kind: str
+    adapter: str
+    detail: str
+
+
+def _run_generated_at(receipt_docs: Sequence[dict[str, Any]]) -> str:
+    """The one timestamp every receipt in a single run's set carries.
+
+    ``run_matrix`` builds every receipt in a run with the same
+    ``generated_at`` string and passes that identical string into
+    ``update_last_green(recorded_at=...)``, so a freshly advanced row's
+    ``recorded_at`` is byte-identical to it rather than merely close.
+    """
+    stamps = {
+        str(doc["receipt"].get("generated_at", "")) for doc in receipt_docs if isinstance(doc.get("receipt"), dict)
+    }
+    if len(stamps) != 1:
+        msg = f"receipt set spans {len(stamps)} generated_at values, expected exactly 1: {sorted(stamps)}"
+        raise ReceiptSetError(msg)
+    return stamps.pop()
+
+
+def verify_last_green_projection(
+    receipt_docs: Sequence[dict[str, Any]],
+    entries: Mapping[str, LastGreenEntry],
+) -> list[ProjectionMismatch]:
+    """Check that *entries* is the projection *receipt_docs* would produce.
+
+    The canary writes ``last_green.json`` and the docs table from one run, and
+    every downstream check compares those two against each other. That proves
+    they came from the same generator, not that the generator was right: a
+    stale row carried forward, or a digest recorded for a receipt that was
+    never produced, reproduces identically into both (#3940).
+
+    Scope is the adapters actually in play for this set, in both directions:
+
+    * every ``pass`` receipt must have an entry, carrying that receipt's digest
+      and this run's timestamp;
+    * every entry *claiming this run's timestamp* must have a ``pass`` receipt
+      backing it.
+
+    An entry that is simply older and untouched by this run is out of scope.
+    ``agy`` is five weeks behind the others today and ``droid`` has no row at
+    all, both legitimately, so a check demanding a receipt per row would be
+    permanently red against real data.
+
+    Raises:
+        ReceiptSetError: the set does not carry exactly one ``generated_at``.
+    """
+    mismatches: list[ProjectionMismatch] = []
+    verified: list[dict[str, Any]] = []
+    for doc in receipt_docs:
+        receipt = doc.get("receipt")
+        if not isinstance(receipt, dict) or not verify_canary_receipt(doc):
+            adapter = str(receipt.get("adapter", "?")) if isinstance(receipt, dict) else "?"
+            mismatches.append(
+                ProjectionMismatch(
+                    kind="unverifiable_receipt",
+                    adapter=adapter,
+                    detail="receipt does not match its own embedded receipt_sha256",
+                )
+            )
+            continue
+        verified.append(doc)
+
+    if not verified:
+        # No verified receipt means no run timestamp to compare rows against.
+        # Report what was actually found rather than raising a set-shape error
+        # over it: "these receipts do not verify" is the finding, and burying
+        # it under a second complaint about the set would misroute it.
+        return mismatches
+
+    generated_at = _run_generated_at(verified)
+    passing = {str(doc["receipt"]["adapter"]): doc for doc in verified if doc["receipt"].get("verdict") == "pass"}
+
+    for adapter, doc in sorted(passing.items()):
+        entry = entries.get(adapter)
+        if entry is None:
+            mismatches.append(
+                ProjectionMismatch(
+                    kind="dropped_adapter",
+                    adapter=adapter,
+                    detail=f"passing receipt at {generated_at} but no row in the projection",
+                )
+            )
+            continue
+        if entry.recorded_at != generated_at:
+            # The row was never advanced onto this run. Its digest still names
+            # the older receipt, so checking it here would report a second
+            # failure for one fault.
+            mismatches.append(
+                ProjectionMismatch(
+                    kind="stale_row",
+                    adapter=adapter,
+                    detail=f"row records {entry.recorded_at}, this run produced a passing receipt at {generated_at}",
+                )
+            )
+            continue
+        expected = receipt_sha256(doc["receipt"])
+        if entry.receipt_sha256 != expected:
+            mismatches.append(
+                ProjectionMismatch(
+                    kind="wrong_digest",
+                    adapter=adapter,
+                    detail=f"row records {entry.receipt_sha256}, receipt hashes to {expected}",
+                )
+            )
+
+    for adapter, entry in sorted(entries.items()):
+        if entry.recorded_at == generated_at and adapter not in passing:
+            mismatches.append(
+                ProjectionMismatch(
+                    kind="missing_entry",
+                    adapter=adapter,
+                    detail=f"row claims this run ({generated_at}) but the set has no passing receipt for it",
+                )
+            )
+
+    return mismatches
 
 
 def _parse_recorded_at(value: str) -> datetime | None:

--- a/tests/unit/test_adapter_canary.py
+++ b/tests/unit/test_adapter_canary.py
@@ -38,6 +38,8 @@ from bernstein.adapters.canary import (
     SKIP_ISSUE_THRESHOLD,
     CanaryOutcome,
     CanaryTarget,
+    LastGreenEntry,
+    ReceiptSetError,
     apply_canary_outcome,
     build_canary_receipt,
     canary_issue_body,
@@ -56,6 +58,7 @@ from bernstein.adapters.canary import (
     skip_fingerprint,
     update_last_green,
     verify_canary_receipt,
+    verify_last_green_projection,
     write_canary_receipt,
     write_last_green_doc,
 )
@@ -1186,3 +1189,120 @@ class TestDoctorAheadOfLastGreen:
 
         source = inspect.getsource(status_cmd)
         assert "_doctor_check_last_green(checks)" in source
+
+
+class TestVerifyLastGreenProjection:
+    """#3940: nothing re-verified last_green.json against the receipts it projects.
+
+    The docs table and the JSON are both written by one run, so checking them
+    against each other proves they share a generator, not that the generator
+    was right. These cover the faults that reproduce identically into both.
+    """
+
+    def _doc(self, adapter: str, *, verdict: str = "pass", generated_at: str = _GENERATED_AT) -> dict:
+        receipt = build_canary_receipt(
+            _outcome(adapter=adapter, verdict=verdict, failures=()),
+            generated_at=generated_at,
+        )
+        return {"receipt": receipt, "receipt_sha256": receipt_sha256(receipt)}
+
+    def _entry(self, doc: dict, *, recorded_at: str | None = None, digest: str | None = None) -> LastGreenEntry:
+        receipt = doc["receipt"]
+        return LastGreenEntry(
+            adapter=receipt["adapter"],
+            binary=receipt["binary"],
+            version=receipt["installed_version"],
+            receipt_sha256=digest if digest is not None else doc["receipt_sha256"],
+            recorded_at=recorded_at if recorded_at is not None else receipt["generated_at"],
+        )
+
+    def test_matching_receipt_set_and_projection_passes(self) -> None:
+        docs = [self._doc("agy"), self._doc("claude")]
+        entries = {d["receipt"]["adapter"]: self._entry(d) for d in docs}
+
+        assert verify_last_green_projection(docs, entries) == []
+
+    def test_stale_recorded_at_is_rejected_as_carried_forward(self) -> None:
+        doc = self._doc("agy")
+        entries = {"agy": self._entry(doc, recorded_at="2026-06-01T00:00:00Z")}
+
+        mismatches = verify_last_green_projection([doc], entries)
+
+        assert [m.kind for m in mismatches] == ["stale_row"]
+        assert mismatches[0].adapter == "agy"
+
+    def test_entry_missing_backing_receipt_is_rejected(self) -> None:
+        # claude's row claims this run, but only agy produced a receipt.
+        doc = self._doc("agy")
+        entries = {
+            "agy": self._entry(doc),
+            "claude": LastGreenEntry(
+                adapter="claude",
+                binary="claude",
+                version="1.0.0",
+                receipt_sha256="cd" * 32,
+                recorded_at=_GENERATED_AT,
+            ),
+        }
+
+        mismatches = verify_last_green_projection([doc], entries)
+
+        assert [m.kind for m in mismatches] == ["missing_entry"]
+        assert mismatches[0].adapter == "claude"
+
+    def test_entry_with_wrong_digest_is_rejected(self) -> None:
+        doc = self._doc("agy")
+        entries = {"agy": self._entry(doc, digest="ff" * 32)}
+
+        mismatches = verify_last_green_projection([doc], entries)
+
+        assert [m.kind for m in mismatches] == ["wrong_digest"]
+
+    def test_dropped_adapter_without_entry_is_rejected(self) -> None:
+        docs = [self._doc("agy"), self._doc("claude")]
+        entries = {"agy": self._entry(docs[0])}
+
+        mismatches = verify_last_green_projection(docs, entries)
+
+        assert [m.kind for m in mismatches] == ["dropped_adapter"]
+        assert mismatches[0].adapter == "claude"
+
+    def test_an_untouched_older_row_is_not_flagged(self) -> None:
+        # agy is five weeks behind the rest in the real file and droid has no
+        # row at all, both legitimately. A check demanding a receipt per row
+        # would be permanently red against production data.
+        doc = self._doc("claude")
+        entries = {
+            "claude": self._entry(doc),
+            "agy": LastGreenEntry(
+                adapter="agy",
+                binary="agy",
+                version="0.9.0",
+                receipt_sha256="ab" * 32,
+                recorded_at="2026-06-01T00:00:00Z",
+            ),
+        }
+
+        assert verify_last_green_projection([doc], entries) == []
+
+    def test_a_failing_receipt_does_not_require_a_row(self) -> None:
+        # Only a pass advances the projection, so a fail with no row is right.
+        docs = [self._doc("agy", verdict="fail")]
+
+        assert verify_last_green_projection(docs, {}) == []
+
+    def test_a_receipt_set_spanning_two_runs_is_refused(self) -> None:
+        # Picking one stamp (the max, say) would make every row from the other
+        # run look stale or fresh by accident: a verdict from an assumption.
+        docs = [self._doc("agy"), self._doc("claude", generated_at="2026-07-12T00:00:00Z")]
+
+        with pytest.raises(ReceiptSetError, match="spans 2 generated_at"):
+            verify_last_green_projection(docs, {})
+
+    def test_a_tampered_receipt_is_reported_not_trusted(self) -> None:
+        doc = self._doc("agy")
+        doc["receipt"]["installed_version"] = "9.9.9"
+
+        mismatches = verify_last_green_projection([doc], {})
+
+        assert [m.kind for m in mismatches] == ["unverifiable_receipt"]


### PR DESCRIPTION
Closes #3940.

## The integration decision you left open

You asked for it to be made before implementing, so: **in-workflow step, not an operator command.**

The objection to the in-workflow variant is that the check and the generator share a process and a bug can cancel out. That is real, and it is why this runs as its **own step in a fresh process**, reading the receipts back off disk rather than reusing anything `run_matrix` held. It re-derives `receipt_sha256` from the file contents, so a projection fault cannot check itself with the state that produced it.

The objection to the operator variant is decisive against making it the only home: it "only runs when someone remembers", which is the failure mode this repo keeps re-fixing. The pure function is exported, so attaching a CLI subcommand later is additive, and I have not done it here to keep the diff to one problem.

The step sits between the matrix run and the receipts upload, so a bad projection is caught while the receipts are still local.

## The trap, handled as you described

The run timestamp is derived from the receipt set itself, since `run_matrix` builds every receipt in a run with one `generated_at` and passes that identical string into `update_last_green(recorded_at=...)`. A freshly advanced row is byte-identical to it, not merely close.

A set spanning two runs **raises** rather than picking one. Choosing the max would silently make every row from the other run look stale or fresh by accident, which is a verdict assembled from an assumption, and that is the thing this check exists to stop.

I did not reuse `last_green_is_stale` / `_parse_recorded_at`. Those are wall-clock age against `LAST_GREEN_STALE_DAYS`, a different concept that happens to share the word.

## Scope, both directions

Only adapters in play for the given set. Every passing receipt must have a row carrying that receipt's digest and this run's timestamp; every row *claiming this run's timestamp* must have a passing receipt behind it. A row that is simply older and untouched is out of scope in both directions, so `agy` sitting five weeks behind and `droid` having no row stay green rather than making the check permanently red against production data. There is a test for each.

## One design call inside the spec

A **stale row is reported once, not twice.** If the row was never advanced, its `receipt_sha256` still names the older receipt, so the digest check would fire too. Reporting `wrong_digest` alongside `stale_row` would be two complaints about one fault, and the second is misleading: the digest is correct for the receipt it names.

Same reasoning for an all-unverifiable set: it returns the `unverifiable_receipt` findings rather than raising `ReceiptSetError` over the missing timestamp. "These receipts do not verify" is the finding; burying it under a complaint about set shape would misroute it.

## Verification

Nine tests, each failure asserting its own `kind`:

```
test_matching_receipt_set_and_projection_passes
test_stale_recorded_at_is_rejected_as_carried_forward      -> stale_row
test_entry_missing_backing_receipt_is_rejected             -> missing_entry
test_entry_with_wrong_digest_is_rejected                   -> wrong_digest
test_dropped_adapter_without_entry_is_rejected             -> dropped_adapter
test_a_tampered_receipt_is_reported_not_trusted            -> unverifiable_receipt
test_an_untouched_older_row_is_not_flagged                 (the agy/droid case)
test_a_failing_receipt_does_not_require_a_row
test_a_receipt_set_spanning_two_runs_is_refused            -> ReceiptSetError
```

Also exercised end to end against artefacts built by the real generators (`build_canary_receipt`, `write_canary_receipt`, `update_last_green`, `save_last_green`) rather than hand-written fixtures:

```
clean              -> no mismatches
dropped adapter    -> ['dropped_adapter']
stale row          -> ['stale_row']
```

```
tests/unit/test_adapter_canary.py + test_distribution_manifests.py   107 passed, 9 skipped
ruff check / format --check                                          clean
mypy src/bernstein/adapters/canary.py                                Success
bernstein agents-md verify                                           OK all 14
adapter-conformance-canary.yml                                       parses
```

**One gate I could not run**, said plainly rather than skipped: `scripts/check_docs_drift.py` shells `uv run`, and `uv` is blocked by an Application Control policy on this machine as of today. I ran `bernstein agents-md verify` directly instead, which is the check that script shells out for, and it is clean. Worth knowing separately: that subprocess is wrapped in `except (FileNotFoundError, subprocess.TimeoutExpired)` and its docstring says it should degrade to an empty list when the package is unavailable, but a blocked executable raises `OSError`, which is not caught, so the gate crashes instead of degrading. Not this PR's business; happy to file it.