### PR TITLE
fix(git): exclude injected scheduled_tasks.json from worktree tracking

### DIFF
--- a/src/bernstein/core/git/worktree.py
+++ b/src/bernstein/core/git/worktree.py
@@ -353,14 +353,20 @@ def _derive_local_exclude_entries() -> tuple[str, ...]:
     list: the orchestrator itself generates a session-specific ``CLAUDE.md``
     at the root of every worktree (see ``worktree_claude_md.write_claude_md``),
     so it is always a duplicate/decoy file at that path, never a genuine
-    target-repo deliverable. All entries are anchored to the worktree root
-    (leading ``/``) so they cannot shadow a same-named path a target project
-    legitimately keeps elsewhere (e.g. a nested ``docs/CLAUDE.md`` or a
-    ``.claude/`` skill/command the agent was tasked to author).
+    target-repo deliverable. Likewise ``/.claude/scheduled_tasks.json``: the
+    spawner injects a per-session health-check cron task at that path (see
+    ``spawner_core._inject_scheduled_tasks``), and the file's content embeds
+    the session id and a creation timestamp, so it always conflicts when two
+    agent branches carrying it merge back. All entries are anchored to the
+    worktree root (leading ``/``) so they cannot shadow a same-named path a
+    target project legitimately keeps elsewhere (e.g. a nested
+    ``docs/CLAUDE.md`` or a ``.claude/`` skill/command the agent was tasked
+    to author).
     """
     entries = [f"/{prefix}" for prefix in _MERGE_DENY_PREFIXES]
     entries.extend(f"/{exact}" for exact in sorted(_MERGE_DENY_EXACT))
     entries.append("/CLAUDE.md")
+    entries.append("/.claude/scheduled_tasks.json")
     return tuple(entries)
 
 

--- a/tests/unit/test_worktree_gitignore.py
+++ b/tests/unit/test_worktree_gitignore.py
@@ -191,6 +191,7 @@ def test_create_writes_worktree_scoped_excludes_not_a_tracked_gitignore(tmp_path
     assert "/.env" in lines
     assert "/.claude/mcp.json" in lines
     assert "/CLAUDE.md" in lines
+    assert "/.claude/scheduled_tasks.json" in lines
 
     # Must not blanket-ignore the whole .claude/ tree -- that would drop a
     # legitimate .claude/ deliverable (e.g. a skill or command).
@@ -279,6 +280,26 @@ def test_generated_session_claude_md_is_not_staged(tmp_path: Path, repo: Path) -
 
     assert "CLAUDE.md" not in staged, "the orchestrator-generated session CLAUDE.md must not be staged"
     assert "src/feature.py" in staged
+
+
+def test_injected_scheduled_tasks_json_does_not_dirty_worktree(tmp_path: Path, repo: Path) -> None:
+    """Regression for #4225: the spawner injects a per-session
+    ``.claude/scheduled_tasks.json`` (health-check cron task) into every
+    agent worktree, and its content embeds the session id and a creation
+    timestamp -- so if it were ever tracked, two agent branches merging back
+    would conflict on it. With the exclude in place, a worktree carrying the
+    injected file must report a clean tree, matching the acceptance
+    criterion in the issue."""
+    mgr = WorktreeManager(repo_root=repo)
+    session_id = "sess-scheduled-tasks"
+    worktree_path = mgr.create(session_id)
+
+    tasks_path = worktree_path / ".claude" / "scheduled_tasks.json"
+    tasks_path.parent.mkdir(parents=True, exist_ok=True)
+    tasks_path.write_text('{"tasks": [{"id": "hc-' + session_id[:8] + '"}]}\n', encoding="utf-8")
+
+    status = _git(worktree_path, "status", "--porcelain")
+    assert status == "", f"injected scheduled_tasks.json must not dirty the worktree, got: {status!r}"
 
 
 def test_git_add_dash_a_still_stages_non_runtime_claude_dir_deliverable(tmp_path: Path, repo: Path) -> None:


### PR DESCRIPTION
## Symptom

Agent worktree merges intermittently conflict on `.claude/scheduled_tasks.json`:

```
WARNING bernstein.core.agents.spawner_merge: Merge conflicts for <agent> in files: .claude/scheduled_tasks.json
```

3 occurrences in a 12-agent run.

## Root cause

Each spawned agent's worktree gets `.claude/scheduled_tasks.json` injected with per-session content — the task id embeds the session id and a creation timestamp (`core/agents/spawner_core.py`). That path was never added to the worktree-scoped local excludes, so an agent finishing with `git add -A` stages it and carries it onto its branch, where it conflicts against every other agent's differing copy at merge time.

## Fix

Add `/.claude/scheduled_tasks.json` to the local-exclude entries built in `_ensure_worktree_local_excludes` (`core/git/worktree.py`), following the same on-top pattern already used for `/CLAUDE.md`.

## Test

A freshly created agent worktree now carries the path in its scoped excludes, and a new regression test confirms `git status` stays clean with the injected file present (`tests/unit/test_worktree_gitignore.py`).

Closes #4225