### PR TITLE
fix(workspace): scope workspace_merge_order task read to caller tenant

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -124,3 +124,4 @@ rather than as its own attribution is exempted by hand there, with the reason.
   call: no orchestrator path invokes it yet, which
   [`docs/concepts/lesson-persistence.md`](../concepts/lesson-persistence.md)
   records as the remaining gap.
+- Workspace merge order calculation is scoped to the caller's tenant (#4155).

--- a/src/bernstein/core/routes/workspace.py
+++ b/src/bernstein/core/routes/workspace.py
@@ -81,9 +81,11 @@ def workspace_status(request: Request) -> WorkspaceResponse:
 )
 def workspace_merge_order(request: Request) -> MergeOrderResponse:
     """Return the repo merge order derived from current cross-repo task dependencies."""
+    from bernstein.core.routes.task_crud import _resolve_request_tenant_scope
+
     workspace = _load_workspace_from_request(request)
     if workspace is None:
         raise HTTPException(status_code=404, detail="No workspace configured")
     store = request.app.state.store
-    repos = workspace.merge_order(store.list_tasks())
+    repos = workspace.merge_order(store.list_tasks(tenant_id=_resolve_request_tenant_scope(request)))
     return MergeOrderResponse(repos=repos)

--- a/tests/unit/test_tenant_scoped_readers.py
+++ b/tests/unit/test_tenant_scoped_readers.py
@@ -26,7 +26,12 @@ def _write_seed(tmp_path: Path) -> None:
         "  - id: team-a\n"
         "    budget: 100\n"
         "  - id: team-b\n"
-        "    budget: 250\n",
+        "    budget: 250\n"
+        "repos:\n"
+        "  - name: frontend\n"
+        "    path: ./frontend\n"
+        "  - name: backend\n"
+        "    path: ./backend\n",
         encoding="utf-8",
     )
 
@@ -46,9 +51,11 @@ async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
         yield async_client
 
 
-async def _create(app: FastAPI, title: str, tenant_id: str, **extra: object) -> None:
+async def _create(app: FastAPI, title: str, tenant_id: str, **extra: object) -> object:
     desc = extra.pop("description", "scoping fixture")
-    await app.state.store.create(TaskCreate(title=title, description=desc, tenant_id=tenant_id, **extra))
+    return await app.state.store.create(
+        TaskCreate(title=title, description=desc, tenant_id=tenant_id, **extra)
+    )
 
 
 class TestBudgetForecastTenantScope:
@@ -145,3 +152,43 @@ class TestHealthCheckTenantScope:
 
         after = await client.get("/health", headers={"X-Tenant-Id": "team-a"})
         assert after.json()["task_count"] == baseline + 1
+
+
+class TestWorkspaceMergeOrderTenantScope:
+    @pytest.mark.asyncio
+    async def test_merge_order_ignores_another_tenants_tasks(self, app: FastAPI, client: AsyncClient) -> None:
+        baseline = (await client.post("/workspace/merge-order", headers={"X-Tenant-Id": "team-a"})).json()
+        assert baseline["repos"] == ["frontend", "backend"]
+
+        b_backend = await _create(app, "team-b backend task", "team-b", repo="backend")
+        await _create(
+            app,
+            "team-b frontend task",
+            "team-b",
+            repo="frontend",
+            depends_on_repo="backend",
+            depends_on=[b_backend.id],  # type: ignore[union-attr]
+        )
+
+        after = await client.post("/workspace/merge-order", headers={"X-Tenant-Id": "team-a"})
+        assert after.status_code == 200
+        assert after.json()["repos"] == baseline["repos"]
+
+    @pytest.mark.asyncio
+    async def test_merge_order_still_uses_own_tasks(self, app: FastAPI, client: AsyncClient) -> None:
+        baseline = (await client.post("/workspace/merge-order", headers={"X-Tenant-Id": "team-a"})).json()
+        assert baseline["repos"] == ["frontend", "backend"]
+
+        a_backend = await _create(app, "team-a backend task", "team-a", repo="backend")
+        await _create(
+            app,
+            "team-a frontend task",
+            "team-a",
+            repo="frontend",
+            depends_on_repo="backend",
+            depends_on=[a_backend.id],  # type: ignore[union-attr]
+        )
+
+        after = await client.post("/workspace/merge-order", headers={"X-Tenant-Id": "team-a"})
+        assert after.status_code == 200
+        assert after.json()["repos"] == ["backend", "frontend"]


### PR DESCRIPTION
Stacked on #4161. Closes #4155.

## What
Scopes the task listing in `POST /workspace/merge-order` to the caller's resolved tenant rather than listing all tasks fleet-wide.

## Why
In a multi-tenant deployment, cross-repo task dependencies from one tenant could influence or corrupt the calculated repository merge order for another tenant.

## How
In `workspace_merge_order` (`src/bernstein/core/routes/workspace.py`), resolve the caller's tenant scope via `_resolve_request_tenant_scope(request)` and pass `tenant_id` to `store.list_tasks(tenant_id=...)`.

## Proof
Added `TestWorkspaceMergeOrderTenantScope` in `tests/unit/test_tenant_scoped_readers.py`:
- `test_merge_order_ignores_another_tenants_tasks`: Confirms Tenant A's merge order is unaffected by Tenant B's cross-repo dependencies (verified failing before fix, passing after fix).
- `test_merge_order_still_uses_own_tasks`: Confirms Tenant A's own cross-repo task dependencies still drive topological merge ordering.

