### PR TITLE
fix(contract): derandomize the smoke-profile Schemathesis sweep so PR and merge-queue gates stop giving different verdicts on the same commit

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -150,6 +150,13 @@ A real bug - an endpoint should never propagate an unhandled
 exception. The reproducer is printed at the bottom of the failure (a
 `curl` invocation against the mounted ASGI app).
 
+The `smoke` profile (the PR/merge-queue gate) is derandomized (#4024): the
+same commit always draws the same example set, so re-running the exact
+command above against an unchanged tree reproduces the same verdict every
+time - no seed to pass back in. The `deep` profile (nightly) is
+deliberately excluded from this and keeps exploring fresh input space on
+every run, which is where new defects should surface first.
+
 ### Snapshot diff
 If the diff is intentional (you changed an audit field on purpose),
 re-run with `--snapshot-update` and commit the updated `.ambr`. If

--- a/tests/contract/test_schemathesis_determinism.py
+++ b/tests/contract/test_schemathesis_determinism.py
@@ -1,0 +1,136 @@
+"""Determinism of the smoke-profile Schemathesis sweep (#4024).
+
+`test_task_server_schemathesis.py`'s ``test_no_unhandled_exceptions`` gates
+both the PR lane and every merge-queue batch. Before #4024's fix it drew a
+fresh Hypothesis example set on every run: the same tree could pass on one
+run and fail on the next, and a merge-queue batch that drew a pathological
+example was dequeued -- along with every entry behind it -- for a defect
+that was not actually new.
+
+The fix branches ``derandomize`` on ``_PROFILE`` so only the *gating* smoke
+lane is pinned; the nightly deep lane keeps exploring fresh input space,
+which is where new defects should be found. These tests assert the property
+directly rather than trusting the settings object was wired correctly by
+inspection alone -- one for each half of the branch, plus the reproducibility
+property itself.
+
+Deliberately a sibling file, not additions to ``test_task_server_schemathesis.py``:
+that file's own docstring scopes it to "fuzz documented operations ... assert
+no 500-class crash leaks". These assert properties of the ``@settings`` object
+and of the generated-case set, not app behaviour, and bundling them in would
+blur that file's stated purpose.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+import schemathesis
+from hypothesis import given, settings
+
+# Imported as a module, not `from ... import test_no_unhandled_exceptions`:
+# schemathesis's own pytest plugin collects any object carrying its schema
+# mark by walking a module's *own* top-level attributes
+# (schemathesis.core.marks.Mark.get reads an attribute set directly on the
+# function object - there is no name-prefix check pytest's default
+# collector applies first). Binding the target function itself as a
+# top-level name here would make schemathesis re-collect and re-run the
+# entire smoke sweep a second time, under this file, on every run.
+# Referencing it through the module keeps it off this file's own
+# top-level namespace, so only its home file collects it.
+from tests.contract import test_task_server_schemathesis as _schemathesis_module
+
+_MAX_EXAMPLES = _schemathesis_module._MAX_EXAMPLES
+_PROFILE = _schemathesis_module._PROFILE
+_SMOKE_PATH_PREFIXES = _schemathesis_module._SMOKE_PATH_PREFIXES
+schema = _schemathesis_module.schema
+
+
+def test_smoke_profile_sets_derandomize() -> None:
+    """Under the profile this session actually resolved, smoke pins its draws.
+
+    ``_PROFILE`` (and therefore ``_DERANDOMIZE_SMOKE``) is read from the
+    environment at import time in the module under test, so this asserts
+    against whichever profile the *current* process resolved to rather than
+    setting the env var itself -- reimporting the already-imported module
+    under a different env var would not change anything it already computed
+    at import time. CI's ``schemathesis-smoke`` job is what actually needs
+    this to hold; see ``test_deep_profile_still_randomizes`` below for the
+    other half of the branch.
+    """
+    if _PROFILE != "smoke":
+        pytest.skip(f"this process resolved SCHEMATHESIS_PROFILE={_PROFILE!r}, not 'smoke'")
+    applied = _schemathesis_module.test_no_unhandled_exceptions._hypothesis_internal_use_settings
+    assert applied.derandomize is True
+
+
+def test_deep_profile_still_randomizes() -> None:
+    """The nightly deep lane must keep exploring; #4024 forbids freezing it too.
+
+    Written first, per the issue brief: a fix that only checks the smoke
+    side can ship green while accidentally setting ``derandomize=True``
+    unconditionally, which would freeze the deep lane's exploration and
+    silently violate the acceptance criterion that forbids it.
+    """
+    if _PROFILE != "deep":
+        pytest.skip(f"this process resolved SCHEMATHESIS_PROFILE={_PROFILE!r}, not 'deep'")
+    applied = _schemathesis_module.test_no_unhandled_exceptions._hypothesis_internal_use_settings
+    assert applied.derandomize is False
+
+
+def _smoke_case_strategy():
+    """The same operation subset the smoke lane fuzzes, as a bare Hypothesis strategy.
+
+    ``schema.parametrize()`` drives Hypothesis through pytest's own
+    collection machinery, which runs every example inside one pytest
+    invocation rather than exposing them as separately inspectable results.
+    Driving the strategy directly with ``@given`` -- schemathesis's own
+    documented "use with @given in non-Schemathesis tests" escape hatch --
+    lets this test capture and compare the exact generated cases across two
+    independent runs, which is the property #4024 asks for.
+    """
+    prefix_pattern = "|".join(re.escape(prefix) for prefix in _SMOKE_PATH_PREFIXES)
+    return schema.include(path_regex=f"^({prefix_pattern})").as_strategy()
+
+
+def _generated_cases() -> list[tuple[str, str, str, str, str]]:
+    """Run one smoke-sized derandomized sweep and return each case's identity.
+
+    Method, path, and every generated part are captured -- not just
+    method+path -- so two runs that hit the same operations with different
+    generated bodies still count as different, matching what the acceptance
+    criterion means by "the same set of generated cases".
+    """
+    collected: list[tuple[str, str, str, str, str]] = []
+    strategy = _smoke_case_strategy()
+
+    @given(case=strategy)
+    @settings(max_examples=_MAX_EXAMPLES, deadline=None, derandomize=True)
+    def _run(case: schemathesis.Case) -> None:
+        collected.append(
+            (
+                case.method,
+                case.path,
+                repr(case.path_parameters),
+                repr(case.query),
+                repr(case.body),
+            )
+        )
+
+    _run()
+    return collected
+
+
+def test_two_consecutive_smoke_runs_generate_identical_cases() -> None:
+    """The property #4024's acceptance criteria name directly.
+
+    Two independent derandomized sweeps over the same operation subset, same
+    settings, same process: the generated case sequence must match exactly,
+    not just up to reordering -- Hypothesis's own derandomize contract is
+    that replay is deterministic *and* ordered.
+    """
+    first = _generated_cases()
+    second = _generated_cases()
+    assert first, "the smoke path allow-list matched no operations; nothing was exercised"
+    assert first == second

--- a/tests/contract/test_task_server_schemathesis.py
+++ b/tests/contract/test_task_server_schemathesis.py
@@ -133,8 +133,28 @@ def _reset_server_mutable_state() -> Any:
     _app.state.draining = False
 
 
+# derandomize only the smoke profile (#4024): PR-time and merge-queue gates
+# must give the same verdict for the same commit, or a pathological draw
+# dequeues an otherwise-clean merge-queue batch and everything behind it
+# reruns for nothing. The nightly deep profile keeps exploring - new draws
+# belong to the lane that is allowed to be flaky, not the one that gates
+# merges, so it is deliberately excluded here.
+#
+# Hypothesis derives the derandomized seed from the test function itself,
+# so there is no seed value to log or maintain - rerunning this exact
+# command against this exact commit reproduces the same example set.
+#
+# What "the same example set" is NOT pinned to: Hypothesis itself.
+# derandomize replays *this resolved Hypothesis version's* deterministic
+# sequence, so a routine `uv lock --upgrade` that bumps hypothesis (floor
+# pinned at pyproject.toml's "hypothesis>=6.100"; currently resolves to
+# 6.151.11) can shift which cases the smoke lane draws even with this fix
+# in place. That is expected, not a regression in this fix.
+_DERANDOMIZE_SMOKE = _PROFILE == "smoke"
+
+
 @schema.parametrize()
-@settings(max_examples=_MAX_EXAMPLES, deadline=None)
+@settings(max_examples=_MAX_EXAMPLES, deadline=None, derandomize=_DERANDOMIZE_SMOKE)
 def test_no_unhandled_exceptions(case: schemathesis.Case) -> None:
     """Every documented endpoint must respond without 500-class crash.
 
@@ -142,16 +162,23 @@ def test_no_unhandled_exceptions(case: schemathesis.Case) -> None:
     transport, so each example is a sub-millisecond round-trip - fast
     enough that a focused critical-surface fuzz stays under 90 s at
     smoke settings.
+
+    Deliberately does not inspect ``response.status_code`` after the call:
+    `not_a_server_error` in `_CHECKS` raises before `call_and_validate` can
+    return one for a real 5xx, and an unhandled exception escaping the
+    handler propagates out of the call itself (this app registers no
+    catch-all exception handler - only `HTTPException`, in
+    `core/fleet/web.py`). Either way Schemathesis's own failure carries the
+    method, path, and a ready-to-run `curl` reproducer (see
+    docs/contributing/testing.md, "Schemathesis 5xx leak"); a
+    status-code check after the call is unreachable dead code, not a
+    second safety net.
     """
     if (case.method.upper(), case.path) in _STREAMING_OPERATIONS:
         pytest.skip(f"{case.method} {case.path} answers with an unbounded stream, covered by the streaming test below")
     if _PROFILE == "smoke" and not _path_in_smoke_set(case.path):
         pytest.skip(f"path {case.path} not in smoke allow-list")
-    response = case.call_and_validate(checks=_CHECKS)
-    if response.status_code >= 500:
-        pytest.fail(
-            f"5xx response from {case.method} {case.path}: status={response.status_code}, body={response.text[:200]}"
-        )
+    case.call_and_validate(checks=_CHECKS)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4024.

## Problem

`schemathesis-smoke` gates the PR lane and every merge-queue batch. Its one `@settings(...)` call site had no `derandomize` and no seed, so every run drew a fresh Hypothesis example set:

```python
# tests/contract/test_task_server_schemathesis.py:137 (before)
@settings(max_examples=_MAX_EXAMPLES, deadline=None)
```

The same tree could pass on one run and fail on the next. A pathological draw dequeues an otherwise-clean merge-queue batch — roughly 45 jobs — for a defect that was not actually new; the retry usually draws differently and passes, so the real defect stays on `main` and the only durable cost is queue churn.

## Fix

`derandomize=True`, branched on `_PROFILE` exactly the way `_MAX_EXAMPLES` already is:

```python
_DERANDOMIZE_SMOKE = _PROFILE == "smoke"

@schema.parametrize()
@settings(max_examples=_MAX_EXAMPLES, deadline=None, derandomize=_DERANDOMIZE_SMOKE)
def test_no_unhandled_exceptions(case: schemathesis.Case) -> None:
```

The nightly deep profile (`nightly-deep-tests.yml`) is deliberately untouched — acceptance criterion 3 forbids freezing it too, and it's the lane meant to explore fresh input space; a new draw there finding a defect is correct behaviour, not a flake.

## The one decision (acceptance criterion 1 accepts either)

Took `derandomize=True` over an explicit seed. No repo-owned magic-number constant to invent and keep in sync, and Hypothesis derives the derandomized seed from the test function itself — rerunning the same command against the same commit *is* the reproduction. Acceptance criterion 2 ("if a seed is used, log it and print the reproduce command") is conditional and does not apply here — stating that plainly so a reviewer isn't hunting for a seed log that was never meant to exist.

One thing worth pinning explicitly rather than assuming: `derandomize` replays *this resolved Hypothesis version's* deterministic sequence (floor-pinned `hypothesis>=6.100`, currently resolves to `6.151.11`). A routine `uv lock --upgrade` can shift which cases the smoke lane draws even with this fix in place. Expected, not a regression — left as a comment at the settings call site so it doesn't read as a mystery later.

## Dead code removed (acceptance criterion 4)

```python
# before
response = case.call_and_validate(checks=_CHECKS)
if response.status_code >= 500:
    pytest.fail(f"5xx response from {case.method} {case.path}: status={response.status_code}, body={response.text[:200]}")
```

Confirmed dead, not by inference — by reading `schemathesis/checks.py` *and* by triggering a real failure and inspecting the actual pytest output:

- `not_a_server_error` raises `ServerError` the instant `call_and_validate()` sees a non-2xx/expected status. It never returns a response with `status_code >= 500` for the `if` to see.
- An unhandled exception escaping a handler propagates out of the call itself — this app registers no catch-all exception handler, only `HTTPException` (`core/fleet/web.py:242`).

Either path already carries method, path, and a ready-to-run `curl` reproducer via Schemathesis's own failure formatting (confirmed against a standalone minimal app that raises inside a route — the exact output `docs/contributing/testing.md`'s "Schemathesis 5xx leak" section already documents). That's what AC4 asks for; there was nothing to build.

```python
# after
case.call_and_validate(checks=_CHECKS)
```

## Tests

New sibling file `tests/contract/test_schemathesis_determinism.py` — `test_task_server_schemathesis.py`'s own docstring scopes it to app behaviour ("no 500-class crash leaks"), and these assert properties of the `@settings` object and the generated-case set instead, so bundling them in would blur that file's stated purpose.

- `test_deep_profile_still_randomizes` / `test_smoke_profile_sets_derandomize` — written in that order per the issue brief, so a fix that only checks the smoke side can't ship green while silently freezing deep too. Each asserts against whichever profile the *current* process resolved and skips the other half, matching how CI actually invokes them (separate jobs, separate processes).
- `test_two_consecutive_smoke_runs_generate_identical_cases` — the property the acceptance criteria name directly. Driven through schemathesis's own documented `@given`-in-non-Schemathesis-tests escape hatch rather than pytest's collection machinery, so two independent runs can be captured and diffed in-process.

**One implementation trap worth flagging for review**, since it cost real debugging time: naively `from ... import test_no_unhandled_exceptions` into the new file made schemathesis's pytest plugin re-collect and re-run the *entire* smoke sweep a second time under it. Its collection hook (`pytest_pycollect_makeitem` in `schemathesis/pytest/plugin.py`) keys off a metadata attribute set directly on the function object — there's no `test_`-prefix check of its own, so an underscore-prefixed alias doesn't avoid it either (verified both ways with `--collect-only`, first showing 488 collected items, then 8 tests still duplicated even under an `_target_test` alias). The new file imports `test_task_server_schemathesis` as a *module* and reaches the target function through it instead, which never binds the function itself as a top-level name in the new file's own namespace — confirmed down to exactly 3 collected items.

## Verification

```
BERNSTEIN_AUTH_DISABLED=1 SCHEMATHESIS_PROFILE=smoke \
  uv run pytest tests/contract/ -q --no-cov --timeout=30 -p no:warnings
# run twice back to back: 96 passed, 406 skipped -- both times, identical

SCHEMATHESIS_PROFILE=deep BERNSTEIN_AUTH_DISABLED=1 \
  uv run pytest tests/contract/ -q --no-cov --timeout=120 -p no:warnings
# test_deep_profile_still_randomizes passes; confirms deep is untouched
```

`ruff check` / `ruff format --check` clean on both touched Python files. `tests/` sits outside mypy's `files=["src"]` scope and pyright's strict include list (`pyrightconfig.strict.json` excludes `**/test_*.py`), so neither type gate applies here.

## Docs

`docs/contributing/testing.md` updated in the same PR per the project's docs-alongside-code rule — the "Schemathesis 5xx leak" section now notes the smoke lane's reproduction is deterministic.

## Out of scope (flagged, not silently left)

`property-tests` (`ci.yml`, required) has the identical missing-derandomize/seed shape across ~169 `@settings(...)` call sites, centrally governed by `tests/property/conftest.py`'s `register_profile`/`load_profile` — fixing it there would likely cascade to all of them at once. A further 18 files under `tests/unit/` use `@settings(...)` directly with no shared profile plumbing, so each would need its own fix. Both share this issue's exact defect shape and are worth their own follow-up rather than folding into this PR.