### PR TITLE
fix(agent_lifecycle): re-evaluate deferred death judgments after reap

### DIFF
--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -409,6 +409,12 @@ def refresh_agent_states(orch: Any, tasks_snapshot: dict[str, list[Task]]) -> No
             continue
         _handle_dead_agent(orch, session, tasks_snapshot)
 
+    # Re-check every death judgment deferred by _probe_liveness_signals: the
+    # session that deferred it is already "dead" and filtered out of the loop
+    # above, so this is the only place left that can still fail a task whose
+    # deferral was never followed by real progress (issue #4222).
+    _reevaluate_pending_death_judgments(orch, tasks_snapshot)
+
     # Purge dead agents to prevent unbounded dict growth (memory leak fix)
     purge_dead_agents(orch)
 
@@ -1634,6 +1640,24 @@ def _mtime_age(path: Path, now: float) -> float | None:
     return None
 
 
+def _mtime_and_size(path: Path | None) -> tuple[float | None, int | None]:
+    """Return ``(mtime, size)`` for ``path``, or ``(None, None)`` if missing/unreadable.
+
+    Used to build and later compare liveness snapshots (see
+    ``_liveness_snapshot`` / ``_reevaluate_pending_death_judgments``): a plain
+    age check can't tell a one-time write (e.g. a crash traceback flushed on
+    the way down) from ongoing output, but a raw mtime/size pair can be
+    compared against a later read to see whether the file moved at all.
+    """
+    if path is None:
+        return None, None
+    with contextlib.suppress(OSError):
+        if path.exists():
+            st = path.stat()
+            return st.st_mtime, st.st_size
+    return None, None
+
+
 def _probe_liveness_signals(orch: Any, session: AgentSession, now: float) -> dict[str, Any]:
     """Collect every liveness signal for a possibly-dead agent and log the judgment.
 
@@ -1713,6 +1737,147 @@ def _probe_liveness_signals(orch: Any, session: AgentSession, now: float) -> dic
         "has_fresh_signal": has_fresh_signal,
         "verdict": verdict,
     }
+
+
+def _liveness_snapshot(orch: Any, session: AgentSession, now: float) -> dict[str, Any]:
+    """Record the liveness signal state at the moment a deferred death judgment
+    is made, so a later tick can tell whether the agent actually kept working.
+
+    Persisted (keyed by task) in ``orch._pending_liveness_judgments`` by the
+    caller, since the session itself is transitioned to "dead" and dropped
+    from the main ``refresh_agent_states`` loop in this same tick -- nothing
+    else keeps this state alive for the next reap cycle to consult.
+    """
+    heartbeat_path = orch._workdir / ".sdd" / "runtime" / "heartbeats" / f"{session.id}.json"
+    log_path = _resolve_agent_log_path(orch._workdir, session)
+    _wt_dir = _resolve_agent_worktree_dir(orch._workdir, session)
+    git_path = (_wt_dir / ".git") if _wt_dir is not None else None
+
+    heartbeat_mtime, _hb_size = _mtime_and_size(heartbeat_path)
+    log_mtime, log_size = _mtime_and_size(log_path)
+    git_mtime, _git_size = _mtime_and_size(git_path)
+
+    return {
+        "session_id": session.id,
+        "pid": session.pid,
+        "recorded_at": now,
+        "heartbeat_path": heartbeat_path,
+        "log_path": log_path,
+        "git_path": git_path,
+        "heartbeat_mtime": heartbeat_mtime,
+        "log_mtime": log_mtime,
+        "log_size": log_size,
+        "git_mtime": git_mtime,
+    }
+
+
+def _reevaluate_pending_death_judgments(orch: Any, tasks_snapshot: dict[str, list[Task]]) -> None:
+    """Re-judge every task whose death was deferred by ``_probe_liveness_signals``.
+
+    A deferral only proves the agent looked alive *at the moment the tracked
+    pid was found dead* -- the fresh signal that triggered it (e.g. a crash
+    traceback flushed to the log on the process's way down) is frequently a
+    one-time write, not evidence of ongoing work, and the old code never
+    re-checked: the session that owned the deferred task is transitioned to
+    "dead" in this same tick, so it is filtered out of every later
+    ``refresh_agent_states`` pass and the promised "next reap cycle"
+    re-evaluation never actually ran, leaving the task claimed indefinitely
+    (issue #4222).
+
+    Runs every tick, independent of ``orch._agents`` state, and fails the
+    task unless a signal has advanced *past* the snapshot recorded at defer
+    time. A double-forked/re-exec'd runner whose log keeps growing after the
+    tracked launcher pid exits keeps advancing its own snapshot on each
+    check and stays correctly deferred, same as before this fix.
+    """
+    pending: dict[str, dict[str, Any]] | None = getattr(orch, "_pending_liveness_judgments", None)
+    if not pending:
+        return
+
+    base = orch._config.server_url
+    all_cached: list[Task] = []
+    for bucket in tasks_snapshot.values():
+        all_cached.extend(bucket)
+    task_by_id = {t.id: t for t in all_cached}
+
+    for task_id in list(pending.keys()):
+        snapshot = pending[task_id]
+
+        task = task_by_id.get(task_id)
+        if task is None:
+            try:
+                resp = orch._client.get(f"{base}/tasks/{task_id}")
+                resp.raise_for_status()
+                task = Task.from_dict(resp.json())
+            except httpx.HTTPError:
+                # Task no longer resolvable (deleted, or stale prior session) --
+                # nothing left to re-judge.
+                del pending[task_id]
+                continue
+        if task.status not in (TaskStatus.OPEN, TaskStatus.CLAIMED, TaskStatus.IN_PROGRESS):
+            # Resolved through some other path (completed/failed/blocked) since
+            # the deferral -- stop tracking it.
+            del pending[task_id]
+            continue
+
+        heartbeat_mtime, _hb_size = _mtime_and_size(snapshot["heartbeat_path"])
+        log_mtime, log_size = _mtime_and_size(snapshot["log_path"])
+        git_mtime, _git_size = _mtime_and_size(snapshot["git_path"])
+
+        advanced = (
+            (heartbeat_mtime is not None and heartbeat_mtime > (snapshot["heartbeat_mtime"] or 0))
+            or (log_mtime is not None and log_mtime > (snapshot["log_mtime"] or 0))
+            or (log_size is not None and log_size > (snapshot["log_size"] or 0))
+            or (git_mtime is not None and git_mtime > (snapshot["git_mtime"] or 0))
+        )
+
+        if advanced:
+            logger.info(
+                "liveness_reeval: task=%s agent=%s still deferred -- a signal advanced past "
+                "the pid-exit snapshot (heartbeat_mtime=%s log_mtime=%s log_size=%s "
+                "git_mtime=%s), so the agent is still doing observable work",
+                task_id,
+                snapshot["session_id"],
+                heartbeat_mtime,
+                log_mtime,
+                log_size,
+                git_mtime,
+            )
+            pending[task_id] = {
+                **snapshot,
+                "heartbeat_mtime": heartbeat_mtime,
+                "log_mtime": log_mtime,
+                "log_size": log_size,
+                "git_mtime": git_mtime,
+            }
+            continue
+
+        logger.warning(
+            "liveness_reeval: task=%s agent=%s pid=%s judged dead on re-evaluation -- no "
+            "signal advanced past the snapshot taken when the tracked pid exited; the earlier "
+            "fresh signal that deferred this judgment was a one-time write (e.g. a crash "
+            "traceback), not ongoing liveness. Failing/retrying the task now instead of "
+            "leaving it claimed indefinitely.",
+            task_id,
+            snapshot["session_id"],
+            snapshot["pid"] or "unknown",
+        )
+        try:
+            retry_or_fail_task(
+                task_id,
+                f"Agent {snapshot['session_id']} died; deferred death judgment re-evaluated "
+                f"and no liveness signal advanced past the pid-exit snapshot",
+                client=orch._client,
+                server_url=base,
+                max_task_retries=orch._config.max_task_retries,
+                retried_task_ids=orch._retried_task_ids,
+                workdir=getattr(orch, "_workdir", None),
+                **_retry_escalation_context(orch),
+            )
+            del pending[task_id]
+        except httpx.HTTPError as exc:
+            logger.error("Failed to retry/fail task %s on liveness re-evaluation: %s", task_id, exc)
+            # Leave it pending -- retried again next tick rather than lost.
 
 
 def _handle_orphan_no_signals(
@@ -1810,8 +1975,9 @@ def _handle_orphan_no_signals(
         logger.warning(
             "Deferring death judgment for task %s: agent %s tracked pid=%s looks dead but "
             "liveness signals are fresh (heartbeat_age_s=%s log_age_s=%s git_age_s=%s, "
-            "grace_s=%.0f) -- NOT failing the task this tick; will re-evaluate on the next "
-            "reap cycle once signals actually go stale.",
+            "grace_s=%.0f) -- NOT failing the task this tick; recording the current signal "
+            "state and re-evaluating on every subsequent tick until a signal actually "
+            "advances past it or the task is resolved another way.",
             task_id,
             session.id,
             _liveness["pid"] or "unknown",
@@ -1820,6 +1986,17 @@ def _handle_orphan_no_signals(
             _liveness["git_age_s"],
             _ORPHAN_LIVENESS_GRACE_S,
         )
+        # The session backing this deferral is transitioned to "dead" and its
+        # worktree cleaned up in this same tick (_handle_dead_agent), so it
+        # won't be around for a later tick to re-check. Persist the pending
+        # judgment on the orchestrator itself, keyed by task, so
+        # _reevaluate_pending_death_judgments can keep re-checking it
+        # independent of the session's lifetime.
+        _pending = getattr(orch, "_pending_liveness_judgments", None)
+        if _pending is None:
+            _pending = {}
+            orch._pending_liveness_judgments = _pending
+        _pending[task_id] = _liveness_snapshot(orch, session, time.time())
         return False, "deferred_liveness_signal_fresh"
 
     # Agent died without output

--- a/tests/unit/test_agent_lifecycle.py
+++ b/tests/unit/test_agent_lifecycle.py
@@ -883,3 +883,124 @@ def test_handle_orphaned_task_provider_fatal_types_fast_fail_and_throttle(tmp_pa
         assert failure_type in retry_or_fail_task.call_args.args[1]
         orch._rate_limit_tracker.throttle_provider.assert_called_once()
         orch._record_provider_health.assert_called_once_with(session, success=False)
+
+
+# ---------------------------------------------------------------------------
+# Issue #4222: deferred death judgment must be re-evaluable after the
+# session that deferred it is reaped, and must not defer forever on a
+# liveness signal that never advances past its pid-exit snapshot.
+# ---------------------------------------------------------------------------
+
+
+def test_deferred_death_judgment_reevaluated_and_failed_when_signal_never_advances(tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    """An instantly-crashed agent's only "fresh" signal is the traceback it
+    wrote on its way down. That write never repeats, so a later
+    re-evaluation must see no advancement past the pid-exit snapshot and
+    fail the task -- instead of deferring forever because the session that
+    made the deferral is already gone by the next tick (ground truth: 12
+    identical runs where the claim was never recovered)."""
+    from bernstein.core.agents.agent_lifecycle import _reevaluate_pending_death_judgments
+
+    task = _make_task()
+    task.status = TaskStatus.CLAIMED
+    session = AgentSession(
+        id="sess-instant-crash",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=[task.id],
+        pid=4242,
+        exit_code=1,  # crashed, not a clean exit
+        spawn_ts=1000.0,
+    )
+    orch = _make_orch_no_ratelimit(tmp_path)
+
+    log_path = tmp_path / ".sdd" / "runtime" / f"{session.id}.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("Traceback (most recent call last):\n  ...\nRuntimeError: boom\n")
+
+    snapshot = {"claimed": [task], "open": [], "in_progress": [], "done": []}
+
+    with (
+        patch("bernstein.core.agents.agent_lifecycle.collect_completion_data", return_value={"files_modified": []}),
+        patch("bernstein.core.agents.agent_lifecycle._has_git_commits_on_branch", return_value=False),
+        patch("bernstein.core.agents.agent_lifecycle._is_process_alive", return_value=False),
+        patch("bernstein.core.agents.agent_lifecycle.complete_task") as mock_complete,
+        patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as mock_retry,
+    ):
+        # Tick 1: the crash traceback is a fresh log write, so the death
+        # judgment defers rather than failing the task outright.
+        handle_orphaned_task(orch, task.id, session, snapshot)
+        mock_retry.assert_not_called()
+        mock_complete.assert_not_called()
+        assert task.id in orch._pending_liveness_judgments
+
+        # The session that made the deferral is gone by the next tick (its
+        # worktree was cleaned up and it was transitioned to "dead"), so
+        # nothing else touches the log. Re-evaluate without any new write.
+        _reevaluate_pending_death_judgments(orch, snapshot)
+
+    # No signal advanced past the pid-exit snapshot -- the task must be
+    # failed/retried now, and the pending judgment must be cleared so it
+    # isn't checked forever.
+    mock_retry.assert_called_once()
+    assert task.id not in orch._pending_liveness_judgments
+
+
+def test_deferred_death_judgment_stays_deferred_while_log_keeps_growing(tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    """Regression guard for the double-fork/re-exec case (defect 8): a dead
+    tracked pid whose log keeps growing after the tracked pid exited is a
+    real live agent (untracked worker still running) and must stay
+    deferred on re-evaluation, not get failed just because a judgment was
+    made once before."""
+    from bernstein.core.agents.agent_lifecycle import _reevaluate_pending_death_judgments
+
+    task = _make_task()
+    task.status = TaskStatus.CLAIMED
+    session = AgentSession(
+        id="sess-doublefork-reeval",
+        role="manager",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=[task.id],
+        pid=77,
+        exit_code=1,
+        spawn_ts=1000.0,
+    )
+    orch = _make_orch_no_ratelimit(tmp_path)
+
+    log_path = tmp_path / ".sdd" / "runtime" / f"{session.id}.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("starting up\n")
+
+    snapshot = {"claimed": [task], "open": [], "in_progress": [], "done": []}
+
+    with (
+        patch("bernstein.core.agents.agent_lifecycle.collect_completion_data", return_value={"files_modified": []}),
+        patch("bernstein.core.agents.agent_lifecycle._has_git_commits_on_branch", return_value=False),
+        patch("bernstein.core.agents.agent_lifecycle._is_process_alive", return_value=False),
+        patch("bernstein.core.agents.agent_lifecycle.complete_task") as mock_complete,
+        patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as mock_retry,
+    ):
+        handle_orphaned_task(orch, task.id, session, snapshot)
+        mock_retry.assert_not_called()
+        mock_complete.assert_not_called()
+        assert task.id in orch._pending_liveness_judgments
+
+        # The untracked worker (still running past the double-fork) writes
+        # more output -- the log grows past the pid-exit snapshot.
+        with log_path.open("a") as fh:
+            fh.write("still working: step 2 of 5 complete\n" * 10)
+
+        _reevaluate_pending_death_judgments(orch, snapshot)
+
+        # Still growing -- must stay deferred, not get failed.
+        mock_retry.assert_not_called()
+        assert task.id in orch._pending_liveness_judgments
+
+        # And once it genuinely stops advancing, the next re-evaluation
+        # still catches it (the mechanism isn't a one-shot check).
+        _reevaluate_pending_death_judgments(orch, snapshot)
+
+    mock_retry.assert_called_once()
+    assert task.id not in orch._pending_liveness_judgments


### PR DESCRIPTION
## Symptom

When an agent process dies within seconds of spawn, its task stays claimed indefinitely. In the observed runs (identical across 12 runs, single cell) nothing recovered the claim; with `--cells 1` the stuck claim occupies the only slot and the run sits at quiescence with zero terminal tasks.

## Root cause

Two defects combine:

1. `_probe_liveness_signals` treats the agent's log as a fresh signal even when that "signal" is only the crash traceback the process wrote on its way down. It compares signal *ages* at judgment time, so an instant crash always defers its own death judgment.
2. The deferral log line promised re-evaluation "on the next reap cycle", but the session is transitioned to `dead` and its worktree is cleaned up in the same tick (`_handle_dead_agent`). `refresh_agent_states` skips sessions with `status == "dead"` on every later tick, so no re-evaluation ever actually runs for that task. The 90s grace window becomes unbounded.

## Fix

- At deferral time, record a liveness snapshot (log mtime/size, heartbeat mtime, git-worktree mtime) keyed by task on the orchestrator (`_pending_liveness_judgments`), not on the session, since the session is gone by the next tick.
- Every tick, `_reevaluate_pending_death_judgments` re-checks each pending entry against the current file state, independent of whether the originating session still exists:
  - If any signal has advanced past its pid-exit snapshot value, the task stays deferred and the snapshot is updated (covers the legitimate double-forked/re-exec'd runner case, whose untracked worker keeps writing after the tracked launcher pid exits).
  - If no signal has advanced, the task is failed/retried now instead of being left claimed.

## Test

`tests/unit/test_agent_lifecycle.py`:
- `test_deferred_death_judgment_reevaluated_and_failed_when_signal_never_advances` — an agent that exits nonzero having written only a traceback to its log is judged dead and its task retried within the grace window, not deferred indefinitely.
- `test_deferred_death_judgment_stays_deferred_while_log_keeps_growing` — the double-fork/re-exec deferral still holds: a dead tracked pid whose log keeps growing after exit is still deferred across repeated re-evaluations.

Closes #4222
