### PR TITLE
fix(verify): let automation gate on receipt provenance tier

### DIFF
--- a/docs/operations/deterministic-replay.md
+++ b/docs/operations/deterministic-replay.md
@@ -217,9 +217,14 @@ The build side is strict too: an unparseable journal or spine row refuses the
 whole build with the physical line named - a receipt is never signed over the
 parseable subset of a corrupted store.
 
-Exit codes for `bernstein verify receipt` (mirrors `bernstein lineage
-verify`): `0` OK, `1` empty/malformed input, `2` tamper detected (first
-divergent journal step index named).
+Exit codes for `bernstein verify receipt`:
+
+| Exit code | Tier / condition |
+|---|---|
+| `0` | OK -- either tier (integrity-only or provenance) passed, and `--require-provenance` was not given, or was given and provenance was reached. |
+| `1` | Empty or malformed input (unreadable file, missing ranges/fields). |
+| `2` | Tamper detected (first divergent journal step index named), or a `--public-key` pin that does not match the embedded key. |
+| `3` | `--require-provenance` was given and only the integrity-only tier was reached. |
 
 **Trust model - what a pass proves depends on where the key came from.** By
 default the verifier checks the signature against the Ed25519 key embedded in
@@ -235,6 +240,24 @@ exit `2`. The CLI verdict is labelled accordingly (`OK (integrity-only:
 embedded key)` vs `OK (provenance: pinned key)`), so a trust-on-first-use
 pass cannot be misread as an authenticated one. Provenance-sensitive review
 (incident triage, compliance handover) should always pin.
+
+**Gating automation on the tier alone.** Exit `0` is indistinguishable
+between the two tiers by itself, so a script that must accept only a
+provenance pass should not rely on `0` on its own. Two ways to do that
+without parsing the verdict prose:
+
+- Pass `--require-provenance`: without a pinned, matching key the command
+  exits `3` instead of `0`, naming the tier it actually reached.
+- Pass `--json`: the response carries a `"tier"` field
+  (`"provenance"`, `"integrity-only"`, or `null` when verification did not
+  pass at all) alongside `"ok"`. `--require-provenance` and `--json` compose:
+  the JSON body still reports `"tier": "integrity-only"` on an exit-`3`
+  refusal, so a caller can log which tier was reached even when gating on
+  the exit code.
+
+Both flags default off, so a `verify receipt $f && deploy` script written
+against today's behaviour keeps exiting `0` on either tier unless it opts
+in.
 
 **Automatic receipts at finalization.** When a signing key is configured via
 `BERNSTEIN_RUN_RECEIPT_SIGNING_KEY_PATH` (key file) or

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -483,7 +483,7 @@ Group: verifies integrity and reproducibility artefacts. It does not run lint / 
 | Subcommand | Purpose |
 |---|---|
 | `run RUN_ID` | Build the signed run receipt for a run (`--workdir`, `--output`, signing-key options). |
-| `receipt RECEIPT_PATH` | Verify a run receipt offline (`--public-key`). |
+| `receipt RECEIPT_PATH` | Verify a run receipt offline (`--public-key`, `--require-provenance`, `--json`). |
 | `ladder RECEIPT_HASH` | Re-derive and verify a verifier-ladder receipt (`--workdir`). |
 | `legacy [WHEELHOUSE_PATH]` | The pre-receipt checks: `--wal-integrity RUN_ID`, `--determinism RUN_ID` (gated by `--expect` / `--baseline`), `--memory-audit`, `--formal TASK_ID`, or a positional wheelhouse path for air-gap signature verification. |
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -92,6 +92,17 @@ rather than as its own attribution is exempted by hand there, with the reason.
   containment distinction #4095 recorded for the pid-file sites).
 
 - Health check task count is scoped to the caller's tenant (#4156).
+- `bernstein verify receipt` distinguishes the integrity-only and provenance
+  tiers for automation instead of leaving both to exit `0` (#4208). A CI gate
+  scripted as `verify receipt $f && deploy` with no `--public-key` configured
+  could not tell a provenance pass from an integrity-only pass that
+  authenticates nothing about the signer; `--require-provenance` now turns an
+  integrity-only pass into exit `3`, naming the tier actually reached, and
+  `--json` adds a `tier` field (`"provenance"` / `"integrity-only"` / `null`)
+  so a caller can read the tier without parsing the verdict prose. Both flags
+  default off, so existing scripts keep today's `0`/`1`/`2` behaviour on
+  either tier unless they opt in. Docs:
+  [`docs/operations/deterministic-replay.md`](../operations/deterministic-replay.md#signed-run-receipt-one-file-offline-verification).
 - Stall escalation produces a degraded terminal receipt on a missing or empty
   event journal instead of raising (#3737). The kill already happened in that
   case; refusing to build the receipt left nothing in the chain to tell

--- a/src/bernstein/cli/commands/verify_cmd.py
+++ b/src/bernstein/cli/commands/verify_cmd.py
@@ -7,10 +7,16 @@ ladder-receipt verb (issue #2927):
   binding the run's journal head, lineage-spine head, and (opt-in) an
   audit-chain range under one Ed25519-signed subject with an embedded
   public JWK.
-* ``bernstein verify receipt <path> [--public-key PEM]`` -- verify a
-  receipt **fully offline** from the file alone: no HMAC key, no ``.sdd/``.
-  Exit codes: ``0`` OK, ``1`` empty/malformed input, ``2`` tamper detected
-  (naming the first divergent journal step index).
+* ``bernstein verify receipt <path> [--public-key PEM] [--require-provenance]
+  [--json]`` -- verify a receipt **fully offline** from the file alone: no
+  HMAC key, no ``.sdd/``. A pass is one of two tiers: *integrity-only*
+  (no ``--public-key``) or *provenance* (embedded key pinned and matched).
+  Exit codes: ``0`` OK (either tier, unless ``--require-provenance``),
+  ``1`` empty/malformed input, ``2`` tamper detected (naming the first
+  divergent journal step index) or a ``--public-key`` pin mismatch, ``3``
+  ``--require-provenance`` was passed and only the integrity-only tier was
+  reached. ``--json`` adds a machine-readable ``tier`` field so a caller
+  need not parse the verdict prose.
 * ``bernstein verify ladder <receipt-hash>`` -- re-derive a pre-merge
   verifier-ladder receipt: per-tier ``tier / config_hash / evidence_hash /
   verdict`` plus the composite claim, re-checked against the
@@ -42,6 +48,7 @@ it ``./run`` (or use ``bernstein verify legacy run``) in that case.
 
 from __future__ import annotations
 
+import json as _json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -1253,7 +1260,26 @@ def verify_run_cmd(
         "embedded JWK."
     ),
 )
-def verify_receipt_cmd(receipt_path: Path, public_key_path: Path | None) -> None:
+@click.option(
+    "--require-provenance",
+    "require_provenance",
+    is_flag=True,
+    default=False,
+    help=(
+        "Fail (exit 3) unless the pass reaches the provenance tier -- i.e. "
+        "--public-key was given and the embedded key matched it. Without this "
+        "flag both tiers exit 0, matching today's behaviour."
+    ),
+)
+@click.option(
+    "--json", "as_json", is_flag=True, default=False, help="Emit the verdict as JSON alongside the exit code."
+)
+def verify_receipt_cmd(
+    receipt_path: Path,
+    public_key_path: Path | None,
+    require_provenance: bool,
+    as_json: bool,
+) -> None:
     """Verify a run receipt offline from RECEIPT_PATH.
 
     Recomputes the journal head, the spine head, and (when present) the
@@ -1269,18 +1295,51 @@ def verify_receipt_cmd(receipt_path: Path, public_key_path: Path | None) -> None
     their own key. With ``--public-key`` the embedded key must match the
     pinned out-of-band key, which additionally proves provenance.
 
+    By default both tiers exit 0 -- a caller gating on provenance alone must
+    pass ``--require-provenance``, which turns an integrity-only pass into a
+    labelled failure instead of an indistinguishable ``0``. ``--json`` adds a
+    ``tier`` field (``"provenance"``, ``"integrity-only"``, or ``null`` when
+    the receipt did not verify at all) so a caller need not parse the verdict
+    prose to tell the tiers apart.
+
     \b
     Exit codes:
-      0  receipt verifies
+      0  receipt verifies (either tier, unless --require-provenance)
       1  empty or malformed input (unreadable file, missing ranges/fields)
-      2  tamper detected (the first divergent journal step index is named)
+      2  tamper detected (the first divergent journal step index is named),
+         or a --public-key pin that does not match the embedded key
+      3  --require-provenance was given and only the integrity-only tier
+         was reached
     """
     from bernstein.core.replay.run_receipt import verify_run_receipt
+
+    def _emit_json(*, tier: str | None, exit_code: int) -> None:
+        console.print(
+            _json.dumps(
+                {
+                    "ok": result.ok,
+                    "status": result.status,
+                    "tier": tier,
+                    "run_id": result.run_id,
+                    "journal_events": result.journal_events,
+                    "spine_entries": result.spine_entries,
+                    "divergent_step": result.divergent_step,
+                    "errors": result.errors,
+                    "pinned_key": public_key_pem is not None,
+                    "require_provenance": require_provenance,
+                    "exit_code": exit_code,
+                },
+                indent=2,
+            )
+        )
 
     try:
         receipt_bytes = receipt_path.read_bytes()
     except OSError as exc:
-        console.print(f"[red]Cannot read receipt:[/red] {exc}")
+        if as_json:
+            console.print(_json.dumps({"ok": False, "status": "malformed", "tier": None, "errors": [str(exc)]}))
+        else:
+            console.print(f"[red]Cannot read receipt:[/red] {exc}")
         raise SystemExit(1) from None
 
     public_key_pem: bytes | None = None
@@ -1288,18 +1347,40 @@ def verify_receipt_cmd(receipt_path: Path, public_key_path: Path | None) -> None
         try:
             public_key_pem = public_key_path.read_bytes()
         except OSError as exc:
-            console.print(f"[red]Cannot read --public-key:[/red] {exc}")
+            if as_json:
+                console.print(_json.dumps({"ok": False, "status": "malformed", "tier": None, "errors": [str(exc)]}))
+            else:
+                console.print(f"[red]Cannot read --public-key:[/red] {exc}")
             raise SystemExit(1) from None
 
     result = verify_run_receipt(receipt_bytes, public_key_pem=public_key_pem)
 
-    console.print()
-    console.print(
-        f"[bold]Run receipt[/bold] run={result.run_id or '(unknown)'} "
-        f"journal_events={result.journal_events} spine_entries={result.spine_entries}"
-    )
+    if not as_json:
+        console.print()
+        console.print(
+            f"[bold]Run receipt[/bold] run={result.run_id or '(unknown)'} "
+            f"journal_events={result.journal_events} spine_entries={result.spine_entries}"
+        )
+
     if result.ok:
-        if public_key_pem is not None:
+        # The tier a pass reached: "provenance" only when a key was pinned
+        # AND matched (a mismatch is caught earlier as status=="tampered",
+        # so reaching here with a pin means it held).
+        tier = "provenance" if public_key_pem is not None else "integrity-only"
+
+        if require_provenance and tier != "provenance":
+            if as_json:
+                _emit_json(tier=tier, exit_code=3)
+            else:
+                console.print(
+                    f"[red]REQUIRE-PROVENANCE NOT MET[/red] -- reached the [yellow]{tier}[/yellow] tier, "
+                    "which --require-provenance does not accept. Pin the worker key with --public-key."
+                )
+            raise SystemExit(3)
+
+        if as_json:
+            _emit_json(tier=tier, exit_code=0)
+        elif tier == "provenance":
             console.print(
                 "[green]OK (provenance: pinned key)[/green] -- every head recomputes from the "
                 "embedded ranges and the signature verifies against the pinned public key."
@@ -1316,16 +1397,24 @@ def verify_receipt_cmd(receipt_path: Path, public_key_path: Path | None) -> None
                 "with the operator's key for provenance.[/dim]"
             )
         raise SystemExit(0)
+
     if result.status == "malformed":
-        console.print("[yellow]MALFORMED[/yellow] -- the receipt cannot be checked:")
+        if as_json:
+            _emit_json(tier=None, exit_code=1)
+        else:
+            console.print("[yellow]MALFORMED[/yellow] -- the receipt cannot be checked:")
+            for err in result.errors:
+                console.print(f"  - {err}")
+        raise SystemExit(1)
+
+    if as_json:
+        _emit_json(tier=None, exit_code=2)
+    else:
+        console.print("[red]TAMPER DETECTED[/red]:")
         for err in result.errors:
             console.print(f"  - {err}")
-        raise SystemExit(1)
-    console.print("[red]TAMPER DETECTED[/red]:")
-    for err in result.errors:
-        console.print(f"  - {err}")
-    if result.divergent_step is not None:
-        console.print(f"  [red]first divergent journal step: {result.divergent_step}[/red]")
+        if result.divergent_step is not None:
+            console.print(f"  [red]first divergent journal step: {result.divergent_step}[/red]")
     raise SystemExit(2)
 
 

--- a/tests/unit/test_verify_run_receipt_cmd.py
+++ b/tests/unit/test_verify_run_receipt_cmd.py
@@ -251,6 +251,118 @@ def test_receipt_verb_wrong_public_key_exits_2(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# --require-provenance / --json (#4208): a script must be able to gate on
+# the provenance tier by exit code, or by the machine-readable tier field,
+# without parsing the human verdict prose.
+# ---------------------------------------------------------------------------
+
+
+def _built_receipt(tmp_path: Path) -> tuple[Path, Path]:
+    """A signed, self-consistent receipt plus the matching pinned pubkey."""
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    _seed_run(workdir)
+    sign_key = tmp_path / "sign.pem"
+    _write_signing_key(sign_key)
+
+    built = CliRunner().invoke(
+        verify_cmd,
+        ["run", _RUN_ID, "-w", str(workdir), "--signing-key-path", str(sign_key)],
+    )
+    assert built.exit_code == 0, built.output
+    receipt_path = workdir / ".sdd" / "runs" / _RUN_ID / "run-receipt.json"
+
+    pub_path = tmp_path / "worker.pub.pem"
+    signing_key = Ed25519PrivateKey.from_private_bytes(b"i" * 32)
+    pub_path.write_bytes(
+        signing_key.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        ),
+    )
+    return receipt_path, pub_path
+
+
+def test_integrity_only_pass_exits_0_without_require_provenance(tmp_path: Path) -> None:
+    """Today's behaviour is preserved by default: no --public-key still exits 0."""
+    receipt_path, _pub_path = _built_receipt(tmp_path)
+
+    result = CliRunner().invoke(verify_cmd, ["receipt", str(receipt_path)])
+
+    assert result.exit_code == 0, result.output
+
+
+def test_integrity_only_pass_under_require_provenance_exits_nonzero(tmp_path: Path) -> None:
+    """The gap #4208 reports: a CI gate must be able to refuse an unpinned pass."""
+    receipt_path, _pub_path = _built_receipt(tmp_path)
+
+    result = CliRunner().invoke(verify_cmd, ["receipt", str(receipt_path), "--require-provenance"])
+
+    assert result.exit_code == 3, result.output
+    assert "integrity-only" in result.output
+
+
+def test_provenance_pass_under_require_provenance_exits_0(tmp_path: Path) -> None:
+    """A pinned, matching key satisfies --require-provenance."""
+    receipt_path, pub_path = _built_receipt(tmp_path)
+
+    result = CliRunner().invoke(
+        verify_cmd,
+        ["receipt", str(receipt_path), "--public-key", str(pub_path), "--require-provenance"],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_json_tier_field_distinguishes_integrity_only_from_provenance(tmp_path: Path) -> None:
+    """A caller reading JSON must not have to parse the verdict sentence."""
+    receipt_path, pub_path = _built_receipt(tmp_path)
+    runner = CliRunner()
+
+    unpinned = runner.invoke(verify_cmd, ["receipt", str(receipt_path), "--json"])
+    pinned = runner.invoke(verify_cmd, ["receipt", str(receipt_path), "--public-key", str(pub_path), "--json"])
+
+    unpinned_payload = json.loads(unpinned.output)
+    pinned_payload = json.loads(pinned.output)
+    assert unpinned.exit_code == 0, unpinned.output
+    assert pinned.exit_code == 0, pinned.output
+    assert unpinned_payload["tier"] == "integrity-only"
+    assert pinned_payload["tier"] == "provenance"
+
+
+def test_json_require_provenance_refusal_still_names_the_tier_reached(tmp_path: Path) -> None:
+    """The exit-3 refusal is JSON-visible too, not only in the human verdict."""
+    receipt_path, _pub_path = _built_receipt(tmp_path)
+
+    result = CliRunner().invoke(
+        verify_cmd,
+        ["receipt", str(receipt_path), "--require-provenance", "--json"],
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 3, result.output
+    assert payload["ok"] is True
+    assert payload["tier"] == "integrity-only"
+    assert payload["require_provenance"] is True
+    assert payload["exit_code"] == 3
+
+
+def test_json_tampered_receipt_reports_null_tier(tmp_path: Path) -> None:
+    """A receipt that never verified has no tier to report."""
+    receipt_path, _pub_path = _built_receipt(tmp_path)
+    doc = json.loads(receipt_path.read_bytes())
+    doc["journal"]["events"][1]["task_id"] = "T-FORGED"
+    tampered = receipt_path.parent / "tampered.json"
+    tampered.write_text(json.dumps(doc), encoding="utf-8")
+
+    result = CliRunner().invoke(verify_cmd, ["receipt", str(tampered), "--json"])
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 2
+    assert payload["tier"] is None
+
+
+# ---------------------------------------------------------------------------
 # Group promotion: legacy modes keep their exact behaviour and exit codes
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Symptom

`bernstein verify receipt` has two verdict tiers: integrity-only (no
`--public-key`; the embedded JWK self-attests) and provenance (pinned key).
Both exit `0`. A CI gate scripted as `verify receipt $f && deploy` with no
`--public-key` configured therefore accepts a receipt that was rewritten,
re-chained, and re-signed under an attacker's fresh embedded key -- the
integrity-only pass authenticates nothing about the signer, but the exit
code is indistinguishable from a provenance pass.

## Root cause

`verify_receipt_cmd` computed the tier only for the human-readable verdict
line (`OK (integrity-only: embedded key)` vs `OK (provenance: pinned key)`)
and never surfaced it anywhere a script could read without parsing that
sentence. No structured output mode existed on the command.

## Fix

Additive, per the picked option -- no existing exit code changes:

- `--require-provenance`: when passed and the pass did not reach the
  provenance tier (no `--public-key`, or a pin that does not hold), exit
  `3` naming the tier actually reached. Without the flag, both tiers still
  exit `0`.
- `--json`: no `--json`/structured mode existed on this command, so one was
  added. Carries `ok`, `status`, `tier` (`"provenance"` / `"integrity-only"`
  / `null`), `run_id`, `journal_events`, `spine_entries`, `divergent_step`,
  `errors`, `pinned_key`, `require_provenance`, `exit_code`. Composes with
  `--require-provenance`: the JSON body still names the tier reached on an
  exit-`3` refusal.
- Docs: exit-code table and trust-model section in
  `docs/operations/deterministic-replay.md`, and the `receipt` row in
  `docs/reference/cli-reference.md`, updated for exit `3` and the two new
  flags.

`0`/`1`/`2` keep their exact prior meaning; both flags default off.

## Test

`tests/unit/test_verify_run_receipt_cmd.py`:
- `test_integrity_only_pass_exits_0_without_require_provenance` -- default
  behaviour unchanged.
- `test_integrity_only_pass_under_require_provenance_exits_nonzero` -- the
  gap the issue reports, closed.
- `test_provenance_pass_under_require_provenance_exits_0`
- `test_json_tier_field_distinguishes_integrity_only_from_provenance`
- `test_json_require_provenance_refusal_still_names_the_tier_reached`
- `test_json_tampered_receipt_reports_null_tier`

All five new behavioural tests fail against the pre-fix command (confirmed
by stashing the source change and re-running) and pass after it.

Closes #4208
