### PR TITLE
fix(audit): make verify read-only and separate post-seal appends from a rewritten prefix

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -129,3 +129,19 @@ rather than as its own attribution is exempted by hand there, with the reason.
   [`docs/concepts/lesson-persistence.md`](../concepts/lesson-persistence.md)
   records as the remaining gap.
 - Workspace merge order calculation is scoped to the caller's tenant (#4155).
+- `bernstein audit verify` reads the store and writes nothing to it, and the
+  daily seal now tells post-seal appends apart from a rewritten prefix (#4210,
+  #4201). The seal is pinned at run finalization while the log keeps growing —
+  a run closing after its own seal appends one more row — and the pillar bound
+  the whole current file, so every re-verification of a finished, untouched run
+  reported `TAMPERED` and exited non-zero. Routine use of a red verdict is how
+  a real one gets ignored. Each leaf is now recomputed over the byte prefix the
+  seal pinned, the root is re-derived from those bytes and compared against the
+  pinned root, and the verdict names the intact prefix and the post-seal row
+  count separately. The fail-closed direction is unchanged: an edit inside the
+  sealed prefix, or a segment shorter than its pin, is still `TAMPERED` with a
+  non-zero exit. Separately, seven verification pillars resolved the audit key
+  through the create-if-absent loader, so verifying a store whose key was
+  missing minted one — key material a fresh chain cannot authenticate, written
+  by the tool whose whole claim is that it only reads. They now use the
+  load-only resolver and report a missing key as a named skip.

--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -333,9 +333,15 @@ deleted, inserted, reordered, or content-tampered daily file.
 
 what the seal binds:
 
-- **leaf per file** - each file's leaf is the hash of its *whole*
-  canonical byte content, so flipping any byte of any line (not just
-  the last) changes the leaf and trips `TAMPERED` on verify.
+- **leaf per file** - each file's leaf is the hash of its canonical
+  byte content, so flipping any byte of any line (not just the last)
+  changes the leaf and trips `TAMPERED` on verify.
+- **prefix, not whole file, on verify** - the seal also pins each
+  segment's byte length. verification recomputes the leaf over exactly
+  those bytes, so rows appended after the seal (a run closing after its
+  own finalization, say) are reported as `Post-seal rows` instead of as
+  tamper. an edit *inside* the sealed prefix, or a segment shorter than
+  its pin, still trips `TAMPERED` and exits non-zero.
 - **domain-separated tree** - leaves are hashed `H(0x00 || bytes)` and
   internal nodes `H(0x01 || left || right)` (RFC-6962 style). a lone
   node at an odd level is promoted unchanged rather than paired with

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -354,6 +354,27 @@ def verify_cmd(merkle_only: bool, hmac_only: bool, receipt_path: str | None, pay
     raise SystemExit(0 if all_passed else 1)
 
 
+def _verify_key(pillar: str) -> bytes | None:
+    """Load the audit key for a verification pillar, never minting one.
+
+    Verification must not write to the store it inspects (#4210). Creating key
+    material here would leave stray key bytes behind and authenticate nothing:
+    a fresh key cannot validate a chain written under the real one, so it would
+    report a fabricated tamper alarm. A missing key is a named degradation -
+    the same limit the HMAC and checkpoint pillars carry - and the HMAC pillar
+    already fails the run when segments exist without a key.
+
+    Returns the key, or ``None`` when there is none to load.
+    """
+    from bernstein.core.security.audit import AuditKeyMissingError, load_audit_key
+
+    try:
+        return load_audit_key()
+    except AuditKeyMissingError:
+        console.print(f"[yellow]{pillar} verification skipped: no audit HMAC key available.[/yellow]")
+        return None
+
+
 def _verify_trajectory_receipts() -> bool:
     """Verify every benchmark-score trajectory receipt and print results.
 
@@ -363,7 +384,6 @@ def _verify_trajectory_receipts() -> bool:
     entry (#2925). When no trajectory receipts exist the check is a silent
     no-op (returns True immediately).
     """
-    from bernstein.core.security.audit import AuditKeyPermissionError, load_or_create_audit_key
     from bernstein.eval.trajectory_receipt import verify_all_trajectory_receipts
 
     # Derive workdir from cwd() for consistency with how the receipts were
@@ -371,11 +391,9 @@ def _verify_trajectory_receipts() -> bool:
     # AUDIT_DIR which may be a relative path that resolves differently.
     workdir = Path.cwd()
 
-    try:
-        key = load_or_create_audit_key()
-    except (OSError, AuditKeyPermissionError) as exc:  # pragma: no cover - filesystem race
-        console.print(f"[red]Failed to load audit key for trajectory receipt verification: {exc}[/red]")
-        return False
+    key = _verify_key("Trajectory receipt")
+    if key is None:
+        return True
 
     results = verify_all_trajectory_receipts(workdir, hmac_key=key)
     if not results:
@@ -428,7 +446,6 @@ def _verify_automation_receipt(receipt_path: str, payload_path: str | None) -> N
     """
     import json as _json
 
-    from bernstein.core.security.audit import load_or_create_audit_key
     from bernstein.core.trigger_sources.receipt import verify_receipt_document
 
     try:
@@ -448,10 +465,16 @@ def _verify_automation_receipt(receipt_path: str, payload_path: str | None) -> N
             console.print(f"[red]Could not read payload:[/red] {exc}")
             raise SystemExit(2) from exc
 
+    # Load-only: answering "does this receipt check out?" must not leave key
+    # material behind in the store being inspected (#4210).
+    hmac_key = _verify_key("Receipt")
+    if hmac_key is None:
+        raise SystemExit(1)
+
     result = verify_receipt_document(
         document,
         audit_dir=AUDIT_DIR,
-        hmac_key=load_or_create_audit_key(),
+        hmac_key=hmac_key,
         body=body,
     )
 
@@ -489,17 +512,15 @@ def _verify_fleet_config() -> bool:
     fleet config events exist the check is a silent no-op.
     """
     from bernstein.core.fleet.config_audit import verify_fleet_config_events
-    from bernstein.core.security.audit import load_or_create_audit_key
     from bernstein.core.security.audit_chain import (
         EVENT_FLEET_VAR_SET,
         AuditChainStore,
     )
 
-    try:
-        chain = AuditChainStore(AUDIT_DIR, key=load_or_create_audit_key())
-    except OSError as exc:  # pragma: no cover - filesystem race
-        console.print(f"[red]Failed to load audit key for fleet config verification: {exc}[/red]")
-        return False
+    key = _verify_key("Fleet config")
+    if key is None:
+        return True
+    chain = AuditChainStore(AUDIT_DIR, key=key)
 
     # Cheap presence probe: if no variable and no connection events exist,
     # stay a silent no-op like the other pillars.
@@ -533,7 +554,10 @@ def _verify_pool_receipts() -> bool:
     """
     from bernstein.cli.commands.pool_cmd import verify_pools
 
-    ok, errors = verify_pools(Path.cwd())
+    key = _verify_key("Pool")
+    if key is None:
+        return True
+    ok, errors = verify_pools(Path.cwd(), key=key)
     console.print()
     if ok:
         console.print(Panel("[bold green]Pool Verification Passed[/bold green]", border_style="green", expand=False))
@@ -574,7 +598,6 @@ def _verify_grant_chains() -> bool:
     chain entry (#2516). When no grant chains exist the check is a silent no-op.
     """
     from bernstein.core.identity import grants
-    from bernstein.core.security.audit import load_or_create_audit_key
 
     grants_dir = AUDIT_DIR / "grants"
     if not grants_dir.is_dir():
@@ -583,11 +606,9 @@ def _verify_grant_chains() -> bool:
     if not run_files:
         return True
 
-    try:
-        key = load_or_create_audit_key()
-    except OSError as exc:  # pragma: no cover - filesystem race
-        console.print(f"[red]Failed to load audit key for grant verification: {exc}[/red]")
-        return False
+    key = _verify_key("Grant chain")
+    if key is None:
+        return True
 
     failures: list[tuple[str, list[str]]] = []
     for path in run_files:
@@ -870,7 +891,13 @@ def ack_tear_cmd(segment: str, offset: int, reason: str, actor: str | None) -> N
 
 
 def _verify_merkle_tree() -> bool:
-    """Verify Merkle tree and print results. Returns True if valid."""
+    """Verify Merkle tree and print results. Returns True if valid.
+
+    The seal is pinned at finalization and the log keeps growing after it, so
+    the verdict separates the two facts an operator needs: the sealed prefix
+    recomputed to the pinned root, and how many rows arrived after the pin
+    (#4201). Only the first is an integrity claim.
+    """
     from bernstein.core.merkle import verify_merkle
 
     result = verify_merkle(AUDIT_DIR, MERKLE_DIR)
@@ -882,6 +909,9 @@ def _verify_merkle_tree() -> bool:
         table.add_column("Key", style="dim", no_wrap=True, min_width=14)
         table.add_column("Value")
         table.add_row("Root hash", result.root_hash)
+        if result.post_seal_rows:
+            table.add_row("Sealed prefix", "intact")
+            table.add_row("Post-seal rows", str(sum(result.post_seal_rows.values())))
         if result.seal_path:
             table.add_row("Seal file", str(result.seal_path))
         console.print(table)
@@ -900,17 +930,14 @@ def _verify_evidence_bundles() -> bool:
     exist the check is a silent no-op.
     """
     from bernstein.core.evidence.bundle import verify_all_evidence_bundles
-    from bernstein.core.security.audit import load_or_create_audit_key
 
     # AUDIT_DIR is ``.sdd/audit``; the project root is two levels up. Bundles
     # live under ``<root>/.sdd/evidence/bundles``.
     workdir = AUDIT_DIR.parent.parent
 
-    try:
-        key = load_or_create_audit_key()
-    except OSError as exc:  # pragma: no cover - filesystem race
-        console.print(f"[red]Failed to load audit key for evidence verification: {exc}[/red]")
-        return False
+    key = _verify_key("Evidence bundle")
+    if key is None:
+        return True
 
     results = verify_all_evidence_bundles(workdir, hmac_key=key)
     if not results:
@@ -945,17 +972,14 @@ def _verify_run_artifacts() -> bool:
     artifacts exist the check is a silent no-op.
     """
     from bernstein.core.evidence.run_artifacts import verify_all_run_artifacts
-    from bernstein.core.security.audit import load_or_create_audit_key
 
     # AUDIT_DIR is ``.sdd/audit``; the project root is two levels up. Artifacts
     # live under ``<root>/.sdd/runs/*/journal.jsonl`` + ``<root>/.sdd/evidence``.
     workdir = AUDIT_DIR.parent.parent
 
-    try:
-        key = load_or_create_audit_key()
-    except OSError as exc:  # pragma: no cover - filesystem race
-        console.print(f"[red]Failed to load audit key for artifact verification: {exc}[/red]")
-        return False
+    key = _verify_key("Run artifact")
+    if key is None:
+        return True
 
     results = verify_all_run_artifacts(workdir, hmac_key=key)
     if not results:
@@ -987,18 +1011,15 @@ def _verify_tournament_receipts() -> bool:
     fail with the task named, exactly like a tampered chain entry (#2353). When
     no receipts exist the check is a silent no-op.
     """
-    from bernstein.core.security.audit import load_or_create_audit_key
     from bernstein.core.tournament.receipt import verify_all_tournament_receipts
 
     # AUDIT_DIR is ``.sdd/audit``; receipts live under
     # ``<root>/.sdd/tournaments/receipts``.
     workdir = AUDIT_DIR.parent.parent
 
-    try:
-        key = load_or_create_audit_key()
-    except OSError as exc:  # pragma: no cover - filesystem race
-        console.print(f"[red]Failed to load audit key for tournament verification: {exc}[/red]")
-        return False
+    key = _verify_key("Tournament receipt")
+    if key is None:
+        return True
 
     results = verify_all_tournament_receipts(workdir, hmac_key=key)
     if not results:
@@ -1037,7 +1058,10 @@ def _verify_approval_cards() -> bool:
     """
     from bernstein.core.approval.card_verify import verify_approval_cards
 
-    result = verify_approval_cards(AUDIT_DIR)
+    key = _verify_key("Approval card")
+    if key is None:
+        return True
+    result = verify_approval_cards(AUDIT_DIR, key=key)
     if result.issued_count == 0 == result.resolved_count:
         return True  # no approval cards recorded; nothing to verify
 
@@ -1079,7 +1103,10 @@ def _verify_sovereign_attestations() -> bool:
     """
     from bernstein.core.security.deployment_profile import verify_sovereign_attestations
 
-    result = verify_sovereign_attestations(AUDIT_DIR)
+    key = _verify_key("Sovereign posture")
+    if key is None:
+        return True
+    result = verify_sovereign_attestations(AUDIT_DIR, key=key)
     if result.attestation_count == 0 == result.drift_count:
         return True  # no sovereign records; nothing to verify
 
@@ -1118,7 +1145,10 @@ def _verify_clearance_gates() -> bool:
     from bernstein.core.communication.signal_actions import verify_clearance_gates
     from bernstein.core.security.audit import AuditLog
 
-    log = AuditLog(AUDIT_DIR)
+    key = _verify_key("Clearance gate")
+    if key is None:
+        return True
+    log = AuditLog(AUDIT_DIR, key=key)
     chain_ok, chain_errors = log.verify()
     if not chain_ok:
         console.print()

--- a/src/bernstein/cli/commands/pool_cmd.py
+++ b/src/bernstein/cli/commands/pool_cmd.py
@@ -43,13 +43,13 @@ def _chain(workdir: Path) -> Any:
     return AuditChainStore(audit_dir)
 
 
-def _pool_events(workdir: Path) -> list[Any]:
+def _pool_events(workdir: Path, *, key: bytes | None = None) -> list[Any]:
     audit_dir = _audit_dir(workdir)
     if not audit_dir.is_dir():
         return []
     from bernstein.core.security.audit_chain import AuditChainStore
 
-    events = AuditChainStore(audit_dir).query()
+    events = AuditChainStore(audit_dir, key=key).query()
     return [e for e in events if str(getattr(e, "event_type", "")).startswith("pool.")]
 
 
@@ -195,17 +195,19 @@ def verify_cmd(workdir: Path) -> None:
     raise SystemExit(1)
 
 
-def verify_pools(workdir: Path) -> tuple[bool, list[str]]:
+def verify_pools(workdir: Path, *, key: bytes | None = None) -> tuple[bool, list[str]]:
     """Verify active pool bodies and stored placement receipts.
 
     Returns ``(ok, errors)``. Reused by ``bernstein audit verify`` so the pool
-    subsystem is a first-class integrity pillar alongside the HMAC chain.
+    subsystem is a first-class integrity pillar alongside the HMAC chain. The
+    caller passes *key* so reading the chain cannot mint one: verification
+    writes nothing to the store it inspects (#4210).
     """
     from bernstein.core.sandbox.pool_placement import verify_placement_receipt
 
     errors: list[str] = []
     store = _store(workdir)
-    active = project_pool_registry(_pool_events(workdir))
+    active = project_pool_registry(_pool_events(workdir, key=key))
     for name, pool_hash in sorted(active.items()):
         try:
             store.get(pool_hash)

--- a/src/bernstein/core/persistence/merkle.py
+++ b/src/bernstein/core/persistence/merkle.py
@@ -26,7 +26,7 @@ import json
 import time
 from contextlib import suppress
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -452,6 +452,10 @@ class VerifyResult:
     errors: list[str] = field(default_factory=list)
     seal_path: Path | None = None
     root_hash: str = ""
+    #: Rows appended to each sealed segment after the seal was pinned. Empty
+    #: for seals that pin no per-leaf byte length (see
+    #: :func:`_check_sealed_prefixes`).
+    post_seal_rows: dict[str, int] = field(default_factory=dict)
 
 
 def load_latest_seal(merkle_dir: Path) -> tuple[dict[str, object], Path] | None:
@@ -478,20 +482,70 @@ def _check_inserted_files(current_files: list[Path], sealed_name_set: set[str]) 
     return [f"INSERTED: {f.name} (on disk, not in seal)" for f in current_files if f.name not in sealed_name_set]
 
 
-def _check_tampered_content(sealed_leaves: list[dict[str, str]], audit_dir: Path, scheme: int) -> list[str]:
-    """Return errors for files whose leaf hash doesn't match the seal.
+def _sealed_byte_len(leaf: dict[str, Any]) -> int | None:
+    """Return the byte length the seal pinned for *leaf*, or ``None``.
 
-    Leaf derivation is recomputed under *scheme* so a seal produced under
-    one scheme always verifies the same way (byte-identical leaf rule).
+    Seals written before the per-leaf length was recorded pin no prefix, so
+    those leaves keep binding the whole file.
+    """
+    raw = leaf.get("byte_len")
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 0:
+        return None
+    return raw
+
+
+def _count_rows(data: bytes) -> int:
+    """Count JSONL rows in *data*; a trailing newline does not add a row."""
+    return sum(1 for line in data.split(b"\n") if line.strip())
+
+
+def _check_sealed_prefixes(
+    sealed_leaves: list[dict[str, Any]],
+    audit_dir: Path,
+    scheme: int,
+) -> tuple[list[str], dict[str, str], dict[str, int]]:
+    """Recompute every sealed leaf over the byte prefix the seal pinned.
+
+    The log is append-only and the seal is pinned at finalization, so a segment
+    that legitimately kept growing is *longer* than the seal recorded. Binding
+    the whole current file reads every such append as tamper, which is what
+    made re-verification of a finished, untouched run permanently red
+    (issue #4201). Binding the pinned prefix keeps the properties that matter -
+    any edit inside the sealed prefix changes the recomputed leaf, and a
+    segment shorter than its pin is a deletion - while the rows past the pin
+    are counted rather than reported as damage.
+
+    Leaf derivation is recomputed under *scheme* so a seal produced under one
+    scheme always verifies the same way (byte-identical leaf rule). Legacy (v1)
+    seals and any leaf without a pinned length still bind the whole file: there
+    is no prefix to recompute over, so the historical rule stands.
+
+    Returns ``(errors, recomputed_leaves, post_seal_rows)``.
     """
     errors: list[str] = []
+    recomputed: dict[str, str] = {}
+    post_seal_rows: dict[str, int] = {}
     for leaf in sealed_leaves:
-        fpath = audit_dir / leaf["file"]
-        if fpath.exists():
+        name = str(leaf["file"])
+        fpath = audit_dir / name
+        if not fpath.exists():
+            continue  # already reported by _check_deleted_files
+        byte_len = _sealed_byte_len(leaf)
+        if byte_len is None or scheme <= _LEGACY_SCHEME_VERSION:
             current_hash = file_leaf_hash(fpath, scheme=scheme)
-            if current_hash != leaf["hash"]:
-                errors.append(f"TAMPERED: {leaf['file']} (hash mismatch)")
-    return errors
+        else:
+            content = fpath.read_bytes()
+            if byte_len > len(content):
+                errors.append(
+                    f"TAMPERED: {name} (sealed prefix truncated: {len(content)} bytes on disk, {byte_len} sealed)"
+                )
+                continue
+            current_hash = _leaf_digest(content[:byte_len])
+            post_seal_rows[name] = _count_rows(content[byte_len:])
+        recomputed[name] = current_hash
+        if current_hash != leaf["hash"]:
+            errors.append(f"TAMPERED: {name} (sealed prefix hash mismatch)")
+    return errors, recomputed, post_seal_rows
 
 
 def _seal_scheme(seal: dict[str, object]) -> int:
@@ -518,6 +572,11 @@ def verify_merkle(audit_dir: Path, merkle_dir: Path) -> VerifyResult:
     mismatches. Verification recomputes leaves and the tree under the
     scheme recorded in the seal, so pre-hardening (v1) seals still verify
     under their original rules.
+
+    Each leaf is recomputed over the byte prefix the seal pinned, so rows
+    appended to a segment after the seal are reported as
+    :attr:`VerifyResult.post_seal_rows` rather than as tamper; an edit inside
+    the sealed prefix still fails (issue #4201).
     """
     result = VerifyResult(valid=False)
 
@@ -531,8 +590,8 @@ def verify_merkle(audit_dir: Path, merkle_dir: Path) -> VerifyResult:
     result.root_hash = str(seal.get("root_hash", ""))
     scheme = _seal_scheme(seal)
 
-    sealed_leaves: list[dict[str, str]] = seal.get("leaves", [])  # type: ignore[assignment]
-    sealed_names = [leaf["file"] for leaf in sealed_leaves]
+    sealed_leaves: list[dict[str, Any]] = seal.get("leaves", [])  # type: ignore[assignment]
+    sealed_names = [str(leaf["file"]) for leaf in sealed_leaves]
     sealed_name_set = set(sealed_names)
 
     current_files = sorted(audit_dir.glob("*.jsonl"))
@@ -540,11 +599,15 @@ def verify_merkle(audit_dir: Path, merkle_dir: Path) -> VerifyResult:
 
     result.errors.extend(_check_deleted_files(sealed_names, current_name_set))
     result.errors.extend(_check_inserted_files(current_files, sealed_name_set))
-    result.errors.extend(_check_tampered_content(sealed_leaves, audit_dir, scheme))
+    prefix_errors, recomputed, post_seal_rows = _check_sealed_prefixes(sealed_leaves, audit_dir, scheme)
+    result.errors.extend(prefix_errors)
+    result.post_seal_rows = post_seal_rows
 
-    # Rebuild tree and verify root
+    # Rebuild the tree from the leaves just recomputed off disk - not from the
+    # seal's own leaf hashes, which would only restate the seal - and compare
+    # against the pinned root.
     if not result.errors:
-        leaf_hashes = [(leaf["file"], leaf["hash"]) for leaf in sealed_leaves]
+        leaf_hashes = [(name, recomputed[name]) for name in sealed_names]
         tree = build_merkle_tree(leaf_hashes, scheme=scheme)
         if tree.root.hash != seal.get("root_hash"):
             result.errors.append(f"ROOT MISMATCH: computed={tree.root.hash}, sealed={seal.get('root_hash')}")

--- a/tests/unit/cli/test_audit_verify_cards.py
+++ b/tests/unit/cli/test_audit_verify_cards.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from bernstein.cli.commands import audit_cmd
 from bernstein.core.approval.card import build_card
 from bernstein.core.approval.card_gate import ApprovalCardGate
@@ -19,6 +21,13 @@ from bernstein.core.security.audit_chain import (
 )
 
 _KEY = b"k" * 32
+
+
+@pytest.fixture(autouse=True)
+def _pin_audit_key(monkeypatch):
+    # The audit-verify path reads the install key and never mints one (#4210),
+    # so pin it to the key the seeded chain was written with.
+    monkeypatch.setattr("bernstein.core.security.audit.load_audit_key", lambda *a, **k: _KEY)
 
 
 def _seed(audit_dir) -> str:

--- a/tests/unit/cli/test_audit_verify_grants.py
+++ b/tests/unit/cli/test_audit_verify_grants.py
@@ -15,8 +15,9 @@ from bernstein.core.identity import grants
 
 @pytest.fixture(autouse=True)
 def _pin_audit_key(monkeypatch):
-    # The audit-verify path loads the install audit key directly, so pin it.
-    monkeypatch.setattr("bernstein.core.security.audit.load_or_create_audit_key", lambda *a, **k: b"k" * 32)
+    # The audit-verify path loads the install audit key directly (load-only,
+    # never minting one -- #4210), so pin it.
+    monkeypatch.setattr("bernstein.core.security.audit.load_audit_key", lambda *a, **k: b"k" * 32)
 
 
 def _seed_grants(audit_dir, *, tamper: bool = False) -> None:

--- a/tests/unit/cli/test_audit_verify_is_read_only.py
+++ b/tests/unit/cli/test_audit_verify_is_read_only.py
@@ -1,0 +1,109 @@
+"""``bernstein audit verify`` inspects the store without writing to it (#4210).
+
+A verifier that changes the evidence cannot be run twice on the same run: the
+second pass judges what the first one wrote. These tests pin the whole command
+down to bytes on disk, and pin the verdict a finished, untouched run must get
+(#4201) - including the fail-closed direction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import stat
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.audit_cmd import audit_group
+from bernstein.core.security.audit import AUDIT_KEY_ENV, AuditLog, load_or_create_audit_key
+
+
+@pytest.fixture
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An isolated project with its own chain and a pinned tmp HMAC key.
+
+    ``AUDIT_DIR`` in the command module is the relative ``Path(".sdd/audit")``,
+    so chdir-ing here keeps every pillar inside *tmp_path*.
+    """
+    key_path = tmp_path / "audit.key"
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(key_path))
+    monkeypatch.chdir(tmp_path)
+    key = load_or_create_audit_key()
+    key_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    log = AuditLog(tmp_path / ".sdd" / "audit", key=key)
+    for i in range(3):
+        log.log("task.complete", "agent-1", "task", f"t-{i}", {"i": i})
+    return tmp_path
+
+
+def _digest(root: Path) -> dict[str, str]:
+    """Content digest of every file in *root*, keyed by relative path."""
+    return {
+        str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in sorted(root.rglob("*"))
+        if p.is_file()
+    }
+
+
+def _close_the_run(project: Path) -> None:
+    """Append the row a run legitimately writes after its seal is pinned."""
+    key = load_or_create_audit_key()
+    AuditLog(project / ".sdd" / "audit", key=key).log("run.closure", "orchestrator", "run", "run-1", {})
+
+
+def _run(*args: str):
+    return CliRunner().invoke(audit_group, list(args))
+
+
+def test_two_verify_runs_leave_the_store_byte_identical(project: Path) -> None:
+    """Nothing about running the verifier changes what the verifier reads."""
+    assert _run("seal").exit_code == 0
+    _close_the_run(project)
+
+    before = _digest(project)
+    _run("verify")
+    after_first = _digest(project)
+    _run("verify")
+    after_second = _digest(project)
+
+    assert after_first == before
+    assert after_second == before
+
+
+def test_verify_mints_no_audit_key(project: Path) -> None:
+    """A verifier that minted a key would authenticate nothing and alarm."""
+    assert _run("seal").exit_code == 0
+    (project / "audit.key").unlink()
+
+    _run("verify")
+
+    assert not (project / "audit.key").exists()
+
+
+def test_finished_untouched_run_verifies_clean_and_names_post_seal_rows(project: Path) -> None:
+    """The seal is pinned at finalization; the rows after it are not damage."""
+    assert _run("seal").exit_code == 0
+    _close_the_run(project)
+
+    result = _run("verify")
+
+    assert result.exit_code == 0, result.output
+    assert "Sealed prefix" in result.output
+    assert "intact" in result.output
+    assert "Post-seal rows" in result.output
+
+
+def test_edit_inside_the_sealed_prefix_exits_nonzero(project: Path) -> None:
+    """Post-seal growth must not become cover for rewriting sealed history."""
+    assert _run("seal").exit_code == 0
+    _close_the_run(project)
+    segment = sorted((project / ".sdd" / "audit").glob("*.jsonl"))[0]
+    content = bytearray(segment.read_bytes())
+    content[5] ^= 0x01
+    segment.write_bytes(bytes(content))
+
+    result = _run("verify")
+
+    assert result.exit_code != 0
+    assert "TAMPERED" in result.output

--- a/tests/unit/eval/test_trajectory_receipt_cli.py
+++ b/tests/unit/eval/test_trajectory_receipt_cli.py
@@ -61,7 +61,7 @@ _FAKE_EVENTS_HASH = "sha256:" + "b" * 64
 def _pin_audit_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pin the install audit key so no filesystem side-effects occur."""
     monkeypatch.setattr(
-        "bernstein.core.security.audit.load_or_create_audit_key",
+        "bernstein.core.security.audit.load_audit_key",
         lambda *a, **kw: _KEY,
     )
 

--- a/tests/unit/test_audit_verify_receipt_cmd.py
+++ b/tests/unit/test_audit_verify_receipt_cmd.py
@@ -40,6 +40,9 @@ def workdir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
     monkeypatch.delenv("BERNSTEIN_AUTOMATION_BRIDGE_ROOT", raising=False)
     (tmp_path / ".sdd" / "audit").mkdir(parents=True)
+    # The command reads the key and never creates one (#4210), so the project
+    # has to carry it the way a real store does.
+    load_or_create_audit_key(tmp_path / "audit.key")
     monkeypatch.chdir(tmp_path)
     return tmp_path
 

--- a/tests/unit/test_merkle_post_seal_appends.py
+++ b/tests/unit/test_merkle_post_seal_appends.py
@@ -1,0 +1,106 @@
+"""The daily seal pins a prefix, not the whole file (issue #4201).
+
+The audit log is append-only and the seal is pinned at run finalization, so a
+segment that keeps growing legitimately is longer than the seal recorded.
+Binding the whole current file made every re-verification of a finished,
+untouched run report ``TAMPERED``. These tests assert the two halves of the
+replacement rule empirically: rows past the pin are counted, and any edit
+inside the pinned prefix (including a shrink) still fails closed.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import TYPE_CHECKING
+
+from bernstein.core.persistence.merkle import compute_seal, save_seal, verify_merkle
+from bernstein.core.security.audit import AuditLog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _log(audit_dir: Path, key: bytes, count: int) -> AuditLog:
+    """Append *count* genuinely HMAC-chained events and return the log."""
+    log = AuditLog(audit_dir, key=key)
+    for i in range(count):
+        log.log(
+            event_type="task.complete",
+            actor="agent-1",
+            resource_type="task",
+            resource_id=f"t-{i}",
+            details={"i": i},
+        )
+    return log
+
+
+def _sealed_project(tmp_path: Path) -> tuple[Path, Path, Path, bytes]:
+    """Seal a 3-event chain; return ``(audit, merkle, segment, key)``."""
+    audit = tmp_path / "audit"
+    merkle = audit / "merkle"
+    key = secrets.token_bytes(32)
+    _log(audit, key, 3)
+    segment = sorted(audit.glob("*.jsonl"))[0]
+
+    _, seal = compute_seal(audit, key=key, checkpoint_gate=False)
+    save_seal(seal, merkle)
+    assert verify_merkle(audit, merkle).valid, "fixture must seal clean"
+    return audit, merkle, segment, key
+
+
+def test_rows_appended_after_the_seal_are_not_tamper(tmp_path: Path) -> None:
+    """A finished run keeps appending; the sealed prefix is still intact."""
+    audit, merkle, _segment, key = _sealed_project(tmp_path)
+
+    AuditLog(audit, key=key).log(
+        event_type="run.closure",
+        actor="orchestrator",
+        resource_type="run",
+        resource_id="run-1",
+        details={},
+    )
+
+    result = verify_merkle(audit, merkle)
+    assert result.valid, result.errors
+    assert sum(result.post_seal_rows.values()) == 1
+
+
+def test_repeated_verification_of_an_untouched_run_stays_green(tmp_path: Path) -> None:
+    """Verification is a pure read: the verdict does not drift across runs."""
+    audit, merkle, _segment, _key = _sealed_project(tmp_path)
+
+    first = verify_merkle(audit, merkle)
+    second = verify_merkle(audit, merkle)
+    assert first.valid and second.valid
+    assert first.post_seal_rows == second.post_seal_rows
+
+
+def test_edit_inside_the_sealed_prefix_still_fails_closed(tmp_path: Path) -> None:
+    """Post-seal growth must not become cover for rewriting sealed history."""
+    audit, merkle, segment, key = _sealed_project(tmp_path)
+
+    AuditLog(audit, key=key).log(
+        event_type="run.closure",
+        actor="orchestrator",
+        resource_type="run",
+        resource_id="run-1",
+        details={},
+    )
+    content = bytearray(segment.read_bytes())
+    content[5] ^= 0x01  # a byte well inside the first sealed record
+    segment.write_bytes(bytes(content))
+
+    result = verify_merkle(audit, merkle)
+    assert not result.valid
+    assert any("TAMPERED" in err and segment.name in err for err in result.errors)
+
+
+def test_a_segment_shorter_than_its_seal_fails_closed(tmp_path: Path) -> None:
+    """A truncation removes sealed bytes; a prefix rule must not excuse it."""
+    audit, merkle, segment, _key = _sealed_project(tmp_path)
+
+    segment.write_bytes(segment.read_bytes()[:-40])
+
+    result = verify_merkle(audit, merkle)
+    assert not result.valid
+    assert any("TAMPERED" in err and segment.name in err for err in result.errors)


### PR DESCRIPTION
## Symptom

`bernstein audit verify` on a finished, untouched run:

```
! TAMPERED: 2026-08-21.jsonl (hash mismatch)
```

Exit 1, permanently, with the HMAC-chain, checkpoint, and pool pillars all green. Reproduced on a `bernstein demo` store: seal pinned at 17 entries, segment holds 18 rows.

Separately, verifying a store whose audit key was absent created one.

## Root cause

Two, in the same design.

1. The daily seal is pinned at run finalization, but the log keeps growing — the run's own `run.closure` row lands after its seal. The seal pillar recomputed each leaf over the *whole current file*, so any legitimate post-seal append changed the leaf and was reported as tamper. The root check was self-referential: the tree was rebuilt from the seal's own leaf hashes rather than from disk.
2. Seven verification pillars resolved the audit key through the create-if-absent loader. On a store with no key, `audit verify` minted one — key material that cannot authenticate an existing chain, written by the command whose claim is that it only reads. The HMAC and checkpoint pillars already used the load-only resolver; the rest did not.

## Fix

- Each sealed leaf is recomputed over the byte prefix the seal pinned (`byte_len`, already recorded per leaf). The root is re-derived from those bytes and compared against the pinned root. Rows past the pin are counted and reported separately in the verdict as `Sealed prefix: intact` / `Post-seal rows: N`.
- Fail-closed is unchanged: an edit inside the sealed prefix, or a segment shorter than its pin, is `TAMPERED` with a non-zero exit. Legacy (v1) seals and any leaf without a pinned length keep the whole-file rule.
- The remaining pillars use the load-only key resolver and report a missing key as a named skip, the same degradation the checkpoint pillar already reports. No opt-in recording flag was added: the default verify path mints no events at HEAD, so there was nothing to gate.

## Test

New:

- `tests/unit/test_merkle_post_seal_appends.py` — post-seal rows are not tamper; repeated verification of an untouched run stays green; an edit inside the sealed prefix fails closed; a segment shorter than its pin fails closed.
- `tests/unit/cli/test_audit_verify_is_read_only.py` — two `audit verify` runs leave every file in the project byte-identical (hashed); verify mints no audit key; a finished untouched run exits 0 with the verdict naming the intact prefix and the post-seal row count; an edit inside the sealed prefix exits non-zero as `TAMPERED`.

Four of these fail on `main` and pass here. Existing tests that pinned `load_or_create_audit_key` for the verify path now pin `load_audit_key`, and the receipt fixture creates the key its docstring already claimed.

Closes #4210
Closes #4201
