### PR TITLE
fix(status): scope health check task count to caller tenant

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -77,3 +77,5 @@ rather than as its own attribution is exempted by hand there, with the reason.
   255-byte component cap now fails as `PathTooLongError` at the check instead
   of reaching `open()` as `OSError(ENAMETOOLONG)` (the same capacity-vs-
   containment distinction #4095 recorded for the pid-file sites).
+
+- Health check task count is scoped to the caller's tenant (#4156).

--- a/src/bernstein/core/routes/status_lifecycle.py
+++ b/src/bernstein/core/routes/status_lifecycle.py
@@ -44,6 +44,8 @@ router = APIRouter()
 @router.get("/health")
 def health_check(request: Request) -> HealthResponse:
     """Liveness check with component-level status."""
+    from bernstein.core.routes.task_crud import _resolve_request_tenant_scope
+
     store = _get_store(request)
     is_readonly: bool = getattr(request.app.state, "readonly", False)
     summary = store.status_summary()
@@ -58,7 +60,7 @@ def health_check(request: Request) -> HealthResponse:
     return HealthResponse(
         status=overall_status,
         uptime_s=round(time.time() - store.start_ts, 2),
-        task_count=len(store.list_tasks()),
+        task_count=len(store.list_tasks(tenant_id=_resolve_request_tenant_scope(request))),
         agent_count=store.agent_count,
         task_queue_depth=summary.get("open", 0),
         memory_mb=float(runtime.get("memory_mb", 0.0)),

--- a/tests/unit/test_tenant_scoped_readers.py
+++ b/tests/unit/test_tenant_scoped_readers.py
@@ -71,3 +71,24 @@ class TestBudgetForecastTenantScope:
 
         after = await client.get("/quality/budget-forecast", headers={"X-Tenant-Id": "team-a"})
         assert after.json()["task_count"] == baseline + 1
+
+
+class TestHealthCheckTenantScope:
+    @pytest.mark.asyncio
+    async def test_health_ignores_another_tenants_tasks(self, app: FastAPI, client: AsyncClient) -> None:
+        baseline = (await client.get("/health", headers={"X-Tenant-Id": "team-a"})).json()
+
+        await _create(app, "team-b work", "team-b")
+
+        after = await client.get("/health", headers={"X-Tenant-Id": "team-a"})
+        assert after.status_code == 200
+        assert after.json()["task_count"] == baseline["task_count"]
+
+    @pytest.mark.asyncio
+    async def test_health_still_counts_own_tasks(self, app: FastAPI, client: AsyncClient) -> None:
+        baseline = (await client.get("/health", headers={"X-Tenant-Id": "team-a"})).json()["task_count"]
+
+        await _create(app, "team-a work", "team-a")
+
+        after = await client.get("/health", headers={"X-Tenant-Id": "team-a"})
+        assert after.json()["task_count"] == baseline + 1


### PR DESCRIPTION
Closes #4156.

### What
Scopes the `task_count` field returned by the `/health` endpoint to the requesting caller's tenant instead of counting all tasks across all tenants.

### Why
In multi-tenant deployments, `health_check` previously queried `store.list_tasks()` without tenant scoping. This caused cross-tenant task count leakage and showed incorrect task numbers when another tenant added tasks.

### How
- In `src/bernstein/core/routes/status_lifecycle.py`, resolved the caller's tenant ID via `_resolve_request_tenant_scope(request)` from `bernstein.core.routes.task_crud`.
- Passed `tenant_id=_resolve_request_tenant_scope(request)` to `store.list_tasks(...)` when computing `task_count`.
- Added unit tests in `tests/unit/test_tenant_scoped_readers.py` (`TestHealthCheckTenantScope`) proving that `/health` `task_count` does not change when another tenant creates a task, while correctly counting own tasks.
- Added release note in `docs/release-notes/unreleased.md`.

### Proof
- `uv run pytest tests/unit/test_tenant_scoped_readers.py -q` fails on unfixed code (`assert 1 == 0`) and passes (4 passed) with the fix.
- Lint and format checks pass cleanly: `uv run ruff check --fix .` and `uv run ruff format src/ tests/`.