### PR TITLE
fix(cli): print overall summary panel last in audit verify (#4202)

### DIFF
--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -275,13 +275,13 @@ def verify_cmd(merkle_only: bool, hmac_only: bool, receipt_path: str | None, pay
         console.print("[red]--payload requires --receipt.[/red]")
         raise SystemExit(2)
 
-    all_passed = True
+    failed_pillars: list[str] = []
 
-    if not merkle_only:
-        all_passed = _verify_hmac_chain() and all_passed
+    if not merkle_only and not _verify_hmac_chain():
+        failed_pillars.append("HMAC Chain")
 
-    if not hmac_only:
-        all_passed = _verify_merkle_tree() and all_passed
+    if not hmac_only and not _verify_merkle_tree():
+        failed_pillars.append("Merkle Tree")
 
     # Checkpoint extension is the pillar that makes a shrink sticky: a
     # truncation that leaves the HMAC chain intact still conflicts with the
@@ -289,69 +289,101 @@ def verify_cmd(merkle_only: bool, hmac_only: bool, receipt_path: str | None, pay
     # failing until an operator acknowledges it. Like the evidence-bundle
     # pillar, it runs regardless of --hmac-only / --merkle-only: a cron job
     # invoking either narrow form must still go red when history shrinks.
-    all_passed = _verify_checkpoints() and all_passed
+    if not _verify_checkpoints():
+        failed_pillars.append("Checkpoints")
 
     # Evidence bundles are a third integrity pillar: a tampered evidence file
     # must fail verify exactly like a tampered chain entry (#2362). This runs
     # regardless of --hmac-only / --merkle-only because it is orthogonal to
     # both the HMAC chain and the Merkle seal.
-    all_passed = _verify_evidence_bundles() and all_passed
+    if not _verify_evidence_bundles():
+        failed_pillars.append("Evidence Bundles")
 
     # Agent-posted artifacts are a further integrity pillar: a flipped byte in a
     # stored artifact blob or its journal row must fail verify with the artifact
     # named (#2553). Orthogonal to both the HMAC chain and the Merkle seal.
-    all_passed = _verify_run_artifacts() and all_passed
+    if not _verify_run_artifacts():
+        failed_pillars.append("Run Artifacts")
 
     # Tournament selection receipts are a further integrity pillar: a tampered
     # score or a hand-picked winner must fail verify exactly like a tampered
     # chain entry (#2353). Orthogonal to both HMAC chain and Merkle seal.
-    all_passed = _verify_tournament_receipts() and all_passed
+    if not _verify_tournament_receipts():
+        failed_pillars.append("Tournament Receipts")
 
     # Clearance gates are a further integrity pillar: a dependent task claimed
     # while its blocker gate was still open, or a tampered graph_delta_hash,
     # must fail verify (#2556). Orthogonal to both HMAC chain and Merkle seal.
-    all_passed = _verify_clearance_gates() and all_passed
+    if not _verify_clearance_gates():
+        failed_pillars.append("Clearance Gates")
 
     # Credential grant chains are a further integrity pillar: a mutated,
     # deleted, or reordered grant / exchange / revocation record must fail
     # verify exactly like a tampered chain entry (#2516). Orthogonal to both
     # HMAC chain and Merkle seal.
-    all_passed = _verify_grant_chains() and all_passed
+    if not _verify_grant_chains():
+        failed_pillars.append("Grant Chains")
 
     # Approval cards are a further integrity pillar: a resolved approval must be
     # re-checkable offline (#2511). A mutated stored envelope, a decision that
     # echoed an unknown card_hash, or a decision made after expiry must fail
     # verify. Orthogonal to both HMAC chain and Merkle seal.
-    all_passed = _verify_approval_cards() and all_passed
+    if not _verify_approval_cards():
+        failed_pillars.append("Approval Cards")
 
     # Fleet config-plane events are a further integrity pillar: a variable
     # write spliced out of its per-name lineage, or a connection resolution
     # naming a document that was never created, must fail verify beyond the
     # HMAC check (#2550). Orthogonal to both HMAC chain and Merkle seal.
-    all_passed = _verify_fleet_config() and all_passed
+    if not _verify_fleet_config():
+        failed_pillars.append("Fleet Config")
 
     # Named sandbox pools are a further integrity pillar: a tampered pool body
     # (its content-addressed hash no longer recomputes) or a forged placement
     # receipt (a widened effective manifest, a swapped backend) must fail verify
     # exactly like a tampered chain entry (#2547). Orthogonal to both the HMAC
     # chain and the Merkle seal.
-    all_passed = _verify_pool_receipts() and all_passed
+    if not _verify_pool_receipts():
+        failed_pillars.append("Pool Receipts")
 
     # Sovereign posture attestations + drift records are a further integrity
     # pillar: a mutated effective-policy document, a forged posture signature,
     # or a drift record whose hashes agree must fail verify exactly like a
     # tampered chain entry (#2518). Orthogonal to both HMAC chain and Merkle seal.
-    all_passed = _verify_sovereign_attestations() and all_passed
+    if not _verify_sovereign_attestations():
+        failed_pillars.append("Sovereign Attestations")
 
     # Benchmark-score trajectory receipts are a further integrity pillar: a
     # tampered published score, a contaminated suite, a fabricated scalar, or a
     # cherry-picked best-of-N candidate must fail verify with the offending task
     # named (#2925). Absent receipts are a silent no-op; any present-and-tampered
     # receipt hard-fails. Orthogonal to both HMAC chain and Merkle seal.
-    all_passed = _verify_trajectory_receipts() and all_passed
+    if not _verify_trajectory_receipts():
+        failed_pillars.append("Trajectory Receipts")
 
     console.print()
-    raise SystemExit(0 if all_passed else 1)
+    if not failed_pillars:
+        console.print(
+            Panel(
+                "[bold green]Audit Verification: PASSED[/bold green]\n"
+                "[dim]All audit log pillars passed verification.[/dim]",
+                border_style="green",
+                expand=False,
+            )
+        )
+        console.print()
+        raise SystemExit(0)
+
+    failing_list = "\n".join(f"  [red]![/red] {p}" for p in failed_pillars)
+    console.print(
+        Panel(
+            f"[bold red]Audit Verification: FAILED[/bold red]\n\n[bold]Failing pillar(s):[/bold]\n{failing_list}",
+            border_style="red",
+            expand=False,
+        )
+    )
+    console.print()
+    raise SystemExit(1)
 
 
 def _verify_trajectory_receipts() -> bool:

--- a/tests/unit/test_audit_verify_summary_panel.py
+++ b/tests/unit/test_audit_verify_summary_panel.py
@@ -1,0 +1,67 @@
+"""Unit tests for audit verify summary panel and exit-code coherence (#4202).
+
+Asserts that an overall summary panel prints LAST in `bernstein audit verify`
+output, displaying PASSED (green) for all-pass runs and FAILED (red) with failing
+pillar names when any pillar fails, matching the exit code.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.audit_cmd import audit_group
+from bernstein.core.security.audit import AuditLog
+
+_HMAC_KEY = b"k" * 32
+
+
+@pytest.fixture(autouse=True)
+def _wide_console(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COLUMNS", "200")
+
+
+@pytest.fixture()
+def seeded_audit_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    sdd_dir = tmp_path / ".sdd"
+    sdd_dir.mkdir(parents=True, exist_ok=True)
+    key_file = tmp_path / "audit.key"
+    key_file.write_bytes(_HMAC_KEY)
+    key_file.chmod(0o600)
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_file))
+
+    audit_log = AuditLog(sdd_dir / "audit", key=_HMAC_KEY)
+    audit_log.log("system_init", actor="test", resource_type="system", resource_id="node-1")
+
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_audit_verify_summary_panel_all_pass(seeded_audit_dir: Path) -> None:
+    """When all pillars pass after seal, summary panel prints PASSED and exit code is 0."""
+    runner = CliRunner()
+    seal_res = runner.invoke(audit_group, ["seal"])
+    assert seal_res.exit_code == 0, seal_res.output
+
+    result = runner.invoke(audit_group, ["verify"])
+    assert result.exit_code == 0, result.output
+    output_lines = [line for line in result.output.splitlines() if line.strip()]
+    last_block = "\n".join(output_lines[-6:])
+    assert "Audit Verification: PASSED" in last_block
+
+
+def test_audit_verify_summary_panel_pillar_failure(seeded_audit_dir: Path) -> None:
+    """When a pillar fails (e.g. unsealed Merkle tree), summary panel prints FAILED with pillar name and exit 1."""
+    runner = CliRunner()
+    # Skip sealing so Merkle Tree pillar fails
+    result = runner.invoke(audit_group, ["verify"])
+    assert result.exit_code == 1
+    assert "Audit Verification: FAILED" in result.output
+    assert "Failing pillar(s):" in result.output
+    assert "Merkle Tree" in result.output
+
+    output_lines = [line for line in result.output.splitlines() if line.strip()]
+    last_block = "\n".join(output_lines[-10:])
+    assert "Audit Verification: FAILED" in last_block


### PR DESCRIPTION
Closes #4202.

### Summary of Changes

1. **Overall Audit Verification Summary Panel**:
   - Updated \erify_cmd\ in \src/bernstein/cli/commands/audit_cmd.py\ to track pillar execution results and display an overall summary panel as the final output on screen.
   - When all pillars pass, prints a green \Audit Verification: PASSED\ panel and exits 0.
   - When one or more pillars fail, prints a red \Audit Verification: FAILED\ panel listing failing pillar names and exits 1.
   - Ensures visual verdict alignment so an operator reading the end of the console scroll sees red iff the command exited non-zero.

2. **Automated Summary Panel Tests**:
   - Created \	ests/unit/test_audit_verify_summary_panel.py\ asserting output coherence and exit code alignment for both all-pass and failure paths.

### Verification

- Verified unit tests pass cleanly: \python -m pytest tests/unit/test_audit_verify_summary_panel.py -v\.
- Ran \uff check\ and \uff format --check\ cleanly.