### PR TITLE
fix(security): settle subject's type in verify_result_bundle

### DIFF
--- a/src/bernstein/core/security/result_receipt_bundle.py
+++ b/src/bernstein/core/security/result_receipt_bundle.py
@@ -43,6 +43,11 @@ field-level error, per the issue's acceptance criteria. HMAC audit-chain
 verification stays with whoever holds the chain key, exactly as
 :func:`audit_dsse.verify_envelope` documents; this bundle composes with it but
 does not require it.
+
+Every field the statement carries -- predicate, bundle, subject, worker,
+patch, gates, and chain -- settles its own type before anything reads it, so
+:func:`verify_result_bundle` returns a verdict for every input shape rather
+than raising on the malformed ones.
 """
 
 from __future__ import annotations
@@ -411,21 +416,57 @@ def verify_result_bundle(
             )
         )
 
-    subjects = statement.get("subject", [])
+    raw_subject = statement.get("subject", [])
     attested_digest = ""
-    if subjects and isinstance(subjects[0], dict):
-        attested_digest = subjects[0].get("digest", {}).get("sha256", "")
+    # A subject that never resolved to a real digest -- wrong-typed outright,
+    # or a first entry that is not a mapping with a digest -- has nothing for
+    # step (2) to compare against. Running that comparison anyway would pair
+    # the type error with a "digest mismatch" that is really just the type
+    # error restated: ``attested_digest`` would still be "", so the check
+    # below fires on every such bundle regardless of the embedded bundle's
+    # actual content, telling the caller nothing #4076's accumulation didn't
+    # already tell them. So this field, alone among the guards in this
+    # function, replaces its downstream check on a settle failure rather than
+    # accumulating past it.
+    subject_settled = True
+    if not isinstance(raw_subject, list):
+        subject_settled = False
+        errors.append(
+            FieldError(
+                "subject",
+                f"expected a list, got {type(raw_subject).__name__}",
+            )
+        )
+    elif raw_subject:
+        # An empty list is not settled-but-wrong -- it is the same "nothing
+        # attested" shape as the key being absent, so it falls through to
+        # step (2) exactly like the absent case always has.
+        first_subject = raw_subject[0]
+        if not isinstance(first_subject, dict):
+            subject_settled = False
+            errors.append(
+                FieldError(
+                    "subject[0]",
+                    f"expected an object, got {type(first_subject).__name__}",
+                )
+            )
+        elif not isinstance(first_subject.get("digest"), dict):
+            subject_settled = False
+            errors.append(FieldError("subject[0]", "missing digest"))
+        else:
+            attested_digest = first_subject["digest"].get("sha256", "")
 
     # (2) internal hash consistency: the embedded bundle must reproduce the
     # subject digest byte-for-byte.
-    recomputed = _sha256_hex(canonical_bytes(raw_bundle))
-    if recomputed != attested_digest:
-        errors.append(
-            FieldError(
-                "subject.digest.sha256",
-                f"embedded bundle hashes to {recomputed}, envelope attests {attested_digest}",
+    if subject_settled:
+        recomputed = _sha256_hex(canonical_bytes(raw_bundle))
+        if recomputed != attested_digest:
+            errors.append(
+                FieldError(
+                    "subject.digest.sha256",
+                    f"embedded bundle hashes to {recomputed}, envelope attests {attested_digest}",
+                )
             )
-        )
 
     # (3) the signer is the worker the bundle names.
     worker = bundle_dict.get("worker", {})

--- a/tests/unit/security/test_result_receipt_bundle.py
+++ b/tests/unit/security/test_result_receipt_bundle.py
@@ -20,6 +20,8 @@ from typing import Any
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from hypothesis import given
+from hypothesis import strategies as st
 
 from bernstein.core.security.audit_dsse import export_public_key_pem, keyid_from_public_key
 from bernstein.core.security.result_receipt_bundle import (
@@ -869,3 +871,183 @@ def test_absent_predicate_keeps_three_error_behavior():
 
     assert v.ok is False
     assert [e.field for e in v.errors] == ["subject.digest.sha256", "patch", "chain"]
+
+
+# --------------------------------------------------------------------------- #
+# #4077: a wrong-typed subject must refuse with a field-level error rather
+# than raising -- the last field in the statement that didn't.
+# --------------------------------------------------------------------------- #
+
+
+def _sign_statement_with_subject(key, bundle_dict: dict[str, Any], subject_val: Any):
+    """Build a validly-signed envelope over a hand-edited ``subject`` value.
+
+    Bypasses ``ad.Statement`` / ``ad.Subject`` -- both enforce the well-formed
+    shape at construction time -- the same way
+    ``test_absent_predicate_keeps_three_error_behavior`` builds the statement
+    dict by hand to carry a missing ``predicate``. This is the only way to get
+    a ``subject`` no real caller would ever produce onto the wire.
+    """
+    import base64 as b64
+
+    from bernstein.core.security import audit_dsse as ad
+    from bernstein.core.security import result_receipt_bundle as rb
+
+    statement_dict = {
+        "_type": ad.IN_TOTO_STATEMENT_TYPE,
+        "predicateType": rb.RESULT_RECEIPT_PREDICATE_TYPE,
+        "predicate": {
+            "schema_version": rb.BUNDLE_SCHEMA_VERSION,
+            "bundle_kind": "result-receipt",
+            "bundle": bundle_dict,
+            "chain": bundle_dict.get("chain") if isinstance(bundle_dict, dict) else None,
+        },
+        "subject": subject_val,
+    }
+    payload = rb.canonical_bytes(statement_dict)
+    sig = key.sign(ad.pae(ad.DSSE_PAYLOAD_TYPE, payload))
+    return ad.Envelope(
+        payload_type=ad.DSSE_PAYLOAD_TYPE,
+        payload_b64=b64.b64encode(payload).decode(),
+        signatures=[ad.Signature(keyid=ad.keyid_from_public_key(key.public_key()), sig=b64.b64encode(sig).decode())],
+    )
+
+
+@pytest.mark.parametrize(
+    ("subject_val", "expected_field", "expected_msg"),
+    [
+        (7, "subject", "expected a list, got int"),
+        (True, "subject", "expected a list, got bool"),
+        (1.5, "subject", "expected a list, got float"),
+        ({"k": "v"}, "subject", "expected a list, got dict"),
+        (None, "subject", "expected a list, got NoneType"),
+        ([7], "subject[0]", "expected an object, got int"),
+        (["x"], "subject[0]", "expected an object, got str"),
+        ([{"name": "t.json"}], "subject[0]", "missing digest"),
+        ([{"digest": "not-a-dict"}], "subject[0]", "missing digest"),
+    ],
+    ids=[
+        "subject-is-int",
+        "subject-is-bool",
+        "subject-is-float",
+        "subject-is-dict",
+        "subject-is-null",
+        "subject-holds-int",
+        "subject-holds-str",
+        "subject-entry-missing-digest",
+        "subject-entry-digest-wrong-type",
+    ],
+)
+def test_wrong_typed_subject_is_refused_rather_than_raised(subject_val: Any, expected_field: str, expected_msg: str):
+    """Refuse a wrong-typed subject with a field-level error rather than raising.
+
+    No pytest.raises here: before the fix, every one of these values raised
+    (TypeError for the scalars, KeyError for the mapping) out of
+    ``verify_result_bundle`` instead of landing in the returned verdict.
+    """
+    key = _key()
+    bundle_dict = _bundle(key).to_dict()
+    env = _sign_statement_with_subject(key, bundle_dict, subject_val)
+
+    v = verify_result_bundle(env, key.public_key())
+
+    assert v.ok is False
+    matched_errors = [e for e in v.errors if e.field == expected_field]
+    assert matched_errors, f"expected field error for {expected_field}, got {v.errors}"
+    assert matched_errors[0].message == expected_msg
+
+
+_subject_scalars = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(),
+    st.floats(allow_nan=False, allow_infinity=False),
+    st.text(max_size=20),
+    st.dictionaries(st.text(max_size=5), st.text(max_size=5), max_size=3),
+)
+
+_subject_entries = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(),
+    st.text(max_size=20),
+    st.lists(st.integers(), max_size=3),
+    st.dictionaries(st.text(max_size=5), st.text(max_size=5), max_size=3).filter(lambda d: "digest" not in d),
+    st.fixed_dictionaries({"digest": st.one_of(st.none(), st.integers(), st.text(max_size=10))}),
+)
+
+
+@given(subject_val=st.one_of(_subject_scalars, st.lists(_subject_entries, min_size=1, max_size=1)))
+def test_no_subject_shape_raises(subject_val: Any):
+    """Fuzz proof for the issue's actual claim -- "never raises" -- rather than
+    the seven or so hand-written cases above, which prove only those seven.
+
+    Mutates ``subject`` to a wrong top-level type or a one-element list whose
+    entry is malformed, re-signs with the same key so the envelope stays
+    valid, and asserts only that ``verify_result_bundle`` returns rather than
+    raising, with a ``subject``-family field named in the verdict.
+    """
+    key = _key()
+    bundle_dict = _bundle(key).to_dict()
+    env = _sign_statement_with_subject(key, bundle_dict, subject_val)
+
+    v = verify_result_bundle(env, key.public_key())
+
+    assert v.ok is False
+    assert any(e.field in ("subject", "subject[0]") for e in v.errors), v.errors
+
+
+def test_empty_subject_list_is_not_itself_a_field_error():
+    """An empty ``subject`` list is "nothing attested", the same shape as the
+    key being absent -- not a field error of its own.
+
+    Decision for #4077: an empty list settles (it is a list) and step (2)
+    runs exactly as it always has for an absent subject, comparing the
+    embedded bundle's hash against the empty ``attested_digest`` and
+    reporting the mismatch under ``subject.digest.sha256``. Only a subject
+    that fails to settle its type at all -- not a list, or a list whose first
+    entry is not a well-shaped mapping -- gets the new ``subject``/
+    ``subject[0]`` error instead.
+    """
+    key = _key()
+    bundle_dict = _bundle(key).to_dict()
+    env = _sign_statement_with_subject(key, bundle_dict, [])
+
+    v = verify_result_bundle(env, key.public_key())
+
+    assert v.ok is False
+    assert [e.field for e in v.errors] == ["subject.digest.sha256"]
+
+
+def test_wrong_typed_subject_does_not_also_report_digest_mismatch():
+    """A wrong-typed subject reports exactly the settle failure, not that
+    failure plus a ``subject.digest.sha256`` mismatch restating it.
+
+    This is the open decision the issue calls out: #4076 accumulated past a
+    settle failure one layer down (a malformed ``bundle`` still lets patch,
+    gates, and chain report their own errors), but here the downstream check
+    step (2) exists to run *is* ``subject.digest.sha256`` -- comparing the
+    embedded bundle's real hash against an ``attested_digest`` that stayed
+    ``""`` only because the subject was never read. Reporting that alongside
+    the settle error would tell the caller nothing the settle error hadn't
+    already told them, so this field replaces its downstream check rather
+    than accumulating past it.
+    """
+    key = _key()
+    bundle_dict = _bundle(key).to_dict()
+    env = _sign_statement_with_subject(key, bundle_dict, 7)
+
+    v = verify_result_bundle(env, key.public_key())
+
+    assert v.ok is False
+    assert [e.field for e in v.errors] == ["subject"]
+
+
+def test_a_well_shaped_subject_still_verifies():
+    """The control: the new guard must refuse only the malformed shapes."""
+    key = _key()
+    env = build_result_bundle(_bundle(key), signing_key=key)
+
+    v = verify_result_bundle(env, key.public_key())
+
+    assert v.ok is True, v.errors


### PR DESCRIPTION
`verify_result_bundle` collects field-level errors for every malformed field in a result receipt bundle except one. The DSSE statement's `subject` was read without settling its type first:

```python
subjects = statement.get("subject", [])
attested_digest = ""
if subjects and isinstance(subjects[0], dict):
    attested_digest = subjects[0].get("digest", {}).get("sha256", "")
```

A scalar `subject` (int, bool, float) raised `TypeError` on `subjects[0]`. A mapping `subject` raised `KeyError` on the same line, since indexing a dict by `0` looks up a key rather than a position. Both cases produced a traceback instead of a verdict, unlike every other field this function checks.

## Fix

`subject`'s type is now settled before it is read, following the same shape `predicate`, `bundle`, `worker`, and `gates` already use:

- `subject` not a list -> `FieldError("subject", "expected a list, got <type>")`
- `subject` a list whose first entry is not a mapping with a `digest` -> `FieldError("subject[0]", ...)`, naming the index the way `gates[i]` does

## Empty list decision

An empty `subject` list settles fine as a list -- it is treated as "nothing attested," the same shape as the key being absent, and falls through to the existing `subject.digest.sha256` comparison exactly as it always has. It is not flagged as its own field error. Pinned in `test_empty_subject_list_is_not_itself_a_field_error`.

## Accumulation decision

When `subject`'s type fails to settle, the `subject.digest.sha256` comparison is skipped rather than also reported. Every other guard in this function accumulates past a settle failure into the checks below it (a malformed `bundle` still lets `patch`, `gates`, and `chain` report their own errors), but here the downstream check exists solely to examine the digest the settle step just failed to produce -- reporting it too would only restate the type error under a different field name with an always-mismatching `""`. Pinned in `test_wrong_typed_subject_does_not_also_report_digest_mismatch`.

## Tests

`tests/unit/security/test_result_receipt_bundle.py`:

- `test_wrong_typed_subject_is_refused_rather_than_raised` -- nine hand-written cases pinning the exact field and message for each shape (scalar subject, dict subject, list holding a non-mapping, list holding a mapping missing `digest`)
- `test_no_subject_shape_raises` -- a Hypothesis fuzz test mutating `subject` across wrong top-level types and malformed single-entry lists, re-signing with the same key, asserting only that verification returns rather than raises
- `test_empty_subject_list_is_not_itself_a_field_error` -- pins the empty-list decision above
- `test_wrong_typed_subject_does_not_also_report_digest_mismatch` -- pins the accumulation decision above
- `test_a_well_shaped_subject_still_verifies` -- control: a valid bundle still verifies

All 63 tests in the file pass, including the 50 that predate this change.

Closes #4077
