### PR TITLE
fix(adapters): gate PYTHONPATH injection behind opt-in flag

### DIFF
--- a/src/bernstein/adapters/clm.py
+++ b/src/bernstein/adapters/clm.py
@@ -427,7 +427,14 @@ class ClmAdapter(CLIAdapter):
         extra_keys = [CLM_ENDPOINT_ENV, CLM_TOKEN_ENV, CLM_MODEL_ENV]
         if tls is not None:
             extra_keys.extend([CLM_CERT_FILE_ENV, CLM_KEY_FILE_ENV, CLM_CA_FILE_ENV, CLM_VERIFY_MODE_ENV])
-        env = build_filtered_env(extra_keys)
+        env = build_filtered_env(
+            extra_keys,
+            # Only the mTLS launcher path runs bernstein's own code via
+            # sys.executable; the plain path execs straight into aider,
+            # an external CLI that must not see the orchestrator's
+            # sys.path (issue #4221).
+            inherit_orchestrator_pythonpath=tls is not None,
+        )
         # Aider speaks the OpenAI wire format; rewire it onto the CLM
         # gateway via the standard OpenAI env vars. The scoped CLM_TOKEN
         # rides as the Bearer credential - never the operator's master.

--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -288,6 +288,7 @@ def build_filtered_env(
     agent_id: str | None = None,
     role: str | None = None,
     credential_policy: AgentCredentialPolicy | None = None,
+    inherit_orchestrator_pythonpath: bool = False,
 ) -> dict[str, str]:
     """Build a filtered copy of the environment safe for agent subprocesses.
 
@@ -320,6 +321,16 @@ def build_filtered_env(
         credential_policy: Explicit policy override.  Primarily used in
             tests; production code should rely on the module-level
             default installed at orchestrator startup.
+        inherit_orchestrator_pythonpath: When ``True`` and the caller's
+            environment carries no ``PYTHONPATH`` of its own, inject the
+            orchestrator's ``sys.path`` as ``PYTHONPATH`` so the spawned
+            process can import ``bernstein`` under ``sys.executable``.
+            Only pass ``True`` from spawn paths that run bernstein's own
+            code via ``sys.executable`` (the worker's Python entrypoints,
+            e.g. ``bernstein.core.orchestration.manager``). External CLI
+            agents (aider, codex, gemini, ...) must never receive this -
+            it shadows their own dependencies with the orchestrator's
+            site-packages (issue #4221). Defaults to ``False``.
 
     Returns:
         A fresh dict containing only the allowed variables that are currently
@@ -372,11 +383,17 @@ def build_filtered_env(
     if not _embedded_teams_opt_in():
         env = {k: v for k, v in env.items() if not _is_embedded_teams_gate(k)}
 
-    # Ensure PYTHONPATH includes directories needed by bernstein-worker.
+    # Ensure PYTHONPATH includes directories needed by bernstein's own
+    # Python entrypoints (the worker's manager/runner/launcher modules).
     # When the orchestrator runs via ``uv run``, sys.executable may point
     # to the framework Python rather than the venv Python.  Without an
-    # explicit PYTHONPATH the worker subprocess cannot import bernstein.
-    if "PYTHONPATH" not in env:
+    # explicit PYTHONPATH such a spawn cannot import bernstein.
+    #
+    # Opt-in only (issue #4221): external CLI agents (aider, codex,
+    # gemini, ...) run under their own interpreter and must never see
+    # the orchestrator's sys.path - it shadows their own dependencies
+    # with bernstein's site-packages instead.
+    if inherit_orchestrator_pythonpath and "PYTHONPATH" not in env:
         import sys
 
         src_dirs = [p for p in sys.path if p and Path(p).is_dir()]

--- a/src/bernstein/adapters/manager.py
+++ b/src/bernstein/adapters/manager.py
@@ -37,7 +37,12 @@ class ManagerAdapter(CLIAdapter):
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
-        env = build_filtered_env(["ANTHROPIC_API_KEY"])
+        env = build_filtered_env(
+            ["ANTHROPIC_API_KEY"],
+            # ManagerAgent is bernstein's own code, run via sys.executable;
+            # it needs bernstein importable (issue #4221).
+            inherit_orchestrator_pythonpath=True,
+        )
 
         # Extract the task ID. The ManagerAgent __main__ expects --task-id
         # We know tasks are passed in the prompt, let's grab the first task id.

--- a/src/bernstein/adapters/openai_agents.py
+++ b/src/bernstein/adapters/openai_agents.py
@@ -566,7 +566,12 @@ class OpenAIAgentsAdapter(PluginAdapter):
             # Pass the override key through the filtered env so the runner
             # can resolve it by name.
             env_keys.append(key_env_name)
-        env = build_filtered_env(env_keys)
+        env = build_filtered_env(
+            env_keys,
+            # openai_agents_runner.py is bernstein's own code, run via
+            # sys.executable; it needs bernstein importable (issue #4221).
+            inherit_orchestrator_pythonpath=True,
+        )
         preexec_fn = self._get_preexec_fn()
         with log_path.open("w") as log_file:
             try:

--- a/src/bernstein/adapters/python_runtime.py
+++ b/src/bernstein/adapters/python_runtime.py
@@ -196,7 +196,12 @@ class PythonRuntimeAdapter(PluginAdapter):
             model=model_config.model,
         )
 
-        env = build_filtered_env(["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY"])
+        env = build_filtered_env(
+            ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY"],
+            # python_runtime_runner.py is bernstein's own code, run via
+            # sys.executable; it needs bernstein importable (issue #4221).
+            inherit_orchestrator_pythonpath=True,
+        )
 
         with log_path.open("w") as log_file:
             try:

--- a/tests/unit/test_env_isolation.py
+++ b/tests/unit/test_env_isolation.py
@@ -135,6 +135,47 @@ class TestBuildFilteredEnv:
             result = build_filtered_env(["ANTHROPIC_API_KEY"])
         assert result == {}
 
+    def test_pythonpath_not_injected_by_default(self, tmp_path: Path) -> None:
+        """Without the opt-in flag, no PYTHONPATH is injected even when the
+        orchestrator's sys.path is non-empty (issue #4221).
+
+        This is the default every external CLI adapter (aider, codex,
+        gemini, ...) gets: their own dependencies must not be shadowed by
+        the orchestrator's site-packages.
+        """
+        fake_env = {"PATH": "/usr/bin"}
+        with (
+            patch("bernstein.adapters.env_isolation.os.environ", fake_env),
+            patch("sys.path", [str(tmp_path)]),
+        ):
+            result = build_filtered_env()
+        assert "PYTHONPATH" not in result
+
+    def test_pythonpath_injected_when_opted_in(self, tmp_path: Path) -> None:
+        """The opt-in flag injects the orchestrator's sys.path entries as
+        PYTHONPATH, for spawn paths that run bernstein's own code via
+        ``sys.executable`` (issue #4221)."""
+        fake_env = {"PATH": "/usr/bin"}
+        with (
+            patch("bernstein.adapters.env_isolation.os.environ", fake_env),
+            patch("sys.path", [str(tmp_path), ""]),
+        ):
+            result = build_filtered_env(inherit_orchestrator_pythonpath=True)
+        assert result["PYTHONPATH"] == str(tmp_path)
+
+    def test_operator_pythonpath_passes_through_unmodified(self, tmp_path: Path) -> None:
+        """An operator-set PYTHONPATH passes through the allowlist unchanged,
+        regardless of the opt-in flag - the injection only fires when the
+        caller's environment carries no PYTHONPATH of its own."""
+        fake_env = {"PATH": "/usr/bin", "PYTHONPATH": "/operator/custom/path"}
+        for flag in (False, True):
+            with (
+                patch("bernstein.adapters.env_isolation.os.environ", fake_env),
+                patch("sys.path", [str(tmp_path)]),
+            ):
+                result = build_filtered_env(inherit_orchestrator_pythonpath=flag)
+            assert result["PYTHONPATH"] == "/operator/custom/path"
+
     def test_result_is_independent_copy(self) -> None:
         """Mutating the result does not affect os.environ or a subsequent call."""
         env = {"PATH": "/bin", "HOME": "/home/user"}
@@ -353,6 +394,185 @@ class TestAdaptersUseFilteredEnv:
         kwargs = popen_spy.call_args.kwargs
         assert "env" in kwargs
         assert kwargs["env"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Call-site gating: only bernstein's own sys.executable spawns opt in
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorPythonPathCallSiteGating:
+    """Regression coverage for issue #4221.
+
+    External CLI adapters must never receive the orchestrator's sys.path
+    as PYTHONPATH - it shadows their own dependencies. Only spawn paths
+    that run bernstein's own code via ``sys.executable`` opt in.
+    """
+
+    def test_aider_does_not_receive_orchestrator_pythonpath(self, tmp_path: Path) -> None:
+        """Aider is an external CLI; it must not see the orchestrator's
+        sys.path even when the caller's environment has no PYTHONPATH of
+        its own (the exact scenario from issue #4221: a 3.12 aider venv
+        poisoned by a 3.14 orchestrator's site-packages)."""
+        from bernstein.core.models import ModelConfig
+
+        from bernstein.adapters.aider import AiderAdapter
+
+        adapter = AiderAdapter()
+        proc_mock = _make_popen_mock()
+        fake_env = {"PATH": "/usr/bin"}
+        with (
+            patch("bernstein.adapters.aider.subprocess.Popen", return_value=proc_mock) as popen_spy,
+            patch("bernstein.adapters.env_isolation.os.environ", fake_env),
+            patch("sys.path", [str(tmp_path)]),
+        ):
+            adapter.spawn(
+                prompt="do work",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="sess-aider-pythonpath",
+            )
+        env = popen_spy.call_args.kwargs["env"]
+        assert "PYTHONPATH" not in env
+
+    def test_manager_adapter_receives_orchestrator_pythonpath(self, tmp_path: Path) -> None:
+        """ManagerAdapter runs ``bernstein.core.orchestration.manager`` via
+        sys.executable - bernstein's own code - so it needs the injection
+        to import bernstein when sys.executable is the uv framework
+        Python."""
+        from bernstein.core.models import ModelConfig
+
+        from bernstein.adapters.manager import ManagerAdapter
+
+        adapter = ManagerAdapter()
+        proc_mock = _make_popen_mock()
+        fake_env = {"PATH": "/usr/bin"}
+        with (
+            patch("bernstein.adapters.manager.subprocess.Popen", return_value=proc_mock) as popen_spy,
+            patch("bernstein.adapters.env_isolation.os.environ", fake_env),
+            patch("sys.path", [str(tmp_path)]),
+        ):
+            adapter.spawn(
+                prompt="do work (id=task-42)",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="sess-manager-pythonpath",
+            )
+        env = popen_spy.call_args.kwargs["env"]
+        assert env["PYTHONPATH"] == str(tmp_path)
+
+    def test_python_runtime_adapter_receives_orchestrator_pythonpath(self, tmp_path: Path) -> None:
+        """PythonRuntimeAdapter runs python_runtime_runner.py - bernstein's
+        own code - via sys.executable, so it needs the injection."""
+        from bernstein.core.models import ModelConfig
+
+        from bernstein.adapters.python_runtime import PythonRuntimeAdapter
+
+        adapter = PythonRuntimeAdapter()
+        proc_mock = _make_popen_mock()
+        fake_env = {"PATH": "/usr/bin"}
+        with (
+            patch("bernstein.adapters.python_runtime.subprocess.Popen", return_value=proc_mock) as popen_spy,
+            patch("bernstein.adapters.env_isolation.os.environ", fake_env),
+            patch("sys.path", [str(tmp_path)]),
+        ):
+            adapter.spawn(
+                prompt="do work",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5.4", effort="high"),
+                session_id="sess-pyruntime-pythonpath",
+                mcp_config={"runtime_module": "custom_agent"},
+                timeout_seconds=0,
+            )
+        env = popen_spy.call_args.kwargs["env"]
+        assert env["PYTHONPATH"] == str(tmp_path)
+
+    def test_openai_agents_adapter_receives_orchestrator_pythonpath(self, tmp_path: Path) -> None:
+        """OpenAIAgentsAdapter always execs
+        ``bernstein.adapters.openai_agents_runner`` - bernstein's own code -
+        via sys.executable, so it needs the injection."""
+        from bernstein.core.models import ModelConfig
+
+        from bernstein.adapters.openai_agents import OpenAIAgentsAdapter
+
+        adapter = OpenAIAgentsAdapter()
+        proc_mock = _make_popen_mock()
+        fake_env = {"PATH": "/usr/bin"}
+        with (
+            patch("bernstein.adapters.openai_agents.subprocess.Popen", return_value=proc_mock) as popen_spy,
+            patch("bernstein.adapters.env_isolation.os.environ", fake_env),
+            patch("sys.path", [str(tmp_path)]),
+        ):
+            adapter.spawn(
+                prompt="do work",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5", effort="high"),
+                session_id="sess-oai-agents-pythonpath",
+            )
+        env = popen_spy.call_args.kwargs["env"]
+        assert env["PYTHONPATH"] == str(tmp_path)
+
+    def test_clm_adapter_pythonpath_only_when_mtls_launcher_used(self, tmp_path: Path) -> None:
+        """ClmAdapter routes through ``clm_tls_launcher`` (bernstein's own
+        code) only when mTLS is configured; the plain path execs straight
+        into aider, an external CLI, and must not get the injection."""
+        from bernstein.core.models import ModelConfig
+
+        from bernstein.adapters.clm import (
+            CLM_CA_FILE_ENV,
+            CLM_CERT_FILE_ENV,
+            CLM_ENDPOINT_ENV,
+            CLM_KEY_FILE_ENV,
+            CLM_MODEL_ENV,
+            CLM_TOKEN_ENV,
+            ClmAdapter,
+        )
+
+        base_env = {
+            "PATH": "/usr/bin",
+            CLM_ENDPOINT_ENV: "https://clm.internal.example/v1/",
+            CLM_TOKEN_ENV: "scoped-jwt-customer-001",
+            CLM_MODEL_ENV: "clm-7b-instruct",
+        }
+
+        # -- no mTLS: plain aider exec, no injection --
+        adapter = ClmAdapter()
+        proc_mock = _make_popen_mock()
+        with (
+            patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen_spy,
+            patch("bernstein.adapters.env_isolation.os.environ", base_env),
+            patch("sys.path", [str(tmp_path)]),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+                session_id="sess-clm-no-mtls",
+            )
+        assert "PYTHONPATH" not in popen_spy.call_args.kwargs["env"]
+
+        # -- mTLS configured: routes through clm_tls_launcher, needs injection --
+        cert, key, ca = tmp_path / "client.crt", tmp_path / "client.key", tmp_path / "ca.crt"
+        for path, label in ((cert, "CERTIFICATE"), (key, "PRIVATE KEY"), (ca, "CERTIFICATE")):
+            path.write_text(f"-----BEGIN {label}-----\nstub\n-----END {label}-----\n", encoding="utf-8")
+        mtls_env = base_env | {
+            CLM_CERT_FILE_ENV: str(cert),
+            CLM_KEY_FILE_ENV: str(key),
+            CLM_CA_FILE_ENV: str(ca),
+        }
+        proc_mock2 = _make_popen_mock()
+        with (
+            patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock2) as popen_spy2,
+            patch("bernstein.adapters.env_isolation.os.environ", mtls_env),
+            patch("sys.path", [str(tmp_path)]),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+                session_id="sess-clm-mtls",
+            )
+        assert popen_spy2.call_args.kwargs["env"]["PYTHONPATH"] == str(tmp_path)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom

`build_filtered_env` exported the orchestrator's entire `sys.path` (including
the interpreter's own stdlib directories) as `PYTHONPATH` for every spawned
agent subprocess whenever the caller's environment carried no `PYTHONPATH` of
its own. When the agent CLI is a Python program running under a different
interpreter than the orchestrator, the injected paths poison its imports.
Observed with the aider adapter: orchestrator under CPython 3.14, aider
installed in a 3.12 venv - every spawned process died at import with an
`SRE module mismatch` assertion, because the 3.12 interpreter resolved
`packaging` from the orchestrator's 3.14 site-packages, which then pulled
`re` from the 3.14 stdlib.

## Root cause

The injection exists for bernstein's own Python entrypoints: they run under
`sys.executable` and must be able to import `bernstein` when the orchestrator
runs via `uv run`, since `sys.executable` may then point to the framework
Python rather than the project venv. Implementing that need inside the
shared env builder applied it to every external CLI adapter (aider, codex,
gemini, ...) and the container/sandbox spawn paths, where it is never needed
and actively harmful - it shadows the CLI's own dependencies with the
orchestrator's site-packages.

## Fix

Added a keyword-only `inherit_orchestrator_pythonpath: bool = False` flag to
`build_filtered_env`. Pass `True` only from spawn paths that execute
bernstein's own code via `sys.executable`:

- `ManagerAdapter` (`bernstein.core.orchestration.manager`)
- `PythonRuntimeAdapter` (`python_runtime_runner.py`)
- `OpenAIAgentsAdapter` (`bernstein.adapters.openai_agents_runner`)
- `ClmAdapter`, only on the mTLS launcher path (`clm_tls_launcher.py`) - the
  plain path execs straight into aider and stays on the default

Every other adapter, and the container/sandbox spawn paths in
`spawner_core.py`, now get no injected `PYTHONPATH` by default. An
operator-set `PYTHONPATH` still passes through the allowlist unchanged in
both modes.

## Test

Extended `tests/unit/test_env_isolation.py`:

- default build injects nothing when `PYTHONPATH` is absent
- opt-in build injects `sys.path` entries
- an operator-set `PYTHONPATH` passes through unmodified in both modes
- per-call-site regression coverage: aider and the mTLS-less CLM path never
  receive the injection (this reproduces the reported bug and fails against
  the pre-fix code); manager, python_runtime, openai_agents, and the CLM
  mTLS-launcher path do receive it

Closes #4221
