### PR TITLE
fix(eval,tasks,plugins,security): route eval/tasks/plugins path checks through contained_subpath; document always_allow's non-conversion

### DIFF
--- a/src/bernstein/core/plugins_core/plugin_installer.py
+++ b/src/bernstein/core/plugins_core/plugin_installer.py
@@ -32,6 +32,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Annotated, Literal
 
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    contained_subpath,
+)
 from bernstein.core.security.url_allowlist import UrlSchemeError, ensure_http_url
 
 logger = logging.getLogger(__name__)
@@ -244,11 +248,17 @@ def _extract_archive(archive_path: Path, dest: Path) -> None:
     name = archive_path.name
     if name.endswith(".zip"):
         with zipfile.ZipFile(archive_path) as zf:
-            resolved_dest = dest.resolve()
             for info in zf.infolist():
-                target = (resolved_dest / info.filename).resolve()
-                if not target.is_relative_to(resolved_dest):
-                    raise ValueError(f"Zip entry would escape target directory: {info.filename}")
+                # contained_subpath splits on both '/' and '\\' regardless of
+                # host platform, so a hostile entry spelled with backslashes
+                # is refused here too -- the zip spec uses '/', but nothing
+                # stops a crafted archive from writing '\\' into the name,
+                # and the old single-separator check let that through inert
+                # on POSIX (a literal backslash byte, not a traversal).
+                try:
+                    target = contained_subpath(dest, info.filename, label="zip entry")
+                except PathContainmentError as exc:
+                    raise ValueError(f"Zip entry would escape target directory: {info.filename}") from exc
                 if info.is_dir():
                     target.mkdir(parents=True, exist_ok=True)
                     _apply_zip_unix_mode(target, info)

--- a/src/bernstein/core/security/always_allow.py
+++ b/src/bernstein/core/security/always_allow.py
@@ -197,6 +197,22 @@ def _is_agent_writable(rules_path: Path, workdir: Path) -> bool:
     a compromised agent.  Paths that resolve outside *workdir* (e.g. the
     orchestrator's ``.sdd/config/`` when rules live there, or an absolute
     path passed via env var) are treated as trusted.
+
+    Left off the #3802/#4035 path-containment sweep on purpose:
+    ``contained_path``/``contained_subpath`` join a caller-supplied relative
+    *segment* onto a base and refuse a result outside it; this function
+    instead classifies an already-resolved, possibly-absolute path's
+    relationship to *workdir*, where "outside" is the routine, expected
+    branch (ENV_ALWAYS_ALLOW_PATH is documented above to point anywhere) and
+    not a refusal. ``validate_relative_path`` rejects a leading ``/`` or
+    drive letter outright, so passing ``str(rules_path)`` as the shared
+    helper's candidate would raise for every legitimate outside-workdir rules
+    path before containment is even checked - the exact "no behaviour change
+    is silently introduced" case #3802's acceptance criteria call out. The
+    ``resolve()``-then-``relative_to()`` shape here already matches what the
+    helper does internally; it stays local because reusing the helper's API
+    would require the same falsify-then-recover step the helper exists to
+    avoid.
     """
     try:
         resolved_rules = rules_path.resolve()
@@ -261,6 +277,12 @@ def write_always_allow_manifest(workdir: Path, rules_path: Path) -> Path:
     """
     manifest_path = workdir / TRUSTED_MANIFEST_REL
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    # Not a #3802/#4035 conversion target: this chooses between a relative
+    # and an absolute *display string* for a manifest this function's own
+    # docstring says only the orchestrator ever calls, on a path it already
+    # trusts - there is no untrusted candidate here for contained_subpath to
+    # prove contained, and the same absolute-candidate mismatch as
+    # _is_agent_writable above applies if it were forced in anyway.
     payload = {
         "version": 1,
         "path": str(rules_path.resolve().relative_to(workdir.resolve()))

--- a/src/bernstein/core/tasks/artifact_completion.py
+++ b/src/bernstein/core/tasks/artifact_completion.py
@@ -61,6 +61,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    contained_subpath,
+)
 from bernstein.core.tasks.artifacts import (
     ArtifactKind,
     ArtifactSpecError,
@@ -217,13 +221,12 @@ def _resolve_contained_artifact_path(workdir: Path, relpath: str) -> Path:
     component swapped between this check and the read changes which contained
     bytes are read, never whether the read stays inside the workdir.
     """
-    base = workdir.resolve()
-    resolved = (base / relpath).resolve()
-    if not resolved.is_relative_to(base):
+    try:
+        return contained_subpath(workdir, relpath, label="artifact output path")
+    except PathContainmentError as exc:
         raise ArtifactCompletionError(
             f"artifact output path {relpath!r} resolves outside the task workdir; refusing to read it"
-        )
-    return resolved
+        ) from exc
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/eval/trajectory_receipt.py
+++ b/src/bernstein/eval/trajectory_receipt.py
@@ -55,6 +55,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    contained_subpath,
+)
 from bernstein.eval.metrics import EvalScoreComponents, TierScores
 from bernstein.eval.significance import suite_content_hash
 
@@ -472,11 +476,19 @@ def trajectory_receipt_path(workdir: Path, receipt_hash: str) -> Path:
         msg = f"receipt_hash is not a canonical sha256 digest: {receipt_hash!r}"
         raise ValueError(msg)
     base = workdir.joinpath(*_BENCH_SUBPATH)
-    candidate = base / f"{receipt_hash}.json"
-    if not candidate.resolve().is_relative_to(base.resolve()):
+    # contained_subpath, not contained_path: the canonical hash carries a
+    # ``sha256:`` prefix, and contained_path's single-segment allowlist has no
+    # ':' in it. The candidate is still one path component -- no '/' or '\\'
+    # ever reaches validate_relative_path -- so contained_subpath's weaker,
+    # multi-component-shaped check enforces the same barrier this needs: the
+    # allowlist step is a no-op given _RECEIPT_HASH_RE above, and the
+    # realpath-containment step is what actually guards a pre-planted symlink
+    # named "<hash>.json" inside the bench directory.
+    try:
+        return contained_subpath(base, f"{receipt_hash}.json", label="receipt hash")
+    except PathContainmentError as exc:
         msg = f"receipt path escapes bench directory: {receipt_hash!r}"
-        raise ValueError(msg)
-    return candidate
+        raise ValueError(msg) from exc
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/eval/test_trajectory_receipt.py
+++ b/tests/unit/eval/test_trajectory_receipt.py
@@ -484,6 +484,33 @@ def test_trajectory_receipt_path_rejects_non_sha256(tmp_path: Path) -> None:
         trajectory_receipt_path(tmp_path, "not-a-hash")
 
 
+def test_trajectory_receipt_path_refuses_hash_that_resolves_outside_bench_dir(tmp_path: Path) -> None:
+    """A pre-planted symlink named ``<hash>.json`` must not smuggle a read/write outside bench.
+
+    The hash itself can never carry ``..`` -- ``_RECEIPT_HASH_RE`` only admits
+    hex -- so the only way this check can fire is the final path component
+    already existing as a symlink out of the bench directory before this
+    function resolves it.
+    """
+    receipt_hash = "sha256:" + "c" * 64
+    workdir = tmp_path / "workdir"
+    bench_dir = workdir.joinpath(".sdd", "eval", "bench")
+    bench_dir.mkdir(parents=True)
+    outside = tmp_path / "host-secret.json"
+    outside.write_text("not a receipt", encoding="utf-8")
+    (bench_dir / f"{receipt_hash}.json").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="escapes bench directory"):
+        trajectory_receipt_path(workdir, receipt_hash)
+
+
+def test_trajectory_receipt_path_accepts_the_ordinary_case(tmp_path: Path) -> None:
+    """Positive control: an un-planted hash still resolves under bench, unaltered."""
+    receipt_hash = "sha256:" + "d" * 64
+    path = trajectory_receipt_path(tmp_path, receipt_hash)
+    assert path == tmp_path.resolve() / ".sdd" / "eval" / "bench" / f"{receipt_hash}.json"
+
+
 # ---------------------------------------------------------------------------
 # Byte integrity -- verification must hash the stored bytes, not a projection
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_plugin_installer.py
+++ b/tests/unit/test_plugin_installer.py
@@ -127,6 +127,23 @@ class TestExtractArchive:
 
         assert not (tmp_path / "out_evil" / "pwned.txt").exists()
 
+    def test_extract_zip_rejects_backslash_traversal_entry(self, tmp_path: Path) -> None:
+        """A '..\\' entry must be refused on every host, not just Windows.
+
+        A bare ``(dest / name).resolve()`` treats a backslash as an ordinary
+        filename character on POSIX, so a zip built to attack a Windows
+        target extracted inertly-but-not-safely on POSIX before this site
+        went through the shared containment helper, which splits on both
+        separators regardless of platform.
+        """
+        archive = _make_zip(tmp_path / "plugin.zip", {"..\\out_evil\\pwned.txt": "owned"})
+        dest = tmp_path / "out"
+
+        with pytest.raises(ValueError, match="Zip entry would escape target directory"):
+            _extract_archive(archive, dest)
+
+        assert not (tmp_path / "out_evil" / "pwned.txt").exists()
+
     def test_extract_zip_preserves_unix_file_mode(self, tmp_path: Path) -> None:
         """Zip extraction preserves the Unix mode on POSIX; extracts on Windows.
 


### PR DESCRIPTION
Closes #4035. Slice 2 of the #3802 leftover bucket, after the orchestration slice (#3855/#3857/#3858, #4034 → #4095).

## The three converted sites

`trajectory_receipt_path`, `_resolve_contained_artifact_path`, and `_extract_archive`'s zip-slip guard are all refuse-on-escape gates, converted directly to `contained_subpath`.

**`trajectory_receipt_path` uses `contained_subpath`, not `contained_path`.** The canonical hash carries a `"sha256:"` prefix, and `contained_path`'s single-segment allowlist (`SAFE_SEGMENT_RE`) has no `':'` in it — a direct swap would reject every legitimate hash before containment is even checked. The candidate is still exactly one path component (the hash format admits no separator), so `contained_subpath`'s multi-component-shaped check is the right fit here: its lexical half is a no-op given `_RECEIPT_HASH_RE` already ran above it, and its realpath-containment half is what actually guards the attack this function defends against — a symlink pre-planted at `<hash>.json` inside the bench directory. Since the hash itself can never carry `".."` (hex-only regex), a directory-level escape was never reachable through this argument; only a planted final-component symlink is. The new test plants exactly that.

**`_resolve_contained_artifact_path` and the zip-slip guard convert directly** — both were already checking a multi-component relative candidate against a base, exactly `contained_subpath`'s shape. Both keep their existing exception type and message (`ArtifactCompletionError` / `ValueError` with the original `"Zip entry would escape..."` text) by catching `PathContainmentError` at the call site, so no caller-visible contract moves. Confirmed against the two existing symlink-escape tests in `test_artifact_completion.py`, which still pass unmodified — they already covered this end-to-end via the public `load_artifact` API.

## A hardening worth calling out, not leaving implicit

`contained_subpath`'s `validate_relative_path` splits on **both** `'/'` and `'\\'` regardless of host platform (per its own docstring: a stored value is written on one host and read on another). The old zip-slip check only split on the host's separator via `Path` join semantics, so a zip entry spelled with a literal backslash used to extract *inertly* on POSIX — one oddly-named file, not a traversal — and would only have actually escaped on a Windows target. It's refused on every host now. Pinned by `test_extract_zip_rejects_backslash_traversal_entry`.

## always_allow.py: no code change, by design

Per the issue's own "or carries a comment explaining why the shared helper doesn't fit" option — I read this as the right call for both sites, for two independent reasons:

1. **Neither is a refuse-on-escape gate.** `_is_agent_writable` returns `False`, not a raise, for a path outside `workdir` — `ENV_ALWAYS_ALLOW_PATH` is documented to point anywhere, so "outside" is the *routine* branch all four callers already handle via `not _is_agent_writable(...)`. Forcing a raise here is exactly the silently-introduced behaviour change #3802's acceptance criteria exist to catch.
2. **The call shape doesn't fit even with a try/except wrapper.** `contained_path`/`contained_subpath` join a caller-supplied *relative segment* onto a base. Here, `rules_path` already exists as an independent, frequently-*absolute* `Path` (an env-var override, or the orchestrator's own `.sdd/config/`), and `validate_relative_path` refuses a leading `/` or drive letter **before containment is even checked**. Passing `str(rules_path)` as the candidate would raise for every legitimate outside-workdir rules path — which is the common case this function exists to classify as trusted, not the exceptional one.

`write_always_allow_manifest`'s read at :266-268 goes one step further than "doesn't fit": its own docstring says only the orchestrator calls it, on a path it already trusts ("Call this from the orchestrator (never from an agent process)"). There is no untrusted candidate here for `contained_subpath` to prove contained in the first place — it is choosing between a relative and absolute *display string* for a manifest, not gating an access.

Both sites now carry an inline comment explaining this, so the non-conversion reads as a decision rather than an oversight the next sweep re-flags.

## Tests

- `tests/unit/eval/test_trajectory_receipt.py`: `test_trajectory_receipt_path_refuses_hash_that_resolves_outside_bench_dir` (symlink-plant attack) + `test_trajectory_receipt_path_accepts_the_ordinary_case` (positive control).
- `tests/unit/test_plugin_installer.py`: `test_extract_zip_rejects_backslash_traversal_entry` (the new cross-platform hardening). The existing `test_extract_zip_rejects_sibling_prefix_escape` and `test_extract_zip` already serve as the escape/positive-control pair the issue's test matrix asks for, so I did not duplicate them.
- `tests/unit/tasks/test_artifact_completion.py`, `tests/unit/test_always_allow.py`: unmodified, run to confirm no regression.

## Verification

```
pytest tests/unit/eval/test_trajectory_receipt.py tests/unit/test_plugin_installer.py \
       tests/unit/tasks/test_artifact_completion.py tests/unit/test_always_allow.py
146 passed
```

`ruff check` / `ruff format --check` clean on all six touched files. `mypy` reports zero errors in any of the four changed modules — confirmed by diffing mypy's per-file error list against an unmodified `origin/main` run, which shows the same 44 pre-existing errors elsewhere and none in these four files.

## Out of scope

The two sites in `always_allow.py` are intentionally undone, per the decision above. Nothing else from #3802's original sixteen remains unconverted after this PR and #4095.