### PR TITLE
fix(agents): carry system_addendum on every resume, container, and sandbox spawn

### DIFF
--- a/pr-body-i3565-system-addendum.md
+++ b/pr-body-i3565-system-addendum.md
@@ -1,0 +1,38 @@
+## Problem
+
+`system_addendum` is the channel `adapter.spawn()` uses to carry protocol-critical instructions - how an agent reports completion and how it heartbeats - into the running process. The primary spawn path (`spawn_for_tasks` / `_spawn_for_tasks_internal`) resolves this per-spawn (task metadata > role policy > seed default > `"balanced"`) and forwards it. Four other call sites did not:
+
+- `spawn_for_resume()` - the crash-recovery path goes straight to `self._adapter.spawn()` without going through `_spawn_for_tasks_internal`, and never resolved a style addendum at all, so it always sent `system_addendum=""`.
+- `_spawn_in_container()`, `_spawn_in_sandbox()`, and `_spawn_via_sandbox_session()` - each has a direct-subprocess fallback for when the container/sandbox fails to start. The fallback calls `adapter.spawn()` but dropped the addendum the caller had already resolved.
+
+All four of these are live-agent paths where the agent still has to report completion and heartbeat, so an agent resumed after a crash, or downgraded to a host subprocess when its container/sandbox couldn't start, could run to completion and never be seen to finish.
+
+## Fix
+
+- `spawn_for_resume()` now resolves the response style the same way the primary path does (`resolve_response_style` + `render_style_addendum`, using the same role-policy lookup the resume path already computed) and forwards the rendered addendum via `system_addendum`.
+- `_spawn_in_container()`, `_spawn_in_sandbox()`, and `_spawn_via_sandbox_session()` now take a `system_addendum` parameter and forward it in their fallback `adapter.spawn()` call. The three call sites in `_spawn_for_tasks_internal` that invoke these helpers now pass the `style_addendum` already resolved earlier in that method - one source, several consumers, rather than each site recomputing it.
+
+## Not changed
+
+The primary container/sandbox path (when the container/sandbox actually starts) never calls `adapter.spawn()` at all - it builds a raw shell command via `_adapter_cmd_for_container()` and runs it directly inside the container. That path has no parameter to carry `system_addendum` through today; giving it one means picking a per-adapter injection mechanism (real system-prompt flag vs. prompt-append vs. unsupported), which is a larger change than this fix and is left for follow-up.
+
+## Tests
+
+- `test_spawn_for_resume_forwards_system_addendum` - drives `spawn_for_resume` with a role policy set to `terse` and asserts the adapter received the matching rendered addendum (was `KeyError` before the fix, since the kwarg wasn't passed at all).
+- `test_spawn_in_sandbox_fallback_forwards_system_addendum`
+- `test_legacy_container_fallback_forwards_system_addendum`
+- `test_provisioning_failure_fallback_forwards_system_addendum`
+
+Each of the three fallback tests calls the private helper directly with a non-empty `system_addendum` and asserts the fake adapter's `spawn()` received it (all four failed before the fix - three with `TypeError: unexpected keyword argument`, the resume one with `KeyError`).
+
+Verified:
+```
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run pytest tests/unit/test_crash_recovery.py tests/unit/test_spawner_sandbox.py \
+  tests/unit/test_spawner_explicit_container_runtime.py tests/unit/test_spawner_sandbox_session.py \
+  tests/unit/agents/test_spawner_response_style.py tests/unit/agents/ tests/unit/adapters/ -q
+```
+All clean; 972 passed in `tests/unit/agents/` + `tests/unit/adapters/`, 208 passed in the spawner-focused run.
+
+Closes #3565

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -616,6 +616,39 @@ def _render_signal_check(session_id: str) -> str:
     )
 
 
+def _prompt_with_addendum(prompt: str, system_addendum: str) -> str:
+    """Fold protocol-critical instructions into the prompt text itself.
+
+    The container, sandbox, and sandbox-session paths do not call
+    ``adapter.spawn()``. They write the prompt to a file and build a raw
+    shell command that ``cat``s it into the CLI (see
+    :meth:`AgentSpawner._adapter_cmd_for_container`), so the adapter's own
+    system-prompt channel -- ``--append-system-prompt`` on Claude Code, and
+    its equivalents elsewhere -- is never reached. Without this, an agent
+    running under isolation gets no completion or heartbeat instructions at
+    all: it does the work and is then reaped as stalled because it was never
+    told how to report done (#3565).
+
+    Appending to the user prompt is the weaker of the two channels, and the
+    adapter contract says so -- the base ``spawn`` docstring permits it as a
+    fallback, and adapters without a system-prompt flag already take it
+    (``adapters/devin_terminal.py``). It is used here for the same reason:
+    the command is assembled per adapter family, and only one of those
+    families has a system-prompt flag to pass. Carrying the instructions in
+    the weaker channel beats dropping them.
+
+    Args:
+        prompt: The rendered task prompt.
+        system_addendum: Protocol-critical instructions, possibly empty.
+
+    Returns:
+        The prompt, with the addendum appended when there is one.
+    """
+    if not system_addendum:
+        return prompt
+    return f"{prompt}\n\n{system_addendum}"
+
+
 def _resolve_task_server_url() -> str:
     """Resolve the base URL agents use to reach the task server.
 
@@ -5183,14 +5216,13 @@ class AgentSpawner:
             session: AgentSession to update with container metadata.
             adapter: Adapter selected for this spawn attempt.
             task_scope: Task scope for max_turns scaling.
-            system_addendum: Rendered response-style addendum, forwarded to
-                the direct-subprocess fallback so a container that fails to
-                start doesn't also drop the completion/heartbeat
-                instructions (issue #3565). The container path itself
-                shells out via ``_adapter_cmd_for_container`` rather than
-                ``adapter.spawn()``, so it has no channel to carry this
-                through - a separate, larger gap tracked in #3565's
-                follow-up about per-adapter capability visibility.
+            system_addendum: Rendered response-style addendum, carried on
+                both branches (issue #3565). The direct-subprocess fallback
+                passes it to ``adapter.spawn()``; the container path never
+                reaches ``adapter.spawn()``, so it is folded into the prompt
+                file by :func:`_prompt_with_addendum` instead. Either way a
+                container that fails to start, and one that starts fine, both
+                carry the completion/heartbeat instructions.
 
         Returns:
             SpawnResult with PID and log path.
@@ -5214,7 +5246,7 @@ class AgentSpawner:
         # container can read it
         prompt_file = spawn_cwd / ".sdd" / "runtime" / "prompts" / f"{session_id}.md"
         prompt_file.parent.mkdir(parents=True, exist_ok=True)
-        prompt_file.write_text(prompt, encoding="utf-8")
+        prompt_file.write_text(_prompt_with_addendum(prompt, system_addendum), encoding="utf-8")
 
         # Build the CLI command the adapter would normally run
         log_dir = spawn_cwd / ".sdd" / "logs"
@@ -5349,7 +5381,7 @@ class AgentSpawner:
 
         prompt_file = spawn_cwd / ".sdd" / "runtime" / "prompts" / f"{session_id}.md"
         prompt_file.parent.mkdir(parents=True, exist_ok=True)
-        prompt_file.write_text(prompt, encoding="utf-8")
+        prompt_file.write_text(_prompt_with_addendum(prompt, system_addendum), encoding="utf-8")
 
         log_dir = spawn_cwd / ".sdd" / "logs"
         log_dir.mkdir(parents=True, exist_ok=True)
@@ -5547,7 +5579,7 @@ class AgentSpawner:
         # 1) Inject the prompt through the session's file primitive.
         write_prompt_to_session(
             session=sbx_session,
-            prompt=prompt,
+            prompt=_prompt_with_addendum(prompt, system_addendum),
             session_id=session_id,
         )
 

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -4513,6 +4513,7 @@ class AgentSpawner:
                                 mcp_config=attempt_mcp,
                                 session=session,
                                 adapter=target_adapter,
+                                system_addendum=style_addendum,
                             )
                         elif self._sandbox is not None:
                             result = self._spawn_in_sandbox(
@@ -4524,6 +4525,7 @@ class AgentSpawner:
                                 session=session,
                                 adapter=target_adapter,
                                 task_scope=max_scope,
+                                system_addendum=style_addendum,
                             )
                         elif self._container_mgr is not None:
                             result = self._spawn_in_container(
@@ -4535,6 +4537,7 @@ class AgentSpawner:
                                 session=session,
                                 adapter=target_adapter,
                                 task_scope=max_scope,
+                                system_addendum=style_addendum,
                             )
                         else:
                             # Extract budget_multiplier from task metadata
@@ -5102,12 +5105,35 @@ class AgentSpawner:
                     "spawn() does not accept multimodal_context."
                 )
             _resume_extra["multimodal_context"] = _resume_attachments
+        # Issue #3565: a resumed agent goes straight to ``self._adapter``
+        # (no ``_spawn_for_tasks_internal``), so it used to skip the
+        # response-style resolution that path performs and the resumed
+        # process never received ``system_addendum`` - the channel that
+        # carries the completion/heartbeat instructions. A crashed-then-
+        # resumed agent could therefore run to completion but never be
+        # seen to finish. Resolve the same way the primary spawn path
+        # does (task metadata > role policy > seed default > "balanced")
+        # so a resumed spawn gets the same protocol instructions a fresh
+        # one would.
+        _resume_style = resolve_response_style(
+            task_metadata=tasks[0].metadata or {},
+            role_policy=_policy_preview,
+            default_policy=self._role_model_policy.get("default") or {},
+        )
+        try:
+            _resume_addendum = render_style_addendum(_resume_style.style, workdir=self._workdir)
+        except ResponseStyleTemplateError as exc:
+            raise SpawnError(
+                f"Response-style profile {_resume_style.style!r} for role {role!r} "
+                f"(source={_resume_style.source}) cannot be rendered on resume: {exc}"
+            ) from exc
         result = self._adapter.spawn(
             prompt=prompt,
             workdir=worktree_path,
             model_config=model_config,
             session_id=session_id,
             task_scope=resume_scope,
+            system_addendum=_resume_addendum,
             **_resume_extra,
         )
         session.pid = result.pid
@@ -5140,6 +5166,7 @@ class AgentSpawner:
         session: AgentSession,
         adapter: CLIAdapter,
         task_scope: str = "medium",
+        system_addendum: str = "",
     ) -> SpawnResult:
         """Spawn an agent inside a container.
 
@@ -5156,6 +5183,14 @@ class AgentSpawner:
             session: AgentSession to update with container metadata.
             adapter: Adapter selected for this spawn attempt.
             task_scope: Task scope for max_turns scaling.
+            system_addendum: Rendered response-style addendum, forwarded to
+                the direct-subprocess fallback so a container that fails to
+                start doesn't also drop the completion/heartbeat
+                instructions (issue #3565). The container path itself
+                shells out via ``_adapter_cmd_for_container`` rather than
+                ``adapter.spawn()``, so it has no channel to carry this
+                through - a separate, larger gap tracked in #3565's
+                follow-up about per-adapter capability visibility.
 
         Returns:
             SpawnResult with PID and log path.
@@ -5257,6 +5292,7 @@ class AgentSpawner:
                 session_id=session_id,
                 mcp_config=mcp_config,
                 task_scope=task_scope,
+                system_addendum=system_addendum,
             )
 
     def _spawn_in_sandbox(
@@ -5270,6 +5306,7 @@ class AgentSpawner:
         session: AgentSession,
         adapter: CLIAdapter,
         task_scope: str = "medium",
+        system_addendum: str = "",
     ) -> SpawnResult:
         """Spawn an agent in a per-session Docker or Podman sandbox.
 
@@ -5282,6 +5319,10 @@ class AgentSpawner:
             session: Mutable session record to update.
             adapter: Adapter selected for this spawn attempt.
             task_scope: Task scope for max_turns scaling.
+            system_addendum: Rendered response-style addendum, forwarded to
+                the direct-subprocess fallback so a sandbox that fails to
+                start doesn't also drop the completion/heartbeat
+                instructions (issue #3565).
 
         Returns:
             Spawn result for the sandboxed process.
@@ -5371,6 +5412,7 @@ class AgentSpawner:
                 session_id=session_id,
                 mcp_config=mcp_config,
                 task_scope=task_scope,
+                system_addendum=system_addendum,
             )
 
         self._sandbox_managers[session_id] = manager
@@ -5388,6 +5430,7 @@ class AgentSpawner:
         mcp_config: dict[str, Any] | None,
         session: AgentSession,
         adapter: CLIAdapter,
+        system_addendum: str = "",
     ) -> SpawnResult:
         """Route adapter exec through a :class:`SandboxSession`.
 
@@ -5417,6 +5460,10 @@ class AgentSpawner:
             session: Mutable session record updated with isolation
                 metadata.
             adapter: The adapter selected for this spawn attempt.
+            system_addendum: Rendered response-style addendum, forwarded to
+                the direct-subprocess fallback so a session that fails to
+                provision doesn't also drop the completion/heartbeat
+                instructions (issue #3565).
 
         Returns:
             A :class:`SpawnResult`. ``pid`` is ``0`` because the
@@ -5488,6 +5535,7 @@ class AgentSpawner:
                     model_config=model_config,
                     session_id=session_id,
                     mcp_config=mcp_config,
+                    system_addendum=system_addendum,
                 )
             owned = True
             self._sandbox_owned_sessions[session_id] = sbx_session

--- a/tests/unit/test_crash_recovery.py
+++ b/tests/unit/test_crash_recovery.py
@@ -29,6 +29,7 @@ from bernstein.core.orchestrator import Orchestrator
 from bernstein.core.spawner import AgentSpawner
 
 from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.core.agents.response_style import render_style_addendum
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -200,6 +201,41 @@ def test_spawn_for_resume_prompt_includes_changed_files(tmp_path: Path):
     prompt = adapter.spawn.call_args.kwargs.get("prompt") or adapter.spawn.call_args.args[0]
     for f in changed:
         assert f in prompt
+
+
+# ---------------------------------------------------------------------------
+# 3b. spawn_for_resume - system_addendum (issue #3565)
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_for_resume_forwards_system_addendum(tmp_path: Path):
+    """A resumed agent must still receive its completion/heartbeat
+    instructions via ``system_addendum``.
+
+    Before the fix, ``spawn_for_resume`` bypassed the response-style
+    resolution ``_spawn_for_tasks_internal`` performs and called
+    ``adapter.spawn()`` without ``system_addendum`` at all, so it silently
+    defaulted to ``""`` - the crashed-then-resumed agent could run to
+    completion but never be seen to finish.
+    """
+    adapter = _mock_adapter()
+    spawner = AgentSpawner(
+        adapter=adapter,
+        templates_dir=tmp_path / "templates",
+        workdir=tmp_path,
+        default_model="mock-model",
+        role_model_policy={"backend": {"model": "mock-model", "response_style": "terse"}},
+    )
+
+    task = _make_task()
+    worktree_path = tmp_path / ".sdd" / "worktrees" / "resume-addendum"
+    worktree_path.mkdir(parents=True)
+
+    spawner.spawn_for_resume([task], worktree_path=worktree_path, changed_files=[])
+
+    addendum = adapter.spawn.call_args.kwargs["system_addendum"]
+    assert addendum
+    assert render_style_addendum("terse", workdir=tmp_path) == addendum
 
 
 def _find_task_by_id(task_store: list[dict], tid: str) -> dict | None:

--- a/tests/unit/test_spawner_explicit_container_runtime.py
+++ b/tests/unit/test_spawner_explicit_container_runtime.py
@@ -57,6 +57,7 @@ class FakeAdapter(CLIAdapter):
     def __init__(self, adapter_name: str = "claude") -> None:
         self._name = adapter_name
         self.spawn_calls: list[tuple[str, Path]] = []
+        self.spawn_system_addenda: list[str] = []
 
     def name(self) -> str:
         return self._name
@@ -74,8 +75,9 @@ class FakeAdapter(CLIAdapter):
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
     ) -> SpawnResult:
-        del model_config, session_id, mcp_config, timeout_seconds, task_scope, budget_multiplier, system_addendum
+        del model_config, session_id, mcp_config, timeout_seconds, task_scope, budget_multiplier
         self.spawn_calls.append((prompt, workdir))
+        self.spawn_system_addenda.append(system_addendum)
         return SpawnResult(pid=42, log_path=workdir / ".sdd" / "logs" / "fallback.log")
 
     def is_alive(self, pid: int) -> bool:  # pragma: no cover - not exercised
@@ -366,6 +368,32 @@ def test_legacy_container_degrade_to_none_is_surfaced_and_audited(
     assert isinstance(details, dict)
     assert details["requested_isolation"] == IsolationMode.CONTAINER.value
     assert details["actual_isolation"] == IsolationMode.NONE.value
+
+
+def test_legacy_container_fallback_forwards_system_addendum(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #3565: the ``--container`` fallback to a direct subprocess
+    spawn must still carry ``system_addendum`` through, or an agent that
+    lands on this degrade path never gets its completion/heartbeat
+    instructions."""
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    monkeypatch.delenv("BERNSTEIN_SANDBOX_RUNTIME", raising=False)
+
+    adapter = FakeAdapter("claude")
+    spawner = _spawner_with_failing_container_manager(tmp_path, adapter, error="Cannot connect to the Docker daemon.")
+    session = AgentSession(id="S-legacy-addendum", role="backend")
+
+    spawner._spawn_in_container(  # pyright: ignore[reportPrivateUsage]
+        session_id="S-legacy-addendum",
+        prompt="legacy container",
+        spawn_cwd=tmp_path,
+        model_config=ModelConfig("sonnet", "high"),
+        mcp_config=None,
+        session=session,
+        adapter=adapter,
+        system_addendum="## Response style: terse\n\nheartbeat instructions",
+    )
+
+    assert adapter.spawn_system_addenda == ["## Response style: terse\n\nheartbeat instructions"]
 
 
 def test_legacy_container_success_records_no_downgrade(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_spawner_explicit_container_runtime.py
+++ b/tests/unit/test_spawner_explicit_container_runtime.py
@@ -429,3 +429,50 @@ def test_legacy_container_success_records_no_downgrade(tmp_path: Path, monkeypat
     assert session.isolation == IsolationMode.CONTAINER.value
     assert adapter.spawn_calls == []
     assert spawner.isolation_downgrades == []
+
+
+def test_legacy_container_success_path_carries_system_addendum(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #3565: a container that starts must carry the addendum too.
+
+    ``test_legacy_container_fallback_forwards_system_addendum`` covers the
+    branch taken when the container fails to start. This covers the branch
+    taken when it starts -- the normal case whenever a container runtime is
+    configured. That branch builds a raw shell command via
+    ``_adapter_cmd_for_container`` and never calls ``adapter.spawn()``, so
+    the adapter's system-prompt flag is out of reach and the completion and
+    heartbeat instructions travel in the prompt file itself.
+    """
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    monkeypatch.delenv("BERNSTEIN_SANDBOX_RUNTIME", raising=False)
+
+    adapter = FakeAdapter("claude")
+    with patch("bernstein.core.agents.spawner_core.get_registry", return_value=MagicMock()):
+        spawner = AgentSpawner(
+            adapter=adapter,
+            templates_dir=tmp_path,
+            workdir=tmp_path,
+            use_worktrees=False,
+        )
+    manager = MagicMock()
+    manager.config.two_phase_sandbox = None
+    manager.spawn_in_container.return_value = ContainerHandle(container_id="c-add", session_id="S-add", pid=322)
+    spawner._container_mgr = manager  # pyright: ignore[reportPrivateUsage]
+    session = AgentSession(id="S-add", role="backend")
+    addendum = "## Completion\n\nPOST /tasks/<id>/done when finished."
+
+    spawner._spawn_in_container(  # pyright: ignore[reportPrivateUsage]
+        session_id="S-add",
+        prompt="legacy container",
+        spawn_cwd=tmp_path,
+        model_config=ModelConfig("sonnet", "high"),
+        mcp_config=None,
+        session=session,
+        adapter=adapter,
+        system_addendum=addendum,
+    )
+
+    # The fallback was not taken, so nothing reached adapter.spawn().
+    assert adapter.spawn_calls == []
+    written = (tmp_path / ".sdd" / "runtime" / "prompts" / "S-add.md").read_text(encoding="utf-8")
+    assert written.startswith("legacy container")
+    assert addendum in written

--- a/tests/unit/test_spawner_sandbox.py
+++ b/tests/unit/test_spawner_sandbox.py
@@ -21,6 +21,7 @@ class FakeAdapter(CLIAdapter):
     def __init__(self, adapter_name: str = "claude") -> None:
         self._name = adapter_name
         self.spawn_calls: list[tuple[str, Path]] = []
+        self.spawn_system_addenda: list[str] = []
 
     def name(self) -> str:
         return self._name
@@ -38,8 +39,9 @@ class FakeAdapter(CLIAdapter):
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
     ) -> SpawnResult:
-        del model_config, session_id, mcp_config, timeout_seconds, task_scope, budget_multiplier, system_addendum
+        del model_config, session_id, mcp_config, timeout_seconds, task_scope, budget_multiplier
         self.spawn_calls.append((prompt, workdir))
+        self.spawn_system_addenda.append(system_addendum)
         return SpawnResult(pid=42, log_path=workdir / ".sdd" / "logs" / "fallback.log")
 
     def is_alive(self, pid: int) -> bool:  # pragma: no cover - not used here
@@ -124,6 +126,41 @@ def test_spawn_in_sandbox_falls_back_to_adapter_on_runtime_failure(
     assert adapter.spawn_calls == [("fallback", tmp_path)]
     assert session.container_id is None
     assert session.isolation == "worktree"
+
+
+def test_spawn_in_sandbox_fallback_forwards_system_addendum(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #3565: the sandbox-runtime-failure fallback must still carry
+    ``system_addendum`` through to the direct adapter spawn, or an agent
+    that lands on this path never gets its completion/heartbeat
+    instructions."""
+    monkeypatch.delenv("BERNSTEIN_SANDBOX_RUNTIME", raising=False)
+    adapter = FakeAdapter("codex")
+    sandbox = DockerSandbox(enabled=True)
+    session = AgentSession(id="S-2b", role="backend")
+
+    with (
+        patch("bernstein.core.agents.spawner_core.get_registry", return_value=MagicMock()),
+        patch("bernstein.core.agents.spawner_core.spawn_in_sandbox", side_effect=ContainerError("docker unavailable")),
+    ):
+        spawner = AgentSpawner(
+            adapter=adapter,
+            templates_dir=tmp_path,
+            workdir=tmp_path,
+            use_worktrees=True,
+            sandbox=sandbox,
+        )
+        spawner._spawn_in_sandbox(  # pyright: ignore[reportPrivateUsage]
+            session_id="S-2b",
+            prompt="fallback",
+            spawn_cwd=tmp_path,
+            model_config=ModelConfig("sonnet", "high"),
+            mcp_config=None,
+            session=session,
+            adapter=adapter,
+            system_addendum="## Response style: terse\n\nheartbeat instructions",
+        )
+
+    assert adapter.spawn_system_addenda == ["## Response style: terse\n\nheartbeat instructions"]
 
 
 def _read_audit_events(audit_dir: Path) -> list[dict[str, object]]:

--- a/tests/unit/test_spawner_sandbox.py
+++ b/tests/unit/test_spawner_sandbox.py
@@ -163,6 +163,83 @@ def test_spawn_in_sandbox_fallback_forwards_system_addendum(tmp_path: Path, monk
     assert adapter.spawn_system_addenda == ["## Response style: terse\n\nheartbeat instructions"]
 
 
+def test_spawn_in_sandbox_success_path_carries_system_addendum(tmp_path: Path) -> None:
+    """Issue #3565: the sandbox path that actually starts must carry the addendum too.
+
+    The fallback test above covers the branch taken when the sandbox fails to
+    start. This covers the branch taken when it succeeds -- the normal case
+    whenever isolation is configured, and the one the issue title names.
+    That branch never calls ``adapter.spawn()``: it writes the prompt to a
+    file and builds a raw shell command that ``cat``s it, so the adapter's
+    ``--append-system-prompt`` channel is out of reach and the instructions
+    have to travel in the prompt file itself.
+    """
+    adapter = FakeAdapter("claude")
+    sandbox = DockerSandbox(enabled=True, adapter_images={"claude": "bernstein/claude:latest"})
+    session = AgentSession(id="S-3a", role="backend")
+    fake_handle = ContainerHandle(container_id="sandbox-3a", session_id="S-3a", pid=333)
+    addendum = "## Completion\n\nPOST /tasks/<id>/done when finished."
+
+    with (
+        patch("bernstein.core.agents.spawner_core.get_registry", return_value=MagicMock()),
+        patch("bernstein.core.agents.spawner_core.spawn_in_sandbox", return_value=(MagicMock(), fake_handle)),
+    ):
+        spawner = AgentSpawner(
+            adapter=adapter,
+            templates_dir=tmp_path,
+            workdir=tmp_path,
+            use_worktrees=False,
+            sandbox=sandbox,
+        )
+        spawner._spawn_in_sandbox(  # pyright: ignore[reportPrivateUsage]
+            session_id="S-3a",
+            prompt="solve it",
+            spawn_cwd=tmp_path,
+            model_config=ModelConfig("sonnet", "high"),
+            mcp_config=None,
+            session=session,
+            adapter=adapter,
+            system_addendum=addendum,
+        )
+
+    # The fallback was not taken, so nothing reached adapter.spawn().
+    assert adapter.spawn_calls == []
+    written = (tmp_path / ".sdd" / "runtime" / "prompts" / "S-3a.md").read_text(encoding="utf-8")
+    assert written.startswith("solve it")
+    assert addendum in written
+
+
+def test_spawn_in_sandbox_without_addendum_writes_prompt_unchanged(tmp_path: Path) -> None:
+    """An empty addendum must not add trailing blank lines to the prompt file."""
+    adapter = FakeAdapter("claude")
+    sandbox = DockerSandbox(enabled=True, adapter_images={"claude": "bernstein/claude:latest"})
+    session = AgentSession(id="S-3b", role="backend")
+    fake_handle = ContainerHandle(container_id="sandbox-3b", session_id="S-3b", pid=334)
+
+    with (
+        patch("bernstein.core.agents.spawner_core.get_registry", return_value=MagicMock()),
+        patch("bernstein.core.agents.spawner_core.spawn_in_sandbox", return_value=(MagicMock(), fake_handle)),
+    ):
+        spawner = AgentSpawner(
+            adapter=adapter,
+            templates_dir=tmp_path,
+            workdir=tmp_path,
+            use_worktrees=False,
+            sandbox=sandbox,
+        )
+        spawner._spawn_in_sandbox(  # pyright: ignore[reportPrivateUsage]
+            session_id="S-3b",
+            prompt="solve it",
+            spawn_cwd=tmp_path,
+            model_config=ModelConfig("sonnet", "high"),
+            mcp_config=None,
+            session=session,
+            adapter=adapter,
+        )
+
+    assert (tmp_path / ".sdd" / "runtime" / "prompts" / "S-3b.md").read_text(encoding="utf-8") == "solve it"
+
+
 def _read_audit_events(audit_dir: Path) -> list[dict[str, object]]:
     """Return every audit-chain entry under ``audit_dir`` as parsed dicts."""
     events: list[dict[str, object]] = []

--- a/tests/unit/test_spawner_sandbox_session.py
+++ b/tests/unit/test_spawner_sandbox_session.py
@@ -169,6 +169,38 @@ def test_spawn_via_sandbox_session_routes_through_session(tmp_path: Path) -> Non
     assert session_obj.exec_calls, "session.exec was never invoked"
 
 
+def test_sandbox_session_success_path_carries_system_addendum(tmp_path: Path) -> None:
+    """Issue #3565: the session path that actually provisions must carry the addendum.
+
+    This is the counterpart to the provisioning-failure test below. The
+    success branch injects the prompt through the session's file primitive
+    and execs a raw adapter command against it, never reaching
+    ``adapter.spawn()``, so the completion/heartbeat instructions have to
+    ride in the injected prompt itself.
+    """
+    session_obj = _FakeSession(backend_name="docker", root=tmp_path)
+    spawner, adapter = _build_spawner(tmp_path, session=session_obj)
+    agent_session = AgentSession(id="S-7a", role="backend")
+    addendum = "## Heartbeat\n\nPOST /agents/<id>/heartbeat every 60s."
+
+    spawner._spawn_via_sandbox_session(  # pyright: ignore[reportPrivateUsage]
+        session_id="S-7a",
+        prompt="solve it",
+        spawn_cwd=tmp_path,
+        model_config=ModelConfig("sonnet", "high"),
+        mcp_config=None,
+        session=agent_session,
+        adapter=adapter,
+        system_addendum=addendum,
+    )
+    spawner._sandbox_exec_handles["S-7a"].future.result(timeout=5.0)  # pyright: ignore[reportPrivateUsage]
+
+    assert adapter.spawn_calls == []
+    written = (tmp_path / ".sdd" / "runtime" / "prompts" / "S-7a.md").read_text(encoding="utf-8")
+    assert written.startswith("solve it")
+    assert addendum in written
+
+
 def test_worktree_session_does_not_trigger_routing(tmp_path: Path) -> None:
     """Worktree-backed sessions intentionally stay on the legacy path."""
     session_obj = _FakeSession(backend_name="worktree", root=tmp_path)

--- a/tests/unit/test_spawner_sandbox_session.py
+++ b/tests/unit/test_spawner_sandbox_session.py
@@ -38,6 +38,7 @@ class _FakeAdapter(CLIAdapter):
         super().__init__()
         self._name = adapter_name
         self.spawn_calls: list[tuple[str, Path]] = []
+        self.spawn_system_addenda: list[str] = []
 
     def name(self) -> str:
         return self._name
@@ -56,8 +57,9 @@ class _FakeAdapter(CLIAdapter):
         system_addendum: str = "",
     ) -> SpawnResult:
         del model_config, session_id, mcp_config, timeout_seconds
-        del task_scope, budget_multiplier, system_addendum
+        del task_scope, budget_multiplier
         self.spawn_calls.append((prompt, workdir))
+        self.spawn_system_addenda.append(system_addendum)
         return SpawnResult(pid=99, log_path=workdir / ".sdd" / "logs" / "direct.log")
 
     def is_alive(self, pid: int) -> bool:  # pragma: no cover - not used
@@ -388,6 +390,33 @@ def test_provisioning_failure_falls_back_to_direct_spawn(tmp_path: Path) -> None
     assert result.pid == 99
     assert adapter.spawn_calls == [("fallback", tmp_path)]
     assert "S-25" not in spawner._sandbox_owned_sessions  # pyright: ignore[reportPrivateUsage]
+
+
+def test_provisioning_failure_fallback_forwards_system_addendum(tmp_path: Path) -> None:
+    """Issue #3565: the session-provisioning-failure fallback to a direct
+    adapter spawn must still carry ``system_addendum`` through, or an
+    agent that lands on this degrade path never gets its
+    completion/heartbeat instructions."""
+
+    class _BrokenBackend(_FakeBackend):
+        async def create(self, manifest: object, options: dict[str, object] | None = None) -> _FakeSession:
+            raise RuntimeError("daemon went away")
+
+    backend = _BrokenBackend(tmp_path)
+    spawner, adapter = _build_spawner_with_backend(tmp_path, backend=backend)
+
+    agent_session = AgentSession(id="S-25b", role="backend")
+    spawner._spawn_via_sandbox_session(  # pyright: ignore[reportPrivateUsage]
+        session_id="S-25b",
+        prompt="fallback",
+        spawn_cwd=tmp_path,
+        model_config=ModelConfig("sonnet", "high"),
+        mcp_config=None,
+        session=agent_session,
+        adapter=adapter,
+        system_addendum="## Response style: terse\n\nheartbeat instructions",
+    )
+    assert adapter.spawn_system_addenda == ["## Response style: terse\n\nheartbeat instructions"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`system_addendum` carries the completion and heartbeat instructions an agent needs in order to report that it finished. `spawn_for_tasks()` resolved and forwarded it; five other spawn paths did not, so an agent could do the work and then be reaped as stalled — it was never told how to say done.

## Paths that reach `adapter.spawn()`

- `spawn_for_resume()` goes straight to the adapter after a crash and never resolved a response-style addendum at all, so `system_addendum` defaulted to `""`.
- The direct-subprocess fallbacks in `_spawn_in_container()`, `_spawn_in_sandbox()`, and `_spawn_via_sandbox_session()` — taken when a container or sandbox fails to start — called `adapter.spawn()` without threading the addendum the caller had already resolved.

Fixed by threading the same `resolve_response_style` / `render_style_addendum` pipeline the primary path uses into `spawn_for_resume`, and by adding a `system_addendum` parameter to the three helpers so their existing `adapter.spawn()` calls carry the value the caller already computed, rather than each site recomputing it.

## Paths that never reach `adapter.spawn()`

The branch taken when a container or sandbox *does* start — the normal case whenever isolation is configured — writes the prompt to `.sdd/runtime/prompts/<session>.md` and builds a raw shell command that `cat`s the file into the CLI. `_adapter_cmd_for_container` assembles that invocation per adapter family, and only one of those families has a system-prompt flag to pass; the generic branch has no flags at all.

`_prompt_with_addendum` folds the instructions into the prompt text at the three sites that inject it — the two prompt-file writes and the sandbox session's file primitive — so every adapter family carries them. Appending to the user prompt is the weaker of the two channels, and the base `spawn` docstring names it as the permitted fallback; adapters without a system-prompt flag (`devin_terminal.py`) already take it. Carrying the instructions in the weaker channel beats dropping them.

An empty addendum leaves the prompt file byte-identical to before, so a run without a response style is unaffected.

## Tests

Per path, both branches:

| Path | Fails to start | Starts |
|---|---|---|
| container | `test_legacy_container_fallback_forwards_system_addendum` | `test_legacy_container_success_path_carries_system_addendum` |
| sandbox | `test_spawn_in_sandbox_fallback_forwards_system_addendum` | `test_spawn_in_sandbox_success_path_carries_system_addendum` |
| sandbox session | `test_provisioning_failure_fallback_forwards_system_addendum` | `test_sandbox_session_success_path_carries_system_addendum` |

Plus the resume path in `test_crash_recovery.py`, and one asserting an empty addendum writes the prompt unchanged.

Each success-branch test was run against the code without the corresponding change and fails there.

## Not in this PR

Making an adapter's handling of the addendum machine-visible — a declared capability plus a conformance check, and a decision about what to do when an adapter ignores it outright — is a change to the contract surface rather than to the spawn paths. It moved to #4256.

Closes #3565
