### PR TITLE
fix(cli): eval list emits run paths unwrapped so they can be piped

### DIFF
--- a/src/bernstein/cli/commands/eval_benchmark_cmd.py
+++ b/src/bernstein/cli/commands/eval_benchmark_cmd.py
@@ -1157,8 +1157,13 @@ def eval_list(state_dir: str) -> None:
     if not runs:
         console.print("[yellow]No YAML eval runs found.[/yellow]")
         return
+    # The paths go through click.echo rather than the Rich console because they
+    # are machine-consumable tokens, and Rich would corrupt them two ways: it
+    # wraps at the console width (80 whenever stdout is not a terminal, which is
+    # exactly the piped case) and it consumes a "[...]" path segment as markup.
+    # The message above is prose for a human and stays on the console.
     for path in runs:
-        console.print(f"  {path}")
+        click.echo(f"  {path}")
 
 
 @eval_group.command("diff")

--- a/tests/unit/cli/test_eval_cmd_paths.py
+++ b/tests/unit/cli/test_eval_cmd_paths.py
@@ -56,7 +56,11 @@ def test_eval_list_empty_reports_no_runs(tmp_path: Path) -> None:
     assert "No YAML eval runs found" in result.output
 
 
-def test_eval_list_shows_run_paths_newest_first(tmp_path: Path) -> None:
+def test_eval_list_shows_run_paths_newest_first(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Pin the width so this test asserts ordering and nothing else. Left to the
+    # ambient terminal its outcome depends on how deep pytest happened to root
+    # tmp_path, which is a property of the runner rather than of the command.
+    monkeypatch.setenv("COLUMNS", "200")
     _seed_yaml_run(tmp_path, "aaa", [{"adapter": "mock", "overall_score": 0.5, "golden_pass_rate": 1.0}])
     _seed_yaml_run(tmp_path, "zzz", [{"adapter": "mock", "overall_score": 0.6, "golden_pass_rate": 1.0}])
 
@@ -68,6 +72,34 @@ def test_eval_list_shows_run_paths_newest_first(tmp_path: Path) -> None:
     assert "yaml_run_zzz.json" in result.output
     # Newest-first ordering: reverse sort puts zzz before aaa.
     assert result.output.index("yaml_run_zzz.json") < result.output.index("yaml_run_aaa.json")
+
+
+def test_eval_list_emits_paths_unwrapped_at_narrow_width(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A run path survives a narrow console intact, so the list can be piped."""
+    monkeypatch.setenv("COLUMNS", "80")
+    # Nested far enough that the rendered path clears any plausible console
+    # width regardless of where pytest rooted tmp_path.
+    state_dir = tmp_path / "a_deliberately_long_state_directory_name_to_exceed_the_default_width"
+    seeded = _seed_yaml_run(state_dir, "aaa", [{"adapter": "mock", "overall_score": 0.5, "golden_pass_rate": 1.0}])
+    assert len(str(seeded)) > 80, "fixture must exceed the width it is meant to defeat"
+
+    runner = CliRunner()
+    result = runner.invoke(eval_group, ["list", "--state-dir", str(state_dir)])
+    assert result.exit_code == 0, result.output
+    emitted = [line.strip() for line in result.output.splitlines() if line.strip()]
+    assert emitted == [str(seeded)]
+
+
+def test_eval_list_preserves_square_brackets_in_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``[...]`` path segment is data, not Rich markup, and must survive."""
+    monkeypatch.setenv("COLUMNS", "200")
+    state_dir = tmp_path / "[bold]"
+    seeded = _seed_yaml_run(state_dir, "aaa", [{"adapter": "mock", "overall_score": 0.5, "golden_pass_rate": 1.0}])
+
+    runner = CliRunner()
+    result = runner.invoke(eval_group, ["list", "--state-dir", str(state_dir)])
+    assert result.exit_code == 0, result.output
+    assert str(seeded) in result.output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`bernstein eval list` prints each run path on one line now, so the output can be piped.

## Why

Fixes #4112. Rich wraps at the console width and falls back to 80 columns when stdout isn't a terminal, so any path over ~78 chars got split mid-filename and `eval list | xargs …` produced two nonexistent paths instead of one real one.

## How

`click.echo` instead of the Rich console. The issue left the choice open between that and `no_wrap=True`; I went this way because `console.print` also eats a `[...]` path segment as markup, which `no_wrap` wouldn't fix. The "No YAML eval runs found." line is prose and stays on the console.

Checked the siblings as the issue asked — `eval_list` is the only output that's entirely bare machine-readable tokens. `a2a publish` prints paths but already has `--json`; the rest are labelled human summaries.

New test pins `COLUMNS=80` with a path long enough to exceed it, so it fails on main wherever pytest roots `tmp_path`. Also made the existing ordering test width-independent — it was green by luck of path length.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` — 539 errors on this file with and without my change; I didn't add any, but it doesn't pass
- [ ] `uv run python scripts/run_tests.py -x` — ran `tests/unit/cli` instead (501 passed); the full runner didn't complete cleanly in my environment
- [x] New code has type hints

Unrelated but maybe useful: on x86_64 macOS a clean install needs a Rust toolchain, since `cryptography>=50` only ships arm64 mac wheels.

### Documentation duty

N/A — restores existing documented behaviour, no new surface.
