### PR TITLE
fix(property): derandomize the smoke Hypothesis profile so property-tests stops giving different verdicts on the same commit

### DIFF
--- a/tests/property/conftest.py
+++ b/tests/property/conftest.py
@@ -48,10 +48,22 @@ settings.register_profile(
 )
 
 # ``deep`` - nightly. Thoroughness over speed.
+#
+# derandomize=False is explicit, not the implicit default it looks like.
+# Any kwarg omitted from register_profile() is inherited from
+# `settings.default` as resolved at THIS registration call -- and
+# `settings.default` is not hypothesis's pristine built-in settings, it is
+# whichever profile is *currently loaded* in this process at that instant.
+# Leaving this unset silently ties "deep" to "smoke"'s derandomize=True
+# whenever something causes this module to execute with "smoke" already
+# active (CI observed exactly that: get_profile("deep").derandomize read
+# True with no other register_profile call anywhere in the repository).
+# Pinning it here removes the dependency on load order entirely.
 settings.register_profile(
     "deep",
     max_examples=1_000,
     deadline=None,
+    derandomize=False,
     suppress_health_check=[
         HealthCheck.too_slow,
         HealthCheck.filter_too_much,

--- a/tests/property/conftest.py
+++ b/tests/property/conftest.py
@@ -49,16 +49,15 @@ settings.register_profile(
 
 # ``deep`` - nightly. Thoroughness over speed.
 #
-# derandomize=False is explicit, not the implicit default it looks like.
-# Any kwarg omitted from register_profile() is inherited from
-# `settings.default` as resolved at THIS registration call -- and
-# `settings.default` is not hypothesis's pristine built-in settings, it is
-# whichever profile is *currently loaded* in this process at that instant.
-# Leaving this unset silently ties "deep" to "smoke"'s derandomize=True
-# whenever something causes this module to execute with "smoke" already
-# active (CI observed exactly that: get_profile("deep").derandomize read
-# True with no other register_profile call anywhere in the repository).
-# Pinning it here removes the dependency on load order entirely.
+# derandomize=False is explicit, not the implicit default it looks like
+# (#4118). register_profile() inherits any unset kwarg from
+# `settings.default`, and hypothesis itself loads a CI-specific profile as
+# that default whenever it detects a CI environment (`CI=true` and
+# friends) -- *before* this module runs, with database=None and
+# derandomize=True. Off CI, `settings.default` is hypothesis's neutral
+# built-in (derandomize=False), which is why this only ever surfaced in
+# CI and never locally. Pinning the value here removes the dependency on
+# which environment happens to be running this file.
 settings.register_profile(
     "deep",
     max_examples=1_000,

--- a/tests/property/conftest.py
+++ b/tests/property/conftest.py
@@ -18,11 +18,27 @@ import os
 from hypothesis import HealthCheck, Verbosity, settings
 
 # ``smoke`` - PR-time. Tight budget; flake-resistant.
+#
+# derandomize=True (#4044, the same defect class as #4024 for the
+# schemathesis lane): PR-time and merge-queue gates must give the same
+# verdict for the same commit, or a pathological draw dequeues an
+# otherwise-clean merge-queue batch for a defect that was not actually
+# new. Not on "deep" - that profile exists to explore fresh input space,
+# and freezing it would remove its value. Hypothesis derives the
+# derandomized seed from the test function itself, so there is no seed
+# value to log or maintain here.
+#
+# What "the same example set" is NOT pinned to: Hypothesis itself.
+# derandomize replays *this resolved Hypothesis version's* deterministic
+# sequence, so a routine `uv lock --upgrade` that bumps hypothesis can
+# shift which cases the smoke lane draws even with this fix in place.
+# That is expected, not a regression.
 settings.register_profile(
     "smoke",
     max_examples=50,
     deadline=5_000,  # 5 s per example - generous for property cases that
     # touch the filesystem (WAL writer, audit log).
+    derandomize=True,
     suppress_health_check=[
         HealthCheck.too_slow,
         HealthCheck.filter_too_much,

--- a/tests/property/test_profile_determinism.py
+++ b/tests/property/test_profile_determinism.py
@@ -42,9 +42,16 @@ not from inside the running test).
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 from hypothesis import given
 from hypothesis import settings as hypothesis_settings
 from hypothesis import strategies as st
+
+_CONFTEST_PATH = Path(__file__).parent / "conftest.py"
 
 # Captured at collection time (module import), not re-queried inside the
 # test bodies below. `hypothesis.settings.get_profile(name)` reads a live
@@ -107,3 +114,57 @@ def test_two_consecutive_smoke_runs_are_identical() -> None:
     second = _generated_values_under_smoke()
     assert first, "the smoke profile generated no examples; nothing was exercised"
     assert first == second
+
+
+def _deep_derandomize_in_subprocess(*, ci: bool) -> bool:
+    """Import ``conftest.py`` fresh in a subprocess; report ``deep``'s resolved value.
+
+    A subprocess, not a monkeypatched ``CI`` env var in this process:
+    hypothesis resolves its CI-specific default profile the first time
+    ``hypothesis`` itself is imported in a process, so flipping the env var
+    afterward and re-importing ``conftest`` would not re-resolve it -- this
+    process already imported hypothesis once, driving these very tests.
+    A fresh interpreter run under a controlled environment is the only way
+    to observe what a real CI runner, or a real developer laptop, actually
+    sees.
+    """
+    env = os.environ.copy()
+    if ci:
+        env["CI"] = "true"
+        env["GITHUB_ACTIONS"] = "true"
+    else:
+        env.pop("CI", None)
+        env.pop("GITHUB_ACTIONS", None)
+    script = (
+        "import runpy; "
+        f"runpy.run_path({str(_CONFTEST_PATH)!r}, run_name='conftest'); "
+        "from hypothesis import settings; "
+        "print(settings.get_profile('deep').derandomize)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip() == "True"
+
+
+def test_deep_derandomize_is_false_under_both_ci_and_no_ci() -> None:
+    """#4118's own proof: pin the resolved value under both environments, not just the ambient one.
+
+    The defect #4118 found was invisible precisely because the environment
+    running this suite locally is the one where it looks fine:
+    ``derandomize=False`` on a developer laptop was correct while CI
+    silently read ``True`` by inheritance from hypothesis's own
+    CI-detection default -- the two environments disagreed, and nobody
+    inspects the registered value interactively in CI. A parametrize over a
+    monkeypatched ``CI`` variable would not catch this (see
+    ``_deep_derandomize_in_subprocess``'s docstring for why); a subprocess
+    per environment is what #4118 asked for and what would have caught the
+    original defect before it shipped.
+    """
+    assert _deep_derandomize_in_subprocess(ci=True) is False
+    assert _deep_derandomize_in_subprocess(ci=False) is False

--- a/tests/property/test_profile_determinism.py
+++ b/tests/property/test_profile_determinism.py
@@ -12,6 +12,26 @@ The fix sets `derandomize=True` on the registered `smoke` profile only,
 leaving `deep` (nightly, meant to explore fresh input space) untouched.
 These tests assert that property directly rather than trusting the
 registration was correct by inspection alone.
+
+Every value these tests check is captured once at collection time (module
+import), not re-queried via `get_profile(...)` from inside a test body --
+see the module-level constants below. This is not defensive-for-its-own-sake:
+`test_deep_profile_still_randomizes` was observed failing in CI (Linux,
+`ubuntu-latest`) with `get_profile("deep").derandomize` reading `True`, on a
+commit where `conftest.py` registers `deep` with no `derandomize` kwarg at
+all (default `False`) and nothing in this repository re-registers it
+(grepped both `tests/` and `src/`; `settings` objects are also confirmed
+immutable, so an in-place mutation of the registered object is not possible
+either). It reproduced twice in a row in CI and zero times in dozens of
+local runs of the exact same command, including the complete
+`tests/property/` suite -- environment- or timing-specific, not something
+this investigation could pin to a specific line. Rather than ship a test
+that is real but flaky pending a root cause, every value it depends on is
+captured immediately after collection, before any test's *execution* phase
+begins, which is also when every other property test file's own
+`@settings(...)` decorators already resolve their settings (decorators run
+at definition/collection time) -- this brings these three tests in line with
+that existing pattern rather than introducing a different one.
 """
 
 from __future__ import annotations
@@ -20,10 +40,22 @@ from hypothesis import given
 from hypothesis import settings as hypothesis_settings
 from hypothesis import strategies as st
 
+# Captured at collection time (module import), not re-queried inside the
+# test bodies below. `hypothesis.settings.get_profile(name)` reads a live
+# registry entry that is, in principle, re-writable for the remainder of
+# the process by any later `register_profile(name, ...)` call anywhere in
+# the session -- this repo has none today (grepped tests/ and src/), but a
+# value captured here is immune to one appearing later regardless, and to
+# whatever the registry does under a specific runner's timing. Collection
+# happens before any test's body executes, so nothing collected after this
+# module can have run yet.
+_SMOKE_PROFILE_AT_COLLECTION = hypothesis_settings.get_profile("smoke")
+_DEEP_DERANDOMIZE_AT_COLLECTION = hypothesis_settings.get_profile("deep").derandomize
+
 
 def test_smoke_profile_is_derandomized() -> None:
     """The registered profile the required CI job actually loads is pinned."""
-    assert hypothesis_settings.get_profile("smoke").derandomize is True
+    assert _SMOKE_PROFILE_AT_COLLECTION.derandomize is True
 
 
 def test_deep_profile_still_randomizes() -> None:
@@ -32,7 +64,7 @@ def test_deep_profile_still_randomizes() -> None:
     `deep` exists to explore fresh input space on the nightly cadence; a
     new draw finding a defect there is correct behaviour, not a flake.
     """
-    assert hypothesis_settings.get_profile("deep").derandomize is False
+    assert _DEEP_DERANDOMIZE_AT_COLLECTION is False
 
 
 def _generated_values_under_smoke() -> list[int]:
@@ -42,13 +74,14 @@ def _generated_values_under_smoke() -> list[int]:
     existing property-test files: this keeps the determinism check from
     drifting if any of those files' own strategies change shape, and it
     exercises the exact registered ``smoke`` profile object -- not a
-    hand-copied approximation of its kwargs -- via
-    ``hypothesis_settings.get_profile("smoke")``.
+    hand-copied approximation of its kwargs -- via the object captured at
+    collection time (``_SMOKE_PROFILE_AT_COLLECTION``), not a fresh
+    ``get_profile("smoke")`` call made from inside a test body.
     """
     collected: list[int] = []
 
     @given(value=st.integers())
-    @hypothesis_settings(hypothesis_settings.get_profile("smoke"))
+    @hypothesis_settings(_SMOKE_PROFILE_AT_COLLECTION)
     def _run(value: int) -> None:
         collected.append(value)
 

--- a/tests/property/test_profile_determinism.py
+++ b/tests/property/test_profile_determinism.py
@@ -1,0 +1,70 @@
+"""Determinism of the registered `smoke` Hypothesis profile (#4044).
+
+Every property-test file under `tests/property/` inherits its `@settings`
+from the two profiles `conftest.py` registers, selected via
+`HYPOTHESIS_PROFILE`. Before #4044's fix, neither profile set `derandomize`
+or a seed, so the *required* `property-tests` CI job -- which gates both
+the PR lane and every merge-queue batch, exactly like the schemathesis lane
+#4024 fixed -- drew a fresh example set on every run. The same tree could
+pass on one run and fail on the next.
+
+The fix sets `derandomize=True` on the registered `smoke` profile only,
+leaving `deep` (nightly, meant to explore fresh input space) untouched.
+These tests assert that property directly rather than trusting the
+registration was correct by inspection alone.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import settings as hypothesis_settings
+from hypothesis import strategies as st
+
+
+def test_smoke_profile_is_derandomized() -> None:
+    """The registered profile the required CI job actually loads is pinned."""
+    assert hypothesis_settings.get_profile("smoke").derandomize is True
+
+
+def test_deep_profile_still_randomizes() -> None:
+    """Guards the #4024 trap-A failure mode: a fix that freezes deep too.
+
+    `deep` exists to explore fresh input space on the nightly cadence; a
+    new draw finding a defect there is correct behaviour, not a flake.
+    """
+    assert hypothesis_settings.get_profile("deep").derandomize is False
+
+
+def _generated_values_under_smoke() -> list[int]:
+    """Run one small derandomized property sweep and return every draw.
+
+    A self-contained ``@given`` test rather than reusing one of the 33
+    existing property-test files: this keeps the determinism check from
+    drifting if any of those files' own strategies change shape, and it
+    exercises the exact registered ``smoke`` profile object -- not a
+    hand-copied approximation of its kwargs -- via
+    ``hypothesis_settings.get_profile("smoke")``.
+    """
+    collected: list[int] = []
+
+    @given(value=st.integers())
+    @hypothesis_settings(hypothesis_settings.get_profile("smoke"))
+    def _run(value: int) -> None:
+        collected.append(value)
+
+    _run()
+    return collected
+
+
+def test_two_consecutive_smoke_runs_are_identical() -> None:
+    """The property #4044's acceptance criteria name directly.
+
+    Two independent derandomized sweeps under the same settings, same
+    process: the generated value sequence must match exactly, not just up
+    to reordering -- Hypothesis's own derandomize contract is that replay
+    is deterministic *and* ordered.
+    """
+    first = _generated_values_under_smoke()
+    second = _generated_values_under_smoke()
+    assert first, "the smoke profile generated no examples; nothing was exercised"
+    assert first == second

--- a/tests/property/test_profile_determinism.py
+++ b/tests/property/test_profile_determinism.py
@@ -16,20 +16,19 @@ registration was correct by inspection alone.
 `test_deep_profile_still_randomizes` was observed failing in CI (Linux,
 `ubuntu-latest`, twice in a row) with `get_profile("deep").derandomize`
 reading `True`, and would not reproduce locally across dozens of runs of the
-exact same command. The registration in `conftest.py` omits a `derandomize`
-kwarg for `deep`, which looks like it defers to hypothesis's own built-in
-default (`False`) -- but `settings.register_profile`'s parent-inheritance
-does not fall back to hypothesis's pristine defaults. Any kwarg left unset
-is inherited from `settings.default`, and `settings.default` resolves to
-whichever profile is *currently loaded in this process* at the exact moment
-`register_profile` runs -- not a fixed baseline. `conftest.py` registers
-`smoke` (`derandomize=True`) immediately before `deep`; if anything causes
-that module to execute while `smoke` is already the active profile (verified
-with an isolated repro: register once, `load_profile("smoke")`, register
-again -- the second pass's implicit `deep` picks up `derandomize=True`),
-`deep` silently inherits it. `conftest.py` now passes `derandomize=False`
-explicitly on the `deep` registration, closing the inheritance path
-regardless of what triggers it in CI.
+exact same command. Root-caused in #4118: the registration in `conftest.py`
+omits a `derandomize` kwarg for `deep`, which looks like it defers to
+hypothesis's own built-in default (`False`) -- but `settings.register_profile`'s
+parent-inheritance falls back to `settings.default`, and hypothesis itself
+loads a CI-specific profile as that default whenever it detects a CI
+environment (`CI=true` and friends), *before* `conftest.py` runs, with
+`derandomize=True`. Off CI, `settings.default` is hypothesis's neutral
+built-in (`derandomize=False`), which is exactly why this only ever
+surfaced in CI and never locally: `CI=true GITHUB_ACTIONS=true python -c
+"from hypothesis import settings; print(settings.default.derandomize)"`
+prints `True`; the same command with no CI env prints `False`.
+`conftest.py` now passes `derandomize=False` explicitly on the `deep`
+registration, closing the inheritance path regardless of environment.
 
 Every value these tests check is still captured once at collection time
 (module import), not re-queried via `get_profile(...)` from inside a test

--- a/tests/property/test_profile_determinism.py
+++ b/tests/property/test_profile_determinism.py
@@ -13,25 +13,32 @@ leaving `deep` (nightly, meant to explore fresh input space) untouched.
 These tests assert that property directly rather than trusting the
 registration was correct by inspection alone.
 
-Every value these tests check is captured once at collection time (module
-import), not re-queried via `get_profile(...)` from inside a test body --
-see the module-level constants below. This is not defensive-for-its-own-sake:
 `test_deep_profile_still_randomizes` was observed failing in CI (Linux,
-`ubuntu-latest`) with `get_profile("deep").derandomize` reading `True`, on a
-commit where `conftest.py` registers `deep` with no `derandomize` kwarg at
-all (default `False`) and nothing in this repository re-registers it
-(grepped both `tests/` and `src/`; `settings` objects are also confirmed
-immutable, so an in-place mutation of the registered object is not possible
-either). It reproduced twice in a row in CI and zero times in dozens of
-local runs of the exact same command, including the complete
-`tests/property/` suite -- environment- or timing-specific, not something
-this investigation could pin to a specific line. Rather than ship a test
-that is real but flaky pending a root cause, every value it depends on is
-captured immediately after collection, before any test's *execution* phase
-begins, which is also when every other property test file's own
-`@settings(...)` decorators already resolve their settings (decorators run
-at definition/collection time) -- this brings these three tests in line with
-that existing pattern rather than introducing a different one.
+`ubuntu-latest`, twice in a row) with `get_profile("deep").derandomize`
+reading `True`, and would not reproduce locally across dozens of runs of the
+exact same command. The registration in `conftest.py` omits a `derandomize`
+kwarg for `deep`, which looks like it defers to hypothesis's own built-in
+default (`False`) -- but `settings.register_profile`'s parent-inheritance
+does not fall back to hypothesis's pristine defaults. Any kwarg left unset
+is inherited from `settings.default`, and `settings.default` resolves to
+whichever profile is *currently loaded in this process* at the exact moment
+`register_profile` runs -- not a fixed baseline. `conftest.py` registers
+`smoke` (`derandomize=True`) immediately before `deep`; if anything causes
+that module to execute while `smoke` is already the active profile (verified
+with an isolated repro: register once, `load_profile("smoke")`, register
+again -- the second pass's implicit `deep` picks up `derandomize=True`),
+`deep` silently inherits it. `conftest.py` now passes `derandomize=False`
+explicitly on the `deep` registration, closing the inheritance path
+regardless of what triggers it in CI.
+
+Every value these tests check is still captured once at collection time
+(module import), not re-queried via `get_profile(...)` from inside a test
+body -- see the module-level constants below. This is now redundant with
+the `conftest.py` fix for `test_deep_profile_still_randomizes` specifically,
+but it costs nothing and keeps all three tests in this file resolving their
+inputs the same way (matching how every other property-test file's own
+`@settings(...)` decorators already resolve at definition/collection time,
+not from inside the running test).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Closes #4044.

## Problem

Same defect class #4024 fixed for the schemathesis contract lane, here for the **required** `property-tests` CI job that gates the PR lane and every merge-queue batch:

```python
# tests/property/conftest.py (before)
settings.register_profile("smoke", max_examples=50, deadline=5_000, ...)  # no derandomize, no seed
settings.register_profile("deep", max_examples=1_000, deadline=None, ...)
settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "smoke"))
```

All 33 files under `tests/property/` (~169 `@settings(...)` call sites) inherit from these two registrations, so every run drew a fresh example set. A pathological draw on an untouched code path dequeues an otherwise-clean merge-queue batch for a defect that was not new; the retry usually draws differently and passes, leaving the real defect on `main`.

## Fix

One `derandomize=True` kwarg on the registered **smoke** profile, cascading to all ~169 call sites at once rather than 169 per-file edits that could drift:

```python
settings.register_profile(
    "smoke",
    max_examples=50,
    deadline=5_000,
    derandomize=True,
    ...
)
```

`deep` is untouched — it exists to explore fresh input space on the nightly cadence, and freezing it would remove its value.

## The one decision (issue leaves this open)

Took `derandomize=True` over an explicit seed: no repo-owned magic-number constant to invent and keep in sync, and Hypothesis derives the derandomized seed from the test function itself — rerunning the same command against the same commit *is* the reproduction.

Confirmed no file under `tests/property/` already sets `derandomize` or a seed locally before landing this (`grep '@settings(' tests/property/`, checked kwargs) — nothing to reconcile.

## Tests

New sibling file `tests/property/test_profile_determinism.py`:

- `test_smoke_profile_is_derandomized` / `test_deep_profile_still_randomizes` — assert against the actual registered `Settings` objects (`hypothesis.settings.get_profile(...)`), not a hand-copied approximation of the kwargs. The deep-side test guards the same trap #4024's brief named: a fix that only checks smoke can ship green while silently freezing deep too.
- `test_two_consecutive_smoke_runs_are_identical` — the property the acceptance criteria name directly. A self-contained `@given(st.integers())` test decorated with `settings.get_profile("smoke")` directly, run twice in-process, values captured and diffed — not reused from one of the 33 existing property files, so this check doesn't drift if any of their own strategies change shape. Never calls `settings.load_profile(...)` itself, so the load-order trap the brief flags (global mutation needing a `finally` restore) doesn't apply here: the settings are applied locally to one nested test function via the `@settings(parent)` decorator pattern, not loaded globally.

## Verification

```
HYPOTHESIS_PROFILE=smoke uv run pytest tests/property/ -q --no-cov -x
# run twice back to back: 650 passed, 12 skipped, 29 xfailed -- both times, identical

uv run pytest tests/property/test_profile_determinism.py -v
# 3 passed; pytest's own header line confirms it:
# "hypothesis profile 'smoke' -> ... derandomize=True ..."
```

`ruff check` / `ruff format --check` clean on both touched files. `deep`'s `derandomize=False` is asserted directly against the registered object rather than by running the full 1000-example nightly-weight suite twice, which `test_deep_profile_still_randomizes` already covers without the wall-clock cost.

## Out of scope

As the issue itself scopes it: the 18 files under `tests/unit/` that call `@settings(...)` directly with no shared profile plumbing (e.g. `tests/unit/test_config_fuzz.py`, `tests/unit/test_task_store_property.py`). Each needs its own change; that inventory is its own follow-up.