### PR TITLE
ci(soc2): wire weekly evidence pack export step to sink

### DIFF
--- a/.github/workflows/soc2-evidence-weekly.yml
+++ b/.github/workflows/soc2-evidence-weekly.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -n "${SOC2_EVIDENCE_SINK:-}" ]]; then
-            echo "SOC2_EVIDENCE_SINK detected (${SOC2_EVIDENCE_SINK}) - exporting evidence pack."
+            echo "SOC2_EVIDENCE_SINK detected - exporting evidence pack."
             uv run python -c "import os; from pathlib import Path; from bernstein.core.storage.soc2_export import export_soc2_evidence_pack; p = os.environ.get('PERIOD_LABEL', 'weekly'); r = os.environ.get('RUN_ID', ''); s = os.environ.get('SOC2_EVIDENCE_SINK', ''); d = Path('.sdd/evidence/soc2'); md = next(d.glob(f'soc2-evidence-{p}.md'), None); js = next(d.glob(f'soc2-evidence-{p}.json'), None); export_soc2_evidence_pack(md, js, sink_name=s, period_label=p, run_id=r)"
           else
             # A dormant export lane is not a failure, but must never look identical

--- a/.github/workflows/soc2-evidence-weekly.yml
+++ b/.github/workflows/soc2-evidence-weekly.yml
@@ -123,3 +123,34 @@ jobs:
           # short of a typical 6-12 month audit window. Durable export
           # beyond this ceiling is tracked separately: issue #3966.
           retention-days: 90
+
+      - name: Export evidence pack to sink
+        # Access control & retention policy:
+        # - Write access: Restricted to the automated CI workflow runner via
+        #   the configured storage sink (e.g. S3/GCS/R2 credentials in repository secrets).
+        # - Read access: Restricted to compliance officers, security auditors,
+        #   and automated GRC ingest pipelines.
+        # - Retention policy: Managed by destination sink bucket lifecycle rules
+        #   (e.g., 7-year immutable archive for SOC 2 / ISO 27001 audit trails).
+        env:
+          SOC2_EVIDENCE_SINK: ${{ secrets.SOC2_EVIDENCE_SINK }}
+          PERIOD_LABEL: ${{ github.event.inputs.period_label || 'weekly' }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${SOC2_EVIDENCE_SINK:-}" ]]; then
+            echo "SOC2_EVIDENCE_SINK detected (${SOC2_EVIDENCE_SINK}) - exporting evidence pack."
+            uv run python -c "import os; from pathlib import Path; from bernstein.core.storage.soc2_export import export_soc2_evidence_pack; p = os.environ.get('PERIOD_LABEL', 'weekly'); r = os.environ.get('RUN_ID', ''); s = os.environ.get('SOC2_EVIDENCE_SINK', ''); d = Path('.sdd/evidence/soc2'); md = next(d.glob(f'soc2-evidence-{p}.md'), None); js = next(d.glob(f'soc2-evidence-{p}.json'), None); export_soc2_evidence_pack(md, js, sink_name=s, period_label=p, run_id=r)"
+          else
+            # A dormant export lane is not a failure, but must never look identical
+            # to an active export. Warn loudly and record to step summary.
+            echo "::warning::SOC2_EVIDENCE_SINK is unset - evidence pack was not exported to remote sink. Configure the SOC2_EVIDENCE_SINK repository secret to enable remote export."
+            {
+              echo "## SOC 2 evidence export: dormant"
+              echo ""
+              echo "\`SOC2_EVIDENCE_SINK\` is unset, so the evidence pack was stored only as a GitHub Actions artifact (90-day ceiling)."
+              echo "Configure the \`SOC2_EVIDENCE_SINK\` repository secret to export packs to durable remote storage."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -204,7 +204,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/required-check-canary.yml | verify: {"contents": "read"} | - |
 | .github/workflows/sbom.yml | workflow: {"contents": "read"}<br>sbom: {"contents": "write"} | - |
 | .github/workflows/scorecard.yml | workflow: {"contents": "read"}<br>analysis: {"actions": "read", "contents": "read", "id-token": "write", "security-events": "write"}<br>upload: {"contents": "read", "security-events": "write"} | - |
-| .github/workflows/soc2-evidence-weekly.yml | workflow: {"contents": "read"} | SOC2_EVIDENCE_ENABLED |
+| .github/workflows/soc2-evidence-weekly.yml | workflow: {"contents": "read"} | SOC2_EVIDENCE_ENABLED, SOC2_EVIDENCE_SINK |
 | .github/workflows/spa-bundle-freshness.yml | workflow: {"contents": "read"}<br>rebuild: {"contents": "read"} | - |
 | .github/workflows/spiffe-extra-e2e.yml | workflow: {"contents": "read"} | - |
 | .github/workflows/stale.yml | workflow: {"contents": "read"}<br>stale: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -24,6 +24,7 @@ rather than as its own attribution is exempted by hand there, with the reason.
 - Export SOC 2 evidence pack to configured storage sinks via `export_soc2_evidence_pack` under canonical keys (#4148).
 - Dashboard colour tokens record measured contrast ratios and are gated against WCAG AA thresholds dynamically from the stylesheet (#3589). Contrast ratios for all body text, metadata, semantic states, and pill variants are catalogued in [`docs/design/web-ui-inventory.md`](../design/web-ui-inventory.md) and enforced by `tests/unit/test_webui_contrast.py`.
 - PostgresTaskStore and BaseTaskStore declare parameterized limit and offset bounds on list_tasks (#4157). PostgresTaskStore.list_tasks mirrors TaskStore.list_tasks by accepting optional limit and offset integer bounds and parameterizing them into the SQL query (LIMIT $n OFFSET $n) to prevent unbounded row fetching across database-backed deployments.
+- Wire weekly SOC 2 evidence pack workflow export step to sink backend via `SOC2_EVIDENCE_SINK` secret (#4149).
 ## Security
 
 - The agent task-scope gate no longer depends on how FastAPI happens to store

--- a/tests/unit/test_soc2_evidence_weekly_workflow_yaml.py
+++ b/tests/unit/test_soc2_evidence_weekly_workflow_yaml.py
@@ -170,3 +170,107 @@ def test_retention_is_githubs_ceiling_and_the_workflow_says_so() -> None:
     raw = WORKFLOW.read_text(encoding="utf-8")
     assert "GitHub's hard ceiling" in raw
     assert "#3966" in raw, "the workflow comment must reference the durable-export follow-up issue"
+
+
+def test_export_step_present_in_pack_job() -> None:
+    """The pack job must include a step to export the pack to a configured sink."""
+    pack = _job("pack")
+    step = _step_by_name(pack, "Export evidence pack to sink")
+    assert step is not None
+    env = step.get("env", {})
+    assert isinstance(env, dict)
+    assert "SOC2_EVIDENCE_SINK" in env
+
+
+def test_export_step_static_checks() -> None:
+    """The export step script must handle both active export and dormant warning branches."""
+    pack = _job("pack")
+    run = _step_by_name(pack, "Export evidence pack to sink").get("run", "")
+    assert isinstance(run, str)
+    assert "SOC2_EVIDENCE_SINK" in run
+    assert "export_soc2_evidence_pack" in run
+    assert "::warning::" in run
+    assert "GITHUB_STEP_SUMMARY" in run
+
+
+def test_export_step_with_sink_unset_warns_and_writes_summary(tmp_path: Path) -> None:
+    """When SOC2_EVIDENCE_SINK is unset, the step stays green but emits a warning and summary."""
+    pack = _job("pack")
+    run = _step_by_name(pack, "Export evidence pack to sink").get("run", "")
+    assert isinstance(run, str)
+
+    output_path = tmp_path / "github_output.txt"
+    summary_path = tmp_path / "github_step_summary.txt"
+    output_path.write_text("", encoding="utf-8")
+    summary_path.write_text("", encoding="utf-8")
+
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "GITHUB_OUTPUT": str(output_path),
+        "GITHUB_STEP_SUMMARY": str(summary_path),
+        "PERIOD_LABEL": "weekly",
+        "RUN_ID": "12345",
+    }
+
+    proc = subprocess.run(
+        ["bash", "-c", run],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0
+    assert "::warning::" in proc.stdout
+    assert "SOC2_EVIDENCE_SINK is unset" in proc.stdout
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "SOC2_EVIDENCE_SINK" in summary
+    assert "dormant" in summary.lower() or "skipped" in summary.lower()
+
+
+def test_export_step_access_control_and_retention_policy_commented() -> None:
+    """Workflow comments must declare write access, read access, and retention policy."""
+    raw = WORKFLOW.read_text(encoding="utf-8")
+    assert "Write access:" in raw
+    assert "Read access:" in raw
+    assert "Retention policy:" in raw
+
+
+def test_export_step_with_sink_set_executes_export(tmp_path: Path) -> None:
+    """When SOC2_EVIDENCE_SINK is set, the step invokes the exporter without warnings."""
+    pack = _job("pack")
+    run = _step_by_name(pack, "Export evidence pack to sink").get("run", "")
+    assert isinstance(run, str)
+
+    evidence_dir = tmp_path / ".sdd" / "evidence" / "soc2"
+    evidence_dir.mkdir(parents=True)
+    (evidence_dir / "soc2-evidence-weekly.md").write_text("# Weekly", encoding="utf-8")
+    (evidence_dir / "soc2-evidence-weekly.json").write_text("{}", encoding="utf-8")
+
+    output_path = tmp_path / "github_output.txt"
+    summary_path = tmp_path / "github_step_summary.txt"
+    output_path.write_text("", encoding="utf-8")
+    summary_path.write_text("", encoding="utf-8")
+
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "GITHUB_OUTPUT": str(output_path),
+        "GITHUB_STEP_SUMMARY": str(summary_path),
+        "PERIOD_LABEL": "weekly",
+        "RUN_ID": "12345",
+        "SOC2_EVIDENCE_SINK": "local_fs",
+    }
+
+    proc = subprocess.run(
+        ["bash", "-c", run],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0
+    assert "SOC2_EVIDENCE_SINK detected" in proc.stdout
+    assert "::warning::" not in proc.stdout
+    assert summary_path.read_text(encoding="utf-8") == ""

--- a/tests/unit/test_soc2_evidence_weekly_workflow_yaml.py
+++ b/tests/unit/test_soc2_evidence_weekly_workflow_yaml.py
@@ -182,6 +182,42 @@ def test_export_step_present_in_pack_job() -> None:
     assert "SOC2_EVIDENCE_SINK" in env
 
 
+def test_export_step_only_runs_after_pack_job_succeeds() -> None:
+    """The export step must never run against a partial or missing pack.
+
+    The sibling issue allows wiring this guarantee via either a new job
+    with an explicit ``needs:``/``if:`` dependency on ``pack``, or a new
+    step within the ``pack`` job itself - a step was chosen here. That
+    choice only delivers "runs after pack succeeds" if the export step
+    sits after pack generation/upload and nothing ahead of it opts out
+    of the default success-only step gating, so assert the structure
+    that actually provides the guarantee rather than just the step's
+    presence.
+    """
+    pack = _job("pack")
+    steps = _steps(pack)
+    names = [step.get("name") for step in steps]
+
+    export_index = names.index("Export evidence pack to sink")
+    generate_index = names.index("Generate SOC 2 evidence pack")
+    upload_index = names.index("Upload evidence pack")
+    assert generate_index < export_index, "export must run after pack generation"
+    assert upload_index < export_index, "export must run after the artifact upload"
+
+    export_step = steps[export_index]
+    assert export_step.get("if") in (None, "success()"), (
+        "the export step must rely on default success-only step gating, not an always()/failure() override"
+    )
+
+    for step in steps[:export_index]:
+        assert step.get("continue-on-error") is not True, (
+            f"{step.get('name')!r} must not swallow failures ahead of the export step"
+        )
+        assert step.get("if") != "always()", (
+            f"{step.get('name')!r} must not run unconditionally ahead of the export step"
+        )
+
+
 def test_export_step_static_checks() -> None:
     """The export step script must handle both active export and dormant warning branches."""
     pack = _job("pack")


### PR DESCRIPTION
Stacked on #4162. Closes #4149.

### What
Wires the weekly SOC 2 evidence pack workflow (`.github/workflows/soc2-evidence-weekly.yml`) to export generated evidence packs into the storage sink specified by the `SOC2_EVIDENCE_SINK` environment variable.

### Why
SOC 2 evidence generated by the weekly CI workflow was previously uploaded only as GitHub Actions artifacts, which expire after 90 days. Exporting to a persistent sink backend provides durable long-term retention and automated compliance ingestion.

### How
- Added an `Export evidence pack to sink` step in `.github/workflows/soc2-evidence-weekly.yml` following the `Upload evidence pack` step.
- Reads `SOC2_EVIDENCE_SINK` from repository secrets.
- When `SOC2_EVIDENCE_SINK` is set, invokes `export_soc2_evidence_pack` to copy the Markdown checklist and JSON manifest to the configured sink under `soc2/{period_label}/{run_id}/{filename}`.
- When unset, follows the preflight gate pattern by emitting a loud `::warning::` annotation and recording a `GITHUB_STEP_SUMMARY` note explaining that remote export is dormant.
- Added workflow comment block detailing write access, read access, and retention policy.
- Extended `tests/unit/test_soc2_evidence_weekly_workflow_yaml.py` with assertions covering presence, scripts, warning/dormancy behavior, and documentation comments.

### Proof
- `uv run pytest tests/unit/test_soc2_evidence_weekly_workflow_yaml.py tests/unit/storage/test_soc2_evidence_export.py tests/unit/test_unreleased_notes_rotation.py -q` (29 passed)
- `uv run ruff check .` and `uv run ruff format --check .` (clean)