### PR TITLE
fix(cli): diagnose a spawned-then-dead agent instead of detaching silently

### DIFF
--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -12,7 +12,7 @@ import sys
 import time
 from contextlib import suppress
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 import click
 import httpx
@@ -44,6 +44,7 @@ from bernstein.cli.run_preflight import (
     validate_seed_or_exit,
 )
 from bernstein.core.cost import estimate_run_cost
+from bernstein.core.errors import BernsteinFirstRunError
 from bernstein.core.manager_parsing import _resolve_depends_on  # pyright: ignore[reportPrivateUsage]
 from bernstein.core.orchestration.process_utils import (
     LIVENESS_ALIVE,
@@ -1347,6 +1348,70 @@ def _poll_quiescent_status() -> dict[str, Any] | None:
     return status_payload
 
 
+#: Statuses that mean a task was actually picked up by an agent at some
+#: point. Deliberately excludes ``open``: an unclaimed task with no live
+#: agent is the ordinary gap before the next agent spawns for it, not
+#: evidence that anything died.
+_CLAIMED_BUT_STUCK_STATUSES: Final[frozenset[str]] = frozenset({"claimed", "in_progress", "orphaned"})
+
+
+def _poll_no_plan_after_spawn() -> dict[str, Any] | None:
+    """One poll: the ``/status`` payload iff a spawned agent died before any plan formed.
+
+    Covers a shape neither :func:`_poll_quiescent_status` nor
+    :func:`_wait_for_run_completion`'s "orchestrator gone" verdict catches: the
+    orchestrator subprocess is still alive and ticking, but the agent it spawned
+    died almost immediately, the goal was never decomposed, and the single root
+    task it left behind never advances past a declared-but-unfinished status.
+    That shape reads as ``open == claimed == 0`` at the top level whenever the
+    task is stuck ``in_progress``/``orphaned`` rather than ``claimed``, so it is
+    NOT quiescent, and the orchestrator process itself never exits, so it is not
+    "gone" either -- both existing checks correctly report "still running" and
+    the CLI would otherwise detach silently (issue #3528).
+
+    Unlike the "orchestrator gone" verdict, ``agent_count`` here is a live
+    figure the task server reports directly rather than an inference from a
+    pidfile, so a single reading of "no agent registered" needs no confirmation
+    window. The false-positive this must avoid is the ordinary startup window,
+    where the same ``agent_count == 0`` reading means "hasn't spawned yet" --
+    callers must only invoke this once :func:`_await_first_spawn_outcome` has
+    already confirmed an agent was alive at some point in this run.
+
+    Returns ``None`` for every other state, including "still running
+    normally", "at least one task has ever reached a terminal state" (a real
+    plan produced real output, whatever is stuck now is a different failure),
+    and "server unreachable".
+    """
+    status_payload = server_get("/status")
+    health_payload = server_get("/health")
+    if not (isinstance(status_payload, dict) and isinstance(health_payload, dict)):
+        return None
+    if int(health_payload.get("agent_count", 0) or 0) != 0:
+        return None
+    n_incomplete, full_counts = _incomplete_declared_counts(status_payload)
+    if full_counts is not None:
+        status_payload["task_counts"] = full_counts
+    total = int(status_payload.get("total", 0) or 0)
+    # Exactly one declared task (the manager's own decompose task) and it is
+    # still the only thing in the graph: decomposition never happened, so no
+    # plan was ever produced. A run that got as far as declaring child tasks
+    # has a plan, even if something else about it later goes wrong -- that is
+    # a different failure with its own diagnosis, not this one.
+    if total != 1 or n_incomplete != 1:
+        return None
+    # "open" alone is not evidence of a death: an unclaimed task with no
+    # live agent is the ordinary gap before the next agent picks it up, and
+    # that gap is exactly as wide whether an agent died or one simply
+    # hasn't spawned for it yet. What is only explained by a death is a task
+    # that WAS claimed -- ``claimed``, ``in_progress``, or ``orphaned`` --
+    # with nobody left holding it.
+    counts = full_counts if full_counts is not None else status_payload
+    was_claimed = sum(int(counts.get(status, 0) or 0) for status in _CLAIMED_BUT_STUCK_STATUSES)
+    if was_claimed != 1:
+        return None
+    return status_payload
+
+
 def _wait_for_run_completion(
     *,
     poll_interval_s: float = 2.0,
@@ -2600,6 +2665,11 @@ def _run_impl(
 
             _finalize_run_output(quiet=quiet)
             return
+        except BernsteinFirstRunError:
+            # Already carries a structured category and exit code; let the
+            # outer first-run guard render its hint instead of flattening it
+            # into a generic "failed to load plan file" message.
+            raise
         except Exception as exc:
             console.print(f"[red]Failed to load plan file:[/red] {exc}")
             raise SystemExit(1) from exc

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -696,6 +696,19 @@ def _finalize_run_output(*, quiet: bool) -> None:
                 console.print(f"[red]Run failed before any work started:[/red] {reason}")
                 console.print("Details: run 'bernstein status' or read .sdd/runtime/retrospective.md")
                 raise SystemExit(1)
+            if outcome == "spawned":
+                # An agent was confirmed alive at least once, so an empty
+                # agent count now is a death, not "hasn't spawned yet". A run
+                # whose spawned agent died before decomposing the goal must
+                # say so instead of detaching silently (issue #3528).
+                from bernstein.cli.run_bootstrap import _poll_no_plan_after_spawn
+                from bernstein.core.errors import BernsteinFirstRunError, ErrorCategory
+
+                if _poll_no_plan_after_spawn() is not None:
+                    raise BernsteinFirstRunError(
+                        "Spawned agent exited before producing a work plan",
+                        category=ErrorCategory.NO_PLAN_PRODUCED,
+                    )
             # A run that already reached a terminal state within the detach
             # window must not report success on its way out.
             _exit_nonzero_on_unhealthy_run(_poll_quiescent_status())

--- a/src/bernstein/core/errors/__init__.py
+++ b/src/bernstein/core/errors/__init__.py
@@ -6,7 +6,7 @@ hint renderer keyed off the category.
 
 Public surface (importable from ``bernstein.core.errors``):
 
-- :class:`ErrorCategory`: closed StrEnum of the 8 categories.
+- :class:`ErrorCategory`: closed StrEnum of the 9 categories.
 - :class:`BernsteinFirstRunError`: typed exception that carries a category.
 - :class:`AdapterAuthError`: marker exception for adapter authentication
   failures (raised by adapters when an auth-failure exit code is observed).

--- a/src/bernstein/core/errors/categories.py
+++ b/src/bernstein/core/errors/categories.py
@@ -29,6 +29,7 @@ class ErrorCategory(StrEnum):
     TIMEOUT = "timeout"
     PERMISSION_DENIED = "permission_denied"
     PORT_CONFLICT = "port_conflict"
+    NO_PLAN_PRODUCED = "no_plan_produced"
     UNKNOWN = "unknown"
 
 
@@ -52,6 +53,7 @@ _EXIT_CODES: Final[dict[ErrorCategory, int]] = {
     ErrorCategory.TIMEOUT: _EX_TEMPFAIL,
     ErrorCategory.PERMISSION_DENIED: _EX_NOPERM,
     ErrorCategory.PORT_CONFLICT: _EX_TEMPFAIL,
+    ErrorCategory.NO_PLAN_PRODUCED: _EX_SOFTWARE,
     ErrorCategory.UNKNOWN: _EX_SOFTWARE,
 }
 

--- a/src/bernstein/core/errors/hints.py
+++ b/src/bernstein/core/errors/hints.py
@@ -46,6 +46,7 @@ _CATEGORY_BORDER: Final[dict[ErrorCategory, str]] = {
     ErrorCategory.TIMEOUT: "orange3",
     ErrorCategory.PERMISSION_DENIED: "red",
     ErrorCategory.PORT_CONFLICT: "yellow",
+    ErrorCategory.NO_PLAN_PRODUCED: "red",
     ErrorCategory.UNKNOWN: "white",
 }
 
@@ -58,6 +59,7 @@ _CATEGORY_TITLE: Final[dict[ErrorCategory, str]] = {
     ErrorCategory.TIMEOUT: "Timed out",
     ErrorCategory.PERMISSION_DENIED: "Permission denied",
     ErrorCategory.PORT_CONFLICT: "Port conflict",
+    ErrorCategory.NO_PLAN_PRODUCED: "No plan produced",
     ErrorCategory.UNKNOWN: "Unhandled error",
 }
 
@@ -160,6 +162,14 @@ def _hint_body(category: ErrorCategory, context: HintContext | None) -> tuple[st
         return (
             f"Port `{port}` already in use. Set `BERNSTEIN_PORT` or stop the conflicting process.",
             f"lsof -i :{port}",
+        )
+    if category is ErrorCategory.NO_PLAN_PRODUCED:
+        adapter = _ctx_get(context, "adapter", "the configured adapter")
+        return (
+            f"The spawned `{adapter}` agent exited before decomposing the goal, so no work "
+            f"plan was produced. Check `.sdd/runtime/retrospective.md` for what the agent did "
+            f"before it died.",
+            "bernstein status",
         )
     # ErrorCategory.UNKNOWN
     repo = _ctx_get(context, "repo", "chernistry/bernstein")

--- a/tests/unit/test_no_plan_after_spawn_diagnosis.py
+++ b/tests/unit/test_no_plan_after_spawn_diagnosis.py
@@ -1,0 +1,232 @@
+"""Regression tests for issue #3528: a spawn failure must not report success.
+
+Ground truth (from the issue's reproduction): the manager agent's process
+died about a second after spawn. The single root task (its own decompose
+task) stayed ``claimed`` forever -- no plan was ever produced. The
+orchestrator subprocess kept ticking (it is not "gone"), and the task never
+reached quiescence (it is stuck ``claimed``, not terminal), so neither of
+the CLI's two existing terminal-state checks fired. The non-interactive
+detach path printed "Run continues in the background" and exited 0.
+
+Three layers are covered:
+
+1. ``_poll_no_plan_after_spawn`` -- the single-poll detector that recognises
+   this shape from ``/status`` + ``/health`` without a confirmation window.
+2. ``_finalize_run_output`` (non-TTY branch) -- a spawned-then-dead agent
+   with no plan must raise a categorised error instead of printing the
+   detach notice and returning.
+3. The structured taxonomy itself -- the new ``NO_PLAN_PRODUCED`` category
+   carries a real sysexits.h exit code and a non-empty hint, exactly like
+   every other first-run category.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bernstein.cli.run_bootstrap import _poll_no_plan_after_spawn
+from bernstein.core.errors import (
+    BernsteinFirstRunError,
+    ErrorCategory,
+    categorize_exception,
+    exit_code_for,
+    hint_for,
+)
+
+
+def _server_get_factory(
+    *,
+    status: dict[str, Any] | None,
+    health: dict[str, Any] | None,
+    counts: dict[str, Any] | None = None,
+) -> Any:
+    """Build a ``server_get`` stub serving /status, /health, /tasks/counts."""
+
+    def _server_get(path: str) -> Any:
+        if path.startswith("/status"):
+            return status
+        if path.startswith("/health"):
+            return health
+        if path.startswith("/tasks/counts"):
+            return counts
+        return None
+
+    return _server_get
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: _poll_no_plan_after_spawn detection
+# ---------------------------------------------------------------------------
+
+
+class TestPollNoPlanAfterSpawn:
+    def test_dead_agent_with_stuck_root_task_is_detected(self) -> None:
+        """The reproduced shape: one claimed task, zero live agents, no plan."""
+        stub = _server_get_factory(
+            status={"total": 1, "open": 0, "claimed": 1, "done": 0, "failed": 0},
+            health={"agent_count": 0},
+            counts={"total": 1, "open": 0, "claimed": 1, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0},
+        )
+        with patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub):
+            result = _poll_no_plan_after_spawn()
+        assert result is not None
+        assert result["total"] == 1
+
+    def test_orphaned_root_task_is_also_detected(self) -> None:
+        """A task the reaper marked orphaned (rather than left claimed) counts too.
+
+        ``/status`` has no bucket for ``orphaned``, so it reads open=claimed=0
+        even though one task is still stuck -- the full histogram is what
+        catches it.
+        """
+        stub = _server_get_factory(
+            status={"total": 1, "open": 0, "claimed": 0, "done": 0, "failed": 0},
+            health={"agent_count": 0},
+            counts={"total": 1, "open": 0, "claimed": 0, "in_progress": 0, "orphaned": 1, "done": 0, "failed": 0},
+        )
+        with patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub):
+            result = _poll_no_plan_after_spawn()
+        assert result is not None
+
+    def test_live_agent_is_not_a_death(self) -> None:
+        """An agent still registered alive must never be diagnosed as dead."""
+        stub = _server_get_factory(
+            status={"total": 1, "open": 0, "claimed": 1, "done": 0, "failed": 0},
+            health={"agent_count": 1},
+        )
+        with patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub):
+            result = _poll_no_plan_after_spawn()
+        assert result is None
+
+    def test_startup_window_with_no_declared_tasks_is_not_a_death(self) -> None:
+        """Before anything is declared, agent_count == 0 means 'not yet', not 'died'."""
+        stub = _server_get_factory(
+            status={"total": 0, "open": 0, "claimed": 0, "done": 0, "failed": 0},
+            health={"agent_count": 0},
+        )
+        with patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub):
+            result = _poll_no_plan_after_spawn()
+        assert result is None
+
+    def test_decomposed_plan_is_not_flagged(self) -> None:
+        """Once the manager decomposed the goal, a plan exists -- a different
+        agent later dying is a different failure, not this one."""
+        stub = _server_get_factory(
+            status={"total": 3, "open": 2, "claimed": 0, "done": 1, "failed": 0},
+            health={"agent_count": 0},
+            counts={"total": 3, "open": 2, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 1, "failed": 0},
+        )
+        with patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub):
+            result = _poll_no_plan_after_spawn()
+        assert result is None
+
+    def test_completed_run_is_not_flagged(self) -> None:
+        """A run whose one task actually finished must not be diagnosed as a death."""
+        stub = _server_get_factory(
+            status={"total": 1, "open": 0, "claimed": 0, "done": 1, "failed": 0},
+            health={"agent_count": 0},
+            counts={"total": 1, "open": 0, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 1, "failed": 0},
+        )
+        with patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub):
+            result = _poll_no_plan_after_spawn()
+        assert result is None
+
+    def test_unclaimed_open_task_is_not_a_death(self) -> None:
+        """An ``open`` task with no live agent is the ordinary gap before the
+        next agent spawns for it, not evidence anything died."""
+        stub = _server_get_factory(
+            status={"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0},
+            health={"agent_count": 0},
+            counts={"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0},
+        )
+        with patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub):
+            result = _poll_no_plan_after_spawn()
+        assert result is None
+
+    def test_unreachable_server_returns_no_verdict(self) -> None:
+        with patch("bernstein.cli.run_bootstrap.server_get", return_value=None):
+            result = _poll_no_plan_after_spawn()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: non-TTY exit path
+# ---------------------------------------------------------------------------
+
+_NON_TTY_CAPS = MagicMock(supports_textual=False, is_tty=False)
+
+
+class TestFinalizeRunOutputNoPlan:
+    def test_dead_agent_no_plan_raises_categorised_error(self) -> None:
+        """A spawned-then-dead agent with no plan must not print the detach
+        notice and exit 0 -- it must surface a stated, categorised reason."""
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        with (
+            patch("bernstein.cli.terminal_caps.detect_capabilities", return_value=_NON_TTY_CAPS),
+            patch(
+                "bernstein.cli.run_bootstrap._await_first_spawn_outcome",
+                return_value=("spawned", None),
+            ),
+            patch(
+                "bernstein.cli.run_bootstrap._poll_no_plan_after_spawn",
+                return_value={"total": 1, "claimed": 1},
+            ),
+            patch("bernstein.cli.run_preflight._show_run_summary"),
+            patch("bernstein.cli.run_bootstrap._poll_quiescent_status", return_value=None),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files") as drain,
+        ):
+            with pytest.raises(BernsteinFirstRunError) as excinfo:
+                _finalize_run_output(quiet=False)
+
+        assert excinfo.value.category is ErrorCategory.NO_PLAN_PRODUCED
+        # Cleanup must still run even though the diagnosis propagates as an
+        # exception rather than a caught SystemExit.
+        drain.assert_called_once()
+
+    def test_healthy_spawn_with_no_death_keeps_detach_notice(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """No regression: a normally-progressing run keeps today's fast detach."""
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        with (
+            patch("bernstein.cli.terminal_caps.detect_capabilities", return_value=_NON_TTY_CAPS),
+            patch(
+                "bernstein.cli.run_bootstrap._await_first_spawn_outcome",
+                return_value=("spawned", None),
+            ),
+            patch("bernstein.cli.run_bootstrap._poll_no_plan_after_spawn", return_value=None),
+            patch("bernstein.cli.run_preflight._show_run_summary"),
+            patch("bernstein.cli.run_bootstrap._poll_quiescent_status", return_value=None),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),
+        ):
+            _finalize_run_output(quiet=False)
+
+        out = capsys.readouterr().out
+        assert "continues in the background" in out
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: taxonomy wiring
+# ---------------------------------------------------------------------------
+
+
+class TestNoPlanProducedCategory:
+    def test_carries_a_sysexits_exit_code(self) -> None:
+        code = exit_code_for(ErrorCategory.NO_PLAN_PRODUCED)
+        assert 64 <= code <= 78
+
+    def test_categorize_exception_preserves_the_category(self) -> None:
+        exc = BernsteinFirstRunError(
+            "Spawned agent exited before producing a work plan",
+            category=ErrorCategory.NO_PLAN_PRODUCED,
+        )
+        assert categorize_exception(exc) is ErrorCategory.NO_PLAN_PRODUCED
+
+    def test_hint_renders_without_error(self) -> None:
+        panel = hint_for(ErrorCategory.NO_PLAN_PRODUCED)
+        assert panel is not None


### PR DESCRIPTION
Partial implementation of #3528.

## Symptom

`bernstein run` (no `--quiet`, no TTY -- the default in scripted/CI use)
detaches after confirming the first agent spawn. If that agent dies almost
immediately -- before decomposing the goal -- the run prints
`Dashboard ready.`, then `Run continues in the background`, and exits 0.
No plan was produced and no reason was given.

Reproduced 12/12 on a controlled harness: single cell, one adapter, twelve
consecutive runs. Every run left exactly one declared task (the manager's
own decompose task) stuck `claimed`/`in_progress`/`orphaned` with zero live
agents, and the CLI reported success anyway.

## Root cause

The non-interactive detach path only checked for literal quiescence
(`open == claimed == 0`, no live agent). That shape is neither quiescent
(the one task never reaches a terminal status) nor "orchestrator gone" (the
orchestrator subprocess itself keeps ticking -- only the agent it spawned
died). Both existing single-poll/wait checks correctly report "still
running", so the CLI detached without ever forming a verdict.

## Fix

Add `_poll_no_plan_after_spawn`: a single-poll detector for exactly this
shape -- an agent confirmed alive at some point, agent count now back to
zero, exactly one declared task, and that task was actually claimed (not
merely undeclared -- an unclaimed `open` task with no agent is the ordinary
gap before the next spawn, not evidence of a death). No confirmation window
is needed because `agent_count` is a figure the task server reports
directly, not an inference from a pidfile.

When it fires, the non-interactive path raises a `BernsteinFirstRunError`
carrying a new `NO_PLAN_PRODUCED` category, added to the existing structured
first-run taxonomy in `core/errors/`. The CLI's existing top-level guard
renders the category's hint and exits with its sysexits.h code, so this
reaches the operator the same way every other first-run diagnosis does,
instead of a bare print.

**Decision:** exit non-zero rather than keep a TUI open with the diagnosis
on screen. The reproduced path is non-interactive, so there is no TUI to
stay in, and exiting matches the existing refused-first-spawn behavior
(gh-2744) so a scripted `bernstein run && deploy` sees the failure.

## Remaining scope

This covers the reproduced non-interactive detach path only. The TTY
dashboard / Rich-fallback branches, and `--quiet` mode, still rely on the
slower, more general checks that already exist for them (the dashboard's
own live view, and `--quiet`'s stall backstop, which can take up to 30
minutes by default). Extending the fast diagnosis to those paths is
follow-up work.

Non-goals per the issue: adapter configuration (#3526), redesigning the
planner, and the three defects behind this reproduction's root cause
(#4221 environment, #4222 death judgment, #4223 summary) -- not touched
here.

## Test

`tests/unit/test_no_plan_after_spawn_diagnosis.py`, each case failing
before this change and passing after:

- detector: dead agent + stuck claimed/orphaned task -> detected
- detector: live agent -> not detected
- detector: no declared tasks yet (startup) -> not detected
- detector: unclaimed `open` task, no agent -> not detected (not a death)
- detector: goal already decomposed (task_count > 1) -> not detected
- detector: task already completed -> not detected
- detector: server unreachable -> no verdict
- non-TTY wiring: dead-agent-no-plan raises the categorised error, cleanup
  still runs
- non-TTY wiring: healthy spawn keeps today's detach notice (no regression)
- taxonomy: category carries a valid sysexits exit code, round-trips
  through `categorize_exception`, and its hint renders
