### PR TITLE
fix(agents): honour an explicitly configured role CLI at spawn

### DIFF
--- a/docs/operations/CONFIG.md
+++ b/docs/operations/CONFIG.md
@@ -109,6 +109,8 @@ role_model_policy:
 
 When `cli: auto` is set at the top level, the orchestrator picks the best available adapter per role based on the `role_model_policy`. When a specific `cli:` is set per role, that adapter is used exclusively for that role.
 
+A per-role `cli:` accepts any adapter registry name that `bernstein adapters list` reports - `ollama`, `aider`, `opencode` and the rest, not only the handful that also answer to a provider alias. The value is resolved by name; a `cli:` that names no registered adapter refuses the spawn and lists the adapters that would have worked, instead of quietly running the role on the run-level adapter.
+
 ### `catalogs` - External agent catalog sources
 
 Point the orchestrator at local directories of agent definitions - a

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -482,6 +482,29 @@ def _build_provider_alias_table() -> None:
     )
 
 
+def _registered_adapter_name(name: str) -> str | None:
+    """Return *name* if it is an adapter registry key, else ``None``.
+
+    The comparison is against exactly what :func:`get_adapter` accepts --
+    the live ``_ADAPTERS`` table plus the ``generic`` pseudo-adapter -- so
+    a name that resolves here is guaranteed to instantiate. Entry-point
+    adapters are discovered first; the callers of this helper have already
+    triggered discovery via :func:`_build_provider_alias_table`, but the
+    call is idempotent and keeps the helper correct in isolation.
+
+    Args:
+        name: Candidate adapter registry name, already lower-cased and
+            stripped by the caller.
+
+    Returns:
+        The registry name, or ``None`` when nothing is registered under it.
+    """
+    _load_entrypoint_adapters()
+    if name == "generic" or name in _ADAPTERS:
+        return name
+    return None
+
+
 def adapter_name_for_provider(provider_name: str | None, model: str) -> str | None:
     """Resolve an adapter registry name from a provider name and/or model string.
 
@@ -493,33 +516,55 @@ def adapter_name_for_provider(provider_name: str | None, model: str) -> str | No
 
     Resolution order:
 
-    1. **Exact match.** ``provider_name`` (case-insensitive, stripped) is
-       looked up directly against the alias table built from every
-       adapter's ``provides`` declaration. Because
+    1. **Exact alias match.** ``provider_name`` (case-insensitive,
+       stripped) is looked up directly against the alias table built from
+       every adapter's ``provides`` declaration. Because
        :func:`_register_provider_alias` refuses ambiguous aliases at
        build time, an exact hit here is guaranteed unambiguous.
-    2. **Substring fallback, longest-alias-first.** Some call sites (for
-       example the sampling-capability probe in ``spawner_core.py``, which
-       calls this with ``provider_name=None``) only have a bare model
-       string like ``"gpt-4.1"`` or ``"claude-opus-4"`` to go on. For that
-       case every registered alias is checked as a substring of
-       ``f"{provider_name} {model}"``, longest alias first. Longest-first
-       guarantees a more specific alias (``"openai_agents"``) always wins
-       over a shorter alias it textually contains (``"openai"``) without
+    2. **Exact registry-name match.** ``provides`` is optional and most
+       adapters declare none: only 7 of the ~49 selectable adapters carry
+       aliases. An operator selecting one of the other 42 by its registry
+       name -- which is what ``cli:`` accepts, and what
+       :func:`selectable_adapter_names` enumerates -- must resolve, or the
+       selection is silently dropped and the spawn lands on some other
+       adapter (issue #4134: ``cli: ollama`` spawned Claude Code and died
+       with ``command not found: claude``). A registry name is checked
+       after the alias table so an adapter registered under a second key
+       (``antigravity``) never shadows another adapter's declared alias.
+    3. **Substring fallback, longest-alias-first -- model text only.**
+       Some call sites (for example the sampling-capability probe in
+       ``spawner_core.py``) pass ``provider_name=None`` and have only a
+       bare model string like ``"gpt-4.1"`` or ``"claude-opus-4"`` to go
+       on. For that case every registered alias is checked as a substring
+       of the model string, longest alias first. Longest-first guarantees
+       a more specific alias (``"openai_agents"``) always wins over a
+       shorter alias it textually contains (``"openai"``) without
        requiring any hand-maintained ordering -- this is what forecloses
        the 042bcbd0 bug class structurally rather than only patching the
        one instance of it.
 
+       This step runs **only** when no provider name was supplied. A
+       supplied provider name is an explicit selection: either it resolves
+       by name (steps 1-2) or it does not resolve at all. Searching the
+       model text underneath it matched aliases across the provider/model
+       boundary -- ``provider='ollama'`` with ``model='qwen2.5:1.5b'``
+       resolved to the Qwen CLI off the concatenated text ``"ollama
+       qwen2.5:1.5b"`` (issue #4134), so the same misconfiguration failed
+       two different ways depending on whether the model name happened to
+       contain another adapter's alias.
+
     Returns:
-        The resolved adapter registry name, or ``None`` if nothing in the
-        alias table matches. Callers apply their own fallback (typically
-        the spawner's currently-active adapter) when ``None`` is returned.
+        The resolved adapter registry name, or ``None`` if nothing
+        matches. Callers apply their own handling (the spawn path refuses
+        an unresolvable operator ``cli:`` by name; probe call sites fall
+        back to the currently-active adapter) when ``None`` is returned.
     """
     logger.debug("registry.adapter_name_for_provider: provider_name=%r model=%r", provider_name, model)
     _build_provider_alias_table()
 
     if provider_name:
-        exact = _PROVIDER_ALIAS_TABLE.get(provider_name.strip().lower())
+        key = provider_name.strip().lower()
+        exact = _PROVIDER_ALIAS_TABLE.get(key)
         if exact is not None:
             logger.info(
                 "registry.adapter_name_for_provider: EXACT match provider_name=%r -> adapter=%r",
@@ -527,8 +572,24 @@ def adapter_name_for_provider(provider_name: str | None, model: str) -> str | No
                 exact,
             )
             return exact
+        registered = _registered_adapter_name(key)
+        if registered is not None:
+            logger.info(
+                "registry.adapter_name_for_provider: REGISTRY-NAME match provider_name=%r -> adapter=%r "
+                "(adapter declares no `provides` aliases)",
+                provider_name,
+                registered,
+            )
+            return registered
+        logger.info(
+            "registry.adapter_name_for_provider: NO MATCH for provider_name=%r (model=%r not consulted -- "
+            "an explicitly named provider resolves by name or not at all); caller must apply its own handling",
+            provider_name,
+            model,
+        )
+        return None
 
-    text = f"{provider_name or ''} {model}".lower()
+    text = model.lower()
     for alias in sorted(_PROVIDER_ALIAS_TABLE, key=len, reverse=True):
         if alias in text:
             excluded = _ALIAS_SUBSTRING_EXCLUSIONS.get(alias, ())
@@ -554,9 +615,8 @@ def adapter_name_for_provider(provider_name: str | None, model: str) -> str | No
             return adapter_name
 
     logger.info(
-        "registry.adapter_name_for_provider: NO MATCH for provider_name=%r model=%r; "
+        "registry.adapter_name_for_provider: NO MATCH for model=%r (no provider_name given); "
         "caller must apply its own fallback",
-        provider_name,
         model,
     )
     return None

--- a/src/bernstein/core/agents/spawn_errors.py
+++ b/src/bernstein/core/agents/spawn_errors.py
@@ -145,6 +145,25 @@ class ModelNotConfiguredError(CategorizedSpawnError):
     retry_strategy = RetryStrategy.RETRY_AFTER_FIX
 
 
+class AdapterNotConfiguredError(CategorizedSpawnError):
+    """An explicitly configured ``cli`` does not name a resolvable adapter.
+
+    ``role_model_policy.<role>.cli`` and a task's per-step ``cli:`` field are
+    operator selections of an adapter, and neither is validated against the
+    adapter catalog at parse time (any non-empty string parses). When such a
+    selection resolves to nothing, the spawn path used to fall through to the
+    run-level adapter, so the run died later with an error naming an adapter
+    the operator never asked for (issue #4134: ``cli: ollama`` reported
+    ``command not found: claude``). Refusing here instead names the value the
+    operator actually wrote.
+
+    ``provider`` carries the unresolvable ``cli`` value so callers can report
+    it without parsing the message.
+    """
+
+    retry_strategy = RetryStrategy.RETRY_AFTER_FIX
+
+
 _SPAWN_ERROR_PATTERNS: list[tuple[type[CategorizedSpawnError], str, tuple[str, ...]]] = [
     (AdapterNotInstalledError, "Adapter binary not found", ("not found", "no such file", "command not found")),
     (WorktreeCreationError, "Worktree creation failed", ("worktree", "git worktree")),

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -50,6 +50,7 @@ from bernstein.core.agents.response_style import (
     resolve_response_style,
 )
 from bernstein.core.agents.spawn_errors import (
+    AdapterNotConfiguredError,
     ModelNotConfiguredError,
     RetryStrategy,
     classify_spawn_error,
@@ -216,6 +217,12 @@ def _list_subdirs_cached(path: Path) -> list[str]:
 
 
 logger = logging.getLogger(__name__)
+
+#: The ``cli:`` value meaning "auto-detect an adapter" rather than naming
+#: one. It is not a registry name, so it must never be resolved against the
+#: adapter catalog (see :meth:`AgentSpawner._resolve_configured_cli`).
+#: Mirrors the seed parser's own sentinel.
+_AUTO_CLI_SENTINEL = "auto"
 
 
 def emit_process_reap_receipt(
@@ -3328,6 +3335,67 @@ class AgentSpawner:
             record_sha256=record_sha256,
         )
 
+    def _resolve_configured_cli(self, configured_cli: object) -> str | None:
+        """Resolve an operator-written ``cli:`` to an adapter registry name.
+
+        ``role_model_policy.<role>.cli`` and a task's per-step ``cli:`` are
+        the operator naming the adapter for that spawn. Neither is checked
+        against the adapter catalog when it is parsed - the seed parser
+        accepts any non-empty string, and a plan file's ``cli:`` is not
+        validated at all - so this is the first place the selection meets
+        the registry.
+
+        A value that resolves to nothing used to fall through to
+        ``self._adapter``, the run-level adapter, and the run then died
+        somewhere downstream naming an adapter the operator never chose
+        (issue #4134 reported ``cli: ollama`` failing with ``command not
+        found: claude``). Refusing here instead names the value that was
+        actually written, next to the adapters that would have worked.
+
+        Args:
+            configured_cli: The raw ``cli`` value from the role policy or
+                the task, or ``None``. The ``"auto"`` sentinel means
+                auto-detection, not an adapter, and resolves to ``None``.
+
+        Returns:
+            The adapter registry name, or ``None`` when no CLI was chosen.
+
+        Raises:
+            AdapterNotConfiguredError: When a CLI was chosen and it names
+                neither a provider alias nor a registered adapter.
+        """
+        if not isinstance(configured_cli, str):
+            return None
+        cli_name = configured_cli.strip()
+        if not cli_name or cli_name == _AUTO_CLI_SENTINEL:
+            return None
+
+        resolved = adapter_name_for_provider(cli_name, "")
+        if resolved is not None:
+            logger.debug(
+                "_resolve_configured_cli: cli=%r -> adapter=%r",
+                cli_name,
+                resolved,
+            )
+            return resolved
+
+        from bernstein.adapters.registry import removed_adapter_message, selectable_adapter_names
+
+        guidance = removed_adapter_message(cli_name)
+        if guidance is None:
+            guidance = f"Available adapters: {', '.join(sorted(selectable_adapter_names()))}."
+        logger.error(
+            "spawn refused: configured cli=%r does not name a known adapter",
+            cli_name,
+        )
+        raise AdapterNotConfiguredError(
+            f"cli={cli_name!r} does not name a known adapter. It was configured for this "
+            f"spawn (role_model_policy.<role>.cli or a task's `cli:` field) and cannot be "
+            f"honoured, so the spawn is refused rather than run on a different adapter. "
+            f"{guidance}",
+            provider=cli_name,
+        )
+
     def _resolve_routing(
         self,
         tasks: list[Task],
@@ -3342,14 +3410,21 @@ class AgentSpawner:
         effective_role_policy: dict[str, Any] = role_policy.copy()
         if tasks[0].cli and "cli" not in effective_role_policy:
             effective_role_policy["cli"] = tasks[0].cli
+        configured_cli = self._resolve_configured_cli(effective_role_policy.get("cli"))
         use_router = _should_use_router(
             role_policy=effective_role_policy,
             adapter_name=self._adapter.name(),
             has_router=self._router is not None and bool(self._router.state.providers),
         )
         if not use_router:
-            if preferred_provider:
-                provider_name = preferred_provider
+            # An explicitly configured `cli:` carries the spawn when nothing
+            # else supplied a provider. The seed parser mirrors `cli` onto
+            # `provider` (so `preferred_provider` usually already holds it),
+            # but policies assembled anywhere else - team manifests,
+            # availability chains, a plan file's per-step `cli:` - carry only
+            # `cli`, and dropping it here left the spawn on the run-level
+            # adapter (issue #4134).
+            provider_name = preferred_provider or configured_cli
             routing_source = "operator-config" if role_policy.get("model") else "heuristic"
             # Adapter-aware heuristic (issue #2743): the batch/heuristic
             # selectors and role templates emit Claude tier names

--- a/tests/unit/test_role_policy_cli_routing.py
+++ b/tests/unit/test_role_policy_cli_routing.py
@@ -1,0 +1,226 @@
+"""An explicitly configured role CLI must survive the spawn path.
+
+``role_model_policy.<role>.cli`` (and the per-step ``cli:`` field on a task)
+is an operator naming the adapter for a role. The spawn path resolves that
+selection once, then re-infers the adapter a second time from the
+provider/model *text* -- and the second lookup is what actually decides
+which binary runs. When the second lookup disagrees with the first, the
+operator's choice is discarded silently and the run dies further downstream
+with an error naming an adapter the operator never asked for.
+
+The tests below are numbered by the property each one protects:
+
+1. An explicitly configured ``cli`` is honoured at spawn even when the
+   provider-alias table (built from adapters' ``provides`` declarations)
+   has no entry for it. Most registered adapters declare no aliases at all.
+2. A configured ``cli`` that cannot be honoured produces a structured
+   refusal naming that ``cli`` -- never a silent substitution of a
+   different adapter.
+3. A model string never routes across an explicit provider boundary: with
+   ``cli: ollama`` a model named ``qwen2.5:7b`` must not be handed to the
+   Qwen CLI because the text happens to contain another adapter's alias.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from bernstein.core.models import ModelConfig, Task
+from bernstein.core.spawner import AgentSpawner
+
+from bernstein.adapters import registry
+from bernstein.core.agents.spawn_errors import AdapterNotConfiguredError
+
+# The reported configuration (issue #4134): a local Ollama model pinned for
+# the manager role. ``ollama`` is a registered, selectable adapter; it simply
+# declares no ``provides`` aliases, like most adapters in the catalog.
+OLLAMA_ROLE_POLICY: dict[str, str] = {
+    "cli": "ollama",
+    "provider": "ollama",  # the seed parser mirrors `cli` onto `provider`
+    "model": "deepseek-r1:1.5b",
+    "effort": "low",
+}
+
+
+def _make_spawner(tmp_path: Path, role_policy: dict[str, str] | None = None) -> AgentSpawner:
+    """Spawner whose run-level adapter is something other than the pinned CLI.
+
+    Mirrors the reported run: ``cli: auto`` picked Claude Code as the
+    run-level adapter, while the manager role pins ``cli: ollama``.
+    """
+    adapter = MagicMock()
+    adapter.name.return_value = "test-adapter"
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    return AgentSpawner(
+        adapter,
+        templates_dir,
+        tmp_path,
+        role_model_policy={"manager": dict(role_policy)} if role_policy else None,
+    )
+
+
+def _manager_task(cli: str | None = None) -> Task:
+    return Task(
+        id="T-4134",
+        title="Fix the failing test",
+        description="Fix the failing test in tests/test_add.py",
+        role="manager",
+        cli=cli,
+    )
+
+
+def _model_config(model: str = "deepseek-r1:1.5b") -> ModelConfig:
+    return ModelConfig(model=model, effort="low")
+
+
+def _resolve(
+    spawner: AgentSpawner,
+    role_policy: dict[str, Any],
+    *,
+    model: str = "deepseek-r1:1.5b",
+    task_cli: str | None = None,
+) -> tuple[ModelConfig, str | None, str]:
+    """Run the spawn path's routing step the way ``spawn_for_tasks`` does."""
+    preferred_provider = task_cli or role_policy.get("provider")
+    return spawner._resolve_routing(  # pyright: ignore[reportPrivateUsage]
+        [_manager_task(cli=task_cli)],
+        _model_config(model),
+        role_policy,
+        preferred_provider,
+    )
+
+
+# --- 1. an explicit `cli` is honoured even with no provider-alias entry ----
+
+
+def test_configured_role_cli_is_honoured_when_registry_has_no_provider_alias(tmp_path: Path) -> None:
+    """`cli: ollama` must resolve to the ollama adapter, not to the run's adapter.
+
+    ``ollama`` is a registered adapter with no ``provides`` aliases, so the
+    alias table has no entry for it. That miss must not be treated as "the
+    operator said nothing" -- it is an operator selection that names a real
+    adapter.
+    """
+    spawner = _make_spawner(tmp_path, OLLAMA_ROLE_POLICY)
+    resolved = spawner._infer_adapter_name_for_provider(  # pyright: ignore[reportPrivateUsage]
+        "ollama", "deepseek-r1:1.5b"
+    )
+    assert resolved == "ollama"
+
+
+def test_registered_adapter_name_resolves_without_a_declared_provider_alias() -> None:
+    """Registry level: a selectable adapter name resolves as itself.
+
+    Only 7 of the ~49 selectable adapters declare ``provides`` aliases. Every
+    other adapter name an operator may legally write in ``cli:`` has to
+    resolve, or the selection is silently dropped.
+    """
+    for adapter_name in ("ollama", "aider", "opencode"):
+        assert adapter_name in registry.selectable_adapter_names()
+        assert registry.adapter_name_for_provider(adapter_name, "deepseek-r1:1.5b") == adapter_name
+
+
+def test_configured_role_cli_reaches_routing_when_only_cli_is_set(tmp_path: Path) -> None:
+    """A policy carrying `cli` but no `provider` still routes to that adapter.
+
+    The seed parser mirrors ``cli`` onto ``provider``, but policies built
+    programmatically (manifests, availability chains, per-step ``cli:``)
+    carry only ``cli``. Routing must not drop the selection on that path.
+    """
+    spawner = _make_spawner(tmp_path, {"cli": "ollama", "model": "deepseek-r1:1.5b"})
+    _config, provider_name, _source = _resolve(spawner, {"cli": "ollama", "model": "deepseek-r1:1.5b"})
+    assert provider_name == "ollama"
+
+
+# --- 2. an unhonourable `cli` refuses by name, never substitutes ----------
+
+
+def test_unresolvable_configured_cli_refuses_by_name(tmp_path: Path) -> None:
+    """A `cli` naming nothing resolvable must refuse, naming that `cli`.
+
+    The failure the reporter saw named ``Claude Code`` -- an adapter they
+    never configured -- because the unresolvable selection fell through to
+    the run-level adapter. The refusal has to name what the operator wrote.
+    """
+    spawner = _make_spawner(tmp_path, {"cli": "ollama-cloud", "model": "deepseek-r1:1.5b"})
+    with pytest.raises(AdapterNotConfiguredError) as excinfo:
+        _resolve(spawner, {"cli": "ollama-cloud", "model": "deepseek-r1:1.5b"})
+    assert "ollama-cloud" in str(excinfo.value)
+    assert excinfo.value.provider == "ollama-cloud"
+
+
+def test_unresolvable_configured_cli_does_not_substitute_the_run_adapter(tmp_path: Path) -> None:
+    """The refusal must not be reachable by falling back to another adapter."""
+    spawner = _make_spawner(tmp_path, {"cli": "ollama-cloud", "model": "deepseek-r1:1.5b"})
+    with pytest.raises(AdapterNotConfiguredError) as excinfo:
+        _resolve(spawner, {"cli": "ollama-cloud", "model": "deepseek-r1:1.5b"})
+    assert "test-adapter" not in str(excinfo.value)
+
+
+def test_unresolvable_per_step_cli_refuses_by_name(tmp_path: Path) -> None:
+    """The per-step `cli:` field on a task gets the same treatment."""
+    spawner = _make_spawner(tmp_path)
+    with pytest.raises(AdapterNotConfiguredError) as excinfo:
+        _resolve(spawner, {}, task_cli="ollama-cloud")
+    assert "ollama-cloud" in str(excinfo.value)
+
+
+# --- 3. no substring matching across an explicit provider boundary --------
+
+
+def test_model_string_never_routes_across_an_explicit_provider_boundary(tmp_path: Path) -> None:
+    """`cli: ollama` + model `qwen2.5:7b` must not reach the Qwen CLI.
+
+    The alias search used to run over the concatenated ``"<provider>
+    <model>"`` text, so any model whose name contains another adapter's
+    alias hijacked an explicit provider selection.
+    """
+    spawner = _make_spawner(tmp_path, {**OLLAMA_ROLE_POLICY, "model": "qwen2.5:7b"})
+    resolved = spawner._infer_adapter_name_for_provider(  # pyright: ignore[reportPrivateUsage]
+        "ollama", "qwen2.5:7b"
+    )
+    assert resolved == "ollama"
+
+
+def test_model_text_is_not_consulted_when_a_provider_was_named() -> None:
+    """Registry level: an unresolvable provider does not fall to the model text.
+
+    ``qwen2.5:7b`` under provider ``ollama-cloud`` must report "no match" so
+    the caller can refuse by name, rather than reporting the Qwen adapter
+    the operator never selected.
+    """
+    assert registry.adapter_name_for_provider("ollama-cloud", "qwen2.5:7b") is None
+
+
+# --- guards on the narrowing above ----------------------------------------
+#
+# These two hold before the fix as well as after it. They are here because
+# the fix narrows two things (which values count as an adapter selection,
+# and when the model text may be consulted) and each narrowing has an
+# obvious way to overshoot.
+
+
+def test_auto_cli_is_not_an_adapter_selection(tmp_path: Path) -> None:
+    """`cli: auto` is the auto-detection sentinel, not an adapter name.
+
+    Overshoot guard: refusing every unresolvable ``cli`` must not refuse
+    ``auto``, which no adapter is registered under.
+    """
+    spawner = _make_spawner(tmp_path)
+    _config, provider_name, _source = _resolve(spawner, {"cli": "auto"})
+    assert provider_name is None
+
+
+def test_model_only_inference_still_works_without_a_provider() -> None:
+    """Call sites with no provider at all keep inferring from the model text.
+
+    Overshoot guard: the sampling-capability probe passes
+    ``provider_name=None`` and has only a bare model string to go on.
+    Closing the provider path must not close that one.
+    """
+    assert registry.adapter_name_for_provider(None, "qwen3-coder") == "qwen"
+    assert registry.adapter_name_for_provider(None, "gpt-5.5") == "codex"


### PR DESCRIPTION
Closes #4134

Reported by @paulo-neuralhub, with spawner logs that made the whole mechanism visible in one paste:

```
role_model_policy resolution for role='manager': match=exact, resolved={'model': 'deepseek-r1:1.5b', 'effort': 'low', 'cli': 'ollama', 'provider': 'ollama'}
Router skipped for role=manager (adapter=ollama): using deepseek-r1:1.5b/low (source=operator-config)
...
registry.adapter_name_for_provider: NO MATCH for provider_name='ollama' model='deepseek-r1:1.5b'; caller must apply its own fallback
_infer_adapter_name_for_provider: no registry match for provider_name='ollama' model='deepseek-r1:1.5b'; falling back to current adapter 'Claude Code'
...
Adapter 'Claude Code' was refused admission (no_contract)
Spawn failure reason extracted ... exit_code=127: bernstein-worker: command not found: claude
```

## Mechanism

The policy resolves correctly on line 1. Then `_infer_adapter_name_for_provider` (`spawner_core.py:2358`) re-derives the adapter from the provider/model text, and *that* result is what the four spawn call sites use. Two things go wrong there:

**The resolved `cli` is discarded when the alias table misses.** `registry.adapter_name_for_provider` only knew the `provides` aliases — 14 aliases across 7 adapters, exactly as the startup log says. `provides` is optional and most adapters declare none, so 42 of the 49 names `bernstein adapters list` reports have no entry. A `cli:` naming one of those missed and fell through to `self._adapter.name()`, the run-level adapter. `ollama` is one of the 42.

**The alias search ran over the concatenated provider+model text.** So when the model name happened to contain another adapter's alias, the explicit selection was hijacked rather than dropped — the reporter's second failure mode, `cli: ollama` with `qwen2.5:1.5b` matching `alias='qwen' in text='ollama qwen2.5:1.5b'` and spawning the Qwen CLI.

Same misconfiguration, two different downstream errors, neither naming anything the operator wrote.

## Change

`registry.adapter_name_for_provider`:
- An explicitly named provider now resolves against the adapter registry names as well as the alias table. Alias first, so an adapter registered under a second key (`antigravity`) can't shadow another adapter's declared alias.
- When a provider name is supplied, the model text is not consulted at all: it resolves by name or not at all. Model-text inference is unchanged for the call sites that pass no provider — the sampling-capability probe has only a bare model string to go on.

`AgentSpawner`:
- A `cli:` that resolves to nothing now refuses the spawn with `AdapterNotConfiguredError` naming that `cli`, followed by the adapters that would have worked (or the migration note, for a removed one). Neither `role_model_policy.<role>.cli` nor a task's `cli:` is checked against the catalog at parse time, so this is the first place the selection meets the registry.
- A policy carrying only `cli` and no mirrored `provider` now reaches routing. The seed parser mirrors `cli` onto `provider`, but team manifests, availability chains and per-step `cli:` don't.

`cli: auto` stays the auto-detect sentinel and is never resolved against the catalog.

## Tests

`tests/unit/test_role_policy_cli_routing.py`, one section per property:

1. an explicitly configured `cli` is honoured even when the alias table has no entry for it;
2. a `cli` that can't be honoured refuses by name, and the message never names the substituted adapter;
3. a model string never routes across an explicit provider boundary (`cli: ollama` + `qwen2.5:7b` stays on ollama).

Plus two guards for the ways the narrowing could overshoot: `cli: auto` must not start refusing, and provider-less model inference must keep working.

All eight property tests fail on `main` — three as `DID NOT RAISE`, the rest as `assert 'qwen' == 'ollama'`, `assert 'qwen' is None` and the fallback to the run adapter.

Green: the new file, `test_adapter_inference.py`, `test_adapter_registry.py`, `test_registry.py`, `test_spawn_errors.py`, `test_spawner*.py`, `test_per_step_routing.py`, `test_model_routing.py`, `tests/unit/routing/`, `test_router.py`, `test_provider_state_*.py`, `test_seed.py`, `test_config_schema.py`, `test_seed_team_manifest.py`, `test_adapter_ollama.py`, `test_adapter_admission.py`, `test_adapter_autodetect.py`, `test_role_adapter_policy.py`, `test_unattended_retry.py`, `test_oauth_refresh.py` — 994 tests. `ruff check` and `ruff format --check` clean on the four touched files; `mypy` reports nothing new (the two `spawner_core.py` attr-defined errors are on `main` too).

`docs/operations/CONFIG.md` gains a line under `role_model_policy` saying what `cli:` accepts and what happens when it names nothing.
