### PR TITLE
feat(cli): reach the run attestation projection from the command line

### DIFF
--- a/docs/security/audit-receipt.md
+++ b/docs/security/audit-receipt.md
@@ -126,6 +126,33 @@ recomputes the run-specific semantic projection from the embedded events. A
 self-embedded JWK establishes cryptographic self-consistency only; provenance
 requires an independently pinned JWK or public key.
 
+### Operator surface
+
+`bernstein identity attest` projects the receipt from the command line. Both
+verbs take the same signing options as `bernstein audit receipt export`, since
+building a projection signs one.
+
+```bash
+# Project without writing; print both verdicts.
+bernstein identity attest show --run <run-id> --signing-key-path key.pem
+
+# Rebuild, verify the projection, and emit the receipt.
+bernstein identity attest verify --run <run-id> --signing-key-path key.pem
+```
+
+`verify` exits non-zero and names each failing check when the recomputed range
+no longer supports the projection. It stages the receipt privately and moves
+it into the evidence directory only after semantic verification passes, so a
+failed projection is never left behind as normal evidence. `show` creates
+neither a receipt nor audit key material. Both verdicts are recomputed from the
+retained range on every invocation; neither is read from a field in the receipt,
+so a serialized claim cannot promote itself through this surface any more than
+it can through the library.
+
+These verbs sit under `identity attest` rather than extending `identity
+verify`, which checks an install-rev fingerprint token. The two answer
+different questions about different objects and only share a noun.
+
 ### Verifying with third-party tooling
 
 Because `intoto` is a plain DSSE envelope wrapping an in-toto v1 Statement, any

--- a/src/bernstein/cli/commands/identity_attest_cmd.py
+++ b/src/bernstein/cli/commands/identity_attest_cmd.py
@@ -1,0 +1,212 @@
+"""``bernstein identity attest`` - run attestation receipt projection.
+
+Subcommands:
+
+* ``bernstein identity attest verify --run <id>`` - rebuild the run's
+  attestation receipt from the audit chain, recompute the retained event
+  range, verify the projection, and only then promote the receipt into the
+  evidence directory.
+* ``bernstein identity attest show --run <id>`` - project the same receipt
+  without writing it, and print the two verdicts.
+
+The projection lives in ``bernstein.core.security.run_attestation_receipt``.
+Both verbs are a surface over it: no verdict is computed here, and no verdict
+is read from a field. ``verify`` exits non-zero and names the failing entry
+when the recomputed range no longer matches the signed subject.
+
+Exit code ``1`` means the key, source chain, projection, or verification
+failed. Exit code ``2`` means the command arguments are invalid.
+
+``identity attest`` is a separate group from ``identity verify`` on purpose.
+``identity verify`` checks an install-rev fingerprint token; these verbs check
+a run's attestation evidence. They share a noun and nothing else.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import click
+
+from bernstein.cli.helpers import console
+
+EXIT_FAILURE = 1
+EXIT_USAGE = 2
+
+_SIGNING_OPTIONS = (
+    click.option("--run", "run_id", required=True, help="Run id to project."),
+    click.option("--signing-key-path", default=None, help="Path to an Ed25519 receipt signing key."),
+    click.option(
+        "--signing-env-var",
+        default=None,
+        help="Environment variable holding the Ed25519 receipt signing key.",
+    ),
+    click.option("--signing-key-id", default=None, help="Key id (kid) recorded in the receipt."),
+    click.option("--workdir", default=".", help="Project directory containing .sdd/."),
+)
+
+
+def _signing_options[CommandCallback: Callable[..., object]](func: CommandCallback) -> CommandCallback:
+    """Apply the shared signing/workdir options in declaration order."""
+    for option in reversed(_SIGNING_OPTIONS):
+        func = option(func)
+    return func
+
+
+def _resolve_audit_dir(workdir: str) -> Path:
+    audit_dir = Path(workdir).resolve() / ".sdd" / "audit"
+    if not audit_dir.is_dir():
+        console.print(f"[red]Audit directory not found:[/red] {audit_dir}")
+        console.print("[dim]Run [bold]bernstein run[/bold] first to generate audit events.[/dim]")
+        raise SystemExit(EXIT_FAILURE)
+    return audit_dir
+
+
+def _prepare_output_dir(workdir: str, output: str | None) -> Path:
+    output_dir = Path(output).resolve() if output else Path(workdir).resolve() / ".sdd" / "evidence"
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        console.print(f"[red]Failed to prepare receipt output directory:[/red] {exc}")
+        raise SystemExit(EXIT_FAILURE) from None
+    return output_dir
+
+
+def _resolve_kms(signing_key_path: str | None, signing_env_var: str | None, signing_key_id: str | None):  # type: ignore[no-untyped-def]
+    from bernstein.core.persistence.lineage_signer import LineageSignerError
+    from bernstein.core.security.lineage_kms import EnvBasedKMSAdapter, FileBasedKMSAdapter, KMSAdapter
+
+    if signing_key_path and signing_env_var:
+        console.print("[red]--signing-key-path and --signing-env-var are mutually exclusive.[/red]")
+        raise SystemExit(EXIT_USAGE)
+
+    kms_adapter: KMSAdapter
+    try:
+        if signing_key_path:
+            kms_adapter = FileBasedKMSAdapter(Path(signing_key_path), kid=signing_key_id)
+        elif signing_env_var:
+            kms_adapter = EnvBasedKMSAdapter(signing_env_var, kid=signing_key_id)
+        else:
+            console.print("[red]Provide either --signing-key-path or --signing-env-var (Ed25519 receipt key).[/red]")
+            raise SystemExit(EXIT_USAGE)
+    except (LineageSignerError, OSError, ValueError) as exc:
+        console.print(f"[red]Failed to load receipt signing key: {exc}[/red]")
+        raise SystemExit(EXIT_FAILURE) from None
+    return kms_adapter
+
+
+def _build(run_id: str, workdir: str, kms_adapter: object, *, write: bool, output_dir: Path | None = None):  # type: ignore[no-untyped-def]
+    from bernstein.core.security.audit import AuditKeyMissingError, AuditKeyPermissionError, load_audit_key
+    from bernstein.core.security.run_attestation_receipt import (
+        RunAttestationReceiptError,
+        build_run_attestation_receipt,
+    )
+
+    audit_dir = _resolve_audit_dir(workdir)
+    try:
+        audit_key = load_audit_key()
+    except (AuditKeyMissingError, AuditKeyPermissionError, OSError) as exc:
+        console.print(f"[red]Failed to load audit key:[/red] {exc}")
+        raise SystemExit(EXIT_FAILURE) from None
+
+    try:
+        return build_run_attestation_receipt(
+            audit_dir,
+            run_id=run_id,
+            key=audit_key,
+            kms_adapter=kms_adapter,  # type: ignore[arg-type]
+            output_dir=output_dir,
+            write=write,
+        )
+    except RunAttestationReceiptError as exc:
+        console.print(f"[red]Run attestation projection failed:[/red] {exc}")
+        raise SystemExit(EXIT_FAILURE) from None
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(EXIT_USAGE) from None
+
+
+@click.group("attest")
+def attest_group() -> None:
+    """Project and verify a run's attestation receipt.
+
+    \b
+      bernstein identity attest show --run r-1234 --signing-key-path key.pem
+      bernstein identity attest verify --run r-1234 --signing-key-path key.pem
+    """
+
+
+@attest_group.command("show")
+@_signing_options
+def show_cmd(
+    run_id: str,
+    signing_key_path: str | None,
+    signing_env_var: str | None,
+    signing_key_id: str | None,
+    workdir: str,
+) -> None:
+    """Project without writing; exit 1 on key or projection failure."""
+    kms_adapter = _resolve_kms(signing_key_path, signing_env_var, signing_key_id)
+    receipt = _build(run_id, workdir, kms_adapter, write=False)
+
+    console.print(f"[bold]run[/bold]                {receipt.run_id}")
+    console.print(f"[bold]identity anchor[/bold]    {receipt.identity_anchor_hmac}")
+    console.print(f"[bold]through[/bold]            {receipt.through_hmac}")
+    console.print(f"[bold]dispatch evidence[/bold]  {receipt.dispatch_evidence_verdict.value}")
+    console.print(f"[bold]whole run[/bold]          {receipt.whole_run_verdict.value}")
+    console.print(f"[bold]receipt sha256[/bold]     {receipt.sha256}")
+    console.print(
+        "\n[dim]Verdicts are recomputed from the retained range, never read from a field. "
+        "Use [bold]identity attest verify[/bold] to re-verify and emit.[/dim]"
+    )
+
+
+@attest_group.command("verify")
+@_signing_options
+@click.option("--output", default=None, help="Directory to write the emitted receipt into.")
+def verify_cmd(
+    run_id: str,
+    signing_key_path: str | None,
+    signing_env_var: str | None,
+    signing_key_id: str | None,
+    workdir: str,
+    output: str | None,
+) -> None:
+    """Rebuild, verify, and emit the run's attestation receipt.
+
+    Exits non-zero and names the failing entry when the recomputed range no
+    longer matches the signed subject. A receipt is promoted into the evidence
+    directory only after semantic verification passes.
+    """
+    from tempfile import TemporaryDirectory
+
+    from bernstein.core.security.run_attestation_receipt import verify_run_attestation_projection
+
+    kms_adapter = _resolve_kms(signing_key_path, signing_env_var, signing_key_id)
+    output_dir = _prepare_output_dir(workdir, output)
+    with TemporaryDirectory(prefix=".attest-", dir=output_dir) as staging_dir:
+        receipt = _build(run_id, workdir, kms_adapter, write=True, output_dir=Path(staging_dir))
+
+        verification = verify_run_attestation_projection(receipt.receipt)
+        if not verification.ok:
+            console.print(f"[red]Run attestation projection failed for[/red] {run_id}")
+            for error in verification.errors:
+                console.print(f"  [red]![/red] {error}")
+            raise SystemExit(EXIT_FAILURE)
+
+        if receipt.receipt_path is None:  # pragma: no cover - builder contract guard
+            console.print("[red]Run attestation projection produced no staged receipt.[/red]")
+            raise SystemExit(EXIT_FAILURE)
+        receipt_path = output_dir / receipt.receipt_path.name
+        try:
+            receipt.receipt_path.replace(receipt_path)
+        except OSError as exc:
+            console.print(f"[red]Failed to promote verified receipt:[/red] {exc}")
+            raise SystemExit(EXIT_FAILURE) from None
+
+    console.print(f"[green]OK[/green] run attestation projection verified for {verification.run_id}")
+    console.print(f"  dispatch evidence  {verification.dispatch_evidence_verdict.value}")
+    console.print(f"  whole run          {verification.whole_run_verdict.value}")
+    console.print(f"  receipt            {receipt_path}")
+    console.print(f"  sha256             {receipt.sha256}")

--- a/src/bernstein/cli/commands/identity_attest_cmd.py
+++ b/src/bernstein/cli/commands/identity_attest_cmd.py
@@ -150,12 +150,12 @@ def show_cmd(
     kms_adapter = _resolve_kms(signing_key_path, signing_env_var, signing_key_id)
     receipt = _build(run_id, workdir, kms_adapter, write=False)
 
-    console.print(f"[bold]run[/bold]                {receipt.run_id}")
-    console.print(f"[bold]identity anchor[/bold]    {receipt.identity_anchor_hmac}")
-    console.print(f"[bold]through[/bold]            {receipt.through_hmac}")
+    console.print(f"[bold]run[/bold]                {receipt.run_id}", soft_wrap=True)
+    console.print(f"[bold]identity anchor[/bold]    {receipt.identity_anchor_hmac}", soft_wrap=True)
+    console.print(f"[bold]through[/bold]            {receipt.through_hmac}", soft_wrap=True)
     console.print(f"[bold]dispatch evidence[/bold]  {receipt.dispatch_evidence_verdict.value}")
     console.print(f"[bold]whole run[/bold]          {receipt.whole_run_verdict.value}")
-    console.print(f"[bold]receipt sha256[/bold]     {receipt.sha256}")
+    console.print(f"[bold]receipt sha256[/bold]     {receipt.sha256}", soft_wrap=True)
     console.print(
         "\n[dim]Verdicts are recomputed from the retained range, never read from a field. "
         "Use [bold]identity attest verify[/bold] to re-verify and emit.[/dim]"
@@ -205,8 +205,11 @@ def verify_cmd(
             console.print(f"[red]Failed to promote verified receipt:[/red] {exc}")
             raise SystemExit(EXIT_FAILURE) from None
 
-    console.print(f"[green]OK[/green] run attestation projection verified for {verification.run_id}")
+    console.print(
+        f"[green]OK[/green] run attestation projection verified for {verification.run_id}",
+        soft_wrap=True,
+    )
     console.print(f"  dispatch evidence  {verification.dispatch_evidence_verdict.value}")
     console.print(f"  whole run          {verification.whole_run_verdict.value}")
-    console.print(f"  receipt            {receipt_path}")
-    console.print(f"  sha256             {receipt.sha256}")
+    console.print(f"  receipt            {receipt_path}", soft_wrap=True)
+    console.print(f"  sha256             {receipt.sha256}", soft_wrap=True)

--- a/src/bernstein/cli/commands/identity_cmd.py
+++ b/src/bernstein/cli/commands/identity_cmd.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import click
 
+from bernstein.cli.commands.identity_attest_cmd import attest_group
 from bernstein.core.identity import install_rev as _identity
 from bernstein.core.identity.install_rev import (
     DISABLED_SENTINEL,
@@ -178,3 +179,10 @@ def disable_cmd() -> None:
     disabled sentinel without touching code.
     """
     click.echo("export BERNSTEIN_DISABLE_IDENTITY=1")
+
+
+# ``identity attest`` is a separate group rather than new verbs here because
+# ``identity verify`` above checks an install-rev fingerprint token, which is a
+# different object from a run's attestation evidence; sharing the verb would
+# give one noun two meanings.
+identity_group.add_command(attest_group, "attest")

--- a/tests/support/run_attestation.py
+++ b/tests/support/run_attestation.py
@@ -1,0 +1,78 @@
+"""Shared real-chain builders for run-attestation CLI and security tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.lineage.identity import AgentCard
+from bernstein.core.security.agent_card_signer import generate_ed25519_keypair, sign_agent_card
+from bernstein.core.security.agent_identity import AgentIdentityCard
+from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.security.identity_spawn_anchor import IdentitySpawnAnchor
+from bernstein.core.security.lineage_kms import FileBasedKMSAdapter
+from bernstein.core.security.native_toolcall_evidence import NativeToolCallEvidenceProvider
+from bernstein.core.security.toolcall_identity import LineageToolCallIdentitySigner
+from bernstein.core.security.toolcall_interlock import ToolCallIntent
+
+HMAC_KEY = b"r" * 32
+SIGNING_SEED = b"s" * 32
+
+
+def kms(tmp_path: Path, *, seed: bytes = SIGNING_SEED, kid: str = "run-receipt-key") -> FileBasedKMSAdapter:
+    """Write a deterministic receipt-signing key and return its adapter."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    key_path = tmp_path / "receipt-signing.pem"
+    key_path.write_bytes(
+        Ed25519PrivateKey.from_private_bytes(seed).private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+    return FileBasedKMSAdapter(key_path, kid=kid)
+
+
+def intent(request_id: int = 1) -> ToolCallIntent:
+    """Return one deterministic tool-call intent for the test run."""
+    return ToolCallIntent.from_request(
+        scope_id="scope:run-1:agent-1",
+        server_name="filesystem",
+        method="tools/call",
+        tool_name="read_file",
+        request_id=request_id,
+        span_id=f"span-{request_id}",
+        arguments={"path": "/secret-that-must-not-be-retained"},
+    )
+
+
+def anchored_provider(tmp_path: Path) -> NativeToolCallEvidenceProvider:
+    """Create a provider whose run identity is anchored in a real audit chain."""
+    chain = AuditChainStore(tmp_path / "audit", key=HMAC_KEY)
+    card_private, card_public = generate_ed25519_keypair()
+    tool_private, tool_public = generate_ed25519_keypair()
+    card = AgentIdentityCard(
+        agent_id="agent-1",
+        role="coder",
+        adapter="codex",
+        model="gpt",
+        created_at=100,
+        expires_at=200,
+    )
+    card_signature = sign_agent_card(card, card_private, kid="spawn-key")
+    identity = IdentitySpawnAnchor(chain, {"spawn-key": card_public}, clock=lambda: 150).anchor(
+        run_id="run-1",
+        card=card,
+        signature=card_signature,
+        run_journal_head="journal:fixed",
+        tool_signing_card=AgentCard("agent-1", "tool-key", tool_public.decode()),
+    )
+    return NativeToolCallEvidenceProvider(
+        chain,
+        run_identity=identity,
+        signer=LineageToolCallIdentitySigner(tool_private.decode(), "tool-key"),
+        run_journal_head=lambda: "journal:fixed",
+        clock_ns=lambda: 123_000_000_001,
+    )

--- a/tests/unit/cli/test_identity_attest_cmd.py
+++ b/tests/unit/cli/test_identity_attest_cmd.py
@@ -1,0 +1,204 @@
+"""CLI contracts for ``bernstein identity attest``.
+
+These cover the surface this module owns: option validation, audit-directory
+resolution, and that the group is reachable under ``identity``. Projection
+semantics are covered by ``tests/unit/security/test_run_attestation_receipt.py``
+and are deliberately not re-asserted here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands import identity_attest_cmd
+from bernstein.cli.commands.identity_cmd import identity_group
+from bernstein.core.security import run_attestation_receipt
+from tests.support.run_attestation import HMAC_KEY, anchored_provider, intent, kms
+
+
+@pytest.fixture
+def attest_cli_env(tmp_path: Path) -> tuple[Path, list[str], dict[str, str]]:
+    """Create one real identity-anchored audit chain for CLI invocation."""
+    provider = anchored_provider(tmp_path / ".sdd")
+    asyncio.run(provider.prepare_dispatch(intent()))
+
+    audit_key_path = tmp_path / "audit.key"
+    audit_key_path.write_bytes(HMAC_KEY)
+    audit_key_path.chmod(0o600)
+    kms(tmp_path / "signing")
+    signing_key_path = tmp_path / "signing" / "receipt-signing.pem"
+    env = {"BERNSTEIN_AUDIT_KEY_PATH": str(audit_key_path)}
+    common = [
+        "--run",
+        "run-1",
+        "--signing-key-path",
+        str(signing_key_path),
+        "--workdir",
+        str(tmp_path),
+    ]
+    return tmp_path, common, env
+
+
+def test_attest_group_is_reachable_under_identity() -> None:
+    assert "attest" in identity_group.commands
+    attest = identity_group.commands["attest"]
+    assert sorted(attest.commands) == ["show", "verify"]
+
+
+def test_attest_verify_is_not_the_install_rev_verify() -> None:
+    """``identity verify`` takes a token; ``identity attest verify`` takes --run.
+
+    One noun, two objects. This asserts they stayed distinct commands rather
+    than one growing an overloaded meaning.
+    """
+    install_rev_verify = identity_group.commands["verify"]
+    attest_verify = identity_group.commands["attest"].commands["verify"]
+    assert install_rev_verify is not attest_verify
+    assert "run_id" in {param.name for param in attest_verify.params}
+    assert "run_id" not in {param.name for param in install_rev_verify.params}
+
+
+def test_signing_sources_are_mutually_exclusive(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        identity_group,
+        [
+            "attest",
+            "verify",
+            "--run",
+            "run-1",
+            "--signing-key-path",
+            str(tmp_path / "key.pem"),
+            "--signing-env-var",
+            "SOME_KEY",
+            "--workdir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 2
+    assert "mutually exclusive" in result.output
+
+
+def test_missing_signing_source_is_refused(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        identity_group,
+        ["attest", "verify", "--run", "run-1", "--workdir", str(tmp_path)],
+    )
+    assert result.exit_code == 2
+    assert "signing-key-path" in result.output
+
+
+def test_missing_audit_directory_names_the_path(tmp_path: Path) -> None:
+    """Fail closed with the resolved path rather than a traceback."""
+    result = CliRunner().invoke(
+        identity_group,
+        [
+            "attest",
+            "show",
+            "--run",
+            "run-1",
+            "--signing-env-var",
+            "BERNSTEIN_TEST_ABSENT_KEY",
+            "--workdir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Audit directory not found" in result.output or "signing key" in result.output
+
+
+def test_run_id_is_required(tmp_path: Path) -> None:
+    result = CliRunner().invoke(identity_group, ["attest", "show", "--workdir", str(tmp_path)])
+    assert result.exit_code == 2
+    assert "--run" in result.output
+
+
+def test_show_does_not_create_a_missing_audit_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A read-only projection must not mint a key and misreport tampering."""
+    (tmp_path / ".sdd" / "audit").mkdir(parents=True)
+    audit_key_path = tmp_path / "state" / "audit.key"
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(audit_key_path))
+    monkeypatch.setattr(identity_attest_cmd, "_resolve_kms", lambda *_args: object())
+
+    result = CliRunner().invoke(
+        identity_group,
+        ["attest", "show", "--run", "run-1", "--signing-env-var", "IGNORED", "--workdir", str(tmp_path)],
+    )
+
+    assert result.exit_code == identity_attest_cmd.EXIT_FAILURE
+    assert "Failed to load audit key" in result.output
+    assert "will not create key material" in result.output
+    assert not audit_key_path.exists()
+
+
+def test_real_chain_show_and_verify_emit(attest_cli_env: tuple[Path, list[str], dict[str, str]]) -> None:
+    """Exercise both verbs against authenticated identity and dispatch evidence."""
+    root, common, env = attest_cli_env
+    runner = CliRunner()
+
+    show = runner.invoke(identity_group, ["attest", "show", *common], env=env)
+    assert show.exit_code == 0, show.output
+    assert "dispatch evidence" in show.output
+    assert "whole run" in show.output
+
+    output_dir = root / "receipts"
+    verify = runner.invoke(
+        identity_group,
+        ["attest", "verify", *common, "--output", str(output_dir)],
+        env=env,
+    )
+    assert verify.exit_code == 0, verify.output
+    assert "projection verified" in verify.output
+    receipts = list(output_dir.glob("run-attestation-*.json"))
+    assert len(receipts) == 1
+    assert not list(output_dir.glob(".attest-*"))
+
+
+def test_real_chain_tamper_exits_nonzero_and_names_entry(
+    attest_cli_env: tuple[Path, list[str], dict[str, str]],
+) -> None:
+    """Physically mutate the chain and require an entry-specific refusal."""
+    root, common, env = attest_cli_env
+    segment = next((root / ".sdd" / "audit").glob("*.jsonl"))
+    rows = segment.read_text().splitlines()
+    first = json.loads(rows[0])
+    first["actor"] = f"tampered-{first['actor']}"
+    rows[0] = json.dumps(first, sort_keys=True, separators=(",", ":"))
+    segment.write_text("\n".join(rows) + "\n")
+
+    result = CliRunner().invoke(identity_group, ["attest", "verify", *common], env=env)
+
+    assert result.exit_code == identity_attest_cmd.EXIT_FAILURE
+    assert "source audit chain verification failed" in result.output
+    assert ".jsonl:1:" in result.output
+    assert not list((root / ".sdd" / "evidence").glob("*.json"))
+
+
+def test_failed_semantic_verification_is_not_promoted(
+    attest_cli_env: tuple[Path, list[str], dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rejected projection must not look like normal verified evidence."""
+    root, common, env = attest_cli_env
+    output_dir = root / "receipts"
+    monkeypatch.setattr(
+        run_attestation_receipt,
+        "verify_run_attestation_projection",
+        lambda _receipt: SimpleNamespace(ok=False, errors=("forced semantic failure",)),
+    )
+
+    result = CliRunner().invoke(
+        identity_group,
+        ["attest", "verify", *common, "--output", str(output_dir)],
+        env=env,
+    )
+
+    assert result.exit_code == identity_attest_cmd.EXIT_FAILURE
+    assert "forced semantic failure" in result.output
+    assert not list(output_dir.glob("*.json"))
+    assert not list(output_dir.glob(".attest-*"))

--- a/tests/unit/security/test_run_attestation_receipt.py
+++ b/tests/unit/security/test_run_attestation_receipt.py
@@ -13,10 +13,7 @@ from typing import Any
 
 import pytest
 import pytest_asyncio
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
-from bernstein.core.lineage.identity import AgentCard
 from bernstein.core.security.agent_card_signer import generate_ed25519_keypair, sign_agent_card
 from bernstein.core.security.agent_identity import AgentIdentityCard
 from bernstein.core.security.audit_chain import (
@@ -24,8 +21,6 @@ from bernstein.core.security.audit_chain import (
     AuditChainStore,
 )
 from bernstein.core.security.identity_spawn_anchor import IdentitySpawnAnchor
-from bernstein.core.security.lineage_kms import FileBasedKMSAdapter
-from bernstein.core.security.native_toolcall_evidence import NativeToolCallEvidenceProvider
 from bernstein.core.security.run_attestation_receipt import (
     RUN_ATTESTATION_RECEIPT_TYPE,
     RunAttestationReceiptError,
@@ -33,26 +28,14 @@ from bernstein.core.security.run_attestation_receipt import (
     verify_run_attestation_projection,
 )
 from bernstein.core.security.run_closure import close_run
-from bernstein.core.security.toolcall_identity import LineageToolCallIdentitySigner
-from bernstein.core.security.toolcall_interlock import AttestationVerdict, ToolCallIntent
+from bernstein.core.security.toolcall_interlock import AttestationVerdict
+from tests.support.run_attestation import HMAC_KEY
+from tests.support.run_attestation import anchored_provider as _anchored_provider
+from tests.support.run_attestation import intent as _intent
+from tests.support.run_attestation import kms as _kms
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 VERIFIER_SCRIPT = REPO_ROOT / "tools" / "verify_audit_receipt.py"
-HMAC_KEY = b"r" * 32
-SIGNING_SEED = b"s" * 32
-
-
-def _kms(tmp_path: Path, *, seed: bytes = SIGNING_SEED, kid: str = "run-receipt-key") -> FileBasedKMSAdapter:
-    tmp_path.mkdir(parents=True, exist_ok=True)
-    key_path = tmp_path / "receipt-signing.pem"
-    key_path.write_bytes(
-        Ed25519PrivateKey.from_private_bytes(seed).private_bytes(
-            serialization.Encoding.PEM,
-            serialization.PrivateFormat.PKCS8,
-            serialization.NoEncryption(),
-        )
-    )
-    return FileBasedKMSAdapter(key_path, kid=kid)
 
 
 def _load_standard_verifier() -> Any:
@@ -70,47 +53,6 @@ def _standard_verify(path: Path, *args: str) -> tuple[int, str]:
     with redirect_stdout(stdout):
         rc = verifier.main(["--receipt", str(path), *args])
     return rc, stdout.getvalue()
-
-
-def _intent(request_id: int = 1) -> ToolCallIntent:
-    return ToolCallIntent.from_request(
-        scope_id="scope:run-1:agent-1",
-        server_name="filesystem",
-        method="tools/call",
-        tool_name="read_file",
-        request_id=request_id,
-        span_id=f"span-{request_id}",
-        arguments={"path": "/secret-that-must-not-be-retained"},
-    )
-
-
-def _anchored_provider(tmp_path: Path) -> NativeToolCallEvidenceProvider:
-    chain = AuditChainStore(tmp_path / "audit", key=HMAC_KEY)
-    card_private, card_public = generate_ed25519_keypair()
-    tool_private, tool_public = generate_ed25519_keypair()
-    card = AgentIdentityCard(
-        agent_id="agent-1",
-        role="coder",
-        adapter="codex",
-        model="gpt",
-        created_at=100,
-        expires_at=200,
-    )
-    card_signature = sign_agent_card(card, card_private, kid="spawn-key")
-    identity = IdentitySpawnAnchor(chain, {"spawn-key": card_public}, clock=lambda: 150).anchor(
-        run_id="run-1",
-        card=card,
-        signature=card_signature,
-        run_journal_head="journal:fixed",
-        tool_signing_card=AgentCard("agent-1", "tool-key", tool_public.decode()),
-    )
-    return NativeToolCallEvidenceProvider(
-        chain,
-        run_identity=identity,
-        signer=LineageToolCallIdentitySigner(tool_private.decode(), "tool-key"),
-        run_journal_head=lambda: "journal:fixed",
-        clock_ns=lambda: 123_000_000_001,
-    )
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
# feat(cli): reach the run attestation projection from the command line

Closes #2931.

## Context

#3518 deliberately landed the run-attestation projection as a provisional
library slice. #3652 added the merge-gate coupling and #3660 made whole-run
completion reachable from authenticated closure evidence. The CLI was kept
last so its operator-visible behavior could sit on those settled semantics.
This is that final surface.

## What changed

- `bernstein identity attest show --run <id>` projects without writing and
  prints the identity anchor, retained boundary, both re-derived verdicts, and
  receipt digest.
- `bernstein identity attest verify --run <id>` verifies the authenticated
  source chain, rebuilds the projection, runs its semantic verifier, and emits
  the receipt only after every check passes.
- both verbs accept the established receipt-signing sources from `bernstein
  audit receipt export`: `--signing-key-path` or `--signing-env-var`, with an
  optional stable key id.
- verification loads existing audit HMAC key material without creating it. A
  missing key is an operator error, not a reason to mint a new key and report a
  false tamper failure.
- failed projections are written only into an invocation-scoped staging
  directory and never promoted into normal evidence; successful promotion is
  an atomic same-filesystem rename.
- `docs/security/audit-receipt.md` now documents the operator workflow beside
  the run-attestation trust boundary it exposes.

## Placement and trust boundary

`attest` is a separate group rather than an extension of `identity verify`.
The existing command verifies an install-rev fingerprint token; these commands
project and verify a run's attestation evidence. Keeping them distinct avoids
one verb silently changing objects beneath the operator.

The CLI does not trust a serialized verdict. `dispatch_evidence_verdict` and
`whole_run_verdict` are re-derived from the retained authenticated range on
every invocation, so a stored `complete` claim cannot promote itself through
this surface. `show` is read-only: it neither writes a receipt nor creates
audit key material. A projection that fails semantic verification leaves no
receipt-shaped file in the normal evidence directory.

The standard receipt formats remain the existing COSE, in-toto/DSSE, and
transparency envelopes. External signature verification and independent key
pinning remain the responsibility of `bernstein audit receipt verify` or the
standalone verifier, as documented by the underlying receipt contract.

## Test boundary

The real-chain setup that previously lived inside the security test module is
now shared through `tests/support/run_attestation.py`. The CLI suite therefore
tests its public behavior against authenticated identity and dispatch evidence
instead of mocking the projection boundary.

The committed regressions cover:

- successful `show` against a real anchored chain;
- successful `verify` and receipt promotion;
- physical mutation of the first audit JSONL entry, with exit 1 and the exact
  `<segment>.jsonl:1` entry named;
- a missing audit key creating no replacement key material; and
- forced semantic failure leaving neither a receipt nor a staging directory.

The existing 21 security tests continue to own projection semantics and use
the same shared builders.

## Validation

- 44 focused and neighboring tests passed: 10 CLI, 21 run-attestation, and 13
  audit-receipt command tests
- 27 documentation/context guard tests passed
- Ruff format check and lint passed on all touched Python files
- mypy and Pyright passed on the new command module
- import-linter kept all 3 architecture contracts
- `bernstein agents-md sync` completed with no generated diff
- `git diff --check` passed

The only warning was the existing Starlette `httpx` deprecation warning.

The issue's original documentation paths have drifted: the README has no
identity section, and `docs/operations/security.md` covers project security
process rather than receipt operation. The canonical run-attestation
documentation is `docs/security/audit-receipt.md`, so the operator surface is
documented there.
