### PR TITLE
fix(orchestration): route stdin-overflow prompt filename through the containment helper

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -59,3 +59,20 @@ rather than as its own attribution is exempted by hand there, with the reason.
   module imports `hashlib`, `re` and `unicodedata` and nothing else, pinned by
   an exact allowlist so it cannot quietly grow a route to a shell, the
   environment, or the network.
+
+- The last hand-rolled filename join in `core/orchestration/worker.py` now
+  goes through the shared containment helper (#4106). `_avoid_shim_line_overflow`
+  derived its stdin-overflow prompt file as `prompt_dir / f"{session}.stdin-overflow"`
+  with no check at all — the only site left in the file where a value reaching
+  the function could name a file outside the intended directory. It is now
+  `contained_path(prompt_dir, f"{session}.stdin-overflow", label="session id")`,
+  the same helper #3802's sweep has been centralising everywhere else (most
+  recently in #4095). This is defence in depth rather than a live hole: `session`
+  has already passed `_SESSION_ID_RE` in `main()` before the function is ever
+  reached, and the allowlists agree on characters, so nothing arriving through
+  the CLI is newly refused. Two behaviours are pinned by tests: a session value
+  the CLI would have rejected now raises `PathContainmentError` instead of
+  naming a file, and an over-long session that passes the regex but exceeds the
+  255-byte component cap now fails as `PathTooLongError` at the check instead
+  of reaching `open()` as `OSError(ENAMETOOLONG)` (the same capacity-vs-
+  containment distinction #4095 recorded for the pid-file sites).

--- a/src/bernstein/core/orchestration/worker.py
+++ b/src/bernstein/core/orchestration/worker.py
@@ -25,6 +25,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.path_containment import contained_path
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -203,7 +205,7 @@ def _avoid_shim_line_overflow(
     prompt = cmd[-1]
     prompt_dir = workdir / ".sdd" / "runtime" / "prompts"
     prompt_dir.mkdir(parents=True, exist_ok=True)
-    prompt_path = prompt_dir / f"{session}.stdin-overflow"
+    prompt_path = contained_path(prompt_dir, f"{session}.stdin-overflow", label="session id")
     prompt_path.write_text(prompt, encoding="utf-8")
 
     trimmed_cmd = cmd[:-1]  # drop the prompt; keep the bare flag

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -18,6 +18,10 @@ from bernstein.core.orchestration.worker import (
     _avoid_shim_line_overflow,
     _resolve_launch_cmd,
 )
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    PathTooLongError,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -265,6 +269,46 @@ class TestAvoidShimLineOverflow:
         assert result == launch_cmd
         assert prompt in result
         assert prompt_path is None
+
+    def test_overflow_prompt_refuses_escaping_session_id(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """A session value that could escape prompt_dir is refused by containment.
+
+        Defence in depth: the CLI already rejects this value via
+        ``_SESSION_ID_RE`` in ``main()``, so the branch is only reachable by
+        calling the function directly with a value that skips CLI validation
+        (the same framing the ``review_board.py`` conversion in #3858 used).
+        The prompt filename is derived from *session*, so without the
+        containment check a hostile session would name a file anywhere the
+        process can write.
+        """
+        prompt = "x" * 16_043
+        cmd = ["claude", "--model", "sonnet", "-p", prompt]
+        launch_cmd = self._windows_shim_launch_cmd(monkeypatch, cmd)
+
+        with pytest.raises(PathContainmentError):
+            _avoid_shim_line_overflow(cmd, launch_cmd, workdir=tmp_path, session="../escape")
+
+        # The uncontained join would have written here; nothing was created.
+        prompt_dir = tmp_path / ".sdd" / "runtime" / "prompts"
+        assert not (prompt_dir / ".." / "escape.stdin-overflow").exists()
+        assert not list(prompt_dir.glob("*.stdin-overflow"))
+
+    def test_overflow_prompt_refuses_overlong_session_id(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """An over-long session now fails as PathTooLongError, not ENAMETOOLONG.
+
+        ``contained_path`` caps a single component at 255 bytes. ``_SESSION_ID_RE``
+        has no length bound, so an id that passes the CLI allowlist but exceeds
+        the filesystem limit previously failed at ``open()`` with
+        ``OSError(ENAMETOOLONG)``; it now fails at the check instead (the same
+        capacity-vs-containment distinction PR #4095 pinned for the pid-file
+        sites).
+        """
+        prompt = "x" * 16_043
+        cmd = ["claude", "--model", "sonnet", "-p", prompt]
+        launch_cmd = self._windows_shim_launch_cmd(monkeypatch, cmd)
+
+        with pytest.raises(PathTooLongError):
+            _avoid_shim_line_overflow(cmd, launch_cmd, workdir=tmp_path, session="a" * 300)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4106.

`_avoid_shim_line_overflow` (`worker.py:206`) derived its stdin-overflow prompt file as `prompt_dir / f"{session}.stdin-overflow"` with no containment check — the last hand-rolled join of this shape left in the file. It now goes through `contained_path(prompt_dir, f"{session}.stdin-overflow", label="session id")`, the same helper #3802 sweep has been centralising everywhere else (most recently #4095).

## Why `contained_path` rather than `contained_subpath`

The candidate is a single segment, and `session` has already passed an alphabet identical to `validate_path_segment`'s (`_SESSION_ID_RE`, `worker.py:38`), so there is nothing like the `sha256:`-prefixed case in `trajectory_receipt.py` that forced the weaker validator.

## Hardening, not a live hole

`_SESSION_ID_RE` is enforced in `main()` at `worker.py:424` and `_avoid_shim_line_overflow` is only reached from `main()` at `worker.py:528` — after that gate. So nothing arriving through the CLI can escape `prompt_dir` today. Same allowlists on characters, so no legitimate `session` value reaching this call site is newly refused.

## Did the helper's semantics differ from the local check?

**One respect: a length cap, not a containment change.** `contained_path` caps a single path component at 255 bytes. `_SESSION_ID_RE` has no length bound, so an id that passes the CLI allowlist but exceeds the filesystem limit previously failed at `open()` with `OSError(ENAMETOOLONG)`; it now fails at the check as `PathTooLongError` (the same capacity-vs-containment distinction #4095 pinned for the pid-file sites). Pinned by `test_overflow_prompt_refuses_overlong_session_id`.

## Tests

Two new tests in the existing `TestAvoidShimLineOverflow` class (the tests for this function's other behaviours already live in `tests/unit/test_worker.py`):

- `test_overflow_prompt_refuses_escaping_session_id` — calls the function directly with a `session` value the CLI would have rejected (`../escape`), asserting `PathContainmentError` and that nothing was written. Only reachable by skipping CLI validation, the same "defence in depth" framing the `review_board.py` conversion in #3858 used.
- `test_overflow_prompt_refuses_overlong_session_id` — pins the new length-cap behaviour above.

The positive control is `test_long_claude_prompt_moved_to_stdin_file` (existing, `session="qa-abc123"` succeeds and writes the file inside `prompt_dir`), unchanged.

## Verification

```
pytest tests/unit/test_worker.py                                  # 22 passed
pytest tests/unit/test_unreleased_notes_rotation.py               # 10 passed
ruff check src/bernstein/core/orchestration/worker.py tests/unit/test_worker.py   # clean
ruff format --check <same>                                        # clean
mypy src/bernstein/core/orchestration/worker.py                   # success
```

Docs: entry added to `docs/release-notes/unreleased.md` (Security).