### PR TITLE
fix(tests): drive determinism regression test with settings the smoke lane actually applies

### DIFF
--- a/tests/contract/test_schemathesis_determinism.py
+++ b/tests/contract/test_schemathesis_determinism.py
@@ -12,7 +12,9 @@ lane is pinned; the nightly deep lane keeps exploring fresh input space,
 which is where new defects should be found. These tests assert the property
 directly rather than trusting the settings object was wired correctly by
 inspection alone -- one for each half of the branch, plus the reproducibility
-property itself.
+property itself, driven by the settings the module under test actually
+applies (not a fresh literal) so a deleted fix fails the test that claims to
+cover it rather than passing for an unrelated, upstream reason.
 
 Deliberately a sibling file, not additions to ``test_task_server_schemathesis.py``:
 that file's own docstring scopes it to "fuzz documented operations ... assert
@@ -104,9 +106,10 @@ def _generated_cases() -> list[tuple[str, str, str, str, str]]:
     """
     collected: list[tuple[str, str, str, str, str]] = []
     strategy = _smoke_case_strategy()
+    applied = _schemathesis_module.test_no_unhandled_exceptions._hypothesis_internal_use_settings
 
     @given(case=strategy)
-    @settings(max_examples=_MAX_EXAMPLES, deadline=None, derandomize=True)
+    @settings(applied)
     def _run(case: schemathesis.Case) -> None:
         collected.append(
             (
@@ -125,11 +128,23 @@ def _generated_cases() -> list[tuple[str, str, str, str, str]]:
 def test_two_consecutive_smoke_runs_generate_identical_cases() -> None:
     """The property #4024's acceptance criteria name directly.
 
-    Two independent derandomized sweeps over the same operation subset, same
-    settings, same process: the generated case sequence must match exactly,
-    not just up to reordering -- Hypothesis's own derandomize contract is
-    that replay is deterministic *and* ordered.
+    Two independent sweeps, driven by the settings the smoke lane actually
+    applies (not a fresh hardcoded ``derandomize=True`` literal, which would
+    only prove Hypothesis's own replay contract and pass even if
+    ``_DERANDOMIZE_SMOKE`` were deleted -- caught in review on #4105): the
+    generated case sequence must match exactly, not just up to reordering,
+    which is what "the same set of generated cases" means for a lane that
+    is supposed to give the same verdict on the same commit every time.
+
+    Skipped outside the smoke profile for the same reason
+    ``test_smoke_profile_sets_derandomize`` is: under ``deep``,
+    ``applied.derandomize`` is ``False`` by design (deep is the lane meant
+    to explore fresh input space), so two independent sweeps have no reason
+    to agree there -- asserting equality unconditionally would make this
+    test flake in the nightly deep job for behaving exactly as intended.
     """
+    if _PROFILE != "smoke":
+        pytest.skip(f"this process resolved SCHEMATHESIS_PROFILE={_PROFILE!r}, not 'smoke'")
     first = _generated_cases()
     second = _generated_cases()
     assert first, "the smoke path allow-list matched no operations; nothing was exercised"

--- a/tests/contract/test_schemathesis_determinism.py
+++ b/tests/contract/test_schemathesis_determinism.py
@@ -1,11 +1,20 @@
 """Determinism of the smoke-profile Schemathesis sweep (#4024).
 
 `test_task_server_schemathesis.py`'s ``test_no_unhandled_exceptions`` gates
-both the PR lane and every merge-queue batch. Before #4024's fix it drew a
-fresh Hypothesis example set on every run: the same tree could pass on one
-run and fail on the next, and a merge-queue batch that drew a pathological
-example was dequeued -- along with every entry behind it -- for a defect
-that was not actually new.
+both the PR lane and every merge-queue batch. Before #4024's fix its
+``@settings(...)`` decorator set no ``derandomize`` kwarg at all -- which,
+per #4118, does not mean "randomized" the way it looks: an unset kwarg is
+inherited from ``settings.default``, and hypothesis's own library loads a
+CI-specific profile as that default whenever it detects a CI environment
+(``derandomize=True``, before any of this repository's code runs). So in
+CI specifically -- the one place this lane actually gates anything -- the
+pre-fix behaviour was already derandomized by that inheritance, same as
+``tests/property/conftest.py``'s ``deep`` profile (#4118's other case).
+What #4024's fix actually buys is not "CI now reproduces where it didn't":
+it is a value that no longer depends on hypothesis's CI-detection heuristic
+or on running under CI at all -- a laptop run and a CI run now agree,
+which they did not before, and the result survives hypothesis changing how
+it detects CI in a future release.
 
 The fix branches ``derandomize`` on ``_PROFILE`` so only the *gating* smoke
 lane is pinned; the nightly deep lane keeps exploring fresh input space,


### PR DESCRIPTION
## Summary

Follow-up to #4105 (merged). The maintainer's review on that PR found that `test_two_consecutive_smoke_runs_generate_identical_cases` — the test whose own docstring says it verifies "the property #4024's acceptance criteria name directly" — still passed with the production fix (`_DERANDOMIZE_SMOKE`) fully reverted, because `_generated_cases()` drove its sweep with a hardcoded `@settings(derandomize=True, ...)` literal instead of the settings `test_no_unhandled_exceptions` actually applies. That proved Hypothesis's own replay contract, not this repo's fix.

#4105 merged before this improvement was committed (crash/branch mixup on my end delayed it), so this is a clean follow-up against current `main` rather than an amendment to a closed PR — per the maintainer's own comment on #4105: "It has to come from you, or say the word and I will land it as a commit here for you to cherry-pick."

- `_generated_cases()` now drives `_run` with `test_no_unhandled_exceptions._hypothesis_internal_use_settings` (the same accessor the two profile tests already use) instead of a fresh literal.
- Added a profile-skip guard to `test_two_consecutive_smoke_runs_generate_identical_cases`, since driving with `applied` settings means the test would otherwise flake under `SCHEMATHESIS_PROFILE=deep` (`applied.derandomize` is `False` there by design).

## Verification

Reverting the fix (`_DERANDOMIZE_SMOKE = False`) and rerunning now correctly fails both:

```
FAILED tests/contract/test_schemathesis_determinism.py::test_smoke_profile_sets_derandomize
FAILED tests/contract/test_schemathesis_determinism.py::test_two_consecutive_smoke_runs_generate_identical_cases
```

With the fix restored, verified both profiles:

```
SCHEMATHESIS_PROFILE=smoke: test_two_consecutive_smoke_runs_generate_identical_cases PASSED, deep half SKIPPED
SCHEMATHESIS_PROFILE=deep:  test_deep_profile_still_randomizes PASSED, smoke half SKIPPED (no longer flakes)
```

`ruff check` / `ruff format --check` clean.

## Test plan

- [x] `uv run pytest tests/contract/test_schemathesis_determinism.py -v --no-cov` under both `SCHEMATHESIS_PROFILE=smoke` and `=deep`
- [x] Confirmed the test fails for the right reason with the fix reverted
- [x] `ruff check` / `ruff format --check`