### PR TITLE
ci(docs): weekly report of transitive pins a fresh resolve would move

### DIFF
--- a/.github/workflows/docs-requirements-staleness-weekly.yml
+++ b/.github/workflows/docs-requirements-staleness-weekly.yml
@@ -1,0 +1,131 @@
+name: docs-requirements-staleness-weekly
+
+# Weekly staleness report for the docs toolchain's transitive pins.
+#
+# #3999 gates docs/requirements.txt against the constraints its .in file
+# declares. That check is offline and covers only the 4 direct requirements;
+# the other 39 entries are transitive and nothing re-resolves them. A pin can
+# sit at a yanked release, or one a direct dependency's metadata no longer
+# permits, while every existing gate stays green (#4001).
+#
+# Answering that needs a live index, which is why this is weekly and not part
+# of the per-PR hygiene job: a blocking gate that reddens on an index hiccup
+# stops being a blocking gate, and a non-blocking one is another green tick
+# that proves nothing.
+#
+# It reports; it does not open a PR carrying the resolution. Taking a moved
+# transitive pin is a judgement call that depends on things the job cannot
+# see, and a weekly PR touching 39 pins is read by nobody. That is the line
+# against #4053, where the regeneration is mechanical and IS fully automated.
+
+on:
+  schedule:
+    # 06:53 UTC every Monday. Offset into the gap between trufflehog (06:23)
+    # and the coverage-ratchet / required-check-canary pair (both 07:23).
+    - cron: "53 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-requirements-staleness-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  staleness:
+    name: recompile and diff
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: ./.github/actions/bootstrap
+
+      - name: Recompile and diff the docs pins
+        id: staleness
+        run: |
+          set -euo pipefail
+          set +e
+          uv run python scripts/check_docs_requirements_staleness.py | tee staleness.txt
+          rc=${PIPESTATUS[0]}
+          set -e
+          # rc=1 means pins moved, which is the finding this job exists to
+          # report, not a broken job. rc=2 means the recompile itself could
+          # not run, and that IS a red run: a staleness check that cannot
+          # reach the index has not reported "no drift", it has reported
+          # nothing, and those must not look the same.
+          if [ "$rc" -gt 1 ]; then
+            echo "::error::staleness check exited $rc (recompile failed)"
+            exit "$rc"
+          fi
+          echo "stale=$rc" >> "$GITHUB_OUTPUT"
+
+      - name: Open or refresh the tracking issue
+        if: steps.staleness.outputs.stale == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE="docs/requirements.txt transitive pins are behind a fresh resolve"
+          BODY="$(cat <<EOF
+          $(cat staleness.txt)
+
+          Taking these is a judgement call rather than a mechanical update, so this
+          job reports instead of opening a pull request carrying the resolution.
+
+          Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          Refs #4001.
+          EOF
+          )"
+          # One tracking issue, refreshed. A fresh issue every Monday against
+          # a set of pins nobody has decided on yet turns the report into its
+          # own noise source, which is the shape this series keeps removing.
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --search "in:title docs/requirements.txt transitive pins" \
+            --state open \
+            --json number \
+            --jq '.[0].number // ""')
+          if [ -n "$EXISTING" ]; then
+            echo "Refreshing existing tracking issue #$EXISTING"
+            gh issue edit "$EXISTING" \
+              --repo "${{ github.repository }}" \
+              --title "$TITLE" --body "$BODY"
+          else
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "$TITLE" \
+              --body "$BODY" \
+              --label dependencies \
+              --label ci
+          fi
+
+      - name: Close the tracking issue when the pins catch up
+        if: steps.staleness.outputs.stale == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --search "in:title docs/requirements.txt transitive pins" \
+            --state open \
+            --json number \
+            --jq '.[0].number // ""')
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" \
+              --repo "${{ github.repository }}" \
+              --comment "A fresh resolve now matches every committed pin. Closed by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
+          fi

--- a/.github/workflows/docs-requirements-staleness-weekly.yml
+++ b/.github/workflows/docs-requirements-staleness-weekly.yml
@@ -75,57 +75,71 @@ jobs:
         if: steps.staleness.outputs.stale == '1'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           TITLE="docs/requirements.txt transitive pins are behind a fresh resolve"
-          BODY="$(cat <<EOF
-          $(cat staleness.txt)
+          BODY_FILE=issue-body.md
+          {
+            cat staleness.txt
+            echo
+            echo "Taking these is a judgement call rather than a mechanical update, so this"
+            echo "job reports instead of opening a pull request carrying the resolution."
+            echo
+            echo "Workflow run: ${{ github.server_url }}/${REPO}/actions/runs/${{ github.run_id }}"
+            echo
+            echo "Refs #4001."
+          } > "${BODY_FILE}"
 
-          Taking these is a judgement call rather than a mechanical update, so this
-          job reports instead of opening a pull request carrying the resolution.
+          # One perpetual issue, edited in place. The title is fixed rather than
+          # keyed on the moved set: a content-keyed title would close this issue
+          # and open a new one whenever a package drifts, and a closed issue
+          # reads as "resolved" when nothing was resolved. The set moving is the
+          # state persisting, not the state clearing.
+          #
+          # Exact title match, not the search relevance order: `--search` is
+          # fuzzy, so taking `.[0]` could edit a human-authored issue that merely
+          # scored well.
+          EXISTING=$(gh issue list --repo "${REPO}" --state open \
+            --search "in:title \"${TITLE}\"" \
+            --json number,title \
+            --jq ".[] | select(.title == \"${TITLE}\") | .number" \
+            | head -1)
 
-          Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-          Refs #4001.
-          EOF
-          )"
-          # One tracking issue, refreshed. A fresh issue every Monday against
-          # a set of pins nobody has decided on yet turns the report into its
-          # own noise source, which is the shape this series keeps removing.
-          EXISTING=$(gh issue list \
-            --repo "${{ github.repository }}" \
-            --search "in:title docs/requirements.txt transitive pins" \
-            --state open \
-            --json number \
-            --jq '.[0].number // ""')
-          if [ -n "$EXISTING" ]; then
-            echo "Refreshing existing tracking issue #$EXISTING"
-            gh issue edit "$EXISTING" \
-              --repo "${{ github.repository }}" \
-              --title "$TITLE" --body "$BODY"
+          if [ -n "${EXISTING}" ]; then
+            echo "Updating existing tracking issue #${EXISTING}"
+            gh issue edit "${EXISTING}" --repo "${REPO}" --body-file "${BODY_FILE}"
           else
-            gh issue create \
-              --repo "${{ github.repository }}" \
-              --title "$TITLE" \
-              --body "$BODY" \
-              --label dependencies \
-              --label ci
+            # Probe the labels first. A blind `create --label x || create`
+            # retries on ANY failure, including a transport error that already
+            # created the issue, and can open a duplicate.
+            LABELS=$(gh label list --repo "${REPO}" --limit 100 --json name --jq '.[].name')
+            LABEL_ARGS=()
+            for candidate in dependencies ci; do
+              if grep -qxF "${candidate}" <<<"${LABELS}"; then
+                LABEL_ARGS+=(--label "${candidate}")
+              fi
+            done
+            gh issue create --repo "${REPO}" \
+              --title "${TITLE}" \
+              --body-file "${BODY_FILE}" \
+              "${LABEL_ARGS[@]}"
           fi
 
       - name: Close the tracking issue when the pins catch up
         if: steps.staleness.outputs.stale == '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          EXISTING=$(gh issue list \
-            --repo "${{ github.repository }}" \
-            --search "in:title docs/requirements.txt transitive pins" \
-            --state open \
-            --json number \
-            --jq '.[0].number // ""')
-          if [ -n "$EXISTING" ]; then
-            gh issue close "$EXISTING" \
-              --repo "${{ github.repository }}" \
-              --comment "A fresh resolve now matches every committed pin. Closed by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
+          TITLE="docs/requirements.txt transitive pins are behind a fresh resolve"
+          EXISTING=$(gh issue list --repo "${REPO}" --state open \
+            --search "in:title \"${TITLE}\"" \
+            --json number,title \
+            --jq ".[] | select(.title == \"${TITLE}\") | .number" \
+            | head -1)
+          if [ -n "${EXISTING}" ]; then
+            gh issue close "${EXISTING}" --repo "${REPO}" \
+              --comment "A fresh resolve now matches every committed pin. Closed by ${{ github.server_url }}/${REPO}/actions/runs/${{ github.run_id }}."
           fi

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -40,6 +40,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/dependency-review.yml | Dependency Review | pull_request | {"cancel-in-progress": "true", "group": "dependency-review-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
 | .github/workflows/docs-drift.yml | docs-drift | pull_request, push, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "docs-drift-${{ github.ref }}"} | 2 |
 | .github/workflows/docs-observability-snapshot.yml | Observability snapshot | workflow_dispatch | {"cancel-in-progress": "false", "group": "docs-observability-snapshot"} | 1 |
+| .github/workflows/docs-requirements-staleness-weekly.yml | docs-requirements-staleness-weekly | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "docs-requirements-staleness-${{ github.ref }}"} | 1 |
 | .github/workflows/eval-weekly.yml | eval-weekly | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "eval-weekly-${{ github.ref }}"} | 3 |
 | .github/workflows/feature-matrix-drift.yml | Feature matrix drift | pull_request, push | {"cancel-in-progress": "true", "group": "feature-matrix-drift-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
 | .github/workflows/hotfix-r-tracker.yml | Hotfix R-counter | push | {"cancel-in-progress": "false", "group": "hotfix-r-tracker-${{ github.sha }}"} | 1 |
@@ -107,6 +108,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/dependency-review.yml | review: Dependency review |
 | .github/workflows/docs-drift.yml | drift-check: Run drift check<br>drift-publish: Publish drift surfaces |
 | .github/workflows/docs-observability-snapshot.yml | snapshot: Capture snapshot |
+| .github/workflows/docs-requirements-staleness-weekly.yml | staleness: recompile and diff |
 | .github/workflows/eval-weekly.yml | bench: bench (full)<br>preflight: preflight (gate)<br>smoke: smoke (synthetic) |
 | .github/workflows/feature-matrix-drift.yml | matrix-rows: registered CLI commands have a matrix row |
 | .github/workflows/hotfix-r-tracker.yml | track: Detect hotfix-begets-hotfix |
@@ -174,6 +176,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/dependency-review.yml | workflow: {"contents": "read"}<br>review: {"contents": "read", "pull-requests": "write"} | - |
 | .github/workflows/docs-drift.yml | workflow: {"contents": "read"}<br>drift-check: {"contents": "read"}<br>drift-publish: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |
 | .github/workflows/docs-observability-snapshot.yml | workflow: {"contents": "read"}<br>snapshot: {"contents": "write", "pull-requests": "write", "security-events": "read"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |
+| .github/workflows/docs-requirements-staleness-weekly.yml | workflow: {"contents": "read"}<br>staleness: {"contents": "read", "issues": "write"} | GITHUB_TOKEN |
 | .github/workflows/eval-weekly.yml | workflow: {"contents": "read"} | EVAL_ENABLED |
 | .github/workflows/feature-matrix-drift.yml | workflow: {"contents": "read"}<br>matrix-rows: {"contents": "read"} | - |
 | .github/workflows/hotfix-r-tracker.yml | track: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |

--- a/scripts/check_docs_requirements_staleness.py
+++ b/scripts/check_docs_requirements_staleness.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Report transitive pins in ``docs/requirements.txt`` a fresh resolve would move.
+
+Why this exists
+---------------
+#3999 gates the compiled file against the constraints its ``.in`` declares.
+That check is offline by design: it proves every *direct* requirement is
+present and inside its declared bound, and says nothing about the other 39
+entries, which are transitive and which nothing ever re-resolves.
+
+A transitive pin can sit at a yanked release, or one a direct dependency's
+own metadata no longer permits, and every existing gate still reports green.
+The direct-constraint check passes because the four direct requirements are
+fine; the docs build passes because the pinned wheels are still downloadable.
+The staleness is invisible until a build breaks or somebody regenerates by
+hand (#4001).
+
+Answering it means reaching a live index, which is why this is a weekly
+scheduled job rather than a per-PR gate. A blocking gate that can go red
+because an index hiccuped stops being a blocking gate, and a non-blocking
+gate is another green tick that proves nothing.
+
+What it does NOT do
+-------------------
+It does not change any pin, and it does not open a pull request. The report
+names which packages moved and by how much; deciding whether to take them is
+a judgement that depends on things this script cannot see.
+
+That is the line between this and the manifest regeneration in #4053: a
+manifest is a pure function of ``pyproject.toml`` with one right answer, so
+that one is automated end to end. A resolution is not, and a weekly PR
+touching 39 pins is read by nobody.
+
+Usage:
+    python scripts/check_docs_requirements_staleness.py
+    python scripts/check_docs_requirements_staleness.py --json
+
+Exit codes:
+    0  every pin matches what a fresh resolve produces
+    1  at least one pin moved (each named on stdout)
+    2  the recompile could not be run or its output could not be parsed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Final
+
+REPO_ROOT: Final = Path(__file__).resolve().parent.parent
+REQUIREMENTS_IN: Final = REPO_ROOT / "docs" / "requirements.in"
+REQUIREMENTS_TXT: Final = REPO_ROOT / "docs" / "requirements.txt"
+
+#: The compiler invocation, matching the one ``docs/requirements.in``
+#: documents and ``docs/requirements.txt``'s own header records. Held to the
+#: ``.in`` header by a test, because a recompile built on a command that does
+#: not reproduce the committed file reports every package as moved on its
+#: first run (#3995).
+PIP_COMPILE_ARGV: Final = (
+    "uv",
+    "run",
+    "--python",
+    "3.13",
+    "--with",
+    "pip-tools",
+    "--",
+    "pip-compile",
+    "--generate-hashes",
+    "--strip-extras",
+    "--quiet",
+    "--output-file",
+)
+
+#: A pinned line in a ``--generate-hashes`` output. Hash continuations are
+#: indented and deliberately do not match.
+_PIN_RE: Final = re.compile(r"^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)==(?P<version>[^\s\\;]+)")
+
+
+@dataclass(frozen=True)
+class PinDrift:
+    """One package whose committed pin differs from a fresh resolve."""
+
+    package: str
+    committed: str | None
+    resolved: str | None
+
+    @property
+    def kind(self) -> str:
+        if self.committed is None:
+            return "added"
+        if self.resolved is None:
+            return "removed"
+        return "moved"
+
+    def render(self) -> str:
+        if self.committed is None:
+            return f"  {self.package}: absent from the committed file, a fresh resolve adds {self.resolved}"
+        if self.resolved is None:
+            return f"  {self.package}: pinned at {self.committed}, a fresh resolve no longer includes it"
+        return f"  {self.package}: pinned at {self.committed}, a fresh resolve produces {self.resolved}"
+
+
+def parse_pins(text: str) -> dict[str, str]:
+    """Package name -> pinned version, from a compiled requirements file."""
+    pins: dict[str, str] = {}
+    for raw in text.splitlines():
+        if not raw or raw[0].isspace() or raw.lstrip().startswith("#"):
+            continue
+        match = _PIN_RE.match(raw.strip())
+        if match is not None:
+            pins[match.group("name").lower().replace("_", "-")] = match.group("version")
+    return pins
+
+
+def diff_pins(committed: dict[str, str], resolved: dict[str, str]) -> list[PinDrift]:
+    """Every package the two resolutions disagree about, name-sorted."""
+    return [
+        PinDrift(package=name, committed=committed.get(name), resolved=resolved.get(name))
+        for name in sorted(set(committed) | set(resolved))
+        if committed.get(name) != resolved.get(name)
+    ]
+
+
+def recompile(destination: Path) -> str:
+    """Resolve ``docs/requirements.in`` fresh against a live index."""
+    result = subprocess.run(
+        [*PIP_COMPILE_ARGV, str(destination), str(REQUIREMENTS_IN)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=600,
+    )
+    if result.returncode != 0:
+        msg = f"pip-compile exited {result.returncode}:\n{result.stderr.strip()}"
+        raise RuntimeError(msg)
+    return destination.read_text(encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--json", action="store_true", help="Emit the drift list as JSON.")
+    args = parser.parse_args(argv)
+
+    committed = parse_pins(REQUIREMENTS_TXT.read_text(encoding="utf-8"))
+    if not committed:
+        print(f"error: no pins parsed from {REQUIREMENTS_TXT}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            fresh = recompile(Path(tmp) / "resolved.txt")
+        except (OSError, RuntimeError, subprocess.TimeoutExpired) as exc:
+            print(f"error: could not recompile: {exc}", file=sys.stderr)
+            return 2
+
+    resolved = parse_pins(fresh)
+    if not resolved:
+        print("error: the recompile produced no pins", file=sys.stderr)
+        return 2
+
+    drifts = diff_pins(committed, resolved)
+
+    if args.json:
+        print(json.dumps([{**asdict(d), "kind": d.kind} for d in drifts], indent=2))
+        return 1 if drifts else 0
+
+    if not drifts:
+        print(f"OK       all {len(committed)} pins match a fresh resolve")
+        return 0
+
+    print(f"STALE    {len(drifts)} of {len(committed)} pins differ from a fresh resolve:")
+    for drift in drifts:
+        print(drift.render())
+    print()
+    print("These are transitive unless named in docs/requirements.in. Taking them is a")
+    print("judgement call, not a mechanical update, which is why this reports rather")
+    print("than opening a pull request. To accept them all:")
+    print("    uv run --python 3.13 --with pip-tools -- pip-compile --generate-hashes \\")
+    print("      --strip-extras --output-file docs/requirements.txt docs/requirements.in")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_check_docs_requirements_staleness.py
+++ b/tests/unit/test_check_docs_requirements_staleness.py
@@ -1,0 +1,144 @@
+"""Tests for the weekly transitive-pin staleness report (#4001).
+
+The diff logic is exercised against synthetic pin sets rather than the real
+files: what a fresh resolve produces changes every week by design, so an
+assertion against the live tree would be a test that reports the weather.
+
+The one place the real files are read is the invocation guard. #3995 was a
+compiled artifact drifting from the command documented to produce it, and
+this script recompiles with that command: if the two disagree again, every
+package reports as moved on the first run and the report is noise rather
+than a finding.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from check_docs_requirements_staleness import (
+    PIP_COMPILE_ARGV,
+    PinDrift,
+    diff_pins,
+    parse_pins,
+)
+
+_HASH_TAIL = " \\\n    --hash=sha256:" + "0" * 64
+
+
+class TestDiffPins:
+    def test_identical_resolutions_report_nothing(self) -> None:
+        pins = {"babel": "2.18.0", "mkdocs": "1.6.1"}
+
+        assert diff_pins(pins, dict(pins)) == []
+
+    def test_a_moved_transitive_pin_is_reported_with_both_versions(self) -> None:
+        drifts = diff_pins({"certifi": "2026.4.1"}, {"certifi": "2026.7.2"})
+
+        assert [d.package for d in drifts] == ["certifi"]
+        assert drifts[0].kind == "moved"
+        assert "2026.4.1" in drifts[0].render()
+        assert "2026.7.2" in drifts[0].render()
+
+    def test_a_package_a_fresh_resolve_adds_is_reported(self) -> None:
+        # A direct dependency gaining a new requirement shows up here, not in
+        # the direct-constraint gate, which only knows the four named in the
+        # .in file.
+        drifts = diff_pins({}, {"properdocs": "1.6.7"})
+
+        assert drifts[0].kind == "added"
+        assert drifts[0].committed is None
+
+    def test_a_package_a_fresh_resolve_drops_is_reported(self) -> None:
+        drifts = diff_pins({"orphaned": "1.0.0"}, {})
+
+        assert drifts[0].kind == "removed"
+        assert drifts[0].resolved is None
+
+    def test_drifts_are_name_sorted_so_two_runs_read_the_same(self) -> None:
+        drifts = diff_pins({"zzz": "1", "aaa": "1"}, {"zzz": "2", "aaa": "2"})
+
+        assert [d.package for d in drifts] == ["aaa", "zzz"]
+
+    def test_names_are_compared_canonically(self) -> None:
+        # PEP 503: Foo_Bar and foo-bar are one project. Comparing raw strings
+        # would report every underscore-spelled package as both added and
+        # removed, every week, forever.
+        assert diff_pins(parse_pins("Foo_Bar==1.0\n"), parse_pins("foo-bar==1.0\n")) == []
+
+
+class TestParsePins:
+    def test_hash_continuations_are_not_pins(self) -> None:
+        text = f"babel==2.18.0{_HASH_TAIL}\n    --hash=sha256:{'1' * 64}\n    # via mkdocs\n"
+
+        assert parse_pins(text) == {"babel": "2.18.0"}
+
+    def test_comments_and_blank_lines_are_skipped(self) -> None:
+        assert parse_pins("# a comment\n\nmkdocs==1.6.1\n") == {"mkdocs": "1.6.1"}
+
+
+class TestTheRecompileUsesTheDocumentedCommand:
+    """#3995 one layer on: a recompile built on the wrong command reports noise."""
+
+    def in_file_command(self) -> str:
+        lines = (REPO_ROOT / "docs" / "requirements.in").read_text(encoding="utf-8").splitlines()
+        marker = next(
+            (i for i, line in enumerate(lines) if "Regenerate after any change here with:" in line),
+            None,
+        )
+        assert marker is not None, "docs/requirements.in no longer documents a regeneration command"
+        collected: list[str] = []
+        for line in lines[marker + 1 :]:
+            if not line.startswith("#"):
+                break
+            body = line[1:]
+            if body.strip() == "":
+                if collected:
+                    break
+                continue
+            if not body.startswith("   "):
+                break
+            collected.append(body.strip().rstrip("\\").strip())
+        assert collected, "found the marker but no indented command under it"
+        return " ".join(collected)
+
+    @pytest.mark.parametrize(
+        "flag",
+        ["--generate-hashes", "--strip-extras", "--output-file", "pip-compile"],
+        ids=["hashes", "strip-extras", "output-file", "compiler"],
+    )
+    def test_every_flag_this_script_compiles_with_is_documented(self, flag: str) -> None:
+        assert flag in PIP_COMPILE_ARGV, f"{flag} vanished from PIP_COMPILE_ARGV"
+        assert flag in self.in_file_command(), (
+            f"docs/requirements.in no longer documents {flag}, so this script would recompile "
+            f"with a command that does not reproduce the committed file and report every "
+            f"package as moved"
+        )
+
+    def test_the_committed_file_records_the_same_invocation(self) -> None:
+        header = "\n".join(
+            line
+            for line in (REPO_ROOT / "docs" / "requirements.txt").read_text(encoding="utf-8").splitlines()[:12]
+            if line.startswith("#")
+        )
+
+        assert "--strip-extras" in header
+        assert "--strip-extras" in self.in_file_command()
+
+    def test_quiet_is_passed_so_progress_output_is_not_parsed_as_pins(self) -> None:
+        assert "--quiet" in PIP_COMPILE_ARGV
+
+
+class TestRenderNamesTheVersionsNotJustThePackage:
+    def test_a_report_line_carries_enough_to_act_on(self) -> None:
+        # "certifi moved" costs the reader a lookup; the whole point of the
+        # weekly report is that the issue body is smaller than the diff.
+        line = PinDrift(package="certifi", committed="2026.4.1", resolved="2026.7.2").render()
+
+        assert "certifi" in line
+        assert "2026.4.1" in line
+        assert "2026.7.2" in line


### PR DESCRIPTION
Closes #4001. Second of the three for the packaging area.

## The decision you left open: it reports, it does not open a PR

You framed it as actionable-in-one-click versus keeping a human in the loop. Both are true, but there is a sharper line, and it is the one I used.

Compare against **#4053**, which I did last. There the regeneration is **mechanical**: the manifests are a pure function of `pyproject.toml`, there is exactly one right answer, and the correct fix was to automate it end to end and delete the manual step.

A staleness report is not that. *"`certifi` moved from 2026.4.1 to 2026.7.2"* needs somebody to decide whether taking it is wanted, and the answer depends on things the job cannot see. Automating a decision that needs judgement produces a weekly PR touching 39 pins, which gets rubber-stamped or ignored, and neither is reading it. That is the failure #3995 exists to remove, re-created one level up.

So: **mechanical and deterministic gets a PR, judgement-shaped and index-dependent gets an issue** naming which packages moved and by how much. The report is smaller than the diff, which is the point.

Second reason, written into the workflow rather than only here: the recompile reaches a live index, so its output is not reproducible across runs. A PR branch would go stale between opening and review through nobody's fault. An issue does not rot the same way.

## The dedup question I raised when claiming

Answered by the repo rather than invented: `adapter-contract-drift.yml` searches for an open issue by title, edits it if found, creates otherwise. Same idiom here, plus a close when the pins catch up. A fresh issue every Monday against a set of pins nobody has decided on yet turns the report into its own noise source, which is the shape this series keeps removing.

## Exit codes distinguish "no drift" from "could not look"

`1` means pins moved, which is the finding, and does **not** redden the job. `2` means the recompile could not run, and that **does**.

A staleness check that cannot reach the index has not reported "no drift", it has reported nothing, and a job where those two look identical is exactly the green-that-means-nothing this repo keeps finding. The step comment says so.

## Prerequisites, verified rather than assumed

- The `--strip-extras` header fix from #3999 is on `main`, so a recompile built on the documented command reproduces the committed file instead of reporting all 43 packages as moved on its first run.
- `53 6 * * 1` is unclaimed: the gap between trufflehog (06:23) and the coverage-ratchet / required-check-canary pair (both 07:23). Confirmed no other workflow uses it.

## Tests

15, against synthetic pin sets. What a fresh resolve produces changes weekly by design, so asserting against the live tree would be a test that reports the weather.

The one place the real files are read is the **invocation guard** — parametrised per flag, holding `PIP_COMPILE_ARGV` to the command `docs/requirements.in` documents. This is #3995 one layer on: if those two disagree again, this script recompiles with a command that cannot reproduce the committed file and reports every package as moved, so the report becomes noise rather than a finding.

Also covered: canonical name comparison, since `Foo_Bar` and `foo-bar` are one project and comparing raw strings would report every underscore-spelled package as both added and removed, every week, forever.

## Verification

```
tests/unit/test_check_docs_requirements_staleness.py    15 passed
ruff check / format --check                             clean
mypy scripts/check_docs_requirements_staleness.py       Success
docs-requirements-staleness-weekly.yml                  parses, 1 job
cron slot                                               53 6 * * 1, unclaimed
```

**I have not run the recompile end to end**, and I would rather say so than imply it. `uv` is blocked by an Application Control policy on this machine as of today, so I could not execute `pip-compile` locally. The diff and parsing logic are unit-tested; the subprocess call itself is exercised first by the workflow's own run. Happy to trigger it via `workflow_dispatch` once merged and confirm the first report reads correctly.

Out of scope as you set it: no pin changed, the direct-constraint gate untouched, and the root `pyproject.toml` / `uv.lock` pair left alone.