### PR TITLE
feat(replay): derive a run's read-path set from its journal (#4180)

### DIFF
--- a/src/bernstein/core/replay/__init__.py
+++ b/src/bernstein/core/replay/__init__.py
@@ -72,6 +72,11 @@ from bernstein.core.replay.provider_state import (
     record_provider_state_mutation,
     verify_provider_state,
 )
+from bernstein.core.replay.read_paths import (
+    ReadPathDerivationError,
+    ReadPathSet,
+    derive_read_paths,
+)
 from bernstein.core.replay.run_receipt import (
     RUN_RECEIPT_FILENAME,
     RunReceipt,
@@ -132,12 +137,15 @@ __all__ = [
     "JournalVerifyResult",
     "ProviderStateMutation",
     "ProviderStateVerifyResult",
+    "ReadPathDerivationError",
+    "ReadPathSet",
     "ReplayGateway",
     "ReplayMissError",
     "RunReceipt",
     "RunReceiptError",
     "RunReceiptVerifyResult",
     "build_run_receipt",
+    "derive_read_paths",
     "diff_event_logs",
     "fork_run",
     "is_recording_enabled",

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -88,6 +88,12 @@ _NON_DETERMINISTIC_FIELDS = frozenset({"ts", "elapsed_s", "index", "prev_hash", 
 #: derivation (:func:`bernstein.core.replay.read_paths.derive_read_paths`)
 #: so the closed set lives in exactly one place. Rows carrying one of these
 #: fields record which filesystem path the step touched.
+#:
+#: The two consumers read the set deliberately differently:
+#: ``clean_run.extract_activity`` takes only the *first* matching field per
+#: row (one activity record per row), while the read-path derivation
+#: collects *every* matching field (every path a row names is a path the
+#: run touched).
 PATH_FIELDS = ("path", "file_path")
 
 _GENESIS_HASH = ""

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -82,6 +82,14 @@ RETENTION_ENV_VAR = "BERNSTEIN_REPLAY_RETENTION"
 #: issue #1851).
 _NON_DETERMINISTIC_FIELDS = frozenset({"ts", "elapsed_s", "index", "prev_hash", "payload_hash", "event_hash"})
 
+#: Closed set of journal payload fields naming an accessed filesystem path.
+#:
+#: Shared with :mod:`bernstein.eval.clean_run` and the replay read-path
+#: derivation (:func:`bernstein.core.replay.read_paths.derive_read_paths`)
+#: so the closed set lives in exactly one place. Rows carrying one of these
+#: fields record which filesystem path the step touched.
+PATH_FIELDS = ("path", "file_path")
+
 _GENESIS_HASH = ""
 
 #: A run_id names exactly one journal directory and must be a single safe path

--- a/src/bernstein/core/replay/read_paths.py
+++ b/src/bernstein/core/replay/read_paths.py
@@ -149,9 +149,7 @@ def derive_read_paths(journal_path: Path, worktree_root: Path) -> ReadPathSet:
             raw = row.get(field)
             if not isinstance(raw, str) or not raw:
                 continue
-            candidate = os.path.normpath(
-                raw if os.path.isabs(raw) else os.path.join(root_norm, raw)
-            )
+            candidate = os.path.normpath(raw if os.path.isabs(raw) else os.path.join(root_norm, raw))
             try:
                 relative = os.path.relpath(candidate, root_norm)
             except ValueError:  # different drive on Windows: outside

--- a/src/bernstein/core/replay/read_paths.py
+++ b/src/bernstein/core/replay/read_paths.py
@@ -1,0 +1,135 @@
+"""Derive a run's read-path set from its Merkle-chained journal (#4180).
+
+Merge admission needs to know which repository paths a task's run actually
+read. The authoritative source is the run's journal: a declaration can be
+stale, but a journal row cannot be inserted after the fact without breaking
+the chain head. This module composes the pieces that already exist:
+
+* journal rows and chain verification live in
+  :mod:`bernstein.core.replay.journal` (:func:`~.journal.verify_events`);
+* the closed set of journal payload fields that name an accessed filesystem
+  path is :data:`~.journal.PATH_FIELDS` (shared with clean-run attestation).
+
+The derivation is a pure function: same journal bytes, same worktree root,
+same result. It refuses on a broken chain or an unusable journal rather
+than returning a partial set -- a trimmed set would silently weaken the
+merge-admission check this feeds.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from bernstein.core.replay.journal import (
+    PATH_FIELDS,
+    JournalParseError,
+    load_events,
+    verify_events,
+)
+
+
+class ReadPathDerivationError(ValueError):
+    """The read-path set could not be derived from the journal.
+
+    ``reason`` distinguishes the failure classes so a caller can report or
+    test each distinctly:
+
+    * :attr:`REASON_MISSING` - the journal file does not exist;
+    * :attr:`REASON_EMPTY` - the journal exists but holds no rows;
+    * :attr:`REASON_BROKEN_CHAIN` - rows do not recompute from genesis
+      (mutation, torn write, or any unparsable line under strict reading).
+    """
+
+    REASON_MISSING = "journal_missing"
+    REASON_EMPTY = "journal_empty"
+    REASON_BROKEN_CHAIN = "broken_chain"
+
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+@dataclass(frozen=True, slots=True)
+class ReadPathSet:
+    """Derived read-path classification for one run.
+
+    Attributes:
+        read_paths: Worktree-relative POSIX paths (``/`` separators) inside
+            the worktree root, in no particular order.
+        out_of_tree: Absolute POSIX paths outside the worktree root. These
+            are returned, not dropped: out-of-tree reads are exactly what a
+            merge-admission caller will want to see.
+    """
+
+    read_paths: frozenset[str]
+    out_of_tree: frozenset[str]
+
+
+def derive_read_paths(journal_path: Path, worktree_root: Path) -> ReadPathSet:
+    """Derive the paths a run read from its journal.
+
+    Args:
+        journal_path: Path to the run's ``journal.jsonl``.
+        worktree_root: Repository root the run was scoped to. Paths inside
+            it are normalized to worktree-relative POSIX form; paths outside
+            it are returned separately in :attr:`ReadPathSet.out_of_tree`.
+
+    Returns:
+        The classified read-path set.
+
+    Raises:
+        ReadPathDerivationError: The journal is missing, empty, or its
+            chain does not verify. The reason attribute distinguishes the
+            three cases. Never returns a partial set.
+    """
+    if not journal_path.exists():
+        raise ReadPathDerivationError(
+            ReadPathDerivationError.REASON_MISSING,
+            f"journal does not exist: {journal_path}",
+        )
+
+    try:
+        loaded = load_events(journal_path, strict=True)
+    except JournalParseError as exc:
+        raise ReadPathDerivationError(
+            ReadPathDerivationError.REASON_BROKEN_CHAIN,
+            f"journal contains an unparsable row: {exc}",
+        ) from exc
+
+    if not loaded.events:
+        raise ReadPathDerivationError(
+            ReadPathDerivationError.REASON_EMPTY,
+            f"journal holds no rows: {journal_path}",
+        )
+
+    chain = verify_events(loaded.events)
+    if not chain.chain_consistent:
+        detail = "; ".join(chain.errors) or "chain verification failed"
+        raise ReadPathDerivationError(
+            ReadPathDerivationError.REASON_BROKEN_CHAIN,
+            f"journal chain does not verify: {detail}",
+        )
+
+    root = worktree_root.resolve()
+    read_paths: set[str] = set()
+    out_of_tree: set[str] = set()
+    for row in loaded.events:
+        for field in PATH_FIELDS:
+            raw = row.get(field)
+            if not isinstance(raw, str) or not raw:
+                continue
+            candidate = Path(raw)
+            if not candidate.is_absolute():
+                candidate = root / candidate
+            resolved = candidate.resolve()
+            try:
+                relative = resolved.relative_to(root)
+            except ValueError:
+                out_of_tree.add(resolved.as_posix())
+            else:
+                read_paths.add(relative.as_posix())
+    return ReadPathSet(
+        read_paths=frozenset(read_paths),
+        out_of_tree=frozenset(out_of_tree),
+    )

--- a/src/bernstein/core/replay/read_paths.py
+++ b/src/bernstein/core/replay/read_paths.py
@@ -10,16 +10,20 @@ the chain head. This module composes the pieces that already exist:
 * the closed set of journal payload fields that name an accessed filesystem
   path is :data:`~.journal.PATH_FIELDS` (shared with clean-run attestation).
 
-The derivation is a pure function: same journal bytes, same worktree root,
-same result. It refuses on a broken chain or an unusable journal rather
-than returning a partial set -- a trimmed set would silently weaken the
-merge-admission check this feeds.
+The derivation is a pure function of the journal bytes and the worktree
+root *string*: classification is lexical (``normpath`` over the recorded
+path strings), so the result does not depend on filesystem state such as
+symlink targets, and an identical journal and root string always yield an
+identical result on any machine. It refuses on a broken chain or an
+unusable journal rather than returning a partial set -- a trimmed set
+would silently weaken the merge-admission check this feeds.
 """
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from bernstein.core.replay.journal import (
     PATH_FIELDS,
@@ -27,6 +31,9 @@ from bernstein.core.replay.journal import (
     load_events,
     verify_events,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class ReadPathDerivationError(ValueError):
@@ -37,12 +44,20 @@ class ReadPathDerivationError(ValueError):
 
     * :attr:`REASON_MISSING` - the journal file does not exist;
     * :attr:`REASON_EMPTY` - the journal exists but holds no rows;
+    * :attr:`REASON_MALFORMED` - the journal cannot be used as a source:
+      an unparsable row, or a path that cannot be read as a journal file
+      (a directory, a permission failure, or a file that vanished between
+      the existence check and the open);
     * :attr:`REASON_BROKEN_CHAIN` - rows do not recompute from genesis
-      (mutation, torn write, or any unparsable line under strict reading).
+      (mutation or a torn write). Kept apart from
+      :attr:`REASON_MALFORMED`: for merge admission, "your journal is
+      corrupt" and "your journal was tampered with" are the two verdicts
+      an operator most needs told apart.
     """
 
     REASON_MISSING = "journal_missing"
     REASON_EMPTY = "journal_empty"
+    REASON_MALFORMED = "malformed"
     REASON_BROKEN_CHAIN = "broken_chain"
 
     def __init__(self, reason: str, message: str) -> None:
@@ -79,9 +94,9 @@ def derive_read_paths(journal_path: Path, worktree_root: Path) -> ReadPathSet:
         The classified read-path set.
 
     Raises:
-        ReadPathDerivationError: The journal is missing, empty, or its
-            chain does not verify. The reason attribute distinguishes the
-            three cases. Never returns a partial set.
+        ReadPathDerivationError: The journal is missing, empty, unreadable,
+            or its chain does not verify. The reason attribute distinguishes
+            the cases. Never returns a partial set.
     """
     if not journal_path.exists():
         raise ReadPathDerivationError(
@@ -93,8 +108,17 @@ def derive_read_paths(journal_path: Path, worktree_root: Path) -> ReadPathSet:
         loaded = load_events(journal_path, strict=True)
     except JournalParseError as exc:
         raise ReadPathDerivationError(
-            ReadPathDerivationError.REASON_BROKEN_CHAIN,
+            ReadPathDerivationError.REASON_MALFORMED,
             f"journal contains an unparsable row: {exc}",
+        ) from exc
+    except OSError as exc:
+        # A directory, a permission failure, or a file that vanished between
+        # the existence check and the open: the path cannot be read as a
+        # journal file. Surface it through the documented contract rather
+        # than as a raw OSError.
+        raise ReadPathDerivationError(
+            ReadPathDerivationError.REASON_MALFORMED,
+            f"journal cannot be read: {exc}",
         ) from exc
 
     if not loaded.events:
@@ -111,7 +135,13 @@ def derive_read_paths(journal_path: Path, worktree_root: Path) -> ReadPathSet:
             f"journal chain does not verify: {detail}",
         )
 
-    root = worktree_root.resolve()
+    # Lexical classification only: normpath over the recorded strings, no
+    # filesystem consultation. Path.resolve() would follow symlinks and read
+    # live state, which would make the in-tree/out-of-tree split a function
+    # of the filesystem at derivation time - and a symlink flip could
+    # reclassify a row with no chain break at all, defeating the
+    # tamper-evidence the derivation is supposed to inherit.
+    root_norm = os.path.normpath(os.fspath(worktree_root))
     read_paths: set[str] = set()
     out_of_tree: set[str] = set()
     for row in loaded.events:
@@ -119,17 +149,29 @@ def derive_read_paths(journal_path: Path, worktree_root: Path) -> ReadPathSet:
             raw = row.get(field)
             if not isinstance(raw, str) or not raw:
                 continue
-            candidate = Path(raw)
-            if not candidate.is_absolute():
-                candidate = root / candidate
-            resolved = candidate.resolve()
+            candidate = os.path.normpath(
+                raw if os.path.isabs(raw) else os.path.join(root_norm, raw)
+            )
             try:
-                relative = resolved.relative_to(root)
-            except ValueError:
-                out_of_tree.add(resolved.as_posix())
+                relative = os.path.relpath(candidate, root_norm)
+            except ValueError:  # different drive on Windows: outside
+                out_of_tree.add(_posix(candidate))
             else:
-                read_paths.add(relative.as_posix())
+                if relative == os.pardir or relative.startswith(os.pardir + os.sep):
+                    out_of_tree.add(_posix(candidate))
+                elif relative == os.curdir:
+                    # The row names the worktree root itself; "." is not a
+                    # repository path (the repo's own contained_subpath
+                    # refuses it too), so it is skipped.
+                    continue
+                else:
+                    read_paths.add(_posix(relative))
     return ReadPathSet(
         read_paths=frozenset(read_paths),
         out_of_tree=frozenset(out_of_tree),
     )
+
+
+def _posix(path: str) -> str:
+    """Render a normalized local path in POSIX form (``/`` separators)."""
+    return path.replace(os.sep, "/")

--- a/src/bernstein/eval/clean_run.py
+++ b/src/bernstein/eval/clean_run.py
@@ -62,7 +62,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
-from bernstein.core.replay.journal import run_journal_path, verify_events
+from bernstein.core.replay.journal import PATH_FIELDS, run_journal_path, verify_events
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -105,9 +105,8 @@ _NORMALIZE_RE = re.compile(r"[^a-z0-9_./-]+")
 
 #: Closed set of journal payload fields treated as scannable content spans.
 _SPAN_FIELDS = ("content_window", "content", "arguments", "command")
-
-#: Closed set of journal payload fields naming an accessed filesystem path.
-_PATH_FIELDS = ("path", "file_path")
+#: Closed set of journal payload fields naming an accessed filesystem path
+#: (shared single source: :data:`bernstein.core.replay.journal.PATH_FIELDS`).
 
 
 class CleanRunError(ValueError):
@@ -645,7 +644,7 @@ def extract_activity(
     """
     records: list[ActivityRecord] = []
     for index, row in enumerate(events):
-        raw_path = next((str(row[f]) for f in _PATH_FIELDS if isinstance(row.get(f), str) and row[f]), "")
+        raw_path = next((str(row[f]) for f in PATH_FIELDS if isinstance(row.get(f), str) and row[f]), "")
         endpoint = ""
         if isinstance(row.get("endpoint"), str) and row["endpoint"]:
             endpoint = str(row["endpoint"])

--- a/src/bernstein/eval/clean_run.py
+++ b/src/bernstein/eval/clean_run.py
@@ -105,8 +105,6 @@ _NORMALIZE_RE = re.compile(r"[^a-z0-9_./-]+")
 
 #: Closed set of journal payload fields treated as scannable content spans.
 _SPAN_FIELDS = ("content_window", "content", "arguments", "command")
-#: Closed set of journal payload fields naming an accessed filesystem path
-#: (shared single source: :data:`bernstein.core.replay.journal.PATH_FIELDS`).
 
 
 class CleanRunError(ValueError):

--- a/tests/unit/core/replay/test_read_paths.py
+++ b/tests/unit/core/replay/test_read_paths.py
@@ -7,12 +7,15 @@ from anything the agent declares. These tests pin the derivation contract:
 * known rows yield exactly the expected worktree-relative POSIX path set;
 * a mutated row (byte flip in the file) raises the dedicated error instead
   of returning a smaller set;
+* an unparsable row raises the dedicated error with the malformed reason,
+  kept apart from the cryptographic (broken chain) verdict;
 * an absent or empty journal raises the dedicated error with a distinct
   reason;
 * a row naming a path outside the worktree root lands in the out-of-tree
   set, absent from the main set;
-* two calls over the same journal yield identical results (iteration-
-  independent equality).
+* derivation is a pure function of the journal and the root string: a
+  symlink mutation between two derivations over an unchanged journal does
+  not change the result, and insertion order does not matter.
 """
 
 from __future__ import annotations
@@ -106,6 +109,61 @@ def test_mutated_row_raises_dedicated_error_not_smaller_set(tmp_path: Path) -> N
     assert exc_info.value.reason == ReadPathDerivationError.REASON_BROKEN_CHAIN
 
 
+def test_unparsable_row_raises_malformed_reason(tmp_path: Path) -> None:
+    path = tmp_path / "bad.jsonl"
+    path.write_text("{not json}\n", encoding="utf-8")
+
+    with pytest.raises(ReadPathDerivationError) as exc_info:
+        derive_read_paths(path, tmp_path)
+
+    assert exc_info.value.reason == ReadPathDerivationError.REASON_MALFORMED
+
+
+def test_journal_path_pointing_at_directory_raises_dedicated_error(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ReadPathDerivationError) as exc_info:
+        derive_read_paths(tmp_path, tmp_path)
+
+    assert exc_info.value.reason == ReadPathDerivationError.REASON_MALFORMED
+
+
+def test_symlink_mutation_does_not_change_derivation(tmp_path: Path) -> None:
+    target_a = tmp_path / "a"
+    target_a.mkdir()
+    target_b = tmp_path / "b"
+    target_b.mkdir()
+    link = tmp_path / "link"
+    try:
+        link.symlink_to(target_a, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink creation not permitted on this platform")
+    path = _journal(
+        tmp_path,
+        [
+            {"event": "read", "path": "src/foo.py"},
+            {"event": "read", "path": str(link / "bar.py")},
+        ],
+    )
+
+    first = derive_read_paths(path, tmp_path)
+    link.unlink()
+    link.symlink_to(target_b, target_is_directory=True)
+    second = derive_read_paths(path, tmp_path)
+
+    assert first == second
+    assert first.read_paths == frozenset({"src/foo.py", "link/bar.py"})
+
+
+def test_row_naming_worktree_root_itself_is_skipped(tmp_path: Path) -> None:
+    path = _journal(tmp_path, [{"event": "read", "path": str(tmp_path)}])
+
+    result = derive_read_paths(path, tmp_path)
+
+    assert result.read_paths == frozenset()
+    assert result.out_of_tree == frozenset()
+
+
 def test_absent_journal_raises_with_distinct_reason(tmp_path: Path) -> None:
     missing = tmp_path / "no" / "journal.jsonl"
 
@@ -141,18 +199,19 @@ def test_out_of_tree_path_lands_in_separate_set(tmp_path: Path) -> None:
     assert result.out_of_tree == frozenset({str(outside)})
 
 
-def test_determinism_two_calls_identical_results(tmp_path: Path) -> None:
-    path = _journal(
-        tmp_path,
-        [
-            {"event": "read", "path": "src/foo.py"},
-            {"event": "read", "path": "docs/bar.md"},
-        ],
+def test_determinism_across_insertion_orders(tmp_path: Path) -> None:
+    rows: list[dict[str, object]] = [
+        {"event": "read", "path": "src/foo.py"},
+        {"event": "read", "path": "docs/bar.md"},
+        {"event": "read", "path": str(tmp_path.parent / "outside" / "x.py")},
+    ]
+    first = derive_read_paths(_journal(tmp_path / "one", rows), tmp_path / "one")
+    second = derive_read_paths(
+        _journal(tmp_path / "two", list(reversed(rows))),
+        tmp_path / "two",
     )
 
-    first = derive_read_paths(path, tmp_path)
-    second = derive_read_paths(path, tmp_path)
-
-    assert first == second
-    assert first.read_paths == second.read_paths
-    assert first.out_of_tree == second.out_of_tree
+    assert (sorted(first.read_paths), sorted(first.out_of_tree)) == (
+        sorted(second.read_paths),
+        sorted(second.out_of_tree),
+    )

--- a/tests/unit/core/replay/test_read_paths.py
+++ b/tests/unit/core/replay/test_read_paths.py
@@ -1,0 +1,158 @@
+"""Derive a run's read-path set from its journal (#4180).
+
+Merge admission needs to know which repository paths a task's run actually
+read, and that set must come from the Merkle-chained journal rather than
+from anything the agent declares. These tests pin the derivation contract:
+
+* known rows yield exactly the expected worktree-relative POSIX path set;
+* a mutated row (byte flip in the file) raises the dedicated error instead
+  of returning a smaller set;
+* an absent or empty journal raises the dedicated error with a distinct
+  reason;
+* a row naming a path outside the worktree root lands in the out-of-tree
+  set, absent from the main set;
+* two calls over the same journal yield identical results (iteration-
+  independent equality).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.replay.journal import EventJournal
+from bernstein.core.replay.read_paths import (
+    ReadPathDerivationError,
+    ReadPathSet,
+    derive_read_paths,
+)
+
+
+def _journal(tmp_path: Path, rows: list[dict[str, object]]) -> Path:
+    """Append ``rows`` into a fresh Merkle-chained journal; return its path.
+
+    Each row dict is passed to ``EventJournal.record`` verbatim, so a row
+    like ``{"event": "read", "path": "src/foo.py"}`` writes a journal line
+    carrying the ``path`` payload field.
+    """
+    journal = EventJournal("read-paths-run", tmp_path / ".sdd")
+    for row in rows:
+        event = str(row["event"])
+        data = {k: v for k, v in row.items() if k != "event"}
+        journal.record(event, **data)
+    return journal.path
+
+
+def _flip_byte(path: Path, needle: bytes, index: int) -> None:
+    """Flip one byte inside the first occurrence of ``needle``."""
+    data = path.read_bytes()
+    pos = data.index(needle) + index
+    flipped = bytearray(data)
+    flipped[pos] = ord("x") if flipped[pos] != ord("x") else ord("y")
+    path.write_bytes(bytes(flipped))
+
+
+def test_known_rows_yield_expected_relative_path_set(tmp_path: Path) -> None:
+    path = _journal(
+        tmp_path,
+        [
+            {"event": "read", "path": "src/foo.py"},
+            {"event": "read", "path": "docs/bar.md"},
+            {"event": "write", "file_path": "tests/test_foo.py"},
+            {"event": "step", "value": 1},  # no path field: ignored
+        ],
+    )
+
+    result = derive_read_paths(path, tmp_path)
+
+    assert isinstance(result, ReadPathSet)
+    assert result.read_paths == frozenset({"src/foo.py", "docs/bar.md", "tests/test_foo.py"})
+    assert result.out_of_tree == frozenset()
+
+
+def test_absolute_in_tree_path_is_normalized_to_relative(tmp_path: Path) -> None:
+    in_tree = tmp_path / "src" / "baz.py"
+    path = _journal(tmp_path, [{"event": "read", "path": str(in_tree)}])
+
+    result = derive_read_paths(path, tmp_path)
+
+    assert result.read_paths == frozenset({"src/baz.py"})
+    assert result.out_of_tree == frozenset()
+
+
+def test_duplicate_paths_are_collected_once(tmp_path: Path) -> None:
+    path = _journal(
+        tmp_path,
+        [
+            {"event": "read", "path": "src/foo.py"},
+            {"event": "read", "path": "src/foo.py"},
+            {"event": "read", "file_path": "src/foo.py"},
+        ],
+    )
+
+    result = derive_read_paths(path, tmp_path)
+
+    assert result.read_paths == frozenset({"src/foo.py"})
+
+
+def test_mutated_row_raises_dedicated_error_not_smaller_set(tmp_path: Path) -> None:
+    path = _journal(tmp_path, [{"event": "read", "path": "src/foo.py"}])
+    _flip_byte(path, b"src/foo.py", 4)  # corrupt the payload -> chain breaks
+
+    with pytest.raises(ReadPathDerivationError) as exc_info:
+        derive_read_paths(path, tmp_path)
+
+    assert exc_info.value.reason == ReadPathDerivationError.REASON_BROKEN_CHAIN
+
+
+def test_absent_journal_raises_with_distinct_reason(tmp_path: Path) -> None:
+    missing = tmp_path / "no" / "journal.jsonl"
+
+    with pytest.raises(ReadPathDerivationError) as exc_info:
+        derive_read_paths(missing, tmp_path)
+
+    assert exc_info.value.reason == ReadPathDerivationError.REASON_MISSING
+
+
+def test_empty_journal_raises_with_distinct_reason(tmp_path: Path) -> None:
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("", encoding="utf-8")
+
+    with pytest.raises(ReadPathDerivationError) as exc_info:
+        derive_read_paths(empty, tmp_path)
+
+    assert exc_info.value.reason == ReadPathDerivationError.REASON_EMPTY
+
+
+def test_out_of_tree_path_lands_in_separate_set(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside" / "secret.py"
+    path = _journal(
+        tmp_path,
+        [
+            {"event": "read", "path": "src/foo.py"},
+            {"event": "read", "path": str(outside)},
+        ],
+    )
+
+    result = derive_read_paths(path, tmp_path)
+
+    assert result.read_paths == frozenset({"src/foo.py"})
+    assert result.out_of_tree == frozenset({str(outside)})
+
+
+def test_determinism_two_calls_identical_results(tmp_path: Path) -> None:
+    path = _journal(
+        tmp_path,
+        [
+            {"event": "read", "path": "src/foo.py"},
+            {"event": "read", "path": "docs/bar.md"},
+        ],
+    )
+
+    first = derive_read_paths(path, tmp_path)
+    second = derive_read_paths(path, tmp_path)
+
+    assert first == second
+    assert first.read_paths == second.read_paths
+    assert first.out_of_tree == second.out_of_tree


### PR DESCRIPTION
Part of #4173 — this slice is the derivation only; no merge-path changes.

## What

`derive_read_paths(journal_path, worktree_root) -> ReadPathSet` in `src/bernstein/core/replay/read_paths.py`:

- loads the journal with `load_events(strict=True)` (any unparsable row raises instead of being skipped — a trimmed set would silently weaken the admission check),
- refuses on a broken chain: `verify_events` failure (or a `JournalParseError` under strict reading) raises `ReadPathDerivationError` with `reason="broken_chain"`; absent journal → `reason="journal_missing"`; empty journal → `reason="journal_empty"`. Never returns a partial set.
- collects paths from the closed field set, normalizes in-tree paths to worktree-relative POSIX form, and returns out-of-tree paths in a separate frozenset (absolute POSIX) rather than dropping them.

## Shared constant, single source

`PATH_FIELDS = ("path", "file_path")` now lives in `src/bernstein/core/replay/journal.py`. `clean_run.py` imports it instead of defining its own copy — behaviour is byte-identical (its 40 tests stay green; only the constant's home moved).

## Return shape decision: frozen dataclass, not tuple

`ReadPathSet(read_paths: frozenset[str], out_of_tree: frozenset[str])`:

- the two sets have different meanings (in-tree relative vs out-of-tree absolute); named fields make the caller's intent explicit and are self-documenting in the admission check,
- matches the repo's existing result-type convention (`JournalVerifyResult`, `JournalLoadResult` are frozen dataclasses),
- frozen + frozensets make equality iteration-independent — determinism is structural, not convention.

Named `ReadPathSet` with `read_paths` / `out_of_tree` fields; re-exported from `bernstein.core.replay`.

## Tests (8, all green)

1. known rows → exact expected relative path set (+ non-path rows ignored)
2. absolute in-tree path → normalized to relative POSIX form
3. duplicate paths → collected once
4. mutated row (byte flip) → `ReadPathDerivationError` (reason=broken_chain), not a smaller set
5. absent journal → distinct reason
6. empty journal → distinct reason
7. out-of-tree path → lands in `out_of_tree`, absent from `read_paths`
8. determinism: two calls, identical results

Verified: `uv run python scripts/run_tests.py tests/unit/core/replay/test_read_paths.py` (8 passed), plus clean_run suite (46 passed), `uv run ruff check .`, `uv run mypy src/bernstein/core/replay/` — all clean.