### PR TITLE
fix(evolve): refuse upgrade-proposal auto-spawn with no terminal task

### DIFF
--- a/src/bernstein/core/orchestration/orchestrator_evolve.py
+++ b/src/bernstein/core/orchestration/orchestrator_evolve.py
@@ -60,6 +60,15 @@ _OPEN_TASK_STATUSES = {
     TaskStatus.BLOCKED,
 }
 
+# Statuses that count as a "terminal baseline" for AutoSpawnGuard's
+# no-terminal-baseline check (#4226): the evolve loop has an actual outcome
+# to improve on once at least one task in the run has finished, successfully
+# or not.
+_TERMINAL_BASELINE_STATUSES = {
+    TaskStatus.DONE,
+    TaskStatus.FAILED,
+}
+
 
 def _run_governance_step(
     orch: Any,
@@ -782,6 +791,14 @@ def _create_upgrade_tasks(orch: Any, proposals: list[Any], result: Any) -> None:
         if getattr(task, "task_type", None) == TaskType.UPGRADE_PROPOSAL
         and getattr(task, "status", None) in _OPEN_TASK_STATUSES
     ]
+    # Run health for the guard's terminal-baseline check (#4226): an
+    # upgrade_proposal has nothing to improve on until something in the run
+    # has actually finished. Computed once here from the run's full task set
+    # (not just UPGRADE_PROPOSAL tasks) and passed to the guard rather than
+    # having the guard reach for task-store state itself.
+    has_terminal_task = any(
+        getattr(task, "status", None) in _TERMINAL_BASELINE_STATUSES for task in latest_tasks.values()
+    )
     for proposal in proposals:
         if proposal.status not in _task_eligible_statuses:
             continue
@@ -792,6 +809,7 @@ def _create_upgrade_tasks(orch: Any, proposals: list[Any], result: Any) -> None:
                 title=title,
                 source_title=None,
                 existing_open_titles=existing_open_titles,
+                has_terminal_task=has_terminal_task,
             )
             if not decision.allowed:
                 continue

--- a/src/bernstein/core/tasks/auto_spawn_guard.py
+++ b/src/bernstein/core/tasks/auto_spawn_guard.py
@@ -14,6 +14,12 @@ This module is shared by both known auto-spawn sites:
 - ``bernstein.core.observability.watchdog.WatchdogManager._create_triage_task``
 
 Guard order (first hit wins, cheapest checks first):
+0. Terminal baseline (``kind="upgrade_proposal"`` only): refuse spawning a
+   self-improvement task while the run has zero done/failed tasks - there is
+   no outcome yet for an "improve task success" proposal to act on, and in a
+   small (e.g. single-cell) run the upgrade task would otherwise claim the
+   run's only capacity ahead of recovering the goal task itself. See
+   ``no-terminal-baseline`` below.
 1. Ancestry depth: refuse spawning a meta-task ABOUT a task that is itself an
    auto-spawned meta-task (its title already carries a known meta-task
    prefix). This caps recursion at depth 1: normal-task -> meta-task is
@@ -59,7 +65,7 @@ class AutoSpawnDecision:
     """Result of an :meth:`AutoSpawnGuard.evaluate` call."""
 
     allowed: bool
-    reason: str  # "allowed" | "depth" | "dedupe" | "cap"
+    reason: str  # "allowed" | "no-terminal-baseline" | "depth" | "dedupe" | "cap"
     ancestry_depth: int
     current_count: int
     cap: int
@@ -172,6 +178,7 @@ class AutoSpawnGuard:
         title: str,
         source_title: str | None,
         existing_open_titles: list[str],
+        has_terminal_task: bool = True,
     ) -> AutoSpawnDecision:
         """Decide whether an auto-spawn of ``title`` (of type ``kind``) is allowed.
 
@@ -185,6 +192,11 @@ class AutoSpawnGuard:
                 about, if any. Used to compute ancestry depth.
             existing_open_titles: Titles of currently-open (open or claimed)
                 auto-spawned tasks, for dedupe comparison.
+            has_terminal_task: Whether the run has at least one done/failed
+                task. Only consulted when ``kind == "upgrade_proposal"``;
+                other call sites (watchdog triage, retry-path recreation)
+                don't pass it and keep their existing behaviour via the
+                ``True`` default. See ``no-terminal-baseline`` below.
 
         Every call - allowed or refused - is logged at INFO with the full
         decision inputs (reason, dedupe key, ancestry depth); this is the
@@ -198,6 +210,35 @@ class AutoSpawnGuard:
         dedupe_key = _normalize_title(title)
         depth = compute_ancestry_depth(source_title)
         count = self._load_count()
+
+        # Terminal baseline: an upgrade_proposal ("self-improve on the run's
+        # own outcomes") has nothing to improve on until at least one task in
+        # the run has actually finished (done or failed). Refusing here keeps
+        # a stuck/crashed goal task's only cell available for its own
+        # recovery instead of the evolve loop displacing it with meta-work
+        # (issue #4226).
+        if kind == "upgrade_proposal" and not has_terminal_task:
+            decision = AutoSpawnDecision(
+                allowed=False,
+                reason="no-terminal-baseline",
+                ancestry_depth=depth,
+                current_count=count,
+                cap=self._max_auto_spawns_per_run,
+            )
+            logger.warning(
+                "Auto-spawn refused (no-terminal-baseline): kind=%s title=%r - run has zero done/failed "
+                "tasks, nothing to improve on yet",
+                kind,
+                title,
+            )
+            self._log_decision(
+                kind=kind,
+                title=title,
+                source_title=source_title,
+                dedupe_key=dedupe_key,
+                decision=decision,
+            )
+            return decision
 
         if depth > self._max_ancestry_depth:
             decision = AutoSpawnDecision(

--- a/tests/unit/tasks/test_auto_spawn_guard.py
+++ b/tests/unit/tasks/test_auto_spawn_guard.py
@@ -213,6 +213,63 @@ def test_evaluate_logs_info_decision_line_for_allowed_spawn(tmp_path: Path, capl
     assert any("ancestry_depth=1" in line for line in decision_lines)
 
 
+def test_no_terminal_baseline_refuses_upgrade_proposal_with_zero_terminal_tasks(tmp_path: Path) -> None:
+    """Issue #4226: an upgrade_proposal auto-spawn is refused while the run
+    has zero done/failed tasks -- there is no outcome yet to improve on, and
+    in a single-cell run the upgrade task would otherwise displace recovery
+    of the goal task itself."""
+    guard = AutoSpawnGuard(tmp_path, max_ancestry_depth=1, max_auto_spawns_per_run=3)
+
+    decision = guard.evaluate(
+        kind="upgrade_proposal",
+        title="Upgrade: Improve task success rate",
+        source_title=None,
+        existing_open_titles=[],
+        has_terminal_task=False,
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "no-terminal-baseline"
+
+    # Refused spawns must not consume the cap.
+    state_path = tmp_path / ".sdd" / "runtime" / "auto_spawn_guard.json"
+    assert not state_path.exists()
+
+
+def test_no_terminal_baseline_allows_upgrade_proposal_with_at_least_one_terminal_task(tmp_path: Path) -> None:
+    """Control: once >=1 task in the run is done/failed, current behaviour
+    (guard falls through to depth/dedupe/cap) is unchanged."""
+    guard = AutoSpawnGuard(tmp_path, max_ancestry_depth=1, max_auto_spawns_per_run=3)
+
+    decision = guard.evaluate(
+        kind="upgrade_proposal",
+        title="Upgrade: Improve task success rate",
+        source_title=None,
+        existing_open_titles=[],
+        has_terminal_task=True,
+    )
+
+    assert decision.allowed is True
+    assert decision.reason == "allowed"
+
+
+def test_no_terminal_baseline_only_applies_to_upgrade_proposal_kind(tmp_path: Path) -> None:
+    """Other call sites (watchdog triage, retry-path recreation) don't pass
+    ``has_terminal_task`` and must keep their existing behaviour -- the
+    no-terminal-baseline check is scoped to kind="upgrade_proposal" only."""
+    guard = AutoSpawnGuard(tmp_path, max_ancestry_depth=1, max_auto_spawns_per_run=3)
+
+    decision = guard.evaluate(
+        kind="watchdog_triage",
+        title="Watchdog triage: Heartbeat stale for task X",
+        source_title=None,
+        existing_open_titles=[],
+    )
+
+    assert decision.allowed is True
+    assert decision.reason == "allowed"
+
+
 def test_evaluate_logs_info_decision_line_for_refused_spawn(tmp_path: Path, caplog) -> None:
     """A refused (depth) decision must ALSO emit the uniform INFO decision
     line, not just the WARNING alert -- the audit-3 evidence flagged that

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -4563,6 +4563,18 @@ class TestRunEvolutionCycle:
         spawner = AgentSpawner(adp, templates_dir, tmp_path)
         client = httpx.Client(transport=transport, base_url="http://testserver")
         orch = Orchestrator(cfg, spawner, tmp_path, client=client, evolution=evolution)
+        # Seed a finished goal task so AutoSpawnGuard's terminal-baseline
+        # check (#4226) doesn't refuse upgrade_proposal spawns in tests that
+        # aren't exercising that check themselves.
+        goal = Task(
+            id="goal",
+            title="Implement the feature",
+            description="desc",
+            role="backend",
+            task_type=TaskType.STANDARD,
+            status=TaskStatus.DONE,
+        )
+        orch._latest_tasks_by_id = {goal.id: goal}
         return orch, evolution
 
     def _make_proposal(self, proposal_id: str = "P-001", title: str = "Improve routing") -> MagicMock:

--- a/tests/unit/test_orchestrator_evolve_upgrade_tasks.py
+++ b/tests/unit/test_orchestrator_evolve_upgrade_tasks.py
@@ -41,6 +41,19 @@ def _proposal(
     )
 
 
+def _done_goal_task() -> Task:
+    """A finished goal task, satisfying AutoSpawnGuard's terminal-baseline
+    check (#4226) so tests unrelated to that check aren't refused by it."""
+    return Task(
+        id="goal",
+        title="Implement the feature",
+        description="desc",
+        role="backend",
+        task_type=TaskType.STANDARD,
+        status=TaskStatus.DONE,
+    )
+
+
 def _orch(workdir: Path, *, latest_tasks: dict[str, Task] | None = None) -> SimpleNamespace:
     client = MagicMock()
     resp = MagicMock()
@@ -52,12 +65,16 @@ def _orch(workdir: Path, *, latest_tasks: dict[str, Task] | None = None) -> Simp
         is_high_risk=lambda score: False,
     )
 
+    if latest_tasks is None:
+        goal = _done_goal_task()
+        latest_tasks = {goal.id: goal}
+
     return SimpleNamespace(
         _workdir=workdir,
         _config=SimpleNamespace(server_url="http://server"),
         _client=client,
         _risk_scorer=risk_scorer,
-        _latest_tasks_by_id=latest_tasks or {},
+        _latest_tasks_by_id=latest_tasks,
     )
 
 
@@ -82,12 +99,45 @@ def test_dedupe_refuses_upgrade_task_matching_existing_open_task(tmp_path: Path)
         task_type=TaskType.UPGRADE_PROPOSAL,
         status=TaskStatus.OPEN,
     )
-    orch = _orch(tmp_path, latest_tasks={existing.id: existing})
+    goal = _done_goal_task()
+    orch = _orch(tmp_path, latest_tasks={existing.id: existing, goal.id: goal})
     result = SimpleNamespace(errors=[])
 
     _create_upgrade_tasks(orch, [_proposal("p1", "Improve task success rate")], result)
 
     assert orch._client.post.call_count == 0
+
+
+def test_no_terminal_baseline_refuses_upgrade_task_when_run_has_no_terminal_task(tmp_path: Path) -> None:
+    """Issue #4226: a run whose only task never reached a terminal state
+    (e.g. crashed at claim) must not have its single cell displaced by an
+    upgrade task."""
+    stuck_goal = Task(
+        id="goal",
+        title="Implement the feature",
+        description="desc",
+        role="backend",
+        task_type=TaskType.STANDARD,
+        status=TaskStatus.CLAIMED,
+    )
+    orch = _orch(tmp_path, latest_tasks={stuck_goal.id: stuck_goal})
+    result = SimpleNamespace(errors=[])
+
+    _create_upgrade_tasks(orch, [_proposal("p1", "Improve task success rate")], result)
+
+    assert orch._client.post.call_count == 0
+
+
+def test_no_terminal_baseline_allows_upgrade_task_once_any_task_is_terminal(tmp_path: Path) -> None:
+    """Control: current behaviour is unchanged once the run has >=1 done or
+    failed task -- see ``_orch``'s default fixture, which already provides
+    one."""
+    orch = _orch(tmp_path)
+    result = SimpleNamespace(errors=[])
+
+    _create_upgrade_tasks(orch, [_proposal("p1", "Improve task success rate")], result)
+
+    assert orch._client.post.call_count == 1
 
 
 def test_cap_refuses_upgrade_tasks_beyond_configured_limit(tmp_path: Path) -> None:


### PR DESCRIPTION
## Symptom

In a single-cell run whose only declared task never reached a terminal
state (its agent crashed at spawn and the claim was stuck), the evolve
loop still created an upgrade task ~11 minutes in and that task claimed
the run's only cell, ahead of any recovery of the goal task itself.

## Root cause

`AutoSpawnGuard.evaluate` gates `upgrade_proposal` auto-spawns on
ancestry depth, dedupe, and a spawn cap, but not on run health. A run
in which nothing has ever completed still qualified for
self-improvement work, so in a 1-cell run that work could displace
recovery of the goal task.

## Fix

`AutoSpawnGuard.evaluate` refuses `kind=upgrade_proposal` while the run
has zero done/failed tasks, with a new `no-terminal-baseline` reason
surfaced in the guard's existing decision log line
(`auto_spawn_decision`). The terminal-task check is computed once in
`orchestrator_evolve._create_upgrade_tasks` from the run's existing
task snapshot (`orch._latest_tasks_by_id`) and passed into the guard as
`has_terminal_task`, rather than giving the guard new task-store
coupling. Other call sites (watchdog triage, retry-path recreation)
don't pass it and keep their existing behaviour via the `True` default.

## Test

- `tests/unit/tasks/test_auto_spawn_guard.py`: both directions at the
  guard level (refuses with zero terminal tasks, unchanged behaviour
  with >=1, and confirms the check is scoped to `kind=upgrade_proposal`
  only).
- `tests/unit/test_orchestrator_evolve_upgrade_tasks.py`: caller-level
  regression reproducing the single-cell scenario (stuck/claimed goal
  task, no terminal tasks -> refused) plus the control case.
- Updated existing `_orch`/`_build_with_evolution_mock` test fixtures
  in `tests/unit/test_orchestrator_evolve_upgrade_tasks.py` and
  `tests/unit/test_orchestrator.py` to seed a finished goal task, since
  they exercise unrelated behaviour and previously relied on an empty
  task snapshot.

Closes #4226
