### PR TITLE
docs(adapters): fix internal-scheduler LLM description drift

### DIFF
--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -20,7 +20,7 @@ Source of truth: `src/bernstein/adapters/registry.py`, individual adapter files.
 Every adapter can serve two roles in Bernstein:
 
 1. **As an agent** - spawned per-task to write code, run tests, commit changes
-2. **As the internal scheduler LLM** - used by the orchestrator for task decomposition, cost estimation, and plan optimization
+2. **As the internal scheduler LLM** - used by the Manager for goal decomposition into tasks, and by the quality gates for automated review (quality gates, review rubric, cross-model verification, janitor cleanup checks)
 
 Set the scheduler model in `bernstein.yaml`:
 ```yaml


### PR DESCRIPTION
## Summary
- ADAPTER_GUIDE.md described the internal scheduler LLM as covering "task decomposition, cost estimation, and plan optimization"
- Grepped `call_llm` call sites at HEAD: no cost-estimation or plan-optimization sites exist
- Actual uses are goal decomposition (`ManagerAgent` - its own docstring says it's "the only LLM-powered component in the orchestrator") and the optional review family (quality gates, review rubric, cross-model verifier, janitor)
- Updated the doc to match what the code actually does

## Test plan
- [x] Docs-only change, no code touched