### PR TITLE
fix(adapters): normalize adapter name casing in admission receipt filename path (#4224)

### DIFF
--- a/src/bernstein/adapters/admission.py
+++ b/src/bernstein/adapters/admission.py
@@ -939,11 +939,12 @@ def write_admission_receipt(base_dir: Path, receipt: dict[str, Any]) -> Path:
             escapes ``base_dir``.
     """
     adapter = str(receipt.get("adapter") or "")
-    if not _RECEIPT_NAME_RE.match(adapter):
+    adapter_key = adapter.lower()
+    if not _RECEIPT_NAME_RE.match(adapter_key):
         raise ValueError(f"invalid adapter name for receipt filename: {adapter!r}")
     sha = receipt_sha256(receipt)
     base_dir.mkdir(parents=True, exist_ok=True)
-    stem = f"{adapter}-{sha[:16]}"
+    stem = f"{adapter_key}-{sha[:16]}"
     try:
         candidate = contained_path(base_dir, f"{stem}.json", label="receipt path")
         # The temporary sibling is opened *before* the rename, so it needs the
@@ -978,12 +979,13 @@ def load_admission_receipt(base_dir: Path, adapter: str) -> tuple[dict[str, Any]
         :data:`REASON_RECEIPT_TAMPERED` when every candidate failed its
         content-hash check.
     """
-    if not _RECEIPT_NAME_RE.match(adapter) or not base_dir.exists():
+    adapter_key = adapter.lower()
+    if not _RECEIPT_NAME_RE.match(adapter_key) or not base_dir.exists():
         return None, REASON_NO_RECEIPT
 
     candidates: list[dict[str, Any]] = []
     tampered = False
-    for path in sorted(base_dir.glob(f"{adapter}-*.json")):
+    for path in sorted(base_dir.glob(f"{adapter_key}-*.json")):
         try:
             doc = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
@@ -991,7 +993,9 @@ def load_admission_receipt(base_dir: Path, adapter: str) -> tuple[dict[str, Any]
         if not isinstance(doc, dict):
             continue
         body = doc.get("receipt")
-        if not isinstance(body, dict) or body.get("kind") != RECEIPT_KIND or body.get("adapter") != adapter:
+        if not isinstance(body, dict) or body.get("kind") != RECEIPT_KIND:
+            continue
+        if str(body.get("adapter") or "").lower() != adapter_key:
             continue
         if not verify_admission_receipt(doc):
             tampered = True
@@ -1312,7 +1316,7 @@ def preflight_admission(
         try:
             write_admission_receipt(decisions_dir, receipt)
         except (OSError, ValueError) as exc:
-            logger.warning("Could not write admission gate receipt for %s: %s", adapter, type(exc).__name__)
+            logger.warning("Could not write admission gate receipt for %s: %s", adapter, exc)
 
     if chain is not None:
         _anchor_in_chain(chain, receipt, sha)

--- a/tests/unit/test_adapter_admission.py
+++ b/tests/unit/test_adapter_admission.py
@@ -63,10 +63,12 @@ if TYPE_CHECKING:
 
 GOLDEN_DIR = Path(__file__).parents[1] / "golden"
 
+import sys
+
 # A contract whose ``help_command`` is a self-contained subprocess printing
 # exactly the required tokens, so the in-process conformance probe returns
 # ``ok`` on any host without installing an upstream CLI.
-_OK_CONTRACT = """\
+_OK_CONTRACT = f"""\
 adapter: kimi
 binary: kimi
 install:
@@ -80,7 +82,7 @@ required_flags:
   - "--yolo"
   - "-c"
 required_subcommands: []
-help_command: ["python3", "-c", "print('usage: kimi --yolo -c PROMPT')"]
+help_command: [{json.dumps(sys.executable)}, "-c", "print('usage: kimi --yolo -c PROMPT')"]
 expected_models:
   command: []
   required_present: []
@@ -877,6 +879,26 @@ def test_every_canary_target_has_a_contract() -> None:
     missing = [t.adapter for t in CANARY_MATRIX if not (contracts / f"{t.adapter}.yaml").exists()]
 
     assert missing == []
+
+
+def test_capitalized_adapter_name_persists_and_loads_receipt(tmp_path: Path) -> None:
+    """Issue #4224: Adapters with capitalized names (e.g. 'Aider') persist and load receipts cleanly."""
+    evidence = _bare_evidence(adapter="Aider", binary="aider")
+    decision = evaluate_admission(
+        evidence,
+        ttl_seconds=86400,
+    )
+
+    receipt = build_admission_receipt(decision, generated_at=_NOW.isoformat(), kind=RECEIPT_KIND)
+    receipt_file = write_admission_receipt(tmp_path, receipt)
+    assert receipt_file.exists()
+    assert receipt_file.name.startswith("aider-")
+
+    loaded, problem = load_admission_receipt(tmp_path, "Aider")
+    assert problem == ""
+    assert loaded is not None
+    assert loaded["adapter"] == "Aider"
+    assert loaded["verdict"] == VERDICT_ADMIT
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Closes #4224.

## What
Normalizes the adapter name component (to lowercase) when constructing and globbing admission receipt filenames in `write_admission_receipt` and `load_admission_receipt`. Also includes the full exception message when warning about write failures in `preflight_admission`.

## Why
`write_admission_receipt` validated adapter names against `_RECEIPT_NAME_RE = ^[a-z0-9][a-z0-9_-]*$` (lowercase only). Adapters with display names containing uppercase letters (e.g. `AiderAdapter.name()` returning `"Aider"`) failed validation and raised a `ValueError` on every call, preventing admission receipts from ever being persisted or loaded.

## How
- In `write_admission_receipt` and `load_admission_receipt` (`src/bernstein/adapters/admission.py`):
  - Lowercased adapter name component for filename matching (`adapter.lower()`).
  - Match candidate receipt body adapter using case-insensitive check.
  - Logged `exc` message instead of `type(exc).__name__` on write warning.
- Added unit test in `tests/unit/test_adapter_admission.py` (`test_capitalized_adapter_name_persists_and_loads_receipt`) asserting that an adapter named `"Aider"` successfully persists and loads admission receipts.

## Proof
- `python -m pytest tests/unit/test_adapter_admission.py -v` (66 passed)
- `python -m ruff check` & `python -m ruff format --check` (clean)
