### PR TITLE
fix(cli): thread resolved model to plan-approval panel and cost estimation (#4214)

### DIFF
--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -229,27 +229,35 @@ def _load_dry_run_tasks(plan_file: Path | None) -> list[Any]:
     return [Task.from_dict(td) for td in tasks_data]
 
 
-def _confirm_run(*, goal: str | None, seed_file: str | None) -> bool:
+def _confirm_run(
+    *,
+    goal: str | None,
+    seed_file: str | None,
+    model_override: str | None = None,
+    cli_override: str | None = None,
+) -> bool:
     """Show confirmation prompt before execution. Returns True to proceed."""
     effective_goal = goal
     team: list[str] | None = None
 
-    if effective_goal is None:
-        _peek_path: Path | None = Path(seed_file) if seed_file is not None else find_seed_file()
-        if _peek_path is not None:
-            with suppress(Exception):
-                from bernstein.core.seed import parse_seed as _parse_seed
+    _peek_path: Path | None = Path(seed_file) if seed_file is not None else find_seed_file()
+    _seed = None
+    if _peek_path is not None:
+        with suppress(Exception):
+            from bernstein.core.seed import parse_seed as _parse_seed
 
-                _seed = _parse_seed(_peek_path)
+            _seed = _parse_seed(_peek_path)
+            if effective_goal is None:
                 effective_goal = _seed.goal
-                team = list(_seed.team) if _seed.team != "auto" else None
-                from bernstein.core.plan_approval import configure_plan_models
+            team = list(_seed.team) if _seed.team != "auto" else None
 
-                configure_plan_models(
-                    _seed.role_model_policy,
-                    default_model=_seed.model,
-                    default_cli=(_seed.cli if _seed.cli and _seed.cli != "auto" else None),
-                )
+    from bernstein.core.plan_approval import configure_plan_models
+
+    configure_plan_models(
+        _seed.role_model_policy if _seed else None,
+        default_model=model_override or (_seed.model if _seed else None),
+        default_cli=cli_override or (_seed.cli if _seed and _seed.cli != "auto" else None),
+    )
 
     if effective_goal:
         plan_obj, plan_tasks = _build_synthetic_plan(effective_goal, team)
@@ -2505,8 +2513,13 @@ def _run_impl(
     # --plan-only`` started a server, spawned an agent, created a worktree and
     # reached the merge path (gh-3255).
     if plan_only:
-        from bernstein.core.plan_approval import create_plan
+        from bernstein.core.plan_approval import configure_plan_models, create_plan
         from bernstein.core.plan_builder import PlanBuilder
+
+        configure_plan_models(
+            default_model=model,
+            default_cli=cli,
+        )
 
         rerun_hint: str | None = None
 
@@ -2615,7 +2628,7 @@ def _run_impl(
             raise SystemExit(1) from exc
 
     # Confirmation prompt before execution (skip with --auto-approve)
-    if not auto_approve and not _confirm_run(goal=goal, seed_file=seed_file):
+    if not auto_approve and not _confirm_run(goal=goal, seed_file=seed_file, model_override=model, cli_override=cli):
         return
 
     if goal is not None:

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -2516,7 +2516,12 @@ def _run_impl(
         from bernstein.core.plan_approval import configure_plan_models, create_plan
         from bernstein.core.plan_builder import PlanBuilder
 
+        # --plan-only previews the run without reading a seed here, so there
+        # is no role policy to apply; the explicit None keeps the required
+        # positional honest rather than letting the panel fall back to the
+        # complexity default for the model.
         configure_plan_models(
+            None,
             default_model=model,
             default_cli=cli,
         )

--- a/src/bernstein/cli/utils/cost_estimate.py
+++ b/src/bernstein/cli/utils/cost_estimate.py
@@ -54,6 +54,7 @@ class TaskCostEstimate:
         estimated_cost_usd: Point estimate of cost in USD.
         confidence: Confidence in the estimate (0.0 -- 1.0).
         estimated_tokens: Approximate token count backing the cost estimate.
+        model: Estimated model to use.
     """
 
     task_id: str
@@ -64,6 +65,7 @@ class TaskCostEstimate:
     estimated_cost_usd: float
     confidence: float
     estimated_tokens: int
+    model: str = "unresolved"
 
 
 @dataclass(frozen=True)
@@ -99,6 +101,7 @@ def estimate_task_cost(
     complexity: str,
     scope: str,
     historical_avg: float | None = None,
+    model: str | None = None,
 ) -> TaskCostEstimate:
     """Estimate the cost of a single task.
 
@@ -113,6 +116,7 @@ def estimate_task_cost(
         complexity: One of ``"low"``, ``"medium"``, ``"high"``, ``"critical"``.
         scope: One of ``"small"``, ``"medium"``, ``"large"``.
         historical_avg: Optional historical average cost for similar tasks.
+        model: Optional resolved model name.
 
     Returns:
         A frozen :class:`TaskCostEstimate`.
@@ -121,12 +125,20 @@ def estimate_task_cost(
     scope_mult = _SCOPE_MULTIPLIER.get(scope, 1.0)
     heuristic_cost = base * scope_mult
 
-    if historical_avg is not None and historical_avg > 0:
+    resolved_model = model or "unresolved"
+    from bernstein.core.cost.model_prices import is_free_route
+
+    if model and is_free_route(model):
+        blended = 0.0
+    elif historical_avg is not None and historical_avg > 0:
         # Blend: 60 % historical, 40 % heuristic
         blended = 0.6 * historical_avg + 0.4 * heuristic_cost
         confidence = min(_BASE_CONFIDENCE + 0.25, 1.0)
     else:
         blended = heuristic_cost
+        confidence = _BASE_CONFIDENCE
+
+    if not (historical_avg is not None and historical_avg > 0):
         confidence = _BASE_CONFIDENCE
 
     estimated_tokens = max(1, int(blended * _TOKENS_PER_USD))
@@ -140,6 +152,7 @@ def estimate_task_cost(
         estimated_cost_usd=round(blended, 6),
         confidence=round(confidence, 2),
         estimated_tokens=estimated_tokens,
+        model=resolved_model,
     )
 
 

--- a/src/bernstein/core/cost/cost.py
+++ b/src/bernstein/core/cost/cost.py
@@ -207,6 +207,10 @@ def get_all_bandit_arms() -> list[str]:
 
 def _model_cost(model: str) -> float:
     """Rough cost per 1k tokens for a model name."""
+    from bernstein.core.cost.model_prices import is_free_route
+
+    if is_free_route(model):
+        return 0.0
     model_lower = model.lower()
     for key, cost in _MODEL_COST_USD_PER_1K.items():
         if key in model_lower:

--- a/src/bernstein/core/security/plan_approval.py
+++ b/src/bernstein/core/security/plan_approval.py
@@ -179,15 +179,18 @@ def _estimate_task_cost(task: Task) -> TaskCostEstimate:
     # seed's global default model, then the complexity default. The seed
     # default keeps the plan labelled with the resolved model instead of a
     # hardcoded ``sonnet`` when a seed sets only a global model (issue #3013).
-    model = (
+    raw_model = (
         _ROLE_MODEL_OVERRIDES.get(task.role)
         or task.model
         or _DEFAULT_MODEL
-        or _DEFAULT_MODEL_BY_COMPLEXITY.get(task.complexity.value, "sonnet")
+        or _DEFAULT_MODEL_BY_COMPLEXITY.get(task.complexity.value)
     )
+    model = raw_model or "auto"
     cli = _ROLE_CLI_OVERRIDES.get(task.role) or _DEFAULT_CLI
-    if cli:
-        model = f"{cli}/{model}"
+    if cli and raw_model:
+        model = f"{cli}/{raw_model}"
+    elif cli and not raw_model:
+        model = f"{cli}/auto"
 
     # Estimate tokens
     estimated_tokens = _TOKENS_BY_SCOPE.get(task.scope.value, 80_000)

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1711,7 +1711,7 @@ class TaskCostEstimate:
     task_id: str
     title: str
     role: str
-    model: str = "sonnet"
+    model: str = "unresolved"
     estimated_tokens: int = 0
     estimated_cost_usd: float = 0.0
     risk_level: Literal["low", "medium", "high", "critical"] = "low"
@@ -1793,7 +1793,7 @@ class TaskPlan:
                 task_id=e["task_id"],
                 title=e["title"],
                 role=e["role"],
-                model=e.get("model", "sonnet"),
+                model=e.get("model", "unresolved"),
                 estimated_tokens=int(e.get("estimated_tokens", 0)),
                 estimated_cost_usd=float(e.get("estimated_cost_usd", 0.0)),
                 risk_level=e.get("risk_level", "low"),

--- a/tests/unit/test_plan_approval.py
+++ b/tests/unit/test_plan_approval.py
@@ -98,9 +98,74 @@ def test_plan_store_reject_flow_updates_status(tmp_path: Path) -> None:
     store = PlanStore(tmp_path / ".sdd")
     plan = create_plan("Do maintenance", [_task("T-store-2", title="Cleanup imports")])
     store.save_plan(plan)
-
-    rejected = store.reject_plan(plan.id, "unsafe right now")
+    rejected = store.reject_plan(plan.id, "out of scope")
 
     assert rejected is not None
     assert rejected.status == PlanStatus.REJECTED
-    assert rejected.decision_reason == "unsafe right now"
+    assert rejected.decision_reason == "out of scope"
+
+
+def test_plan_approval_panel_shows_configured_model_and_prices_free_route() -> None:
+    """Issue #4214: Plan-approval panel shows configured model and prices free route at $0.00."""
+    import io
+
+    from bernstein.core.plan_approval import configure_plan_models
+    from rich.console import Console
+
+    from bernstein.cli.plan.plan_display import render_plan
+
+    configure_plan_models(None, default_model="openrouter/cohere/north-mini-code:free")
+    task = _task("T-free-1", title="Fix one-liner bug", role="manager")
+    plan = create_plan("Fix bug", [task])
+
+    assert plan.task_estimates[0].model == "openrouter/cohere/north-mini-code:free"
+    assert plan.total_estimated_cost_usd == 0.0
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=100)
+    render_plan(plan, [task], console=console)
+    output = buf.getvalue()
+
+    assert "openrouter/cohere/north-mini-code:free" in output
+    assert "$0.00" in output
+
+
+def test_plan_approval_panel_shows_explicit_model_override() -> None:
+    """Issue #4214: Plan-approval panel renders the specified --model override."""
+    import io
+
+    from bernstein.core.plan_approval import configure_plan_models
+    from rich.console import Console
+
+    from bernstein.cli.plan.plan_display import render_plan
+
+    configure_plan_models(None, default_model="opus")
+    task = _task("T-opus-1", title="Complex refactor", role="manager")
+    plan = create_plan("Refactor", [task])
+
+    assert plan.task_estimates[0].model == "opus"
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=100)
+    render_plan(plan, [task], console=console)
+    output = buf.getvalue()
+
+    assert "opus" in output
+
+
+def test_plan_approval_panel_and_post_approval_line_agree_for_free_route() -> None:
+    """Issue #4214: Panel cost estimate ($0.00) agrees with estimate_run_cost ($0.00-$0.00)."""
+    from bernstein.core.plan_approval import configure_plan_models
+
+    from bernstein.core.cost import estimate_run_cost
+
+    model_name = "openrouter/cohere/north-mini-code:free"
+    configure_plan_models(None, default_model=model_name)
+    task = _task("T-agree-1", title="Quick fix", role="manager")
+    plan = create_plan("Quick fix", [task])
+
+    low_usd, high_usd = estimate_run_cost(1, model_name)
+
+    assert plan.total_estimated_cost_usd == 0.0
+    assert low_usd == 0.0
+    assert high_usd == 0.0


### PR DESCRIPTION
Closes #4214.

## What
Threads the resolved model passed via `--model` / config down to `configure_plan_models()` and `estimate_task_cost()` so the plan-approval panel and Agent Assignments box display the model that will actually be used and price the run accordingly.

## Why
Previously, `TaskCostEstimate` defaulted `model` to `"sonnet"` and `_confirm_run()` did not configure `configure_plan_models()` with the `--model` override. As a result, running `bernstein run --model <M>` (including free-tier routes like `openrouter/cohere/north-mini-code:free`) printed a plan-approval panel that always named `sonnet` and priced the run with `sonnet` pricing ($0.72), which contradicted the post-approval cost estimate line ($0.00).

## How
- In `src/bernstein/cli/run_bootstrap.py`:
  - Threaded `model_override` and `cli_override` into `_confirm_run()` and called `configure_plan_models()` prior to synthetic plan generation and confirmation display.
- In `src/bernstein/cli/utils/cost_estimate.py`:
  - Added `model` parameter to `estimate_task_cost()` and `model` attribute to `TaskCostEstimate`.
  - Zeroed task estimate cost when `is_free_route(model)` is `True`.
- In `src/bernstein/core/cost/cost.py`:
  - Updated `_model_cost()` to check `is_free_route(model)` so free-tier routes price at `$0.00` in `estimate_run_cost()`.
- Added unit tests in `tests/unit/test_plan_approval.py`:
  - `test_plan_approval_panel_shows_configured_model_and_prices_free_route`
  - `test_plan_approval_panel_shows_explicit_model_override`
  - `test_plan_approval_panel_and_post_approval_line_agree_for_free_route`

## Proof
- `python -m pytest tests/unit/test_plan_approval.py` (8 passed)
- `python -m ruff check` & `python -m ruff format --check` (clean)
