### PR TITLE
feat(tasks): enforce well-founded bounded recursive task decomposition (#4179)

### DIFF
--- a/src/bernstein/core/tasks/decomposition_guard.py
+++ b/src/bernstein/core/tasks/decomposition_guard.py
@@ -1,0 +1,154 @@
+"""Bounded recursive task decomposition guard (#4179).
+
+Enforces strict well-foundedness (strictly decreasing non-negative ranks)
+on recursive task decomposition, refusing non-decreasing or exhausted rank
+proposals with machine-readable codes and recording spawn-side refusal receipts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_ROOT_RANK = 5
+ENV_MAX_DECOMPOSITION_DEPTH = "BERNSTEIN_MAX_DECOMPOSITION_DEPTH"
+
+
+def get_default_root_rank() -> int:
+    """Return configured or default root decomposition rank ceiling."""
+    raw = os.environ.get(ENV_MAX_DECOMPOSITION_DEPTH, "").strip()
+    if raw.isdigit():
+        return int(raw)
+    return DEFAULT_ROOT_RANK
+
+
+class DecompositionRefusalCode:
+    DECOMPOSITION_RANK_EXHAUSTED = "DECOMPOSITION_RANK_EXHAUSTED"
+    DECOMPOSITION_RANK_NON_DECREASING = "DECOMPOSITION_RANK_NON_DECREASING"
+
+
+@dataclass(frozen=True)
+class DecompositionRefusalReceipt:
+    """Spawn-side refusal receipt for illegal or un-bounded task decomposition."""
+
+    parent_task_id: str
+    offending_child_id: str
+    parent_rank: int
+    child_rank: int
+    reason_code: str
+    timestamp: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "parent_task_id": self.parent_task_id,
+            "offending_child_id": self.offending_child_id,
+            "parent_rank": self.parent_rank,
+            "child_rank": self.child_rank,
+            "reason_code": self.reason_code,
+            "timestamp": self.timestamp,
+        }
+
+    def canonical_bytes(self) -> bytes:
+        """Return deterministic JSON bytes excluding timestamp for audit verification."""
+        d = {
+            "parent_task_id": self.parent_task_id,
+            "offending_child_id": self.offending_child_id,
+            "parent_rank": self.parent_rank,
+            "child_rank": self.child_rank,
+            "reason_code": self.reason_code,
+        }
+        return json.dumps(d, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+@dataclass(frozen=True)
+class DecompositionGuardVerdict:
+    """Outcome of decomposition proposal evaluation."""
+
+    accepted: bool
+    reason_code: str | None = None
+    receipt: DecompositionRefusalReceipt | None = None
+
+
+def evaluate_decomposition_proposal(
+    parent_task_id: str,
+    parent_rank: int | None,
+    child_proposals: list[dict[str, Any]],
+    *,
+    now_ts: float | None = None,
+) -> tuple[DecompositionGuardVerdict, list[int]]:
+    """Evaluate decomposition proposal against strict rank reduction.
+
+    Args:
+        parent_task_id: Identifier of the parent task being decomposed.
+        parent_rank: Rank of the parent task, or None to use default root rank.
+        child_proposals: List of proposed child task dicts (may contain 'rank').
+        now_ts: Optional explicit timestamp for deterministic testing.
+
+    Returns:
+        Tuple of (verdict, assigned_child_ranks).
+    """
+    ts = now_ts if now_ts is not None else time.time()
+    effective_parent_rank = parent_rank if parent_rank is not None else get_default_root_rank()
+
+    if effective_parent_rank <= 0:
+        receipt = DecompositionRefusalReceipt(
+            parent_task_id=parent_task_id,
+            offending_child_id=str(child_proposals[0].get("id", "child-0")) if child_proposals else "none",
+            parent_rank=effective_parent_rank,
+            child_rank=effective_parent_rank,
+            reason_code=DecompositionRefusalCode.DECOMPOSITION_RANK_EXHAUSTED,
+            timestamp=ts,
+        )
+        _logger.warning(
+            "Refused task decomposition for %s: parent rank %d exhausted",
+            parent_task_id,
+            effective_parent_rank,
+        )
+        return DecompositionGuardVerdict(
+            accepted=False,
+            reason_code=DecompositionRefusalCode.DECOMPOSITION_RANK_EXHAUSTED,
+            receipt=receipt,
+        ), []
+
+    assigned_ranks: list[int] = []
+    default_child_rank = effective_parent_rank - 1
+
+    for i, child in enumerate(child_proposals):
+        child_id = str(child.get("id", f"child-{i}"))
+        raw_child_rank = child.get("decomposition_rank")
+        if raw_child_rank is not None and isinstance(raw_child_rank, int):
+            proposed_rank = raw_child_rank
+        else:
+            proposed_rank = default_child_rank
+
+        if proposed_rank >= effective_parent_rank:
+            receipt = DecompositionRefusalReceipt(
+                parent_task_id=parent_task_id,
+                offending_child_id=child_id,
+                parent_rank=effective_parent_rank,
+                child_rank=proposed_rank,
+                reason_code=DecompositionRefusalCode.DECOMPOSITION_RANK_NON_DECREASING,
+                timestamp=ts,
+            )
+            _logger.warning(
+                "Refused task decomposition for %s -> child %s: rank %d >= parent rank %d",
+                parent_task_id,
+                child_id,
+                proposed_rank,
+                effective_parent_rank,
+            )
+            return DecompositionGuardVerdict(
+                accepted=False,
+                reason_code=DecompositionRefusalCode.DECOMPOSITION_RANK_NON_DECREASING,
+                receipt=receipt,
+            ), []
+
+        assigned_ranks.append(proposed_rank)
+
+    return DecompositionGuardVerdict(accepted=True), assigned_ranks

--- a/tests/unit/tasks/test_decomposition_guard.py
+++ b/tests/unit/tasks/test_decomposition_guard.py
@@ -1,0 +1,90 @@
+"""Unit tests for bounded recursive task decomposition guard (#4179)."""
+
+from __future__ import annotations
+
+from bernstein.core.tasks.decomposition_guard import (
+    DEFAULT_ROOT_RANK,
+    ENV_MAX_DECOMPOSITION_DEPTH,
+    DecompositionRefusalCode,
+    evaluate_decomposition_proposal,
+    get_default_root_rank,
+)
+
+
+def test_single_level_decomposition_defaults_root_rank_and_passes() -> None:
+    """Existing single-level decompositions pass without configuration."""
+    children = [{"id": "c1", "title": "Child 1"}, {"id": "c2", "title": "Child 2"}]
+    verdict, child_ranks = evaluate_decomposition_proposal("P-100", None, children, now_ts=1000.0)
+
+    assert verdict.accepted is True
+    assert verdict.reason_code is None
+    assert verdict.receipt is None
+    assert child_ranks == [DEFAULT_ROOT_RANK - 1, DEFAULT_ROOT_RANK - 1]
+
+
+def test_non_decreasing_rank_refused_with_machine_readable_code() -> None:
+    """Decomposition whose child rank >= parent rank is refused with DECOMPOSITION_RANK_NON_DECREASING."""
+    children = [
+        {"id": "c1", "decomposition_rank": 3},
+        {"id": "c2", "decomposition_rank": 5},  # Illegal: child_rank 5 >= parent_rank 5
+    ]
+    verdict, child_ranks = evaluate_decomposition_proposal("P-101", 5, children, now_ts=1000.0)
+
+    assert verdict.accepted is False
+    assert verdict.reason_code == DecompositionRefusalCode.DECOMPOSITION_RANK_NON_DECREASING
+    assert verdict.receipt is not None
+    assert verdict.receipt.parent_task_id == "P-101"
+    assert verdict.receipt.offending_child_id == "c2"
+    assert verdict.receipt.parent_rank == 5
+    assert verdict.receipt.child_rank == 5
+    assert child_ranks == []
+
+
+def test_decomposition_chain_terminates_at_depth_limit() -> None:
+    """A chain of valid decompositions terminates when parent rank reaches 0."""
+    root_rank = 3
+    current_parent_rank = root_rank
+    current_parent_id = "P-0"
+
+    # Walk down 3 levels: rank 3 -> 2 -> 1 -> 0
+    for level in range(3):
+        children = [{"id": f"P-{level + 1}"}]
+        verdict, assigned = evaluate_decomposition_proposal(
+            current_parent_id, current_parent_rank, children, now_ts=1000.0
+        )
+        assert verdict.accepted is True
+        current_parent_id = f"P-{level + 1}"
+        current_parent_rank = assigned[0]
+
+    assert current_parent_rank == 0
+
+    # Level 4 from parent_rank 0 must be refused with DECOMPOSITION_RANK_EXHAUSTED
+    children = [{"id": "P-4"}]
+    verdict, assigned = evaluate_decomposition_proposal(current_parent_id, current_parent_rank, children, now_ts=1000.0)
+    assert verdict.accepted is False
+    assert verdict.reason_code == DecompositionRefusalCode.DECOMPOSITION_RANK_EXHAUSTED
+    assert verdict.receipt is not None
+    assert verdict.receipt.parent_rank == 0
+    assert verdict.receipt.offending_child_id == "P-4"
+
+
+def test_receipt_canonical_bytes_determinism() -> None:
+    """The refusal receipt produces deterministic byte-identical canonical output."""
+    children = [{"id": "bad-child", "decomposition_rank": 10}]
+    v1, _ = evaluate_decomposition_proposal("P-200", 5, children, now_ts=1000.0)
+    v2, _ = evaluate_decomposition_proposal("P-200", 5, children, now_ts=9999.0)
+
+    assert v1.receipt is not None
+    assert v2.receipt is not None
+    assert v1.receipt.canonical_bytes() == v2.receipt.canonical_bytes()
+
+
+def test_env_var_overrides_default_root_rank(monkeypatch) -> None:
+    """BERNSTEIN_MAX_DECOMPOSITION_DEPTH environment variable configures root rank ceiling."""
+    monkeypatch.setenv(ENV_MAX_DECOMPOSITION_DEPTH, "10")
+    assert get_default_root_rank() == 10
+
+    children = [{"id": "c1"}]
+    verdict, assigned = evaluate_decomposition_proposal("P-300", None, children, now_ts=1000.0)
+    assert verdict.accepted is True
+    assert assigned == [9]


### PR DESCRIPTION
Closes #4179.

## What
Implements well-founded recursive task decomposition bounds in `src/bernstein/core/tasks/decomposition_guard.py`. Enforces strictly decreasing non-negative ranks (`child_rank < parent_rank`) at task decomposition time, refusing non-decreasing or rank-exhausted proposals with machine-readable codes and recording deterministic spawn-side refusal receipts.

## Why
Previously, no guard prevented unbounded recursive task decomposition, allowing decomposition loops (parent -> child -> parent restatement) to consume agent runtime indefinitely without a clear progress bound.

## How
- Created `src/bernstein/core/tasks/decomposition_guard.py`:
  - `evaluate_decomposition_proposal(parent_task_id, parent_rank, child_proposals)`: checks parent rank against non-negative ceiling (default root rank 5, configurable via `BERNSTEIN_MAX_DECOMPOSITION_DEPTH`).
  - Returns `DecompositionGuardVerdict` with machine-readable refusal codes (`DECOMPOSITION_RANK_EXHAUSTED`, `DECOMPOSITION_RANK_NON_DECREASING`).
  - Emits `DecompositionRefusalReceipt` containing `parent_task_id`, `offending_child_id`, `parent_rank`, `child_rank`, `reason_code`, and deterministic `canonical_bytes()`.
- Added unit tests in `tests/unit/tasks/test_decomposition_guard.py` asserting single-level pass, non-decreasing refusal, depth limit termination, canonical receipt byte determinism, and environment variable override support.

## Proof
- `python -m pytest tests/unit/tasks/test_decomposition_guard.py -v` (5 passed)
- `python -m ruff check` & `python -m ruff format --check` (clean)
