### PR TITLE
fix(adapters): narrow agent subprocess PYTHONPATH to bernstein package root (#4221)

### DIFF
--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -281,6 +281,24 @@ def record_embedded_teams_opt_in(
         )
 
 
+def _get_bernstein_package_dir() -> str | None:
+    """Return the parent directory of the bernstein package if importable.
+
+    This ensures agent subprocesses can import bernstein without inheriting
+    the orchestrator's full sys.path as PYTHONPATH (issue #4221).
+    """
+    try:
+        import bernstein
+
+        if getattr(bernstein, "__file__", None):
+            pkg_root = Path(bernstein.__file__).resolve().parent.parent
+            if pkg_root.is_dir():
+                return str(pkg_root)
+    except Exception:
+        pass
+    return None
+
+
 def build_filtered_env(
     extra_keys: Iterable[str] = (),
     *,
@@ -372,16 +390,15 @@ def build_filtered_env(
     if not _embedded_teams_opt_in():
         env = {k: v for k, v in env.items() if not _is_embedded_teams_gate(k)}
 
-    # Ensure PYTHONPATH includes directories needed by bernstein-worker.
+    # Ensure PYTHONPATH includes only the directory needed to import bernstein.
     # When the orchestrator runs via ``uv run``, sys.executable may point
-    # to the framework Python rather than the venv Python.  Without an
-    # explicit PYTHONPATH the worker subprocess cannot import bernstein.
-    if "PYTHONPATH" not in env:
-        import sys
-
-        src_dirs = [p for p in sys.path if p and Path(p).is_dir()]
-        if src_dirs:
-            env["PYTHONPATH"] = os.pathsep.join(src_dirs)
+    # to the framework Python rather than the venv Python. Instead of dumping
+    # the orchestrator's full sys.path into PYTHONPATH (#4221), we narrow
+    # PYTHONPATH to the bernstein package root.
+    if env and "PYTHONPATH" not in env:
+        pkg_dir = _get_bernstein_package_dir()
+        if pkg_dir:
+            env["PYTHONPATH"] = pkg_dir
 
     # Overlay secrets from external provider (if configured).
     if secrets_config is not None:

--- a/tests/unit/test_env_isolation.py
+++ b/tests/unit/test_env_isolation.py
@@ -29,6 +29,25 @@ class TestBuildFilteredEnv:
         assert result["HOME"] == "/root"
         assert result["LANG"] == "en_US.UTF-8"
 
+    def test_pythonpath_does_not_inherit_full_sys_path(self) -> None:
+        """PYTHONPATH contains only the bernstein package directory, not orchestrator's full sys.path (issue #4221)."""
+        fake_env = {"PATH": "/usr/bin", "HOME": "/root"}
+        fake_sys_path = [
+            "/usr/lib/python3.12",
+            "/usr/lib/python3.12/site-packages",
+            "/tmp/unrelated_dir",
+            "/orchestrator/internal",
+        ]
+        with (
+            patch("bernstein.adapters.env_isolation.os.environ", fake_env),
+            patch("sys.path", fake_sys_path),
+        ):
+            result = build_filtered_env()
+        # PYTHONPATH must NOT contain unrelated orchestrator sys.path entries
+        assert "PYTHONPATH" in result
+        assert "/tmp/unrelated_dir" not in result["PYTHONPATH"]
+        assert "/orchestrator/internal" not in result["PYTHONPATH"]
+
     def test_pathext_in_allowlist(self) -> None:
         """PATHEXT must be allowlisted so bernstein-worker's shutil.which can
         recognise .cmd/.bat/.exe shims on Windows (issue #2287).


### PR DESCRIPTION
Fixes #4221.

### Summary of Changes

- Updated \uild_filtered_env\ in \src/bernstein/adapters/env_isolation.py\ to resolve the \ernstein\ package root directory via \_get_bernstein_package_dir()\ when setting \PYTHONPATH\ for agent subprocesses, instead of dumping all directories in the orchestrator's \sys.path\.
- Prevents environment leakage of unrelated site-packages and orchestrator internal directories into agent subprocesses.
- Added unit test \	est_pythonpath_does_not_inherit_full_sys_path\ in \	ests/unit/test_env_isolation.py\.

### Verification

- Verified all 30 unit tests pass cleanly: \python -m pytest tests/unit/test_env_isolation.py -v\.
- Ran \uff check\ and \uff format --check\ cleanly.