### PR TITLE
fix(planning): materialise a DAG node whose every inbound edge skipped

### DIFF
--- a/src/bernstein/core/planning/workflow_dsl.py
+++ b/src/bernstein/core/planning/workflow_dsl.py
@@ -72,7 +72,7 @@ import time
 import uuid
 from collections import defaultdict, deque
 from contextlib import suppress
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
@@ -82,8 +82,11 @@ from bernstein.core.knowledge.task_graph import EdgeType
 from bernstein.core.models import Scope, Task, TaskStatus
 from bernstein.core.planning.recovery_receipt import DEFAULT_JOURNAL_TAIL
 from bernstein.core.planning.workflow import WorkflowDefinition, WorkflowPhase
+from bernstein.core.tasks.lifecycle import DEPENDENCY_BLOCKED_STATUSES
+from bernstein.core.tasks.unreachable import blocking_dependency, unreachable_tasks
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     from bernstein.core.lineage.spine import LineageSpine
@@ -825,7 +828,27 @@ class EdgeResolution(StrEnum):
     PENDING = "pending"  # Upstream not yet terminal.
 
 
-TERMINAL_STATUSES: frozenset[TaskStatus] = frozenset({TaskStatus.DONE, TaskStatus.FAILED, TaskStatus.CANCELLED})
+TERMINAL_STATUSES: frozenset[TaskStatus] = frozenset(
+    {
+        TaskStatus.DONE,
+        TaskStatus.FAILED,
+        TaskStatus.CANCELLED,
+        # A node materialised as unreachable (#3622) never ran and never will,
+        # so an edge out of it is as resolved as an edge out of a failure.
+        # Left out of this set its own dependents resolve PENDING forever and
+        # the strand stops at the first ring.
+        TaskStatus.BLOCKED_BY_FAILED_DEP,
+    }
+)
+
+# The node whose skipped edge stranded this one. Deliberately the same key the
+# task store stamps on its own cascade (#3452), so a record from either
+# scheduler answers "why did this never run" with a lookup rather than an
+# inference.
+BLOCKING_NODE_METADATA_KEY = "blocking_task_id"
+
+# The inbound edges that all resolved SKIPPED, rendered "source -> target".
+SKIPPED_EDGES_METADATA_KEY = "skipped_edges"
 
 
 class DAGExecutor:
@@ -874,6 +897,13 @@ class DAGExecutor:
                 return EdgeResolution.SATISFIED
             return EdgeResolution.SKIPPED
 
+        # A source materialised as unreachable produced no result, so there is
+        # no outcome for a guard to test. Skipping without evaluating keeps the
+        # strand propagating instead of letting a guard such as
+        # ``status != 'done'`` read a node that never ran as a live failure.
+        if source_task.status == TaskStatus.BLOCKED_BY_FAILED_DEP:
+            return EdgeResolution.SKIPPED
+
         # Conditional edge: evaluate guard predicate.
         ctx = build_condition_context(source_task)
         try:
@@ -895,16 +925,27 @@ class DAGExecutor:
             return self.should_retry(node_id, existing)
         return existing is None
 
-    def _are_deps_resolved(self, incoming: list[DAGEdge], tasks: dict[str, Task]) -> bool:
-        """Return True if all incoming edges are resolved and at least one is satisfied."""
+    def _resolve_incoming(self, incoming: list[DAGEdge], tasks: dict[str, Task]) -> EdgeResolution:
+        """Collapse a node's inbound edges into a single resolution.
+
+        ``SATISFIED`` when at least one edge is satisfied and none is still
+        pending: the node is eligible. ``PENDING`` when any edge is still
+        pending: the node may yet become eligible. ``SKIPPED`` when every edge
+        resolved ``SKIPPED``: the node can never become eligible.
+
+        That last case is the one a bool return could not express (#3622). It
+        collapsed into the same "not ready" as PENDING, so ``ready_nodes``
+        omitted the node and no caller could tell a node that was still
+        waiting from one that had run out of paths in.
+        """
         any_satisfied = False
         for edge in incoming:
             resolution = self.resolve_edge(edge, tasks)
             if resolution == EdgeResolution.PENDING:
-                return False
+                return EdgeResolution.PENDING
             if resolution == EdgeResolution.SATISFIED:
                 any_satisfied = True
-        return any_satisfied
+        return EdgeResolution.SATISFIED if any_satisfied else EdgeResolution.SKIPPED
 
     def ready_nodes(self, tasks: dict[str, Task]) -> list[str]:
         """Return node IDs whose dependencies are fully resolved.
@@ -936,10 +977,127 @@ class DAGExecutor:
                     ready.append(node.id)
                 continue
 
-            if self._are_deps_resolved(incoming, tasks) and self._is_node_eligible(node.id, existing):
+            if self._resolve_incoming(incoming, tasks) == EdgeResolution.SATISFIED and self._is_node_eligible(
+                node.id, existing
+            ):
                 ready.append(node.id)
 
         return ready
+
+    def materialize_unreachable(self, tasks: dict[str, Task]) -> list[str]:
+        """Record every node that can no longer become ready, and what stranded it.
+
+        A node whose inbound edges all resolved ``SKIPPED`` is never returned
+        by ``ready_nodes``, so before this no Task was constructed for it and
+        the run record simply did not mention it: the node was neither blocked
+        nor cancelled, it was absent. Here it is written into *tasks* in
+        ``BLOCKED_BY_FAILED_DEP`` - the state the task store moves a stranded
+        dependent into (#3452) - carrying the skipped edges and the node that
+        stranded it.
+
+        Only a node stranded by an *unsuccessful* upstream is materialised. A
+        node whose inbound edges all skipped because their guards were false
+        while the sources completed is a branch not taken, not a strand, and
+        stays absent exactly as before. That distinction is
+        ``blocking_dependency``'s rather than a second one stated here.
+
+        Nodes are materialised a ring at a time: a node stranded by one
+        materialised in this call is found on the following pass rather than
+        mid-pass, so the answer does not depend on DAG node order.
+
+        Args:
+            tasks: Map of node_id -> Task for the run. Mutated in place.
+
+        Returns:
+            The node IDs materialised by this call, sorted.
+        """
+        materialized: list[str] = []
+
+        while True:
+            ring: dict[str, Task] = {}
+            for node in self._dag.nodes:
+                if node.id in tasks:
+                    continue
+                incoming = self._edges_by_target.get(node.id, [])
+                if not incoming or self._resolve_incoming(incoming, tasks) != EdgeResolution.SKIPPED:
+                    continue
+                blocked = self._blocked_task(node, incoming)
+                blocking_node = blocking_dependency(blocked, tasks)
+                if blocking_node is None:
+                    continue
+                blocked.metadata[BLOCKING_NODE_METADATA_KEY] = blocking_node
+                blocked.result_summary = f"dependency {blocking_node} is {tasks[blocking_node].status.value}"
+                ring[node.id] = blocked
+
+            if not ring:
+                return sorted(materialized)
+
+            tasks.update(ring)
+            materialized.extend(ring)
+
+    def unreachable_nodes(self, tasks: Mapping[str, Task]) -> list[tuple[str, str]]:
+        """Return ``(node_id, blocking_node_id)`` for nodes that could never run.
+
+        Derived from the run record alone: no edge is re-resolved and nothing
+        is re-executed, so a replayed journal yields the same answer as the
+        live map, and two runs over the same graph yield the same pairs in the
+        same order.
+
+        The rule is ``unreachable_tasks`` (#3452) rather than a second one
+        stated here, applied to a projection of the record. The projection is
+        keyed by node id, because that is what a DAG edge names while a Task
+        id carries a per-run suffix; and it carries inbound edges only for the
+        nodes materialised as blocked. The two schedulers read a dependency
+        differently - the store needs every dependency to have delivered, a
+        DAG node needs only one inbound edge satisfied - so projecting every
+        node's inbound edges would report a node that ran on one satisfied
+        edge while another was skipped. What strands a DAG node is its whole
+        inbound set resolving ``SKIPPED``, which is exactly the set
+        ``materialize_unreachable`` records.
+
+        Args:
+            tasks: Map of node_id -> Task for the run.
+
+        Returns:
+            ``(node_id, blocking_node_id)`` pairs, sorted by node ID.
+        """
+        projection = [
+            replace(
+                task,
+                id=node_id,
+                depends_on=list(task.depends_on) if task.status in DEPENDENCY_BLOCKED_STATUSES else [],
+            )
+            for node_id, task in tasks.items()
+        ]
+        return unreachable_tasks(projection)
+
+    def _blocked_task(self, node: DAGNode, incoming: list[DAGEdge]) -> Task:
+        """Build the terminal record for a node that can never become ready.
+
+        ``depends_on`` carries every inbound source rather than
+        ``create_task``'s unconditional subset, because all of them skipped -
+        that whole set is what the node waited on and never got.
+        """
+        task = Task(
+            # Deterministic where ``create_task`` mints a uuid: this node never
+            # runs, so nothing claims it by id, and a replay of the same run
+            # should reproduce the row rather than a fresh one.
+            id=f"{node.id}-unreachable",
+            title=node.description or f"DAG node: {node.id}",
+            description=node.description,
+            role=node.role,
+            priority=2,
+            scope=Scope.MEDIUM,
+            estimated_minutes=node.estimated_minutes,
+            status=TaskStatus.BLOCKED_BY_FAILED_DEP,
+            depends_on=sorted(edge.source for edge in incoming),
+            created_at=time.time(),
+        )
+        task.terminal_reason = "blocked_by_failed_dependency"
+        task.metadata[SKIPPED_EDGES_METADATA_KEY] = [
+            f"{edge.source} -> {edge.target}" for edge in sorted(incoming, key=lambda e: (e.source, e.target))
+        ]
+        return task
 
     def should_retry(self, node_id: str, task: Task) -> bool:
         """Check if a failed task should be retried per the node's retry policy.

--- a/tests/unit/test_workflow_dsl.py
+++ b/tests/unit/test_workflow_dsl.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 from bernstein.core.models import Task, TaskStatus
 from bernstein.core.workflow import WorkflowDefinition, WorkflowPhase
 from bernstein.core.workflow_dsl import (
+    BLOCKING_NODE_METADATA_KEY,
+    SKIPPED_EDGES_METADATA_KEY,
     ConditionError,
     ConditionExpr,
     DAGEdge,
@@ -1194,3 +1196,155 @@ class TestEndToEnd:
         assert executor.should_retry("fix", tasks["fix"])
         executor.record_retry("fix")
         assert not executor.should_retry("fix", tasks["fix"])
+
+
+class TestUnreachableNodes:
+    """A node whose every path in was skipped is recorded, not dropped (#3622)."""
+
+    @staticmethod
+    def _fan_in_dag() -> WorkflowDAG:
+        """Two workers feeding one merge node over unconditional edges."""
+        return WorkflowDAG(
+            definition=_simple_definition(),
+            nodes=(
+                DAGNode(id="w1", phase="implement", role="backend"),
+                DAGNode(id="w2", phase="implement", role="frontend"),
+                DAGNode(id="merge", phase="verify", role="qa"),
+            ),
+            edges=(
+                DAGEdge(source="w1", target="merge"),
+                DAGEdge(source="w2", target="merge"),
+            ),
+        )
+
+    @staticmethod
+    def _guarded_dag(guard: str) -> WorkflowDAG:
+        """One node reachable only through a single guarded edge."""
+        return WorkflowDAG(
+            definition=_simple_definition(),
+            nodes=(
+                DAGNode(id="test", phase="plan", role="qa"),
+                DAGNode(id="deploy", phase="verify", role="manager"),
+            ),
+            edges=(DAGEdge(source="test", target="deploy", condition=ConditionExpr(raw=guard)),),
+        )
+
+    def test_sole_inbound_edge_skipped_materializes_the_node(self) -> None:
+        executor = DAGExecutor(self._guarded_dag("status == 'done'"))
+        tasks = {"test": _task("test", role="qa", status=TaskStatus.FAILED)}
+
+        # The guard is false against a failed source, so deploy is not ready.
+        assert "deploy" not in executor.ready_nodes(tasks)
+
+        assert executor.materialize_unreachable(tasks) == ["deploy"]
+
+        blocked = tasks["deploy"]
+        assert blocked.status == TaskStatus.BLOCKED_BY_FAILED_DEP
+        assert blocked.metadata[BLOCKING_NODE_METADATA_KEY] == "test"
+        assert blocked.metadata[SKIPPED_EDGES_METADATA_KEY] == ["test -> deploy"]
+        assert blocked.terminal_reason == "blocked_by_failed_dependency"
+
+        # Derivable from the record alone, and the node stays off the ready list.
+        assert executor.unreachable_nodes(tasks) == [("deploy", "test")]
+        assert "deploy" not in executor.ready_nodes(tasks)
+
+    def test_all_of_several_inbound_edges_skipped(self) -> None:
+        executor = DAGExecutor(self._fan_in_dag())
+        tasks = {
+            "w1": _task("w1", status=TaskStatus.FAILED),
+            "w2": _task("w2", status=TaskStatus.CANCELLED),
+        }
+
+        assert executor.materialize_unreachable(tasks) == ["merge"]
+
+        blocked = tasks["merge"]
+        assert blocked.status == TaskStatus.BLOCKED_BY_FAILED_DEP
+        assert blocked.metadata[SKIPPED_EDGES_METADATA_KEY] == ["w1 -> merge", "w2 -> merge"]
+        # Both sources strand the node; the lowest id is the recorded cause.
+        assert blocked.metadata[BLOCKING_NODE_METADATA_KEY] == "w1"
+        assert executor.unreachable_nodes(tasks) == [("merge", "w1")]
+
+    def test_one_satisfied_edge_leaves_the_node_schedulable(self) -> None:
+        executor = DAGExecutor(self._fan_in_dag())
+        tasks = {
+            "w1": _task("w1", status=TaskStatus.DONE),
+            "w2": _task("w2", status=TaskStatus.FAILED),
+        }
+
+        assert "merge" in executor.ready_nodes(tasks)
+        assert executor.materialize_unreachable(tasks) == []
+        assert "merge" not in tasks
+        assert executor.unreachable_nodes(tasks) == []
+
+    def test_dependents_of_an_unreachable_node_are_unreachable_too(self) -> None:
+        # a -> b -> c, with a failed: b is stranded by a, c by b.
+        executor = DAGExecutor(_simple_dag())
+        tasks = {"a": _task("a", status=TaskStatus.FAILED)}
+
+        assert executor.materialize_unreachable(tasks) == ["b", "c"]
+        # Each stranded node names its nearest cause, not the original failure.
+        assert tasks["b"].metadata[BLOCKING_NODE_METADATA_KEY] == "a"
+        assert tasks["c"].metadata[BLOCKING_NODE_METADATA_KEY] == "b"
+        assert executor.unreachable_nodes(tasks) == [("b", "a"), ("c", "b")]
+
+    def test_a_branch_not_taken_is_not_unreachable(self) -> None:
+        # The source completed; the guard simply chose the other branch. The
+        # node did not run, but nothing stranded it.
+        executor = DAGExecutor(self._guarded_dag("status == 'failed'"))
+        tasks = {"test": _task("test", role="qa", status=TaskStatus.DONE)}
+
+        assert "deploy" not in executor.ready_nodes(tasks)
+        assert executor.materialize_unreachable(tasks) == []
+        assert "deploy" not in tasks
+        assert executor.unreachable_nodes(tasks) == []
+
+    def test_a_retrying_node_keeps_its_escape(self) -> None:
+        dag = WorkflowDAG(
+            definition=_simple_definition(),
+            nodes=(
+                DAGNode(
+                    id="a",
+                    phase="plan",
+                    role="manager",
+                    retry=RetryPolicy(max_attempts=3),
+                ),
+            ),
+            edges=(),
+        )
+        executor = DAGExecutor(dag)
+        tasks = {"a": _task("a", status=TaskStatus.FAILED)}
+
+        assert "a" in executor.ready_nodes(tasks)
+        assert executor.materialize_unreachable(tasks) == []
+        assert executor.unreachable_nodes(tasks) == []
+        assert "a" in executor.ready_nodes(tasks)
+
+    def test_unreachable_set_is_identical_across_derivations(self) -> None:
+        def derive() -> list[tuple[str, str]]:
+            dag = WorkflowDAG(
+                definition=_simple_definition(),
+                nodes=(
+                    DAGNode(id="root", phase="plan", role="manager"),
+                    DAGNode(id="w2", phase="implement", role="backend"),
+                    DAGNode(id="w1", phase="implement", role="frontend"),
+                    DAGNode(id="tail", phase="verify", role="qa"),
+                ),
+                edges=(
+                    DAGEdge(source="root", target="w2"),
+                    DAGEdge(source="root", target="w1"),
+                    DAGEdge(source="w2", target="tail"),
+                    DAGEdge(source="w1", target="tail"),
+                ),
+            )
+            executor = DAGExecutor(dag)
+            tasks = {"root": _task("root", status=TaskStatus.FAILED)}
+            executor.materialize_unreachable(tasks)
+            return executor.unreachable_nodes(tasks)
+
+        first = derive()
+        second = derive()
+
+        assert first == [("tail", "w1"), ("w1", "root"), ("w2", "root")]
+        assert len(first) == len(second)
+        for left, right in zip(first, second, strict=True):
+            assert left == right


### PR DESCRIPTION
Closes #3622.

## Symptom

A DAG node whose every inbound edge resolved `SKIPPED` did not exist in the run record. Not blocked, not cancelled — absent. `test` fails, `deploy` depends on it through `condition: "status == 'done'"`, and the only thing an operator could observe was that `deploy` never appeared. The run reported no error and no node to point at.

## Root cause

`resolve_edge` correctly resolves a terminal-but-not-`DONE` source to `SKIPPED`. `_are_deps_resolved` then folded two different situations into one `bool`:

```python
if resolution == EdgeResolution.PENDING:
    return False       # still waiting; may yet become ready
...
return any_satisfied   # False here means every edge skipped: never becomes ready
```

`ready_nodes` consumed that bool and omitted the node from a `list[str]`, so no caller could tell the cases apart and `create_task` was never reached. The only escape was `should_retry`, and only for nodes that declare `retry:`.

`_check_reachability` does not cover this: it validates static graph shape at parse time and cannot see a node made unreachable at runtime by a failure. It is untouched here.

## Fix

**The bool becomes a tri-state.** `_are_deps_resolved` is now `_resolve_incoming`, returning `EdgeResolution.SATISFIED` / `PENDING` / `SKIPPED`. `ready_nodes` tests for `SATISFIED`, so its membership is byte-for-byte what it was; the `SKIPPED` case simply has a name now.

**`materialize_unreachable(tasks)`** writes an all-skipped node into the run's task map instead of dropping it: status `BLOCKED_BY_FAILED_DEP`, `terminal_reason="blocked_by_failed_dependency"`, `metadata["skipped_edges"]` naming every inbound edge as `"source -> target"`, and `metadata["blocking_task_id"]` naming the node that stranded it. It runs a ring at a time — a node stranded by one materialised in the same call is found on the following pass, not mid-pass — so the result does not depend on DAG node order. `BLOCKED_BY_FAILED_DEP` joins `TERMINAL_STATUSES` and short-circuits guard evaluation in `resolve_edge`, which is what lets the strand reach the next ring: a node that never ran produced no result for a guard to test, so a guard like `status != 'done'` must not read it as a live failure.

**Only a genuine strand is materialised.** A node whose inbound edges all skipped because their guards were false while the sources completed is a branch not taken. `test_conditional_edge_gating` is exactly that shape, and recording it as blocked-by-failed-dependency would be a lie about a workflow that worked. The discrimination is `blocking_dependency`'s — a dependency strands only from an unsuccessful terminal status — not a second rule restated here.

**`unreachable_nodes(tasks)`** derives `(node_id, blocking_node_id)` pairs from the record alone, with nothing re-resolved and nothing re-executed, by delegating to `unreachable_tasks`. The projection is keyed by node id, because that is what a DAG edge names while a `Task.id` carries a per-run suffix, and it carries inbound edges only for nodes materialised as blocked. That last part matters: the two schedulers read a dependency differently — the store needs every dependency to have delivered, a DAG node needs only one inbound edge satisfied — so projecting every node's inbound edges would report a node that ran on one satisfied edge while another was skipped. What strands a DAG node is its whole inbound set resolving `SKIPPED`, which is exactly the set materialisation records. Sorting is `unreachable_tasks`' own, so two derivations over the same graph are equal element-for-element.

### The status, and why

`BLOCKED_BY_FAILED_DEP`, reused rather than a new member. #4243 added it for the same meaning on the store side, and the two schedulers should not describe the same fact with two names. Reuse also means no new transition-table entries: the node is constructed in that status rather than transitioned into it, and the recovery edges back to `OPEN` / `CANCELLED` / `ABANDONED` already exist for an operator who requeues the upstream. `BLOCKED` was rejected as too general — it does not say a dependency is the reason — and a third member distinct from `BLOCKED_BY_FAILED_DEP` would have split one condition across two names for no gain in what the record can answer.

## Test

`TestUnreachableNodes` in `tests/unit/test_workflow_dsl.py`, seven cases. Four fail before the change and pass after:

- a node whose only inbound edge skipped, materialised with `test -> deploy` and blocker `test`, and the derived set exactly `[("deploy", "test")]`
- a fan-in whose both inbound edges skipped (`FAILED` and `CANCELLED` sources), both edges named, lowest source id recorded as the cause
- the chain `a -> b -> c` with `a` failed: `b` and `c` both materialised, `c` naming `b` rather than `a`, derived set `[("b", "a"), ("c", "b")]`
- determinism: two derivations over the same graph compared element by element

Three hold before and after, and guard what must not move:

- one satisfied and one skipped inbound edge: the node stays ready, nothing is materialised
- a branch not taken off a `DONE` source: nothing is materialised, the derived set is empty
- a `retry:`-declaring node that failed: still in `ready_nodes`, still not materialised

`TestRetryPolicy::test_retry_in_ready_nodes` and `TestValidateDAG::test_truly_unreachable_node` are unchanged and green — `_check_reachability` still rejects a statically unreachable graph at parse time with the same error.

Removing the materialisation while keeping the API in place is what the four defect tests catch:

```
FAILED TestUnreachableNodes::test_sole_inbound_edge_skipped_materializes_the_node
FAILED TestUnreachableNodes::test_all_of_several_inbound_edges_skipped
FAILED TestUnreachableNodes::test_dependents_of_an_unreachable_node_are_unreachable_too
FAILED TestUnreachableNodes::test_unreachable_set_is_identical_across_derivations
4 failed, 3 passed
```

## Verification

```
uv run ruff check src/ tests/                       # All checks passed!
uv run ruff format --check src/ tests/              # 4570 files already formatted
uv run pytest tests/unit/test_workflow_dsl.py \
  tests/unit/tasks/test_failed_dependency_propagation.py \
  tests/unit/test_lifecycle_transitions.py -q       # 442 passed
uv run pytest tests/unit/test_recovery_receipt.py \
  tests/unit/lineage/test_spine_cli.py \
  tests/unit/test_workflow_dsl.py -q                # 106 passed
```

Two files changed: `src/bernstein/core/planning/workflow_dsl.py`, `tests/unit/test_workflow_dsl.py`.

