### PR TITLE
fix(tasks): propagate failure to dependents and derive an unreachable set

### DIFF
--- a/docs/diagrams/task_lifecycle.md
+++ b/docs/diagrams/task_lifecycle.md
@@ -17,6 +17,7 @@ stateDiagram-v2
     pending_approval : pending_approval
     abandoned : abandoned
     blocked_by_abandon : blocked_by_abandon
+    blocked_by_failed_dep : blocked_by_failed_dep
     refused : refused
 
     planned --> open : approve
@@ -71,6 +72,13 @@ stateDiagram-v2
     claimed --> refused : claimed_to_refused
     in_progress --> refused : in_progress_to_refused
     pending_approval --> done : pending_approval_to_done
+    open --> blocked_by_failed_dep : open_to_blocked_by_failed_dep
+    claimed --> blocked_by_failed_dep : claimed_to_blocked_by_failed_dep
+    in_progress --> blocked_by_failed_dep : in_progress_to_blocked_by_failed_dep
+    waiting_for_subtasks --> blocked_by_failed_dep : waiting_for_subtasks_to_blocked_by_failed_dep
+    blocked_by_failed_dep --> open : blocked_by_failed_dep_to_open
+    blocked_by_failed_dep --> cancelled : blocked_by_failed_dep_to_cancelled
+    blocked_by_failed_dep --> abandoned : blocked_by_failed_dep_to_abandoned
 
     classDef terminal fill:#f96,stroke:#333,stroke-width:2px
     class closed terminal
@@ -99,6 +107,7 @@ stateDiagram-v2
 | pending_approval | Completed, awaiting human approval | No |
 | abandoned | abandoned | Yes |
 | blocked_by_abandon | blocked_by_abandon | No |
+| blocked_by_failed_dep | blocked_by_failed_dep | No |
 | refused | refused | Yes |
 
 ## Transitions
@@ -157,3 +166,10 @@ stateDiagram-v2
 | claimed | refused | claimed_to_refused |
 | in_progress | refused | in_progress_to_refused |
 | pending_approval | done | pending_approval_to_done |
+| open | blocked_by_failed_dep | open_to_blocked_by_failed_dep |
+| claimed | blocked_by_failed_dep | claimed_to_blocked_by_failed_dep |
+| in_progress | blocked_by_failed_dep | in_progress_to_blocked_by_failed_dep |
+| waiting_for_subtasks | blocked_by_failed_dep | waiting_for_subtasks_to_blocked_by_failed_dep |
+| blocked_by_failed_dep | open | blocked_by_failed_dep_to_open |
+| blocked_by_failed_dep | cancelled | blocked_by_failed_dep_to_cancelled |
+| blocked_by_failed_dep | abandoned | blocked_by_failed_dep_to_abandoned |

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -150,7 +150,7 @@
     "/agents": {
       "get": {
         "summary": "List Agents",
-        "description": "Return a flat list of agent sessions for the web GUI grid.\n\nWhen ``TaskStore.agents`` is empty (e.g. only mock adapters spawned and\nthey never heartbeat) we fall back to synthesising one entry per\nclaimed/in-progress task, marked with ``\"synthetic\": true``. That keeps\nthe GUI grid populated during demos and avoids the dreaded \"0 sessions\"\nempty state when work is obviously in flight.",
+        "description": "Return a flat list of agent sessions for the web GUI grid.\n\nWhen ``TaskStore.agents`` is empty (e.g. only mock adapters spawned and\nthey never heartbeat) we fall back to synthesising one entry per\nclaimed/in-progress task, marked with ``\"synthetic\": true``. That keeps\nthe GUI grid populated during demos and avoids the dreaded \"0 sessions\"\nempty state when work is obviously in flight.\n\nBoth branches render the id and title of the task a session is on, so\nboth narrow to the caller's tenant scope: the live sessions carry no\ntenant of their own and are placed by the task they name, while the\nsynthesised entries are built from a scoped read in the first place.",
         "operationId": "list_agents_agents_get",
         "responses": {
           "200": {
@@ -5158,7 +5158,7 @@
     "/observability/deps": {
       "get": {
         "summary": "Observability Deps",
-        "description": "Return dependency-graph validation status for current tasks.",
+        "description": "Return dependency-graph validation status for current tasks.\n\nThe response names the ids it walked - the ready set, the critical path,\nand both broken-edge lists - so the walk is narrowed to the caller's\ntenant scope rather than the whole store.",
         "operationId": "observability_deps_observability_deps_get",
         "responses": {
           "200": {
@@ -8117,7 +8117,7 @@
     "/metrics/predictions": {
       "get": {
         "summary": "Get Predictions",
-        "description": "Evaluate all predictive forecasts and return active alerts.\n\nChecks three forecast dimensions:\n\n- **Budget exhaustion**: At current spend velocity, when will the\n  budget cap be reached?\n- **Completion rate decline**: Is the task completion rate trending\n  downward, indicating the run will take longer than expected?\n- **Run duration overrun**: Based on current throughput, will the run\n  exceed the configured time window?\n\nUse ``budget_cap`` to enable the budget forecast. The run duration\nforecast requires at least one completed task.\n\nReturns a list of ``alerts`` ordered by severity (critical first).\nEach alert has: ``kind``, ``severity``, ``message``,\n``minutes_until_impact``, ``confidence``.",
+        "description": "Evaluate all predictive forecasts and return active alerts.\n\nChecks three forecast dimensions:\n\n- **Budget exhaustion**: At current spend velocity, when will the\n  budget cap be reached?\n- **Completion rate decline**: Is the task completion rate trending\n  downward, indicating the run will take longer than expected?\n- **Run duration overrun**: Based on current throughput, will the run\n  exceed the configured time window?\n\nUse ``budget_cap`` to enable the budget forecast. The run duration\nforecast requires at least one completed task.\n\nBoth numeric parameters are echoed back in the response body, so both\nrefuse non-finite values with a 422 instead of admitting them: a range\nbound alone does not exclude them (``inf >= 0.0`` is true, and every\ncomparison against ``NaN`` is false), and the JSON renderer cannot\nserialise either one.\n\nThe budget forecast is scoped to ``tenant_id``: the spend series it is\nbuilt from is narrowed to cost points recorded for the caller's tenant,\nthe same way the rest of the cost surface is (see\n``load_cost_history``).  Cost points written before per-tenant\nattribution existed are treated as the default tenant's spend, so a\nlegacy single-tenant install keeps its existing numbers.\n\nReturns a list of ``alerts`` ordered by severity (critical first).\nEach alert has: ``kind``, ``severity``, ``message``,\n``minutes_until_impact``, ``confidence``.",
         "operationId": "get_predictions_metrics_predictions_get",
         "parameters": [
           {
@@ -8966,7 +8966,7 @@
     "/api/v1/agents": {
       "get": {
         "summary": "List Agents",
-        "description": "Return a flat list of agent sessions for the web GUI grid.\n\nWhen ``TaskStore.agents`` is empty (e.g. only mock adapters spawned and\nthey never heartbeat) we fall back to synthesising one entry per\nclaimed/in-progress task, marked with ``\"synthetic\": true``. That keeps\nthe GUI grid populated during demos and avoids the dreaded \"0 sessions\"\nempty state when work is obviously in flight.",
+        "description": "Return a flat list of agent sessions for the web GUI grid.\n\nWhen ``TaskStore.agents`` is empty (e.g. only mock adapters spawned and\nthey never heartbeat) we fall back to synthesising one entry per\nclaimed/in-progress task, marked with ``\"synthetic\": true``. That keeps\nthe GUI grid populated during demos and avoids the dreaded \"0 sessions\"\nempty state when work is obviously in flight.\n\nBoth branches render the id and title of the task a session is on, so\nboth narrow to the caller's tenant scope: the live sessions carry no\ntenant of their own and are placed by the task they name, while the\nsynthesised entries are built from a scoped read in the first place.",
         "operationId": "list_agents_api_v1_agents_get",
         "responses": {
           "200": {
@@ -13974,7 +13974,7 @@
     "/api/v1/observability/deps": {
       "get": {
         "summary": "Observability Deps",
-        "description": "Return dependency-graph validation status for current tasks.",
+        "description": "Return dependency-graph validation status for current tasks.\n\nThe response names the ids it walked - the ready set, the critical path,\nand both broken-edge lists - so the walk is narrowed to the caller's\ntenant scope rather than the whole store.",
         "operationId": "observability_deps_api_v1_observability_deps_get",
         "responses": {
           "200": {
@@ -16933,7 +16933,7 @@
     "/api/v1/metrics/predictions": {
       "get": {
         "summary": "Get Predictions",
-        "description": "Evaluate all predictive forecasts and return active alerts.\n\nChecks three forecast dimensions:\n\n- **Budget exhaustion**: At current spend velocity, when will the\n  budget cap be reached?\n- **Completion rate decline**: Is the task completion rate trending\n  downward, indicating the run will take longer than expected?\n- **Run duration overrun**: Based on current throughput, will the run\n  exceed the configured time window?\n\nUse ``budget_cap`` to enable the budget forecast. The run duration\nforecast requires at least one completed task.\n\nReturns a list of ``alerts`` ordered by severity (critical first).\nEach alert has: ``kind``, ``severity``, ``message``,\n``minutes_until_impact``, ``confidence``.",
+        "description": "Evaluate all predictive forecasts and return active alerts.\n\nChecks three forecast dimensions:\n\n- **Budget exhaustion**: At current spend velocity, when will the\n  budget cap be reached?\n- **Completion rate decline**: Is the task completion rate trending\n  downward, indicating the run will take longer than expected?\n- **Run duration overrun**: Based on current throughput, will the run\n  exceed the configured time window?\n\nUse ``budget_cap`` to enable the budget forecast. The run duration\nforecast requires at least one completed task.\n\nBoth numeric parameters are echoed back in the response body, so both\nrefuse non-finite values with a 422 instead of admitting them: a range\nbound alone does not exclude them (``inf >= 0.0`` is true, and every\ncomparison against ``NaN`` is false), and the JSON renderer cannot\nserialise either one.\n\nThe budget forecast is scoped to ``tenant_id``: the spend series it is\nbuilt from is narrowed to cost points recorded for the caller's tenant,\nthe same way the rest of the cost surface is (see\n``load_cost_history``).  Cost points written before per-tenant\nattribution existed are treated as the default tenant's spend, so a\nlegacy single-tenant install keeps its existing numbers.\n\nReturns a list of ``alerts`` ordered by severity (critical first).\nEach alert has: ``kind``, ``severity``, ``message``,\n``minutes_until_impact``, ``confidence``.",
         "operationId": "get_predictions_api_v1_metrics_predictions_get",
         "parameters": [
           {
@@ -20841,6 +20841,11 @@
           "blocked_by_abandon": {
             "type": "integer",
             "title": "Blocked By Abandon",
+            "default": 0
+          },
+          "blocked_by_failed_dep": {
+            "type": "integer",
+            "title": "Blocked By Failed Dep",
             "default": 0
           },
           "refused": {

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -890,6 +890,7 @@ class TaskCountsResponse(BaseModel):
     orphaned: int = 0
     abandoned: int = 0
     blocked_by_abandon: int = 0
+    blocked_by_failed_dep: int = 0
     refused: int = 0
     suspended: int = 0
     total: int = 0

--- a/src/bernstein/core/tasks/lifecycle.py
+++ b/src/bernstein/core/tasks/lifecycle.py
@@ -228,11 +228,84 @@ TASK_TRANSITIONS: dict[tuple[TaskStatus, TaskStatus], Callable[[Task], bool]] = 
     # accepts it completes the task. Without this edge the state has no way
     # out and the sign-off is rejected by ``transition_task``.
     (TaskStatus.PENDING_APPROVAL, TaskStatus.DONE): _always,
+    # Failed-dependency cascade (#3452) - the FAILED counterpart of the
+    # abandon cascade above. A task whose dependency ended without
+    # delivering moves here instead of being re-queued forever. Kept
+    # distinct from BLOCKED_BY_ABANDON so the record still says whether the
+    # upstream was abandoned on purpose or broke while trying.
+    (TaskStatus.OPEN, TaskStatus.BLOCKED_BY_FAILED_DEP): _always,
+    (TaskStatus.CLAIMED, TaskStatus.BLOCKED_BY_FAILED_DEP): _always,
+    (TaskStatus.IN_PROGRESS, TaskStatus.BLOCKED_BY_FAILED_DEP): _always,
+    (TaskStatus.WAITING_FOR_SUBTASKS, TaskStatus.BLOCKED_BY_FAILED_DEP): _always,
+    # Same operator recovery paths the abandon-blocked state has: requeue
+    # once the upstream is retried, or close the branch out.
+    (TaskStatus.BLOCKED_BY_FAILED_DEP, TaskStatus.OPEN): _always,
+    (TaskStatus.BLOCKED_BY_FAILED_DEP, TaskStatus.CANCELLED): _always,
+    (TaskStatus.BLOCKED_BY_FAILED_DEP, TaskStatus.ABANDONED): _always,
 }
 
 # Precompute terminal statuses (no outbound transitions).
 TERMINAL_TASK_STATUSES: frozenset[TaskStatus] = frozenset(
     s for s in TaskStatus if s not in {frm for (frm, _to), _guard in TASK_TRANSITIONS.items()}
+)
+
+
+# ---------------------------------------------------------------------------
+# Dependency-satisfaction classification (#3452)
+# ---------------------------------------------------------------------------
+
+# ``TERMINAL_TASK_STATUSES`` answers "can this status transition at all", which
+# is the wrong question for a dependent waiting on an upstream. FAILED,
+# ORPHANED and both blocked-by states each keep a recovery edge back to OPEN,
+# so they are absent from that set while still stranding every dependent until
+# an operator intervenes. The three sets below answer the dependency question
+# instead, and partition ``TaskStatus`` exhaustively so a newly added status
+# cannot slip through unclassified (asserted by the lifecycle FSM tests).
+
+# A dependency in one of these has delivered; dependents may proceed.
+SUCCESSFUL_TASK_STATUSES: frozenset[TaskStatus] = frozenset(
+    {
+        TaskStatus.DONE,
+        TaskStatus.CLOSED,
+    }
+)
+
+# A dependency in one of these will never deliver on its own. Dependents are
+# stranded until the upstream is explicitly requeued.
+UNSUCCESSFUL_TERMINAL_STATUSES: frozenset[TaskStatus] = frozenset(
+    {
+        TaskStatus.FAILED,
+        TaskStatus.CANCELLED,
+        TaskStatus.REFUSED,
+        TaskStatus.ORPHANED,
+        TaskStatus.ABANDONED,
+        TaskStatus.BLOCKED_BY_ABANDON,
+        TaskStatus.BLOCKED_BY_FAILED_DEP,
+    }
+)
+
+# The subset of the above that a task reaches because its own dependency was
+# stranded, rather than by running and ending. Members propagate the strand
+# onward but are themselves reported as stranded rather than as a root cause.
+DEPENDENCY_BLOCKED_STATUSES: frozenset[TaskStatus] = frozenset(
+    {
+        TaskStatus.BLOCKED_BY_ABANDON,
+        TaskStatus.BLOCKED_BY_FAILED_DEP,
+    }
+)
+
+# Neither delivered nor ended: the dependent may still become claimable.
+IN_FLIGHT_TASK_STATUSES: frozenset[TaskStatus] = frozenset(
+    {
+        TaskStatus.PLANNED,
+        TaskStatus.OPEN,
+        TaskStatus.CLAIMED,
+        TaskStatus.IN_PROGRESS,
+        TaskStatus.BLOCKED,
+        TaskStatus.WAITING_FOR_SUBTASKS,
+        TaskStatus.SUSPENDED,
+        TaskStatus.PENDING_APPROVAL,
+    }
 )
 
 

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -189,6 +189,7 @@ class TaskStatus(Enum):
     PENDING_APPROVAL = "pending_approval"  # Completed; awaiting human approval before taking effect
     ABANDONED = "abandoned"  # Agent voluntarily abandoned with a structured reason (#1350)
     BLOCKED_BY_ABANDON = "blocked_by_abandon"  # Downstream task waiting on an abandoned dependency (#1350)
+    BLOCKED_BY_FAILED_DEP = "blocked_by_failed_dep"  # Downstream task whose dependency ended unsuccessfully (#3452)
     REFUSED = "refused"  # Worker reported a typed refusal via the completion contract (#2244)
 
 

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -41,6 +41,7 @@ from bernstein.core.tasks.models import (
     TaskType,
     UpgradeProposalDetails,
 )
+from bernstein.core.tasks.unreachable import blocking_dependency, unreachable_tasks
 from bernstein.core.tenanting import ensure_tenant_layout, normalize_tenant_id, try_normalize_tenant_id
 
 if TYPE_CHECKING:
@@ -1175,6 +1176,76 @@ class TaskStore:
 
         return dfs(new_task.id)
 
+    async def _mark_blocked_by_failed_dep(self, task: Task, blocking_task_id: str) -> bool:
+        """Move *task* to ``BLOCKED_BY_FAILED_DEP``, naming what stranded it.
+
+        Mirrors the abandon cascade's per-downstream body (#1350): the claim is
+        surrendered, the row is journalled, and a release receipt is minted,
+        because a downstream can be CLAIMED or IN_PROGRESS under a different
+        node than the one whose task ended.
+
+        Returns ``True`` when the task moved, ``False`` when it was already
+        past the point where the cascade applies.
+        """
+        blocker = self._tasks.get(blocking_task_id)
+        if blocker is None:
+            return False
+        reason = f"dependency {blocking_task_id} is {blocker.status.value}"
+        snapshot = self._claim_snapshot(task)
+        self._index_remove(task)
+        try:
+            transition_task(task, TaskStatus.BLOCKED_BY_FAILED_DEP, actor="task_store", reason=reason)
+        except IllegalTransitionError:
+            # Restore index entry - leave the task untouched, exactly as the
+            # abandon cascade does for a downstream it may not move.
+            self._index_add(task)
+            return False
+        task.result_summary = reason
+        task.terminal_reason = "blocked_by_failed_dependency"
+        # The id, not an inference: "why did this never run" is answered by a
+        # task id a replay can look up.
+        task.metadata["blocking_task_id"] = blocking_task_id
+        task.version += 1
+        self._index_add(task)
+        await self._append_jsonl(self._task_to_record(task))
+        self._record_release_receipt(
+            task,
+            snapshot,
+            release_path="failed_dependency_cascade",
+            reason=reason,
+        )
+        logger.info(
+            "Task %s blocked by failed dependency %s (%s)",
+            task.id,
+            blocking_task_id,
+            blocker.status.value,
+        )
+        return True
+
+    async def _cascade_failed_dependency(self, task_id: str) -> None:
+        """Strand every task that can no longer run because *task_id* ended.
+
+        Propagation is transitive: a task moved to ``BLOCKED_BY_FAILED_DEP``
+        is itself a stranding dependency, so the next ring is found on the
+        following pass. Each ring is walked in id order and each stranded task
+        records its own nearest cause, so a chain A -> B -> C names B as C's
+        cause rather than A.
+
+        Must be called with ``self._lock`` held.
+        """
+        frontier = {task_id}
+        while frontier:
+            next_frontier: set[str] = set()
+            for candidate in sorted(self._tasks.values(), key=lambda t: t.id):
+                if candidate.id in frontier or not frontier.intersection(candidate.depends_on):
+                    continue
+                blocker_id = blocking_dependency(candidate, self._tasks)
+                if blocker_id is None:
+                    continue
+                if await self._mark_blocked_by_failed_dep(candidate, blocker_id):
+                    next_frontier.add(candidate.id)
+            frontier = next_frontier
+
     def _dependencies_satisfied(self, task: Task) -> bool:
         # A dependency is satisfied by either terminal-success status: tasks
         # move from "done" to "closed" once their agent is reaped and its
@@ -1186,25 +1257,11 @@ class TaskStore:
         )
         done_ids = {done_task.id for done_task in completed_tasks}
 
-        # Check for terminal-not-successful dependencies (issue #3621)
-        # A task whose depends_on contains any task in a terminal-not-successful
-        # status should not be re-queued forever.
-        terminal_failed = {
-            TaskStatus.FAILED,
-            TaskStatus.CANCELLED,
-            TaskStatus.REFUSED,
-            TaskStatus.ORPHANED,
-        }
-        for dep_id in task.depends_on:
-            dep_task = self._tasks.get(dep_id)
-            if dep_task and dep_task.status in terminal_failed:
-                logger.warning(
-                    "Task %s dependency %s is %s — task will never run",
-                    task.id,
-                    dep_id,
-                    dep_task.status.value,
-                )
-                return False
+        # A dependency that ended without delivering never satisfies its
+        # dependents (#3452). The classification lives in one place so a path
+        # that moves a task to a new terminal status cannot forget it.
+        if blocking_dependency(task, self._tasks) is not None:
+            return False
 
         if not all(dep in done_ids for dep in task.depends_on):
             return False
@@ -1827,6 +1884,9 @@ class TaskStore:
                 return None
             task: Task | None = None
             blocked_entries: list[tuple[int, str]] = []
+            # Stranded candidates are moved off the queue rather than back
+            # onto it (#3452); mutating mid-drain would reorder the heap.
+            stranded_entries: list[tuple[Task, str]] = []
             normalized_tenant = normalize_tenant_id(tenant_id) if tenant_id is not None else None
             while pq:
                 priority, task_id = heapq.heappop(pq)
@@ -1844,6 +1904,13 @@ class TaskStore:
                 if parent_session_id is not None and candidate.parent_session_id != parent_session_id:
                     blocked_entries.append((priority, task_id))
                     continue
+                # A dependency that ended without delivering makes this
+                # candidate unclaimable for good, so re-queuing it just burns
+                # a heap slot every tick, forever (#3452).
+                stranding_dep = blocking_dependency(candidate, self._tasks)
+                if stranding_dep is not None:
+                    stranded_entries.append((candidate, stranding_dep))
+                    continue
                 if not self._dependencies_satisfied(candidate):
                     blocked_entries.append((priority, task_id))
                     continue
@@ -1857,6 +1924,8 @@ class TaskStore:
                 break
             for entry in blocked_entries:
                 heapq.heappush(pq, entry)
+            for stranded, stranding_dep in stranded_entries:
+                await self._mark_blocked_by_failed_dep(stranded, stranding_dep)
             if task is None:
                 return None
             self._index_remove(task)
@@ -2175,6 +2244,7 @@ class TaskStore:
             await self._append_jsonl(self._task_to_record(task))
             await self._append_archive(task, completed_at)
             self._record_release_receipt(task, snapshot, release_path="fail", reason=reason)
+            await self._cascade_failed_dependency(task_id)
             return task
 
     async def fail_contract_violation(self, task_id: str, violation: ContractViolation) -> Task:
@@ -2219,6 +2289,7 @@ class TaskStore:
             await self._append_jsonl(self._task_to_record(task))
             await self._append_archive(task, completed_at)
             self._record_release_receipt(task, snapshot, release_path="fail_contract_violation", reason=reason)
+            await self._cascade_failed_dependency(task_id)
         self._audit_contract_outcome(task_id, outcome="violation", schema_error_path=violation.path)
         return task
 
@@ -2265,6 +2336,7 @@ class TaskStore:
             await self._append_jsonl(self._task_to_record(task))
             await self._append_archive(task, completed_at)
             self._record_release_receipt(task, snapshot, release_path="refuse", reason=outcome)
+            await self._cascade_failed_dependency(task_id)
         self._audit_contract_outcome(task_id, outcome=outcome)
         return task
 
@@ -2785,6 +2857,7 @@ class TaskStore:
             await self._append_jsonl(self._task_to_record(task))
             await self._append_archive(task, completed_at)
             self._record_release_receipt(task, snapshot, release_path="cancel", reason=reason)
+            await self._cascade_failed_dependency(task_id)
             return task
 
     # -- TASK-002: WAITING_FOR_SUBTASKS timeout with escalation ---------------
@@ -3356,6 +3429,13 @@ class TaskStore:
             "refused": status_counts[TaskStatus.REFUSED],
             "per_role": per_role,
             "total_cost_usd": round(total_cost, 4),
+            # Read-only projection (#3452): tasks that can never run, each
+            # with the dependency that stranded it. Derived from the graph on
+            # every read, so an operator recomputing it from the journal gets
+            # the same list in the same order.
+            "unreachable": [
+                {"task_id": task_id, "blocked_by": blocking_id} for task_id, blocking_id in unreachable_tasks(tasks)
+            ],
         }
         self._attach_bandit_stats(summary)
         return summary

--- a/src/bernstein/core/tasks/unreachable.py
+++ b/src/bernstein/core/tasks/unreachable.py
@@ -1,0 +1,97 @@
+"""Derived unreachable-task projection (#3452).
+
+A task whose dependency ended without delivering can never become claimable,
+but nothing in the record used to say so: the dependent kept its ``OPEN``
+status and was pushed back onto the claim heap every tick. This module is the
+predicate that answers "which tasks could never have run, and because of
+what", computed from the recorded task graph alone.
+
+Everything here is pure. The same task set produces the same answer in the
+same order regardless of insertion order, so two operators reading the same
+journal derive an identical set and can compare them directly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bernstein.core.tasks.lifecycle import (
+    DEPENDENCY_BLOCKED_STATUSES,
+    SUCCESSFUL_TASK_STATUSES,
+    UNSUCCESSFUL_TERMINAL_STATUSES,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    from bernstein.core.tasks.models import Task
+
+__all__ = ["blocking_dependency", "unreachable_tasks"]
+
+
+def blocking_dependency(task: Task, tasks: Mapping[str, Task]) -> str | None:
+    """Return the id of the dependency that strands *task*, if any.
+
+    Only direct dependencies are considered, and only those already recorded
+    in an unsuccessful terminal status. A task stranded transitively is found
+    through its own direct dependency once that dependency has itself been
+    moved to a dependency-blocked status - which is what makes the recorded
+    cause of a transitive strand the nearest link in the chain rather than the
+    original failure.
+
+    With several stranded dependencies the lowest id wins, so the recorded
+    cause does not depend on ``depends_on`` ordering.
+    """
+    blockers = sorted(
+        dep_id
+        for dep_id in task.depends_on
+        if (dep := tasks.get(dep_id)) is not None and dep.status in UNSUCCESSFUL_TERMINAL_STATUSES
+    )
+    return blockers[0] if blockers else None
+
+
+def unreachable_tasks(tasks: Iterable[Task]) -> list[tuple[str, str]]:
+    """Return ``(task_id, blocking_task_id)`` for every task that cannot run.
+
+    A task is unreachable when it has not reached a successful status, has not
+    itself ended by running, and at least one of its dependencies is either in
+    an unsuccessful terminal status or is itself unreachable.
+
+    The result is sorted by task id, and each blocking id is the lowest
+    qualifying dependency id, so the projection is a function of the graph and
+    not of traversal order.
+    """
+    by_id = {task.id: task for task in tasks}
+
+    # A task that ran and ended - failed, was cancelled, refused, orphaned or
+    # abandoned - is a root cause, not a casualty. The dependency-blocked
+    # statuses are the casualties already on record, and stay in the answer.
+    self_ended = UNSUCCESSFUL_TERMINAL_STATUSES - DEPENDENCY_BLOCKED_STATUSES
+    reportable = {
+        task_id
+        for task_id, task in by_id.items()
+        if task.status not in SUCCESSFUL_TASK_STATUSES and task.status not in self_ended
+    }
+
+    def _strands(dep_id: str, stranded: set[str]) -> bool:
+        dep = by_id.get(dep_id)
+        return dep is not None and (dep.status in UNSUCCESSFUL_TERMINAL_STATUSES or dep_id in stranded)
+
+    # Phase 1 - fixpoint over the set. Iterating to convergence rather than
+    # walking edges once means the answer does not depend on the order tasks
+    # were inserted, only on which edges exist.
+    stranded: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for task_id in sorted(reportable - stranded):
+            if any(_strands(dep_id, stranded) for dep_id in by_id[task_id].depends_on):
+                stranded.add(task_id)
+                changed = True
+
+    # Phase 2 - name the cause once the set is final, so a task whose cause
+    # only becomes stranded on a later pass still reports the lowest id.
+    return sorted(
+        (task_id, min(dep_id for dep_id in by_id[task_id].depends_on if _strands(dep_id, stranded)))
+        for task_id in stranded
+    )

--- a/tests/unit/tasks/test_failed_dependency_propagation.py
+++ b/tests/unit/tasks/test_failed_dependency_propagation.py
@@ -1,0 +1,278 @@
+"""A failed task tells its dependents (#3452).
+
+Two halves are exercised here: the pure ``unreachable_tasks`` projection, and
+the live task store, where a stranded dependent must reach a terminal,
+operator-visible status instead of being re-queued every tick forever.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.tasks.lifecycle import (
+    IN_FLIGHT_TASK_STATUSES,
+    SUCCESSFUL_TASK_STATUSES,
+    TASK_TRANSITIONS,
+    UNSUCCESSFUL_TERMINAL_STATUSES,
+)
+from bernstein.core.tasks.models import Task, TaskStatus
+from bernstein.core.tasks.task_store_core import TaskStore
+from bernstein.core.tasks.unreachable import unreachable_tasks
+
+UNSUCCESSFUL_DEPENDENCY_STATUSES = [
+    TaskStatus.FAILED,
+    TaskStatus.CANCELLED,
+    TaskStatus.REFUSED,
+    TaskStatus.ORPHANED,
+]
+
+
+def _task(task_id: str, status: TaskStatus, depends_on: list[str] | None = None) -> Task:
+    return Task(
+        id=task_id,
+        title=task_id,
+        description="d",
+        role="backend",
+        status=status,
+        depends_on=list(depends_on or []),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The projection: a function of the graph, not of traversal order
+# ---------------------------------------------------------------------------
+
+
+class TestUnreachableProjection:
+    def test_set_is_a_function_of_the_graph_not_insertion_order(self) -> None:
+        # A fails; B depends on A; C depends on B.
+        a = _task("A", TaskStatus.FAILED)
+        b = _task("B", TaskStatus.OPEN, ["A"])
+        c = _task("C", TaskStatus.OPEN, ["B"])
+        expected = [("B", "A"), ("C", "B")]
+        for order in ([a, b, c], [c, b, a], [b, c, a]):
+            assert unreachable_tasks(order) == expected
+
+    def test_transitive_dependent_names_its_nearest_dependency_as_cause(self) -> None:
+        tasks = [
+            _task("A", TaskStatus.FAILED),
+            _task("B", TaskStatus.OPEN, ["A"]),
+            _task("C", TaskStatus.OPEN, ["B"]),
+        ]
+        causes = dict(unreachable_tasks(tasks))
+        assert causes["C"] == "B", "a transitive strand must name the link that stranded it, not the root failure"
+
+    def test_several_stranded_dependencies_report_the_lowest_id_stably(self) -> None:
+        tasks = [
+            _task("A", TaskStatus.FAILED),
+            _task("Z", TaskStatus.CANCELLED),
+            _task("B", TaskStatus.OPEN, ["Z", "A"]),
+        ]
+        assert dict(unreachable_tasks(tasks))["B"] == "A"
+        # Same graph, dependency edges declared the other way round.
+        tasks[2] = _task("B", TaskStatus.OPEN, ["A", "Z"])
+        assert dict(unreachable_tasks(tasks))["B"] == "A"
+
+    def test_a_cause_stranded_only_on_a_later_pass_still_wins_by_id(self) -> None:
+        # "AA" is stranded transitively via "M"; "ZZ" is a root failure. The
+        # cause must be "AA" (lowest id) even though it only enters the set on
+        # the second fixpoint pass.
+        tasks = [
+            _task("M", TaskStatus.FAILED),
+            _task("AA", TaskStatus.OPEN, ["M"]),
+            _task("ZZ", TaskStatus.FAILED),
+            _task("T", TaskStatus.OPEN, ["ZZ", "AA"]),
+        ]
+        assert dict(unreachable_tasks(tasks))["T"] == "AA"
+
+    def test_successful_dependency_leaves_the_set_empty(self) -> None:
+        for done in (TaskStatus.DONE, TaskStatus.CLOSED):
+            tasks = [
+                _task("A", done),
+                _task("B", TaskStatus.OPEN, ["A"]),
+                _task("C", TaskStatus.OPEN, ["B"]),
+            ]
+            assert unreachable_tasks(tasks) == []
+
+    @pytest.mark.parametrize("status", UNSUCCESSFUL_DEPENDENCY_STATUSES)
+    def test_every_unsuccessful_terminal_status_strands_its_dependents(self, status: TaskStatus) -> None:
+        tasks = [_task("A", status), _task("B", TaskStatus.OPEN, ["A"])]
+        assert unreachable_tasks(tasks) == [("B", "A")]
+
+    def test_one_stranded_dependency_strands_a_task_with_a_live_one_too(self) -> None:
+        tasks = [
+            _task("A", TaskStatus.FAILED),
+            _task("B", TaskStatus.IN_PROGRESS),
+            _task("C", TaskStatus.OPEN, ["A", "B"]),
+        ]
+        assert unreachable_tasks(tasks) == [("C", "A")]
+
+    def test_a_task_that_ended_on_its_own_is_a_cause_not_a_casualty(self) -> None:
+        # B failed while running; it is the root of C's strand, not a member.
+        tasks = [
+            _task("A", TaskStatus.FAILED),
+            _task("B", TaskStatus.FAILED, ["A"]),
+            _task("C", TaskStatus.OPEN, ["B"]),
+        ]
+        assert unreachable_tasks(tasks) == [("C", "B")]
+
+    def test_unknown_dependency_id_does_not_strand(self) -> None:
+        # A dangling edge is a different defect; the projection stays quiet.
+        assert unreachable_tasks([_task("B", TaskStatus.OPEN, ["missing"])]) == []
+
+
+# ---------------------------------------------------------------------------
+# The classification the projection is derived from
+# ---------------------------------------------------------------------------
+
+
+class TestStatusClassification:
+    def test_every_task_status_is_classified_exactly_once(self) -> None:
+        # A newly added TaskStatus must be classified, or the projection would
+        # silently treat it as in-flight and strand nothing.
+        buckets = (SUCCESSFUL_TASK_STATUSES, UNSUCCESSFUL_TERMINAL_STATUSES, IN_FLIGHT_TASK_STATUSES)
+        union = set().union(*buckets)
+        assert union == set(TaskStatus)
+        assert sum(len(bucket) for bucket in buckets) == len(union)
+
+    def test_blocked_by_failed_dep_has_the_same_recovery_edges_as_blocked_by_abandon(self) -> None:
+        for target in (TaskStatus.OPEN, TaskStatus.CANCELLED, TaskStatus.ABANDONED):
+            assert (TaskStatus.BLOCKED_BY_FAILED_DEP, target) in TASK_TRANSITIONS
+
+    def test_blocked_by_failed_dep_cannot_reach_a_successful_status(self) -> None:
+        for target in (TaskStatus.DONE, TaskStatus.CLOSED):
+            assert (TaskStatus.BLOCKED_BY_FAILED_DEP, target) not in TASK_TRANSITIONS
+
+
+# ---------------------------------------------------------------------------
+# The live task store
+# ---------------------------------------------------------------------------
+
+
+def _store(tmp_path: Path) -> TaskStore:
+    runtime = tmp_path / "runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    return TaskStore(runtime / "tasks.jsonl", archive_path=tmp_path / "archive" / "tasks.jsonl")
+
+
+async def _insert(store: TaskStore, task_id: str, **overrides: Any) -> Task:
+    base: dict[str, Any] = {
+        "id": task_id,
+        "title": task_id,
+        "description": "d",
+        "role": "backend",
+        "status": TaskStatus.OPEN,
+    }
+    base.update(overrides)
+    task = Task(**base)
+    store._tasks[task.id] = task  # type: ignore[attr-defined]
+    store._index_add(task)  # type: ignore[attr-defined]
+    return task
+
+
+@pytest.mark.asyncio
+class TestTaskStoreFailurePropagation:
+    async def test_dependent_of_a_failed_task_reaches_a_terminal_blocked_state(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _insert(store, "A", status=TaskStatus.IN_PROGRESS)
+        dependent = await _insert(store, "B", depends_on=["A"])
+        await store.fail("A", "boom")
+        assert dependent.status is TaskStatus.BLOCKED_BY_FAILED_DEP
+
+    async def test_transitive_dependent_of_a_failed_task_reaches_it_too(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _insert(store, "A", status=TaskStatus.IN_PROGRESS)
+        b = await _insert(store, "B", depends_on=["A"])
+        c = await _insert(store, "C", depends_on=["B"])
+        await store.fail("A", "boom")
+        assert b.status is TaskStatus.BLOCKED_BY_FAILED_DEP
+        assert c.status is TaskStatus.BLOCKED_BY_FAILED_DEP
+
+    async def test_blocked_dependent_records_the_causing_task_id(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _insert(store, "A", status=TaskStatus.IN_PROGRESS)
+        b = await _insert(store, "B", depends_on=["A"])
+        c = await _insert(store, "C", depends_on=["B"])
+        await store.fail("A", "boom")
+        assert b.metadata["blocking_task_id"] == "A"
+        # The nearest link, so the chain is walkable one hop at a time.
+        assert c.metadata["blocking_task_id"] == "B"
+        assert "A" in (b.result_summary or "")
+
+    async def test_dependent_of_a_failed_task_is_not_requeued_on_later_ticks(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        # The dependency reaches FAILED without going through fail(), which is
+        # how a crash-recovery or restored-journal row arrives: only the
+        # derived check in the claim path can catch this one.
+        await _insert(store, "A", status=TaskStatus.FAILED)
+        dependent = await _insert(store, "B", depends_on=["A"])
+        assert await store.claim_next("backend") is None
+        assert dependent.status is TaskStatus.BLOCKED_BY_FAILED_DEP
+        # The defect was a heap slot burned every tick, forever.
+        queue = store._priority_queues.get(("backend", TaskStatus.OPEN), [])  # type: ignore[attr-defined]
+        assert queue == []
+        assert await store.claim_next("backend") is None
+        assert queue == []
+
+    @pytest.mark.parametrize("status", UNSUCCESSFUL_DEPENDENCY_STATUSES)
+    async def test_each_unsuccessful_dependency_status_blocks_its_dependent(
+        self, tmp_path: Path, status: TaskStatus
+    ) -> None:
+        store = _store(tmp_path)
+        await _insert(store, "A", status=status)
+        dependent = await _insert(store, "B", depends_on=["A"])
+        await store.claim_next("backend")
+        assert dependent.status is TaskStatus.BLOCKED_BY_FAILED_DEP
+
+    async def test_cancel_propagates_to_dependents(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _insert(store, "A", status=TaskStatus.IN_PROGRESS)
+        dependent = await _insert(store, "B", depends_on=["A"])
+        await store.cancel("A", "operator stopped it")
+        assert dependent.status is TaskStatus.BLOCKED_BY_FAILED_DEP
+
+    async def test_a_live_sibling_dependency_does_not_keep_the_dependent_claimable(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _insert(store, "A", status=TaskStatus.IN_PROGRESS)
+        await _insert(store, "B", status=TaskStatus.IN_PROGRESS)
+        dependent = await _insert(store, "C", depends_on=["A", "B"])
+        await store.fail("A", "boom")
+        assert dependent.status is TaskStatus.BLOCKED_BY_FAILED_DEP
+        assert await store.claim_next("backend") is None
+
+    async def test_a_satisfied_dependency_still_yields_a_claim(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _insert(store, "A", status=TaskStatus.DONE)
+        await _insert(store, "B", depends_on=["A"])
+        claimed = await store.claim_next("backend")
+        assert claimed is not None
+        assert claimed.id == "B"
+
+    async def test_abandon_cascade_still_uses_blocked_by_abandon(self, tmp_path: Path) -> None:
+        # The two states must stay distinguishable in the record.
+        store = _store(tmp_path)
+        await _insert(store, "A", status=TaskStatus.IN_PROGRESS)
+        dependent = await _insert(store, "B", depends_on=["A"])
+        await store.abandon("A", "out_of_scope", "not doable")
+        assert dependent.status is TaskStatus.BLOCKED_BY_ABANDON
+
+    async def test_status_summary_reports_the_unreachable_set_with_causes(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _insert(store, "A", status=TaskStatus.IN_PROGRESS)
+        await _insert(store, "B", depends_on=["A"])
+        await _insert(store, "C", depends_on=["B"])
+        await store.fail("A", "boom")
+        summary = store.status_summary()
+        assert summary["unreachable"] == [
+            {"task_id": "B", "blocked_by": "A"},
+            {"task_id": "C", "blocked_by": "B"},
+        ]
+
+    async def test_status_summary_unreachable_is_empty_on_a_healthy_graph(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _insert(store, "A", status=TaskStatus.DONE)
+        await _insert(store, "B", depends_on=["A"])
+        assert store.status_summary()["unreachable"] == []


### PR DESCRIPTION
Partial implementation of #3452 — the live task server half. The `DAGExecutor` half (#3622) is not in this PR; see "What remains" below.

## Symptom

A task whose dependency ends without delivering waits forever. It keeps its `OPEN` status, `claim_next` pops it, finds the dependency unsatisfied, and pushes it straight back onto the heap — every tick, for the life of the run. No status change, no counter, no terminal record. A run reports no error, never finishes, and contains tasks that a replay can prove were never going to run with nothing in the record saying so.

## Root cause

`_dependencies_satisfied` counts only `DONE` and `CLOSED`, so `FAILED`, `CANCELLED`, `REFUSED` and `ORPHANED` never satisfy it, permanently. `fail()` never touched dependents. #3657 added a warning for the condition but changed neither the status nor the re-queue, so the dependent still spun and the log line repeated once per tick.

The asymmetry was the design already made: `abandon` cascades consumers into `BLOCKED_BY_ABANDON` precisely so they stop waiting forever, and `cancel_cascade` walks the parent/child tree. The far more common `FAILED` case had no equivalent.

## Fix

**A terminal blocked state, mirroring the one abandon already has.** `BLOCKED_BY_FAILED_DEP` gets the same source edges (`OPEN`, `CLAIMED`, `IN_PROGRESS`, `WAITING_FOR_SUBTASKS`) and the same operator recovery paths (`OPEN`, `CANCELLED`, `ABANDONED`) as `BLOCKED_BY_ABANDON`. The two are kept distinct so the record still says whether the upstream was abandoned on purpose or broke while trying.

**Propagation, transitively.** `fail()`, `fail_contract_violation()`, `refuse()` and `cancel()` each cascade. The cascade walks rings in id order; a task moved to `BLOCKED_BY_FAILED_DEP` is itself a stranding dependency, so the next ring is found on the following pass. Each stranded task records its own nearest cause — for `A -> B -> C`, `C` names `B`, not `A` — in `metadata["blocking_task_id"]`, so the chain is walkable one hop at a time and answers "why did this never run" with a task id rather than an inference. Each transition surrenders the claim and mints a release receipt, matching the abandon cascade, because a downstream can be claimed under a different node than the one whose task ended.

**The re-queue.** `claim_next` marks a stranded candidate instead of pushing it back. This is also the backstop for a task that reaches a terminal status outside those four methods — a restored journal row or a crash-recovery `ORPHANED` — so the behaviour cannot be forgotten by a path added later.

**Classification in one place.** `SUCCESSFUL_TASK_STATUSES` / `UNSUCCESSFUL_TERMINAL_STATUSES` / `IN_FLIGHT_TASK_STATUSES` in `lifecycle.py`, replacing the hand-listed set at the call site.

Worth recording, because the issue suggested otherwise: `TERMINAL_TASK_STATUSES` cannot serve as the source here. It is derived from "has no outbound edge", and `FAILED`, `ORPHANED` and both blocked-by states each keep a recovery edge back to `OPEN` — so all four are absent from it while still stranding every dependent until an operator intervenes. Deriving from it would have missed `FAILED`, the exact case. The three sets are declared instead, and a test asserts they partition `TaskStatus` exhaustively, so a newly added status cannot slip through unclassified.

**The projection.** `src/bernstein/core/tasks/unreachable.py` — pure, no store dependency. `unreachable_tasks(tasks)` returns `(task_id, blocking_task_id)` for every task that could never run: sorted by task id, cause resolved as the lowest qualifying dependency id, and computed as a two-phase fixpoint (set first, causes second) so a task whose cause only becomes stranded on a later pass still reports the same id. The result is a function of the graph, not of insertion or traversal order. Surfaced read-only under `unreachable` in `status_summary()`, which is what `/status` and `/health` read.

## Test

`tests/unit/tasks/test_failed_dependency_propagation.py`, 29 cases, each named for the property it protects.

Before this change, on a chain `A` failed / `B` depends on `A` / `C` depends on `B`: both dependents stayed `open`, the heap held `[(2, 'B'), (2, 'C')]` after one tick and again after two, and `status_summary()` had no `unreachable` key. After: both reach `blocked_by_failed_dep`, the heap drains to `[]` and stays empty, and the summary reports `B -> A`, `C -> B`.

Covered: a dependent of a `FAILED` task; the transitive case; the recorded cause being the nearest link; every one of `FAILED`/`CANCELLED`/`REFUSED`/`ORPHANED` as the stranding status, each in its own case; the heap not re-queuing across ticks; a task with one stranded and one still-running dependency not staying claimable; a satisfied dependency still yielding a claim; the projection's independence from insertion order across three orderings; a task that ended by running being reported as a cause rather than a casualty; and `abandon` still cascading to `BLOCKED_BY_ABANDON`, because the two states must stay distinguishable in the record.

```
uv run --frozen pytest tests/unit/tasks/ tests/unit/test_abandon_lifecycle.py tests/unit/test_lifecycle_diagrams.py \
  tests/unit/test_abandon_models.py tests/unit/test_abandon_ledger.py -q     # 631 passed
uv run --frozen pytest tests/unit/test_task_store_property.py tests/unit/test_api_contracts.py \
  tests/unit/test_lifecycle_transitions.py tests/unit/test_mcp_completion_surface.py \
  tests/property/test_abandon_properties.py -q                               # 436 passed
uv run --frozen pytest tests/unit/test_crash_recovery.py tests/unit/test_task_release_receipt.py \
  tests/unit/test_claim_by_id_double_claim.py tests/unit/test_mcp_tasks.py \
  tests/unit/test_run_closure_owner.py -q                                    # 104 passed, 3 skipped
```

`docs/diagrams/task_lifecycle.md` is regenerated from the transition table (additive only).

## What remains for #3452

- **`DAGExecutor` (#3622).** Its dependents are never constructed at all rather than left waiting, so the fix shares no code with this one. `BLOCKED_BY_FAILED_DEP` is the name and meaning to materialise an all-skipped node into; the `unreachable_tasks` projection added here is deliberately store-agnostic and takes any task iterable, so that slice can reuse it rather than defining a second notion of unreachable.
- **Aligning the two schedulers' reading of a terminal source.** `_dependencies_satisfied` treats non-`DONE` as unsatisfied forever; `resolve_edge` treats it as `SKIPPED` and drops the node. This PR settles the store side only; the executor side is a deliberate decision that belongs in that PR.
- **Retry exhaustion entering the propagation**, which is executor-side.
