### PR TITLE
fix(replay): make journal verify seal-aware for identity verdicts

### DIFF
--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1848,20 +1848,60 @@ def _resolve_journal_path(run_id: str, runs_dir: Path) -> Path:
     return contained_path(runs_dir, run_id, _REPLAY_JSONL, label="run id")
 
 
+def _replay_sealed_journal_head(*, run_id: str, sdd_dir: str) -> str | None:
+    """Look up the run's journal-head seal from the lineage spine, if any.
+
+    A finalized run writes its journal head into the lineage spine at
+    completion (``seal_journal_into_spine``, issue #2293 AC5); a fresh run's
+    single spine entry *is* that seal. Returns the sealed head hash, or
+    ``None`` when the run has no spine, the spine's HMAC chain does not
+    verify (so nothing it carries can be trusted), or the audit key needed to
+    check that chain is not configured -- every one of those is exactly the
+    "no seal to check against" case, so callers fall back to the existing
+    ``unverifiable`` verdict rather than erroring (issue #4203).
+    """
+    from bernstein.core.lineage.spine import JOURNAL_SEAL_STEP_PREFIX, LineageSpine, SpineStatus
+    from bernstein.core.security.audit import AuditKeyMissingError, load_audit_key
+
+    lineage_root = Path(sdd_dir) / "lineage"
+    spine_path = lineage_root / run_id / "spine.jsonl"
+    if not spine_path.exists():
+        return None
+    try:
+        hmac_key = load_audit_key()
+    except AuditKeyMissingError:
+        return None
+
+    spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key)
+    if spine.verify().status is SpineStatus.TAMPERED:
+        return None
+
+    head = ""
+    for entry in spine.iter_entries():
+        if entry.step_id.startswith(JOURNAL_SEAL_STEP_PREFIX):
+            head = entry.step_id.removeprefix(JOURNAL_SEAL_STEP_PREFIX)
+    return head or None
+
+
 def _replay_verify_journal(*, run_id: str, sdd_dir: str, as_json: bool) -> None:
     """Recompute the journal head and report the first divergent step.
 
     On an intact journal, reports chain consistency, reader coverage, and the
-    external-identity verdict. When a step diverges, writes a
-    ``divergence_report.json`` artifact listing ``(step_index, expected_hash,
-    actual_hash)`` and exits non-zero (issue #2293, AC2).
+    external-identity verdict. When a sealed run's spine records a
+    journal-head seal, the recomputed head and event count are checked
+    against it and the identity verdict is ``verified`` or a loud
+    ``mismatched`` -- never the weaker ``unverifiable``, which stays reserved
+    for a run with no seal to check against (issue #4203). When a step
+    diverges, writes a ``divergence_report.json`` artifact listing
+    ``(step_index, expected_hash, actual_hash)`` and exits non-zero
+    (issue #2293, AC2).
 
     Flagged provider-side mutation entries (a mutation that arrived in
     deterministic mode despite suppression being requested) fail
     verification closed even when the chain itself is intact
     (issue #2507).
     """
-    from bernstein.core.replay.journal import verify_journal
+    from bernstein.core.replay.journal import JournalIdentityStatus, JournalSeal, verify_journal
 
     runs_dir = Path(sdd_dir) / "runs"
     journal_path = _resolve_journal_path(run_id, runs_dir)
@@ -1869,9 +1909,26 @@ def _replay_verify_journal(*, run_id: str, sdd_dir: str, as_json: bool) -> None:
         console.print(f"[red]Journal not found:[/red] {journal_path}")
         raise SystemExit(1)
 
-    result = verify_journal(journal_path)
+    resolved_run_id = _replay_resolve_latest(runs_dir) if run_id == "latest" else run_id
+    sealed_head = _replay_sealed_journal_head(run_id=resolved_run_id, sdd_dir=sdd_dir)
+    seal = None
+    if sealed_head is not None:
+        # The seal records only the head (in the spine entry's step_id), not
+        # an event count. A head recomputed over the journal's Merkle chain
+        # folds each step's index into its hash, so a head match already
+        # cryptographically commits to the exact event count it was computed
+        # over -- there is no journal state that reaches the sealed head with
+        # a different count. Feeding the just-recomputed count back in as the
+        # seal's count is therefore sound: the comparison that actually does
+        # the work is the head, not this.
+        seal = JournalSeal(head=sealed_head, event_count=verify_journal(journal_path).count)
+
+    result = verify_journal(journal_path, seal=seal)
     if result.chain_consistent and not result.discarded_line_indices:
         _fail_on_flagged_provider_mutations(run_id=run_id, journal_path=journal_path, as_json=as_json)
+        if result.identity is JournalIdentityStatus.MISMATCHED:
+            _print_identity_mismatch(run_id=run_id, result=result, as_json=as_json)
+            return
         if as_json:
             console.print_json(
                 json.dumps(
@@ -1935,6 +1992,38 @@ def _fail_on_flagged_provider_mutations(*, run_id: str, journal_path: Path, as_j
         )
         for err in state.errors:
             console.print(f"[dim]{err}[/dim]")
+    raise SystemExit(1)
+
+
+def _print_identity_mismatch(*, run_id: str, result: Any, as_json: bool) -> None:
+    """Render a sealed run's identity mismatch and exit non-zero (issue #4203).
+
+    The parsed chain still recomputes cleanly from genesis here -- this is a
+    different failure than :func:`_print_verify_divergence` -- but it does
+    not reach the head (and event count) an independent seal committed to,
+    so the run's identity cannot be trusted and must not be reported as the
+    weaker ``unverifiable``.
+    """
+    if as_json:
+        console.print_json(
+            json.dumps(
+                {
+                    "run_id": run_id,
+                    "chain_consistent": True,
+                    "coverage": result.coverage.value,
+                    "identity": result.identity.value,
+                    "count": result.count,
+                    "errors": result.errors,
+                }
+            )
+        )
+    else:
+        console.print(
+            f"[red]IDENTITY MISMATCH[/red] for [bold]{run_id}[/bold] ({result.count} steps); "
+            "journal does not match its sealed head"
+        )
+        for err in result.errors:
+            console.print(f"  - {err}")
     raise SystemExit(1)
 
 

--- a/tests/unit/test_replay_verify_cli.py
+++ b/tests/unit/test_replay_verify_cli.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
 from bernstein.cli.advanced_cmd import replay_cmd
 from click.testing import CliRunner
 
-from bernstein.core.replay.journal import JOURNAL_FILENAME, EventJournal
+from bernstein.core.replay.journal import JOURNAL_FILENAME, EventJournal, seal_journal_into_spine
+
+_SEAL_KEY = b"k" * 32
 
 
 def _make_journal(sdd_dir: Path, run_id: str) -> EventJournal:
@@ -18,6 +21,29 @@ def _make_journal(sdd_dir: Path, run_id: str) -> EventJournal:
     journal.record("task_claimed", task_id="T-1")
     journal.record("task_completed", task_id="T-1")
     journal.record("run_completed", run_id=run_id)
+    return journal
+
+
+def _sealed_journal(sdd_dir: Path, run_id: str) -> EventJournal:
+    """Build a journal, finalize it, and seal its head into the lineage spine.
+
+    Writes the HMAC key to the path the per-test ``_isolate_audit_key``
+    fixture (``tests/conftest.py``) already pointed ``BERNSTEIN_AUDIT_KEY_PATH``
+    at, so the CLI's read-only ``load_audit_key()`` resolves the same key the
+    seal was written under.
+    """
+    key_path = Path(os.environ["BERNSTEIN_AUDIT_KEY_PATH"])
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key_path.write_bytes(_SEAL_KEY)
+    key_path.chmod(0o600)
+
+    journal = _make_journal(sdd_dir, run_id)
+    seal_journal_into_spine(
+        journal,
+        lineage_root=sdd_dir / "lineage",
+        hmac_key=_SEAL_KEY,
+        actor="orchestrator",
+    )
     return journal
 
 
@@ -31,6 +57,45 @@ def test_verify_reports_chain_consistency_without_overclaiming_identity(tmp_path
     assert result.exit_code == 0
     assert "chain intact" in result.output.lower()
     assert "identity=unverifiable" in result.output.lower()
+
+
+def test_verify_reports_verified_identity_for_a_sealed_untouched_run(tmp_path: Path) -> None:
+    """A sealed run whose journal is untouched reports identity=verified (#4203)."""
+    sdd_dir = tmp_path / ".sdd"
+    _sealed_journal(sdd_dir, "run-sealed-1")
+
+    result = CliRunner().invoke(replay_cmd, ["run-sealed-1", "--sdd-dir", str(sdd_dir), "--verify"])
+
+    assert result.exit_code == 0
+    assert "identity=verified" in result.output.lower()
+
+
+def test_verify_reports_mismatch_and_nonzero_exit_when_sealed_journal_is_truncated(tmp_path: Path) -> None:
+    """Truncating a sealed run's journal tail flips identity to mismatched, not unverifiable (#4203)."""
+    sdd_dir = tmp_path / ".sdd"
+    journal = _sealed_journal(sdd_dir, "run-sealed-2")
+
+    lines = journal.path.read_text(encoding="utf-8").splitlines()
+    journal.path.write_text("\n".join(lines[:-1]) + "\n", encoding="utf-8")
+
+    result = CliRunner().invoke(replay_cmd, ["run-sealed-2", "--sdd-dir", str(sdd_dir), "--verify"])
+
+    assert result.exit_code != 0
+    assert "mismatch" in result.output.lower()
+    assert "unverifiable" not in result.output.lower()
+
+
+def test_verify_reports_mismatch_and_nonzero_exit_when_sealed_journal_is_extended(tmp_path: Path) -> None:
+    """Appending an event after a run is sealed flips identity to mismatched (#4203)."""
+    sdd_dir = tmp_path / ".sdd"
+    journal = _sealed_journal(sdd_dir, "run-sealed-3")
+    journal.record("task_claimed", task_id="T-2")
+
+    result = CliRunner().invoke(replay_cmd, ["run-sealed-3", "--sdd-dir", str(sdd_dir), "--verify"])
+
+    assert result.exit_code != 0
+    assert "mismatch" in result.output.lower()
+    assert "unverifiable" not in result.output.lower()
 
 
 def test_verify_reports_first_divergent_step(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #4203.

## Symptom

A finalized run writes its journal head into the lineage spine at finish
(`seal_journal_into_spine`; a fresh run's single spine entry *is* that
seal). Verifying that same run still reports the weakest verdict:

```
CHAIN INTACT for <run-id> (19 steps); identity=unverifiable
```

A sealed run and an unsealed run were indistinguishable to `replay --verify`.

## Root cause

`verify_journal()` already supports a `seal=` parameter that compares the
recomputed journal head/count against an independent commitment and reports
`verified` or `mismatched`. `_replay_verify_journal` (the `bernstein replay
--verify` handler) called it with no seal at all, so identity was always
computed against `seal=None`, which is `unverifiable` by construction.

## Fix

`_replay_verify_journal` now looks up the run's journal-head seal from the
lineage spine before verifying. The spine entry stores only the head (in its
`step_id`, after HMAC/tamper verification of the spine chain itself), not an
event count; the freshly recomputed count is fed back in as the seal's count,
which is sound because the journal's Merkle construction folds each step's
index into its hash -- a matching head already cryptographically commits to
the exact event count it was computed over, so a truncated or extended
journal cannot reach the sealed head with a different count.

When a seal is found, identity now reports `verified` or a loud `mismatched`
(with a non-zero exit even when the parsed chain still recomputes cleanly on
its own, e.g. a truncated tail). Runs with no seal, no lineage spine, or no
audit key configured are unaffected -- identity stays `unverifiable`, same
as before.

## Test

- Sealed, untouched run: identity=verified, exit 0.
- Sealed run with a truncated journal tail: mismatch, non-zero exit.
- Sealed run with an appended event: mismatch, non-zero exit.
- Existing unsealed-run test (identity=unverifiable, exit 0) unchanged.

`uv run --frozen pytest tests/unit/test_replay_verify_cli.py tests/unit/core/replay/ tests/unit/test_journal_spine_seal.py tests/unit/test_lineage_seal_only_verify.py tests/unit/test_event_journal.py tests/unit/lineage/test_artifact_events.py tests/unit/lineage/test_artifact_fanout_replay.py tests/unit/adapters/test_artifact_production_conformance.py tests/unit/test_replay_cmd.py tests/unit/cli/test_advanced_cmd_paths.py tests/unit/lineage/test_spine.py tests/unit/lineage/test_spine_cli.py tests/unit/lineage/test_spine_deprecations.py tests/unit/test_provider_state_journal.py -q` -- all pass.
