### PR TITLE
fix(cli): thread --model into the plan-approval panel

### DIFF
--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -229,10 +229,13 @@ def _load_dry_run_tasks(plan_file: Path | None) -> list[Any]:
     return [Task.from_dict(td) for td in tasks_data]
 
 
-def _confirm_run(*, goal: str | None, seed_file: str | None) -> bool:
+def _confirm_run(*, goal: str | None, seed_file: str | None, model_override: str | None = None) -> bool:
     """Show confirmation prompt before execution. Returns True to proceed."""
     effective_goal = goal
     team: list[str] | None = None
+    role_model_policy: dict[str, dict[str, str]] | None = None
+    seed_model: str | None = None
+    seed_cli: str | None = None
 
     if effective_goal is None:
         _peek_path: Path | None = Path(seed_file) if seed_file is not None else find_seed_file()
@@ -243,15 +246,24 @@ def _confirm_run(*, goal: str | None, seed_file: str | None) -> bool:
                 _seed = _parse_seed(_peek_path)
                 effective_goal = _seed.goal
                 team = list(_seed.team) if _seed.team != "auto" else None
-                from bernstein.core.plan_approval import configure_plan_models
-
-                configure_plan_models(
-                    _seed.role_model_policy,
-                    default_model=_seed.model,
-                    default_cli=(_seed.cli if _seed.cli and _seed.cli != "auto" else None),
-                )
+                role_model_policy = _seed.role_model_policy
+                seed_model = _seed.model
+                seed_cli = _seed.cli if _seed.cli and _seed.cli != "auto" else None
 
     if effective_goal:
+        # An explicit --model always wins over the seed's default, mirroring
+        # _resolve_model_and_cli's precedence in run_preflight.py. Without
+        # this the panel fell back to the seed model (or the "sonnet"
+        # complexity default when there was no seed), so
+        # `bernstein run --model X` showed a plan-approval panel that named
+        # and priced a model the run would not use (issue #4214).
+        from bernstein.core.plan_approval import configure_plan_models
+
+        configure_plan_models(
+            role_model_policy,
+            default_model=model_override or seed_model,
+            default_cli=seed_cli,
+        )
         plan_obj, plan_tasks = _build_synthetic_plan(effective_goal, team)
         from bernstein.cli.plan_display import display_plan_and_confirm
 
@@ -2615,7 +2627,7 @@ def _run_impl(
             raise SystemExit(1) from exc
 
     # Confirmation prompt before execution (skip with --auto-approve)
-    if not auto_approve and not _confirm_run(goal=goal, seed_file=seed_file):
+    if not auto_approve and not _confirm_run(goal=goal, seed_file=seed_file, model_override=model):
         return
 
     if goal is not None:

--- a/tests/unit/test_issue_4214_plan_panel_model.py
+++ b/tests/unit/test_issue_4214_plan_panel_model.py
@@ -1,0 +1,82 @@
+"""Regression tests for issue #4214.
+
+``bernstein run --model <M>`` printed a plan-approval panel that always
+named ``sonnet`` and priced the run with it, whatever ``--model`` was
+passed: ``_confirm_run`` (the entry point that builds the synthetic plan
+shown for approval) never received the CLI's resolved model, so
+``configure_plan_models`` only ever saw a seed's ``model:`` key -- and not
+at all for an inline goal with no seed. ``_estimate_task_cost`` then fell
+back to the "sonnet" complexity default, disagreeing with the model the
+run actually used (confirmed correct in the post-approval "Cost estimate:"
+line and the run's own journal).
+
+Pinned here, against the *rendered* panel (not internal state):
+
+* The task table and the Agent Assignments box name the resolved
+  ``--model``, not the "sonnet" fallback.
+* Cost is computed from that model.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import pytest
+from bernstein.core.plan_approval import configure_plan_models
+
+from bernstein.cli.helpers import console
+from bernstein.cli.run_bootstrap import _confirm_run
+
+
+@pytest.fixture(autouse=True)
+def _reset_plan_models() -> object:
+    """Ensure the module-global seed defaults never leak between tests."""
+    configure_plan_models(None)
+    yield
+    configure_plan_models(None)
+
+
+def _render_confirm_panel(model_override: str | None) -> str:
+    """Run ``_confirm_run`` for an inline goal and capture the panel text.
+
+    Non-TTY (pytest has no real terminal), so ``_confirm_run`` renders and
+    auto-approves without blocking on a keypress.
+    """
+    with console.capture() as cap:
+        approved = _confirm_run(goal="fix the two one-liners", seed_file=None, model_override=model_override)
+    assert approved is True
+    return cap.get()
+
+
+def test_panel_names_and_prices_the_explicit_model_override() -> None:
+    """An explicit --model that differs from the default reaches the panel."""
+    out = _render_confirm_panel("opus")
+
+    assert "opus" in out, out
+    # The task table's Model column and the Agent Assignments box both read
+    # est.model; neither should fall back to the hardcoded default.
+    assert "sonnet" not in out.lower(), out
+
+
+def test_panel_names_default_model_when_no_override_given() -> None:
+    """Baseline: with no --model, the panel still falls back sensibly."""
+    out = _render_confirm_panel(None)
+
+    assert "sonnet" in out.lower(), out
+
+
+def test_panel_model_matches_configure_plan_models_default() -> None:
+    """The resolved model reaches every TaskCostEstimate construction site.
+
+    Mirrors the dry-run path's pattern of threading ``model_override``
+    straight into the estimate, so the panel and the post-approval
+    ``Cost estimate:`` line agree for the same run.
+    """
+    from bernstein.core.models import Task
+    from bernstein.core.plan_approval import _estimate_task_cost
+
+    _confirm_run(goal="fix the two one-liners", seed_file=None, model_override="opus")
+
+    est = _estimate_task_cost(Task(id="t1", title="do work", description="", role="manager"))
+    assert est.model == "opus"
+    assert est.estimated_cost_usd > 0.0


### PR DESCRIPTION
## Symptom

`bernstein run --model <M>` printed a plan-approval panel that always named `sonnet` and priced the run with it, whatever `--model` was passed. The line printed a few steps later, after approval, named the real model — the two disagreed inside a single run, and on a free/self-hosted model the panel's figure was not an over-estimate, it was unrelated to the run.

## Root cause

The panel's cost estimate (`_estimate_task_cost` / `TaskCostEstimate.model`) is fed by `configure_plan_models`, which sets the default model used when a task carries none of its own. `_confirm_run` — the entry point that builds the synthetic plan shown for approval — only called `configure_plan_models` with a seed's `model:` key, and only when the run had no inline goal. An explicit `--model` never reached it at all, so the estimate fell back to the "sonnet" complexity default regardless of what was requested.

The separate post-approval `Cost estimate:` line (`_resolve_model_and_cli` in `run_preflight.py`) already resolved `--model` correctly, which is why only the panel disagreed.

## Fix

Thread the resolved `--model` into `_confirm_run` and pass it to `configure_plan_models` as the default model, giving it the same precedence over the seed default that `_resolve_model_and_cli` already uses — so the panel and the post-approval line agree.

## Test

`tests/unit/test_issue_4214_plan_panel_model.py` asserts against the *rendered* panel:
- an explicit `--model` differing from the default is named (and priced) in the panel, with no "sonnet" fallback leaking through
- the no-override baseline still falls back sensibly
- the resolved model reaches `TaskCostEstimate` for every construction site the panel reads

All three fail against the pre-fix code (`_confirm_run() got an unexpected keyword argument 'model_override'`) and pass after.

Closes #4214
