### PR TITLE
fix(orchestration): regenerate summary.json at shutdown

### DIFF
--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -2658,7 +2658,7 @@ class Orchestrator:
         self._running = False
 
     def _regenerate_final_retrospective(self, trigger_path: str) -> None:
-        """Regenerate the FINAL retrospective by re-reading final event state.
+        """Regenerate the FINAL retrospective and summary.json from final event state.
 
         Idempotent and safe to call from more than one terminal path
         (tick-loop drain, tick-level quiescence self-stop, future
@@ -2667,6 +2667,11 @@ class Orchestrator:
         single source of truth for "what triggered shutdown-final
         regeneration" so a `grep` of the logs always finds an explicit
         answer (logging-is-the-debugging-interface rule).
+
+        Also regenerates ``summary.json`` (issue #4223) alongside the
+        retrospective: both are written mid-run by the 8b quiescence path
+        under the same ``_summary_written`` one-shot latch, so both need
+        the same final-state overwrite at true shutdown.
 
         Args:
             trigger_path: Human-readable name of the terminal path that
@@ -2705,14 +2710,39 @@ class Orchestrator:
             status_histogram = {status: len(tasks) for status, tasks in final_tasks.items()}
             runtime_dir = self._workdir / ".sdd" / "runtime"
             runtime_dir.mkdir(parents=True, exist_ok=True)
+            final_done = final_tasks.get("done", [])
+            final_failed = final_tasks.get("failed", [])
+            collector = get_collector(self._workdir / ".sdd" / "metrics")
             generate_retrospective(
-                done_tasks=final_tasks.get("done", []),
-                failed_tasks=final_tasks.get("failed", []),
-                collector=get_collector(self._workdir / ".sdd" / "metrics"),
+                done_tasks=final_done,
+                failed_tasks=final_failed,
+                collector=collector,
                 runtime_dir=runtime_dir,
                 run_start_ts=self._run_start_ts,
                 trigger_reason="shutdown-final",
                 full_status_counts=status_histogram,
+            )
+            # Issue #4223: summary.json has the same "written once at
+            # interim quiescence, never again" problem the retrospective
+            # above was already fixed for (A5). ``_generate_run_summary``'s
+            # 8b tick-level call into ``_emit_summary_card`` is the only
+            # writer, and it's gated by the ``_summary_written`` one-shot
+            # latch - so a run whose first quiescence fire caught a task
+            # mid-flight (e.g. one still in a deferred death judgment, per
+            # #4222) ships that stale done/failed/wall-clock snapshot
+            # forever, even though the journal keeps recording events for
+            # minutes afterward. Re-run the same summary_data assembly here,
+            # against the ``final_tasks`` this shutdown path just fetched,
+            # so the last write reflects the run's actual terminal state.
+            # The interim fire from 8b is left on disk until this point -
+            # this call is what supersedes it, exactly like the
+            # retrospective regeneration above.
+            self._emit_summary_card(
+                done_tasks=final_done,
+                failed_tasks=final_failed,
+                collector=collector,
+                wall_clock_s=time.time() - self._run_start_ts,
+                total_cost=collector.get_total_cost(),
             )
             self._final_retrospective_regenerated = True
         except Exception:

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -4458,6 +4458,98 @@ class TestShutdownFinalOnQuiescenceSelfStop:
         assert final_content != interim_content, "final retrospective must overwrite the interim snapshot"
         assert "INTERIM" not in final_content, "the FINAL retrospective must not be labeled interim"
 
+    def test_summary_json_reflects_final_state_not_stale_interim_quiescence(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Issue #4223: ``summary.json`` has the same stale-interim problem the
+        retrospective test above already covers, but for the machine-readable
+        report instead of the human-readable one.
+
+        Same two-tick shape as
+        ``test_regeneration_fires_on_later_quiescence_after_unconfirmed_first``:
+        tick 1 quiesces on a single done task and writes summary.json via the
+        8b interim path, then the settle window finds a retry task so the run
+        continues; tick 2 quiesces for real once the retry has permanently
+        failed. Before the fix, tick 2 skipped ``_generate_run_summary``
+        entirely (gated on ``_summary_written``) and nothing else ever
+        rewrote summary.json, so the file shipped with the run's true
+        terminal state was the tick-1 snapshot: 1 task, no failure recorded,
+        even though the run went on to fail a task afterward.
+        """
+        monkeypatch.setenv("BERNSTEIN_QUIESCENCE_SETTLE_S", "0")
+
+        def _mk(task_id: str, title: str, status: str) -> dict[str, Any]:
+            return {
+                "id": task_id,
+                "title": title,
+                "description": title,
+                "role": "qa",
+                "priority": 1,
+                "scope": "small",
+                "complexity": "low",
+                "estimated_minutes": 5,
+                "status": status,
+                "depends_on": [],
+                "owned_files": [],
+                "assigned_agent": None,
+                "result_summary": "done" if status == "done" else None,
+                "task_type": "standard",
+                "retry_count": 0,
+                "max_retries": 3,
+            }
+
+        done_task = _mk("aaaa11112222", "Implement hello subcommand", "done")
+        retry_task_open = _mk("bbbb33334444", "Add test for hello subcommand (retry)", "open")
+        retry_task_failed = dict(retry_task_open, status="failed")
+
+        phase = {"n": 1, "tasks_calls": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET" and request.url.path == "/tasks":
+                phase["tasks_calls"] += 1
+                if phase["n"] == 1:
+                    if phase["tasks_calls"] >= 3:
+                        return _tasks_response(request.url, [done_task, retry_task_open])
+                    return _tasks_response(request.url, [done_task])
+                return _tasks_response(request.url, [done_task, retry_task_failed])
+            return httpx.Response(200, json={})
+
+        cfg = OrchestratorConfig(
+            server_url="http://testserver",
+            evolve_mode=False,
+            evolution_enabled=False,
+        )
+        orch = _build_orchestrator(tmp_path, httpx.MockTransport(handler), config=cfg)
+        orch._running = True  # as run() sets before its tick loop
+
+        # Tick 1: quiescence detected -> summary.json written with the
+        # interim (1-task, 0-failed) snapshot; settle window finds the
+        # retry task -> run continues.
+        orch.tick()
+
+        summary_path = tmp_path / ".sdd" / "runs" / orch._run_id / "summary.json"
+        interim_summary = json.loads(summary_path.read_text())
+        assert interim_summary["tasks_total"] == 1, "tick 1 sees only the already-done task"
+        assert interim_summary["tasks_failed"] == 0
+        assert orch._summary_written is True
+
+        # Tick 2: truly quiescent - the retry task has permanently failed.
+        phase["n"] = 2
+        orch.tick()
+
+        assert orch._running is False, "tick 2 must self-stop on confirmed quiescence"
+        assert orch._final_retrospective_regenerated is True
+
+        final_summary = json.loads(summary_path.read_text())
+        assert final_summary["tasks_total"] == 2, (
+            "summary.json must be regenerated at shutdown to include the retry task "
+            "that appeared after the interim fire"
+        )
+        assert final_summary["tasks_completed"] == 1
+        assert final_summary["tasks_failed"] == 1, (
+            "the retry task's eventual failure must reach summary.json, not just the retrospective"
+        )
+
 
 # --- DryRun ---
 


### PR DESCRIPTION
## Symptom

`.sdd/runs/<run_id>/summary.json` for a run that fires an interim
quiescence summary early and then keeps going for minutes afterward
still holds that first snapshot: stale task counts, stale
`wall_clock_seconds`, no record of anything that happened later
(including a task that eventually failed).

## Root cause

`_generate_run_summary`'s tick-level "queue looks empty" (8b) call is
the only writer of `summary.json`, and it's gated behind the
`_summary_written` one-shot latch. Once that latch is set, no later
tick rewrites the file - not further ticks, not `stop()`'s drain, not
the tick-loop's own shutdown path.

`_regenerate_final_retrospective` already solves the equivalent problem
for `retrospective.md`: it re-fetches the run's final task state at
true shutdown (stop/drain, quiescence self-stop, stall self-stop) and
overwrites the interim report. It never touched `summary.json`.

## Fix

`_regenerate_final_retrospective` now also rebuilds `summary.json` from
the same final task snapshot it already fetches for the retrospective,
reusing the existing `summary_data` assembly (`RunSummaryData` +
`write_summary_json`, via `_emit_summary_card`) instead of duplicating
the formulas. The interim quiescence write stays on disk until this
point; this is what supersedes it once the run actually ends.

## Test

`test_summary_json_reflects_final_state_not_stale_interim_quiescence`
reproduces the two-tick shape from the bug report: tick 1 quiesces on a
single done task and writes the interim `summary.json`
(`tasks_total=1`), the settle window finds a retry task so the run
continues, and tick 2 quiesces for real once the retry has permanently
failed. Asserts the final `summary.json` reflects both tasks and the
failure, not the tick-1 snapshot. Fails against the pre-fix code
(`1 == 2`), passes after.

Closes #4223
