### PR TITLE
fix(cli): diagnose a spawned-then-dead agent on the remaining run surfaces

### DIFF
--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -604,6 +604,42 @@ def _make_profile_ctx(profile: bool, workdir: Path) -> contextlib.AbstractContex
     return contextlib.nullcontext()
 
 
+def _raise_if_no_plan_after_spawn() -> None:
+    """Diagnose a spawned-then-dead agent before a display branch's own wait.
+
+    The non-interactive detach path (issue #3528, #4246) briefly confirms the
+    first agent spawn and takes one poll to see whether that agent already
+    died before the goal was ever decomposed -- the reproduced shape where a
+    run leaves its one root task stuck ``claimed``/``in_progress``/``orphaned``
+    forever with no live agent and no plan. The TTY dashboard, the Rich
+    fallback, and ``--quiet`` all reproduce the same silence: none of them
+    checks for this shape, so they detach (or keep waiting) exactly as if the
+    run were healthy.
+
+    Called at the start of each of those three branches, before the branch's
+    own longer-running work begins, so the check lands close to the failure
+    window described in the reproduction (the agent dies almost immediately
+    after spawn) rather than after a dashboard session or a multi-hour quiet
+    wait have already moved past it.
+
+    Raises the same ``BernsteinFirstRunError``/``NO_PLAN_PRODUCED`` pair the
+    non-interactive branch raises, so this is the single producer of the
+    diagnosis text across every surface -- no renderer composes its own
+    message. A spawn refusal is left untouched here; each branch's existing
+    terminal-state check already accounts for it once the refused task
+    reaches a terminal status.
+    """
+    from bernstein.cli.run_bootstrap import _await_first_spawn_outcome, _poll_no_plan_after_spawn
+    from bernstein.core.errors import BernsteinFirstRunError, ErrorCategory
+
+    outcome, _reason = _await_first_spawn_outcome()
+    if outcome == "spawned" and _poll_no_plan_after_spawn() is not None:
+        raise BernsteinFirstRunError(
+            "Spawned agent exited before producing a work plan",
+            category=ErrorCategory.NO_PLAN_PRODUCED,
+        )
+
+
 def _finalize_run_output(*, quiet: bool) -> None:
     """Render either the interactive dashboard or the final summary.
 
@@ -642,6 +678,11 @@ def _finalize_run_output(*, quiet: bool) -> None:
     changes nothing. It fires when a run reached a terminal state inside that
     window, which is the fast-failure case.
 
+    A spawned-then-dead agent that never produced a plan (issue #3528) is
+    diagnosed the same way on every branch via ``_raise_if_no_plan_after_spawn``,
+    called before each branch's own wait so the check lands near the failure
+    window instead of after it.
+
     Args:
         quiet: When True, wait for quiescence and print only the terminal summary.
     """
@@ -653,6 +694,11 @@ def _finalize_run_output(*, quiet: bool) -> None:
 
     try:
         if quiet:
+            # `--quiet` means "no progress chatter", not "swallow the reason
+            # the run produced nothing" -- run the same fast diagnosis every
+            # other branch runs before falling back to the slower, general
+            # terminal-state wait below (issue #3528).
+            _raise_if_no_plan_after_spawn()
             final_status = _wait_for_run_completion()
             _show_run_summary()
             _exit_nonzero_on_unhealthy_run(final_status)
@@ -663,6 +709,7 @@ def _finalize_run_output(*, quiet: bool) -> None:
         caps = detect_capabilities()
 
         if caps.supports_textual:
+            _raise_if_no_plan_after_spawn()
             try:
                 from bernstein.cli.dashboard import BernsteinApp as DashboardApp
 
@@ -681,6 +728,7 @@ def _finalize_run_output(*, quiet: bool) -> None:
             _exit_nonzero_on_unhealthy_run(_poll_quiescent_status())
         elif caps.is_tty:
             # TTY but Textual not supported -- use Rich fallback (TUI-003)
+            _raise_if_no_plan_after_spawn()
             _try_fallback_display()
             _exit_nonzero_on_unhealthy_run(_poll_quiescent_status())
         else:

--- a/tests/unit/test_no_plan_after_spawn_diagnosis.py
+++ b/tests/unit/test_no_plan_after_spawn_diagnosis.py
@@ -8,7 +8,7 @@ reached quiescence (it is stuck ``claimed``, not terminal), so neither of
 the CLI's two existing terminal-state checks fired. The non-interactive
 detach path printed "Run continues in the background" and exited 0.
 
-Three layers are covered:
+Four layers are covered:
 
 1. ``_poll_no_plan_after_spawn`` -- the single-poll detector that recognises
    this shape from ``/status`` + ``/health`` without a confirmation window.
@@ -18,6 +18,10 @@ Three layers are covered:
 3. The structured taxonomy itself -- the new ``NO_PLAN_PRODUCED`` category
    carries a real sysexits.h exit code and a non-empty hint, exactly like
    every other first-run category.
+4. ``_finalize_run_output``'s remaining display branches -- the TTY
+   dashboard, the Rich fallback, and ``--quiet`` -- reuse the same
+   ``_raise_if_no_plan_after_spawn`` producer so the diagnosis reaches every
+   surface, not only the non-interactive one.
 """
 
 # pyright: reportPrivateUsage=false
@@ -208,6 +212,175 @@ class TestFinalizeRunOutputNoPlan:
 
         out = capsys.readouterr().out
         assert "continues in the background" in out
+
+
+# ---------------------------------------------------------------------------
+# Layer 2b: the remaining display branches -- TTY dashboard, Rich fallback,
+# and --quiet -- must reuse the same diagnosis (issue #3528 remaining scope).
+# ---------------------------------------------------------------------------
+
+_TEXTUAL_CAPS = MagicMock(supports_textual=True, is_tty=True)
+_RICH_FALLBACK_CAPS = MagicMock(supports_textual=False, is_tty=True)
+
+
+class TestFinalizeRunOutputNoPlanOnRemainingSurfaces:
+    """The TTY dashboard, the Rich fallback, and ``--quiet`` still detached
+    silently on this exact shape before #3528's remaining-scope fix: none of
+    them called ``_poll_no_plan_after_spawn`` at all, so a dead-agent-no-plan
+    run rendered (or waited) as if it were healthy on every one of them.
+    """
+
+    def test_dashboard_raises_categorised_error_before_rendering(self) -> None:
+        """The Textual dashboard must not even open on a pre-diagnosed death.
+
+        Asserting the dashboard was never constructed is what proves the
+        check runs before the branch's own display work, matching the
+        non-interactive branch's placement relative to the detach notice.
+        """
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        # `_restart_on_exit=False` and mocked `exec_restart`/fallback are
+        # defensive, not exercised on the passing path: they only matter if
+        # this assertion regresses and the dashboard branch actually runs,
+        # so a broken check fails loudly on its own assertions instead of
+        # hanging in a real Rich Live fallback with no server behind it.
+        dashboard_app = MagicMock()
+        dashboard_app.return_value = MagicMock(_restart_on_exit=False)
+        with (
+            patch("bernstein.cli.terminal_caps.detect_capabilities", return_value=_TEXTUAL_CAPS),
+            patch(
+                "bernstein.cli.run_bootstrap._await_first_spawn_outcome",
+                return_value=("spawned", None),
+            ),
+            patch(
+                "bernstein.cli.run_bootstrap._poll_no_plan_after_spawn",
+                return_value={"total": 1, "claimed": 1},
+            ),
+            patch("bernstein.cli.dashboard.BernsteinApp", dashboard_app),
+            patch("bernstein.cli.run_bootstrap.exec_restart", side_effect=AssertionError("must not re-exec")),
+            patch("bernstein.cli.run_preflight._try_fallback_display") as fallback,
+            patch("bernstein.cli.run_bootstrap._poll_quiescent_status", return_value=None),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files") as drain,
+        ):
+            with pytest.raises(BernsteinFirstRunError) as excinfo:
+                _finalize_run_output(quiet=False)
+
+        assert excinfo.value.category is ErrorCategory.NO_PLAN_PRODUCED
+        dashboard_app.assert_not_called()
+        fallback.assert_not_called()
+        drain.assert_called_once()
+
+    def test_dashboard_healthy_spawn_still_renders(self) -> None:
+        """No regression: a normal run still opens the Textual dashboard."""
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        dashboard_app = MagicMock()
+        dashboard_app.return_value = MagicMock(_restart_on_exit=False)
+        with (
+            patch("bernstein.cli.terminal_caps.detect_capabilities", return_value=_TEXTUAL_CAPS),
+            patch(
+                "bernstein.cli.run_bootstrap._await_first_spawn_outcome",
+                return_value=("spawned", None),
+            ),
+            patch("bernstein.cli.run_bootstrap._poll_no_plan_after_spawn", return_value=None),
+            patch("bernstein.cli.dashboard.BernsteinApp", dashboard_app),
+            patch("bernstein.cli.run_bootstrap._poll_quiescent_status", return_value=None),
+            patch("bernstein.cli.run_bootstrap.exec_restart", side_effect=AssertionError("must not re-exec")),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),
+        ):
+            _finalize_run_output(quiet=False)
+
+        dashboard_app.assert_called_once()
+
+    def test_rich_fallback_raises_categorised_error_before_rendering(self) -> None:
+        """The Rich fallback renderer must not run on a pre-diagnosed death."""
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        with (
+            patch("bernstein.cli.terminal_caps.detect_capabilities", return_value=_RICH_FALLBACK_CAPS),
+            patch(
+                "bernstein.cli.run_bootstrap._await_first_spawn_outcome",
+                return_value=("spawned", None),
+            ),
+            patch(
+                "bernstein.cli.run_bootstrap._poll_no_plan_after_spawn",
+                return_value={"total": 1, "claimed": 1},
+            ),
+            patch("bernstein.cli.run_preflight._try_fallback_display") as fallback,
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files") as drain,
+        ):
+            with pytest.raises(BernsteinFirstRunError) as excinfo:
+                _finalize_run_output(quiet=False)
+
+        assert excinfo.value.category is ErrorCategory.NO_PLAN_PRODUCED
+        fallback.assert_not_called()
+        drain.assert_called_once()
+
+    def test_rich_fallback_healthy_spawn_still_renders(self) -> None:
+        """No regression: a normal run still runs the Rich fallback display."""
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        with (
+            patch("bernstein.cli.terminal_caps.detect_capabilities", return_value=_RICH_FALLBACK_CAPS),
+            patch(
+                "bernstein.cli.run_bootstrap._await_first_spawn_outcome",
+                return_value=("spawned", None),
+            ),
+            patch("bernstein.cli.run_bootstrap._poll_no_plan_after_spawn", return_value=None),
+            patch("bernstein.cli.run_preflight._try_fallback_display") as fallback,
+            patch("bernstein.cli.run_bootstrap._poll_quiescent_status", return_value=None),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),
+        ):
+            _finalize_run_output(quiet=False)
+
+        fallback.assert_called_once()
+
+    def test_quiet_raises_categorised_error_instead_of_waiting(self) -> None:
+        """``--quiet`` must state the reason, not swallow it behind the wait.
+
+        ``_wait_for_run_completion`` is asserted un-called: quiet mode must
+        not fall through to its slow, general terminal-state wait once the
+        fast diagnosis has already produced a verdict.
+        """
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        with (
+            patch(
+                "bernstein.cli.run_bootstrap._await_first_spawn_outcome",
+                return_value=("spawned", None),
+            ),
+            patch(
+                "bernstein.cli.run_bootstrap._poll_no_plan_after_spawn",
+                return_value={"total": 1, "claimed": 1},
+            ),
+            patch("bernstein.cli.run_bootstrap._wait_for_run_completion") as wait_for_completion,
+            patch("bernstein.cli.run_preflight._show_run_summary"),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files") as drain,
+        ):
+            with pytest.raises(BernsteinFirstRunError) as excinfo:
+                _finalize_run_output(quiet=True)
+
+        assert excinfo.value.category is ErrorCategory.NO_PLAN_PRODUCED
+        wait_for_completion.assert_not_called()
+        drain.assert_called_once()
+
+    def test_quiet_healthy_spawn_still_waits_for_completion(self) -> None:
+        """No regression: a normal ``--quiet`` run still waits as before."""
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        with (
+            patch(
+                "bernstein.cli.run_bootstrap._await_first_spawn_outcome",
+                return_value=("spawned", None),
+            ),
+            patch("bernstein.cli.run_bootstrap._poll_no_plan_after_spawn", return_value=None),
+            patch("bernstein.cli.run_bootstrap._wait_for_run_completion", return_value=None) as wait_for_completion,
+            patch("bernstein.cli.run_preflight._show_run_summary"),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),
+        ):
+            _finalize_run_output(quiet=True)
+
+        wait_for_completion.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom

`bernstein run`'s TTY dashboard, its Rich fallback (used when a terminal is a
TTY but does not support Textual), and `--quiet` all detach the same way the
non-interactive path used to: when the spawned agent dies right after spawn,
before the goal is ever decomposed, none of these three branches notices.
The dashboard/fallback exit and the CLI falls through to a single quiescence
poll that cannot see the failure (the one root task is stuck `claimed`, not
terminal); `--quiet` waits for a terminal state that, for this exact shape,
never arrives inside its own confirmation logic either. All three exit 0 (or
keep waiting) with no plan and no stated reason.

## Root cause

The fast diagnosis added for the non-interactive branch (`_poll_no_plan_after_spawn`)
was wired into that one branch only. The other three display branches never
call it, so they inherit none of the benefit.

## Fix

Add `_raise_if_no_plan_after_spawn`, a small helper that repeats the existing
non-interactive sequence -- confirm the first spawn, then take one poll for
the no-plan-after-spawn shape -- and raises the same
`BernsteinFirstRunError`/`NO_PLAN_PRODUCED` pair the non-interactive branch
already raises. It is now called at the start of the TTY dashboard branch,
the Rich fallback branch, and `--quiet`, before each branch's own
longer-running work begins, so the check lands close to the failure window
the reproduction describes rather than after a dashboard session or a
multi-hour quiet wait have already moved past it.

`--quiet` no longer means "swallow the reason the run produced nothing": on
this shape it now raises immediately instead of falling through to its
general terminal-state wait.

The non-interactive branch itself is untouched -- it keeps its own inline
handling of both spawn refusal and the no-plan diagnosis, since it also
covers a case (a flatly refused first spawn) the other three branches do not
need reproduced here.

## Test

`tests/unit/test_no_plan_after_spawn_diagnosis.py`, extended with
`TestFinalizeRunOutputNoPlanOnRemainingSurfaces`, each case failing before
this change and passing after:

- TTY dashboard: a pre-diagnosed death raises the categorised error and
  never constructs the dashboard app; a healthy spawn still opens it
- Rich fallback: a pre-diagnosed death raises the categorised error and
  never runs the fallback display; a healthy spawn still runs it
- `--quiet`: a pre-diagnosed death raises the categorised error without
  calling the terminal-state wait; a healthy spawn still waits as before

Closes #3528
