### PR TITLE
fix(scripts): select test files from positional paths in run_tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,9 @@ whatever the last person in a hurry did.
 ```bash
 uv run python scripts/run_tests.py -x        # all tests (isolated per-file, stops on first failure)
 uv run python scripts/run_tests.py -k router  # filter by keyword
-uv run pytest tests/unit/test_foo.py -x -q    # single file (fast)
+uv run python scripts/run_tests.py tests/unit/test_foo.py            # single file
+uv run python scripts/run_tests.py tests/unit/test_foo.py::test_bar  # single test
+uv run pytest tests/unit/test_foo.py -x -q    # single file, straight pytest
 ```
 
 > **WARNING: Never run `uv run pytest tests/ -x -q`** - the full suite keeps references across 2000+ tests and can leak 100+ GB RAM. The isolated runner in `scripts/run_tests.py` caps each file at ~200 MB.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -279,6 +279,10 @@ is a flake waiting to happen.
 # Full unit suite with the guard active (per-file isolated runner):
 uv run python scripts/run_tests.py --parallel 4
 
+# One file or one test, same runner:
+uv run python scripts/run_tests.py tests/unit/test_foo.py
+uv run python scripts/run_tests.py tests/unit/test_foo.py::test_bar
+
 # Or straight pytest:
 uv run pytest tests/unit/ -q --no-cov
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -9,6 +9,9 @@ Usage:
     python scripts/run_tests.py              # run all unit tests (parallel by default)
     python scripts/run_tests.py -x           # stop on first failure
     python scripts/run_tests.py -k adapter   # filter by keyword
+    python scripts/run_tests.py tests/unit/test_router.py    # run one file
+    python scripts/run_tests.py tests/unit/test_router.py::test_pick  # one test
+    python scripts/run_tests.py tests/integration          # run one directory
     python scripts/run_tests.py --parallel 4 # run 4 files at once
     python scripts/run_tests.py --parallel 1 # force sequential execution
     python scripts/run_tests.py --coverage   # collect coverage and emit coverage.json
@@ -181,6 +184,50 @@ def discover_test_files(test_dir: Path, keyword: str | None = None) -> list[Path
     if keyword:
         files = [f for f in files if keyword in f.stem]
     return files
+
+
+def split_test_targets(entries: list[str]) -> tuple[list[Path], list[str], list[str]]:
+    """Split positional CLI entries into explicit test targets and pytest args.
+
+    Positional entries serve two purposes that must not be conflated. An entry
+    naming an existing test file, directory, or ``file::node-id`` selects what
+    to run; anything else - flags and their values, such as the
+    ``no:cacheprovider`` in ``-p no:cacheprovider`` - is passed through to
+    every pytest subprocess unchanged.
+
+    Returns ``(targets, passthrough, missing)``. ``missing`` holds entries that
+    look like a path but do not exist: a mistyped path is a typo, not a pytest
+    argument, and silently forwarding it would turn an intended targeted run
+    into a full-suite run.
+    """
+    targets: list[Path] = []
+    passthrough: list[str] = []
+    missing: list[str] = []
+    for entry in entries:
+        if entry.startswith("-"):
+            passthrough.append(entry)
+            continue
+        head = Path(entry.split("::", 1)[0])
+        if head.is_dir():
+            targets.extend(sorted(head.rglob("test_*.py")))
+        elif head.is_file():
+            targets.append(Path(entry))
+        elif head.suffix == ".py" or "/" in entry or os.sep in entry:
+            missing.append(entry)
+        else:
+            passthrough.append(entry)
+    return targets, passthrough, missing
+
+
+def dedupe_paths(paths: list[Path]) -> list[Path]:
+    """Drop duplicate paths, preserving first-seen order."""
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for path in paths:
+        if path not in seen:
+            seen.add(path)
+            unique.append(path)
+    return unique
 
 
 def parse_shard_spec(spec: str) -> tuple[int, int]:
@@ -630,8 +677,25 @@ def main() -> None:
             "and the union of all N shards covers every file exactly once."
         ),
     )
-    parser.add_argument("extra", nargs="*", help="Extra args passed to pytest")
+    parser.add_argument(
+        "extra",
+        nargs="*",
+        metavar="TARGET_OR_PYTEST_ARG",
+        help=(
+            "Test files, directories, or file::node-id targets to run instead of "
+            "discovering --test-dir; any other value is passed through to pytest"
+        ),
+    )
     args = parser.parse_args()
+
+    targets, extra_args, missing = split_test_targets(args.extra)
+    if missing:
+        for entry in missing:
+            print(f"Test path not found: {entry}")
+        sys.exit(2)
+    if targets and args.affected is not None:
+        print("--affected selects test files itself; pass explicit test paths or --affected, not both")
+        sys.exit(2)
 
     workers: int = max(1, args.parallel)
 
@@ -664,19 +728,24 @@ def main() -> None:
         print(f"Running {len(files)} affected test files{shard_label} (each in its own process)")
         print(f"{'=' * 60}")
         if workers > 1:
-            code = run_parallel(files, args.extra, workers, args.fail_fast, args.coverage)
+            code = run_parallel(files, extra_args, workers, args.fail_fast, args.coverage)
         else:
-            code = run_sequential(files, args.extra, args.fail_fast, args.coverage)
+            code = run_sequential(files, extra_args, args.fail_fast, args.coverage)
         if args.coverage:
             _finalize_coverage()
         sys.exit(code)
 
-    test_dir = Path(args.test_dir)
-    if not test_dir.exists():
-        print(f"Test directory not found: {test_dir}")
-        sys.exit(1)
+    if targets:
+        files = dedupe_paths(targets)
+        if args.keyword:
+            files = [f for f in files if args.keyword in f.name]
+    else:
+        test_dir = Path(args.test_dir)
+        if not test_dir.exists():
+            print(f"Test directory not found: {test_dir}")
+            sys.exit(1)
+        files = discover_test_files(test_dir, args.keyword)
 
-    files = discover_test_files(test_dir, args.keyword)
     if shard is not None:
         files = shard_files(files, *shard)
     if not files:
@@ -689,9 +758,9 @@ def main() -> None:
     print(f"{'=' * 60}")
 
     if workers > 1:
-        code = run_parallel(files, args.extra, workers, args.fail_fast, args.coverage)
+        code = run_parallel(files, extra_args, workers, args.fail_fast, args.coverage)
     else:
-        code = run_sequential(files, args.extra, args.fail_fast, args.coverage)
+        code = run_sequential(files, extra_args, args.fail_fast, args.coverage)
 
     if args.coverage:
         _finalize_coverage()

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -10,7 +10,7 @@ capability contracts; plus `property/`, `snapshot/`, `golden/`,
 ```
 uv run python scripts/run_tests.py -x         # all tests, isolated per-file
 uv run python scripts/run_tests.py -k router  # filter by keyword
-uv run pytest tests/unit/test_foo.py -x -q    # single file (fast)
+uv run python scripts/run_tests.py tests/unit/test_foo.py[::test_name]  # one file/test
 ```
 
 ## Invariants

--- a/tests/unit/test_run_tests_selection.py
+++ b/tests/unit/test_run_tests_selection.py
@@ -1,0 +1,131 @@
+"""Unit tests for scripts/run_tests.py - positional target selection."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Make scripts/ importable
+_SCRIPTS = Path(__file__).parent.parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from run_tests import dedupe_paths, split_test_targets
+
+_RUNNER = _SCRIPTS / "run_tests.py"
+
+
+def _write_suite(root: Path) -> tuple[Path, Path]:
+    """Write two trivially passing test files and return their paths."""
+    first = root / "test_first.py"
+    second = root / "test_second.py"
+    first.write_text("def test_first() -> None:\n    assert True\n", encoding="utf-8")
+    second.write_text("def test_second() -> None:\n    assert True\n", encoding="utf-8")
+    return first, second
+
+
+class TestSplitTestTargets:
+    def test_existing_file_is_a_target(self, tmp_path: Path) -> None:
+        path = tmp_path / "test_one.py"
+        path.touch()
+
+        targets, passthrough, missing = split_test_targets([str(path)])
+
+        assert targets == [path]
+        assert passthrough == []
+        assert missing == []
+
+    def test_directory_expands_to_its_test_files(self, tmp_path: Path) -> None:
+        first, second = _write_suite(tmp_path)
+        (tmp_path / "helper.py").touch()
+
+        targets, _passthrough, missing = split_test_targets([str(tmp_path)])
+
+        assert targets == [first, second]
+        assert missing == []
+
+    def test_node_id_keeps_its_suffix(self, tmp_path: Path) -> None:
+        path = tmp_path / "test_one.py"
+        path.touch()
+        entry = f"{path}::test_case"
+
+        targets, _passthrough, missing = split_test_targets([entry])
+
+        assert [str(t) for t in targets] == [entry]
+        assert missing == []
+
+    def test_pytest_arguments_pass_through(self, tmp_path: Path) -> None:
+        path = tmp_path / "test_one.py"
+        path.touch()
+
+        targets, passthrough, missing = split_test_targets(["-p", "no:cacheprovider", str(path)])
+
+        assert targets == [path]
+        assert passthrough == ["-p", "no:cacheprovider"]
+        assert missing == []
+
+    def test_mistyped_path_is_reported_not_forwarded(self) -> None:
+        targets, passthrough, missing = split_test_targets(["tests/unit/test_absent.py"])
+
+        assert targets == []
+        assert passthrough == []
+        assert missing == ["tests/unit/test_absent.py"]
+
+
+class TestDedupePaths:
+    def test_preserves_first_seen_order(self) -> None:
+        a, b = Path("a.py"), Path("b.py")
+
+        assert dedupe_paths([b, a, b]) == [b, a]
+
+
+class TestPositionalPathRunsOnlyThatFile:
+    def test_single_file_argument_runs_that_file_alone(self, tmp_path: Path) -> None:
+        """A positional test path selects that file instead of the whole suite.
+
+        The regression this pins: the path used to be appended to pytest's
+        argument list for every discovered file, so an intended one-file run
+        silently became a full-suite run.
+        """
+        first, _second = _write_suite(tmp_path)
+
+        result = subprocess.run(
+            [sys.executable, str(_RUNNER), str(first), "--test-dir", str(tmp_path), "--parallel", "1"],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "1 test files" in result.stdout
+        assert "test_first.py" in result.stdout
+        assert "test_second.py" not in result.stdout
+        assert "1 passed, 0 failed, 0 ran no tests, 1 total" in result.stdout
+
+    def test_bare_invocation_still_discovers_the_directory(self, tmp_path: Path) -> None:
+        _write_suite(tmp_path)
+
+        result = subprocess.run(
+            [sys.executable, str(_RUNNER), "--test-dir", str(tmp_path), "--parallel", "1"],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "2 passed, 0 failed, 0 ran no tests, 2 total" in result.stdout
+
+    def test_mistyped_path_fails_instead_of_running_everything(self, tmp_path: Path) -> None:
+        _write_suite(tmp_path)
+
+        result = subprocess.run(
+            [sys.executable, str(_RUNNER), str(tmp_path / "test_absent.py"), "--test-dir", str(tmp_path)],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+        assert result.returncode == 2
+        assert "Test path not found" in result.stdout
+        assert "passed" not in result.stdout


### PR DESCRIPTION
## What

`scripts/run_tests.py tests/unit/test_foo.py` now runs that one file. Directories and `file.py::test_name` node ids work too.

## Why

Positional arguments were forwarded to pytest as extra flags for **every** discovered file, so a targeted run silently became a full-suite run — minutes instead of seconds — and each unrelated file picked up the path as a second pytest target, inflating its own reported count. Reproduction on `origin/main`, with two trivially passing files in one directory:

```
$ uv run python scripts/run_tests.py "$D/test_a.py" --test-dir "$D" --parallel 1
Running 2 test files sequential (each in its own process)
  PASS [1/2] test_a.py (3.0s) 1 passed
  PASS [2/2] test_b.py (0.9s) 2 passed
```

`test_b.py` reported two tests because `test_a.py` was appended to its argument list. The runner's own docs only ever showed `-k <keyword>`, but the positional form is what anyone types first — it is pytest's own interface — so the failure mode was reachable without doing anything unusual.

## How

`split_test_targets()` partitions the positional entries:

- an existing file, directory, or `file::node-id` becomes a selection target (directories expand to their `test_*.py` files);
- anything else — flags and their values, such as the `no:cacheprovider` in `-p no:cacheprovider` — is passed through to pytest unchanged, as before;
- a path-shaped entry that does not exist exits 2 with `Test path not found:` rather than being forwarded, so a typo fails loudly instead of quietly widening to the full suite.

Explicit paths alongside `--affected` exit 2: `--affected` does its own selection, and silently letting one win would repeat the original defect in a new shape. Discovery, sharding, keyword filtering, parallelism, and coverage are untouched — explicit targets simply replace the discovery step that feeds them.

`tests/unit/test_run_tests_selection.py` covers the split directly and drives the runner end-to-end: one positional path runs exactly one file, a bare invocation still discovers the whole directory, and a mistyped path exits 2 without running anything.

## Checklist

- [x] `uv run ruff check src/` passes (also clean on the changed files)
- [x] `uv run pyright src/` passes (repo-wide `[tool.pyright]` scope unchanged: 0 errors on `scripts/run_tests.py`)
- [x] `uv run python scripts/run_tests.py --affected origin/main` passes — 136 files, one pre-existing unrelated failure (`tests/unit/cli/test_run_banner.py::test_bare_invocation_prints_banner_when_splash_disabled`, splash-future `TimeoutError`, reproduces identically on a pristine `origin/main` tree)
- [x] New code has type hints

### Documentation duty

- [x] `CONTRIBUTING.md`, `tests/AGENTS.md`, and `docs/contributing/testing.md` show the targeted-run form; `--help` and the module docstring document it
- [x] N/A — no public API surface or new module
- [x] Tests cover the documented behaviour
