### PR TITLE
fix(tests): resolve conflicting Hypothesis "deep" profile registrations

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -50,11 +50,20 @@ try:
         verbosity=Verbosity.normal,
     )
 
+    # derandomize=False, matching tests/property/conftest.py's "deep" profile
+    # (#4118): "deep" exists to explore fresh input space on the nightly
+    # cadence, so freezing it here would silence the thing it is for. #4128
+    # copied the smoke profile's derandomize=True onto this registration too,
+    # which both violates that invariant on its own and, if this file and
+    # tests/property/conftest.py ever load in the same pytest process,
+    # collides with the other file's registration of the same profile name --
+    # whichever conftest imports last wins, silently, so the effective value
+    # is order-dependent rather than a stated choice from either file.
     settings.register_profile(
         "deep",
         max_examples=1_000,
         deadline=None,
-        derandomize=True,
+        derandomize=False,
         suppress_health_check=[
             HealthCheck.too_slow,
             HealthCheck.filter_too_much,

--- a/tests/unit/test_harness_local_discovery.py
+++ b/tests/unit/test_harness_local_discovery.py
@@ -92,9 +92,7 @@ def test_matching_lockfile_admits_the_directory(tmp_path: Path) -> None:
     """
     claude_agents = _harness_dir_with_agent(tmp_path)
     digest = compute_catalog_digest(claude_agents)
-    (claude_agents / "agents.lock").write_text(
-        json.dumps({"content_digest": digest}), encoding="utf-8"
-    )
+    (claude_agents / "agents.lock").write_text(json.dumps({"content_digest": digest}), encoding="utf-8")
 
     entries = _discover(tmp_path)
 

--- a/tests/unit/test_hypothesis_profile_registrations_agree.py
+++ b/tests/unit/test_hypothesis_profile_registrations_agree.py
@@ -47,9 +47,7 @@ def _registered_profiles(source: str) -> dict[str, dict[str, object]]:
         if not isinstance(name, str):
             continue
         kwargs = {
-            kw.arg: kw.value.value
-            for kw in node.keywords
-            if kw.arg is not None and isinstance(kw.value, ast.Constant)
+            kw.arg: kw.value.value for kw in node.keywords if kw.arg is not None and isinstance(kw.value, ast.Constant)
         }
         profiles[name] = kwargs
     return profiles

--- a/tests/unit/test_hypothesis_profile_registrations_agree.py
+++ b/tests/unit/test_hypothesis_profile_registrations_agree.py
@@ -1,0 +1,116 @@
+"""No two conftests may register the same Hypothesis profile with conflicting kwargs.
+
+``hypothesis.settings.register_profile`` keys its registry by name, globally
+within a process. ``tests/property/conftest.py`` and ``tests/unit/conftest.py``
+each register a profile named ``"deep"`` -- with, until this fix, conflicting
+``derandomize`` values (``False`` in the former, ``True`` in the latter,
+introduced by #4128 copy-pasting the ``smoke`` profile's ``derandomize=True``
+onto ``deep`` as well).
+
+Today the two conftests are not both imported in the same pytest process in
+CI: ``nightly-deep-tests.yml``'s ``hypothesis-deep`` job scopes its run to
+``tests/property/``, and ``scripts/run_tests.py`` defaults to ``tests/unit``
+only. But that separation lives in CI workflow YAML and a script default, not
+in anything this test file enforces, so a future change that runs
+``pytest tests/`` from the repo root -- in CI or on a developer's laptop --
+would silently pick whichever file's registration happened to import last,
+with no test catching the regression. This test reads every conftest's
+source directly, so it needs no such invocation to fail: it is order- and
+CI-topology-independent by construction.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _registered_profiles(source: str) -> dict[str, dict[str, object]]:
+    """Map profile name -> {kwarg: literal value} for every ``register_profile`` call.
+
+    Only calls whose name argument and kwarg values are literals are
+    recorded; a computed value cannot be compared statically, and pretending
+    otherwise would make this test lie rather than fail.
+    """
+    profiles: dict[str, dict[str, object]] = {}
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "register_profile"):
+            continue
+        if not node.args or not isinstance(node.args[0], ast.Constant):
+            continue
+        name = node.args[0].value
+        if not isinstance(name, str):
+            continue
+        kwargs = {
+            kw.arg: kw.value.value
+            for kw in node.keywords
+            if kw.arg is not None and isinstance(kw.value, ast.Constant)
+        }
+        profiles[name] = kwargs
+    return profiles
+
+
+def _conftests() -> list[Path]:
+    return sorted(p for p in (REPO_ROOT / "tests").rglob("conftest.py") if p.is_file())
+
+
+def test_same_named_profile_has_identical_settings_across_conftests() -> None:
+    by_name: dict[str, list[tuple[Path, dict[str, object]]]] = {}
+    for conftest in _conftests():
+        for name, kwargs in _registered_profiles(conftest.read_text(encoding="utf-8")).items():
+            by_name.setdefault(name, []).append((conftest, kwargs))
+
+    offenders: list[str] = []
+    for name, registrations in by_name.items():
+        if len(registrations) < 2:
+            continue
+        _, first_kwargs = registrations[0]
+        for conftest, kwargs in registrations[1:]:
+            shared_keys = kwargs.keys() & first_kwargs.keys()
+            mismatched = {k for k in shared_keys if kwargs[k] != first_kwargs[k]}
+            if mismatched:
+                offenders.append(
+                    f"{conftest.relative_to(REPO_ROOT)} registers {name!r} with "
+                    f"{mismatched} differing from {registrations[0][0].relative_to(REPO_ROOT)}"
+                )
+
+    assert not offenders, (
+        "these conftests register the same Hypothesis profile name with "
+        f"conflicting values: {offenders}. register_profile() is keyed by name "
+        "globally within a process, so if both files are ever imported in the "
+        "same pytest run, whichever registers last silently wins -- give the "
+        "profiles distinct names or make the conflicting kwargs agree."
+    )
+
+
+def test_the_profile_scan_actually_finds_something() -> None:
+    """A scan that silently matched nothing would pass the test above forever."""
+    conftests = _conftests()
+    assert conftests, "no conftest.py found under tests/ -- the scan is looking in the wrong place"
+
+    found = False
+    for conftest in conftests:
+        if _registered_profiles(conftest.read_text(encoding="utf-8")):
+            found = True
+            break
+    assert found, (
+        "no conftest registers a Hypothesis profile by literal name, so the "
+        "agreement check above cannot fail on anything. If every conftest "
+        "genuinely stopped calling register_profile with literals, delete both "
+        "tests rather than keeping a check that guards nothing."
+    )
+
+
+def test_a_profile_registration_is_read_out_of_register_profile_source() -> None:
+    """Pin the extractor itself: it reads name and kwargs, not just the call site."""
+    source = (
+        "from hypothesis import settings\n"
+        "settings.register_profile('x', derandomize=True, max_examples=1)\n"
+        "settings.register_profile(computed_name, derandomize=False)\n"
+    )
+    assert _registered_profiles(source) == {"x": {"derandomize": True, "max_examples": 1}}

--- a/tests/unit/volunteer/test_claim.py
+++ b/tests/unit/volunteer/test_claim.py
@@ -183,9 +183,7 @@ def test_resolved_other_claim_is_treated_as_free() -> None:
     # GitHub does not move a comment's createdAt on an edit, so without
     # checking `resolved` this comment would look exactly as fresh as an
     # active claim for the rest of the staleness window (acceptance case 5).
-    runner = FakeRunner(
-        issue=_issue_payload(comments=[_comment(1, mine=False, age=timedelta(hours=1), resolved=True)])
-    )
+    runner = FakeRunner(issue=_issue_payload(comments=[_comment(1, mine=False, age=timedelta(hours=1), resolved=True)]))
     decision = should_skip(_state(runner), now=NOW, staleness=DEFAULT_CLAIM_STALENESS)
     assert not decision.skip
     assert decision.reason is None


### PR DESCRIPTION
## Problem

`tests/property/conftest.py` and `tests/unit/conftest.py` each register a Hypothesis profile named `"deep"` — with conflicting `derandomize` values (`False` vs `True`). `hypothesis.settings.register_profile` keys its registry by name globally within a process, so if both conftests are ever imported in the same pytest run (e.g. `pytest tests/` from the repo root), whichever registers last silently wins and the other's registration is discarded.

`tests/unit/conftest.py`'s `derandomize=True` was carried over from the `smoke` profile registration added alongside it and never reconciled with `deep`'s own purpose: exploring fresh input space on the nightly cadence rather than replaying a fixed example set (the same invariant `tests/property/conftest.py` already documents and tests for).

In current CI this doesn't bite — the nightly deep-profile job scopes its run to `tests/property/`, and the default test runner scopes to `tests/unit/` — but that separation lives in workflow YAML and a script default, not in anything a test enforces, so a change that runs both suites in one process would hit it silently.

## Fix

- `tests/unit/conftest.py`: align the `deep` profile's `derandomize` to `False`, matching `tests/property/conftest.py`.
- Add `tests/unit/test_hypothesis_profile_registrations_agree.py`: statically scans every `conftest.py` under `tests/` and fails if any two ever register the same Hypothesis profile name with conflicting values, independent of whether they're ever imported together in CI today.

## Test plan

- [x] Reproduced the collision directly (import property's conftest then unit's conftest in one process; `get_profile("deep").derandomize` read `True` before the fix, `False` after, regardless of import order)
- [x] New regression test verified to fail against the original (reverted) value and pass against the fix
- [x] `tests/property/test_profile_determinism.py` (existing suite) still passes
- [x] Broader unit-suite Hypothesis smoke (admission, config_fuzz, cost_envelope, task_store_property — 101 tests) still passes