### PR TITLE
fix(adapters): stop passing an unsupported flag to codex exec

### DIFF
--- a/src/bernstein/adapters/codex.py
+++ b/src/bernstein/adapters/codex.py
@@ -115,12 +115,13 @@ class CodexAdapter(CLIAdapter):
             "-o",
             str(output_path),
         ]
-        # Bind a deterministic session id so a replay of this run reaches
-        # the same conversation slot and parallel codex sessions in the
-        # same worktree do not collide. The orchestrator session_id is the
-        # stable conversation key available at spawn time. When the codex
-        # contract declares no session-id flag this is an empty list and
-        # the argv is unchanged.
+        # Session-id binding is contract-driven: the argv gains a flag only
+        # when the contract names one. ``codex exec`` exposes no flag that
+        # accepts a caller-supplied session id -- only a ``resume
+        # <SESSION_ID>`` subcommand, which reattaches to an existing session
+        # and cannot bind one at spawn time -- so the codex contract names no
+        # flag and this stays an empty list (issue #4135). The derived id is
+        # still recorded in orchestrator state for cross-reference.
         cmd.extend(self.session_id_args(session_id))
         cmd.append(prompt)
 

--- a/tests/contract/contracts/codex.yaml
+++ b/tests/contract/contracts/codex.yaml
@@ -20,10 +20,14 @@ required_subcommands:
   - "exec"
 # Codex sub-flags live under ``codex exec --help``, not ``codex --help``.
 help_command: ["codex", "exec", "--help"]
-# Deterministic session-id binding: codex exec accepts a caller-supplied
-# session id, so the adapter pins the derived id for replay isolation.
-# See docs/adapters/session_isolation.md.
-session_id_flag: "--session-id"
+# No deterministic session-id binding: ``codex exec`` exposes no flag that
+# accepts a caller-supplied session id. Its only session surface is the
+# ``resume <SESSION_ID>`` subcommand, which reattaches to a session that
+# already exists and so cannot bind one at spawn time. Declaring a flag here
+# makes ``CLIAdapter.session_id_args`` emit it into every codex spawn, and
+# codex exits immediately with ``unexpected argument '--session-id' found``
+# (issue #4135). The derived id is still recorded in orchestrator state for
+# cross-reference. See docs/adapters/session_isolation.md.
 expected_models:
   command: []
   required_present: []

--- a/tests/unit/adapters/test_session_id_binding.py
+++ b/tests/unit/adapters/test_session_id_binding.py
@@ -31,6 +31,7 @@ from bernstein.adapters.session_id import (
     SessionIdIndex,
     derive_session_id,
 )
+from tests.unit._adapter_test_helpers import inner_cmd
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -145,9 +146,15 @@ def test_contract_blank_session_id_flag_is_none(tmp_path: Path) -> None:
     assert spec.session_id_flag is None
 
 
-def test_real_codex_contract_declares_session_id_flag() -> None:
+def test_real_codex_contract_declares_no_session_id_flag() -> None:
+    # Property (1), root cause. ``codex exec`` has no top-level flag that
+    # accepts a caller-supplied session id - the only session surface is the
+    # ``resume <SESSION_ID>`` subcommand, which reattaches to a session that
+    # already exists and so cannot bind one at spawn time. A contract that
+    # names a flag here makes ``session_id_args`` emit it into every spawn
+    # (issue #4135).
     spec = _contract.ContractSpec.load("codex")
-    assert spec.session_id_flag == "--session-id"
+    assert spec.session_id_flag is None
 
 
 def test_real_copilot_contract_declares_session_id_flag() -> None:
@@ -185,14 +192,37 @@ def test_session_id_args_empty_when_flag_absent(tmp_path: Path) -> None:
         assert adapter.session_id_args("conv-1") == []
 
 
-def test_codex_session_id_args_emits_flag_and_derived_id() -> None:
+def test_codex_session_id_args_is_empty() -> None:
+    # Property (1). No declared flag means no argv contribution; the derived
+    # id is still recorded in orchestrator state for cross-reference.
     adapter = CodexAdapter()
-    args = adapter.session_id_args("conv-1")
-    assert args[0] == "--session-id"
-    assert args[1] == str(derive_session_id("conv-1", "codex"))
+    assert adapter.session_id_args("conv-1") == []
 
 
-def test_codex_spawn_passes_deterministic_session_id(tmp_path: Path) -> None:
+def test_codex_declares_no_native_resume() -> None:
+    # Property (3). ``codex exec resume <SESSION_ID>`` is a subcommand, not a
+    # flag, and reattaching is not wired for this adapter: the contract
+    # declares resume unsupported, so no resume token is built at all.
+    from bernstein.adapters._contract import ResumeStrategy
+
+    assert CodexAdapter().strategy().resume is ResumeStrategy.UNSUPPORTED
+
+
+def test_copilot_session_id_args_unchanged_by_codex_fix() -> None:
+    # Property (2), blast radius. ``session_id_args`` is shared: copilot must
+    # keep pinning its derived id through the flag its own CLI does accept.
+    from bernstein.adapters.copilot import CopilotAdapter
+
+    adapter = CopilotAdapter()
+    assert adapter.session_id_args("conv-1") == [
+        "--session-id",
+        str(derive_session_id("conv-1", "copilot")),
+    ]
+
+
+def test_codex_spawn_argv_has_no_session_id_flag(tmp_path: Path) -> None:
+    # Property (1) at the spawn boundary. This is the exact argv codex-cli
+    # rejected with ``error: unexpected argument '--session-id' found``.
     adapter = CodexAdapter()
     proc = MagicMock(spec=subprocess.Popen)
     proc.pid = 4242
@@ -208,12 +238,33 @@ def test_codex_spawn_passes_deterministic_session_id(tmp_path: Path) -> None:
         )
 
     argv = list(popen.call_args_list[0][0][0])
-    assert "--session-id" in argv
-    derived = str(derive_session_id("qa-abc123", "codex"))
-    assert derived in argv
-    # The prompt stays last so the derived id never displaces the positional
-    # prompt argument.
+    assert "--session-id" not in argv
+    assert str(derive_session_id("qa-abc123", "codex")) not in argv
+    # The prompt stays last so codex reads it as the positional PROMPT.
     assert argv[-1] == "do work"
+
+
+def test_copilot_spawn_argv_still_pins_session_id(tmp_path: Path) -> None:
+    # Property (2) at the spawn boundary: the shared helper still emits
+    # copilot's flag/id pair after the codex contract change.
+    from bernstein.adapters.copilot import CopilotAdapter
+
+    adapter = CopilotAdapter()
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = 4343
+    proc.stdout = MagicMock()
+
+    with patch("bernstein.adapters.copilot.subprocess.Popen", return_value=proc) as popen:
+        adapter.spawn(
+            prompt="do work",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="gpt-5.4", effort="high"),
+            session_id="copilot-4135",
+            timeout_seconds=0,
+        )
+
+    inner = inner_cmd(popen.call_args.args[0])
+    assert inner[inner.index("--session-id") + 1] == str(derive_session_id("copilot-4135", "copilot"))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4135

Reported by @paulo-neuralhub against codex-cli 0.147.0. Reproduced locally on codex-cli 0.130.0, so this is not specific to one upstream release.

## Root cause

Not the call site. `tests/contract/contracts/codex.yaml` declared:

```yaml
session_id_flag: "--session-id"
```

`CLIAdapter.session_id_args` (`src/bernstein/adapters/base.py:985`) is contract-driven: it returns `[flag, derived_id]` when the contract names a flag and `[]` when it does not. With the flag declared, `src/bernstein/adapters/codex.py:124` extended every codex spawn with `--session-id <uuid>` — which `codex exec` does not accept:

```
$ codex exec --help
Usage: codex exec [OPTIONS] [PROMPT]
       codex exec [OPTIONS] <COMMAND> [ARGS]

Commands:
  resume  Resume a previous session by id or pick the most recent with --last
```

There is no top-level session-id option. The only session surface is the `resume <SESSION_ID>` subcommand, which reattaches to a session that already exists and therefore cannot bind one at spawn time. Codex declares `ResumeStrategy.UNSUPPORTED`, so no resume token is built either.

The comment already at `codex.py:120` said the list "is an empty list" for codex — the code was written against a contract that did not match the binary. Nothing validated the declaration: `session_id_flag` is the one declared token the drift checker never asserts against `--help`, so this shipped silently.

## Fix

Remove the declaration from the codex contract. `session_id_args` now returns `[]` for codex and the argv is the documented surface again:

```
codex exec --sandbox workspace-write -m <model> --json -o <path> <prompt>
```

The derived id is still recorded in orchestrator state for cross-reference, per the contract in `docs/adapters/session_isolation.md`. The base method and the codex call site are unchanged — the call stays declarative, so if codex ever gains such a flag, naming it in the contract is the whole change.

## Blast radius

`session_id_args` is shared; `src/bernstein/adapters/copilot.py:141` calls it too, and copilot's CLI genuinely accepts `--session-id`. Copilot's contract is untouched, and two tests prove its behaviour is unchanged rather than asserting it by reading:

- `test_copilot_session_id_args_unchanged_by_codex_fix` — the helper still returns `["--session-id", <derived>]` for copilot.
- `test_copilot_spawn_argv_still_pins_session_id` — the flag and derived id still reach copilot's spawn argv.

Both pass before and after the change, alongside the pre-existing copilot coverage in `tests/unit/test_adapter_copilot.py`.

## Tests

Three properties, each failing on `main` before the fix:

1. `test_real_codex_contract_declares_no_session_id_flag` — the contract names no flag.
2. `test_codex_session_id_args_is_empty` / `test_codex_spawn_argv_has_no_session_id_flag` — the built spawn argv contains neither the flag nor the derived id, and the prompt stays last so codex reads it as the positional `PROMPT`.
3. `test_codex_declares_no_native_resume` — resume is honestly declared unsupported for codex, so no `resume <SESSION_ID>` subcommand is synthesised either.

On `main` the three codex properties fail (`3 failed, 25 passed`) with `assert ['--session-id', '...'] == []`. After the fix the file is green.

Scoped runs, all green: `tests/unit/adapters`, `tests/unit/test_adapter_contract.py`, `tests/unit/test_adapter_conformance.py`, `tests/unit/test_adapter_contract_check.py`, `tests/unit/test_adapter_admission.py`, `tests/unit/test_adapter_canary.py`, `tests/unit/test_adapter_copilot.py`, `tests/unit/test_adapter_verification_data_in_wheel.py`, `tests/unit/test_codex_cloudflare.py`, `tests/integration/test_adapter_conformance_lifecycle.py`, `tests/integration/test_adapter_e2e.py`, `tests/integration/adapters/test_adapters_check_cli.py`, `tests/integration/test_cross_adapter_orchestration.py`, `tests/integration/test_failover.py`, `tests/integration/test_resume_lifecycle.py`.

## Follow-up worth a separate issue

A declared `session_id_flag` is a flag the adapter always passes, but it is not in `required_flags`, so the contract-drift job never checks it against the live `--help`. Folding it into the capability check would have caught this at authoring time. That change also touches copilot's drift gate, and I could not verify `copilot --help` locally (binary not installed), so it is deliberately out of this PR.
