### PR TITLE
fix(adapters): lowercase adapter name for admission receipt filenames

### DIFF
--- a/src/bernstein/adapters/admission.py
+++ b/src/bernstein/adapters/admission.py
@@ -929,21 +929,24 @@ def receipt_is_stale(receipt: dict[str, Any], *, now: datetime) -> bool:
 def write_admission_receipt(base_dir: Path, receipt: dict[str, Any]) -> Path:
     """Write a receipt under its content-addressed name.
 
-    The filename embeds the adapter name and the receipt hash prefix. The
-    adapter component is validated against a strict allow-pattern and the
-    resolved path is containment-checked against ``base_dir``, so a hostile
-    adapter string can never escape the receipts directory.
+    The filename embeds the lowercased adapter name and the receipt hash
+    prefix -- lowercased so a display name like ``"Aider"`` addresses the
+    same file a lookup by registry key would. The adapter component is
+    validated against a strict allow-pattern and the resolved path is
+    containment-checked against ``base_dir``, so a hostile adapter string can
+    never escape the receipts directory.
 
     Raises:
         ValueError: The adapter name fails validation, or the resolved path
             escapes ``base_dir``.
     """
     adapter = str(receipt.get("adapter") or "")
-    if not _RECEIPT_NAME_RE.match(adapter):
+    adapter_key = adapter.lower()
+    if not _RECEIPT_NAME_RE.match(adapter_key):
         raise ValueError(f"invalid adapter name for receipt filename: {adapter!r}")
     sha = receipt_sha256(receipt)
     base_dir.mkdir(parents=True, exist_ok=True)
-    stem = f"{adapter}-{sha[:16]}"
+    stem = f"{adapter_key}-{sha[:16]}"
     try:
         candidate = contained_path(base_dir, f"{stem}.json", label="receipt path")
         # The temporary sibling is opened *before* the rename, so it needs the
@@ -978,12 +981,13 @@ def load_admission_receipt(base_dir: Path, adapter: str) -> tuple[dict[str, Any]
         :data:`REASON_RECEIPT_TAMPERED` when every candidate failed its
         content-hash check.
     """
-    if not _RECEIPT_NAME_RE.match(adapter) or not base_dir.exists():
+    adapter_key = adapter.lower()
+    if not _RECEIPT_NAME_RE.match(adapter_key) or not base_dir.exists():
         return None, REASON_NO_RECEIPT
 
     candidates: list[dict[str, Any]] = []
     tampered = False
-    for path in sorted(base_dir.glob(f"{adapter}-*.json")):
+    for path in sorted(base_dir.glob(f"{adapter_key}-*.json")):
         try:
             doc = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
@@ -1312,7 +1316,7 @@ def preflight_admission(
         try:
             write_admission_receipt(decisions_dir, receipt)
         except (OSError, ValueError) as exc:
-            logger.warning("Could not write admission gate receipt for %s: %s", adapter, type(exc).__name__)
+            logger.warning("Could not write admission gate receipt for %s: %s", adapter, exc)
 
     if chain is not None:
         _anchor_in_chain(chain, receipt, sha)

--- a/tests/unit/test_adapter_admission.py
+++ b/tests/unit/test_adapter_admission.py
@@ -411,6 +411,20 @@ def test_load_admission_receipt_returns_the_newest(receipts_dir: Path) -> None:
     assert stored["installed_version"] == "kimi 1.0.0"
 
 
+def test_receipt_round_trips_for_a_non_lowercase_adapter_name(receipts_dir: Path) -> None:
+    """A display name like ``AiderAdapter.name()``'s "Aider" must persist and load (#4224)."""
+    decision = evaluate_admission(_bare_evidence(adapter="Aider", binary="aider"))
+    receipt = build_admission_receipt(decision, generated_at=_NOW.isoformat())
+
+    write_admission_receipt(receipts_dir, receipt)
+    stored, problem = load_admission_receipt(receipts_dir, "Aider")
+
+    assert problem == ""
+    assert stored is not None
+    assert stored["adapter"] == "Aider"
+    assert stored["verdict"] == receipt["verdict"]
+
+
 # ---------------------------------------------------------------------------
 # The gate
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom

Every admission decision logged:

```
WARNING bernstein.adapters.admission: Could not write admission gate receipt for Aider: ValueError
```

No admission receipt was ever persisted for such adapters, and the warning printed only the exception type, hiding the actual cause.

## Root cause

`write_admission_receipt` validates the receipt's adapter component against `_RECEIPT_NAME_RE = ^[a-z0-9][a-z0-9_-]*$`, lowercase only. The receipt's adapter field carries the adapter's display name (e.g. `AiderAdapter.name()` returns `"Aider"`), which fails the pattern and raises `ValueError` on every write. `load_admission_receipt` applies the same pattern, so such a receipt could never be loaded either.

## Fix

- Lowercase the adapter component used for the receipt filename in both `write_admission_receipt` and `load_admission_receipt`, keeping them symmetric.
- The hostile-string validation still runs (case-folding doesn't affect path-traversal characters), so `test_write_admission_receipt_rejects_a_hostile_adapter_name` still holds.
- The receipt body itself keeps the original-case adapter name.
- The write-failure warning at the admission gate now includes the exception message, not just its type.

## Test

`tests/unit/test_adapter_admission.py::test_receipt_round_trips_for_a_non_lowercase_adapter_name` — seals and reloads a receipt for adapter `"Aider"`, asserting the round-trip preserves the decision. Confirmed it fails on pre-fix code (`ValueError: invalid adapter name for receipt filename: 'Aider'`) and passes after the fix.

Closes #4224