### PR TITLE
fix(tasks): propagate a cascade cancel to dependents outside the subtree

### DIFF
--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -1222,8 +1222,8 @@ class TaskStore:
         )
         return True
 
-    async def _cascade_failed_dependency(self, task_id: str) -> None:
-        """Strand every task that can no longer run because *task_id* ended.
+    async def _cascade_failed_dependency(self, *task_ids: str) -> None:
+        """Strand every task that can no longer run because *task_ids* ended.
 
         Propagation is transitive: a task moved to ``BLOCKED_BY_FAILED_DEP``
         is itself a stranding dependency, so the next ring is found on the
@@ -1231,9 +1231,15 @@ class TaskStore:
         records its own nearest cause, so a chain A -> B -> C names B as C's
         cause rather than A.
 
+        Several ids seed one walk rather than one walk each, so a subtree
+        cancelled together strands its dependents in a single pass and a task
+        depending on two of them still records only its nearest cause
+        (#4247). The four single-task terminal transitions pass one id; the
+        cancel cascade passes the whole set it cancelled.
+
         Must be called with ``self._lock`` held.
         """
-        frontier = {task_id}
+        frontier = set(task_ids)
         while frontier:
             next_frontier: set[str] = set()
             for candidate in sorted(self._tasks.values(), key=lambda t: t.id):
@@ -3005,6 +3011,17 @@ class TaskStore:
                     reason=cascade_reason,
                 )
                 cancelled.append(task)
+
+            # Dependents are stranded after the whole subtree is cancelled,
+            # not per task inside the loop. A dependent that is itself a
+            # descendant must be cancelled by the walk above rather than
+            # marked blocked first: ``cancellable`` does not include
+            # ``BLOCKED_BY_FAILED_DEP``, so an early mark would make the
+            # cascade skip it and a subtask would end in the wrong terminal
+            # status. Seeding one walk with the whole set also means a task
+            # depending on two cancelled tasks records a single nearest cause.
+            if cancelled:
+                await self._cascade_failed_dependency(*(t.id for t in cancelled))
 
         return cancelled
 

--- a/tests/unit/tasks/test_failed_dependency_propagation.py
+++ b/tests/unit/tasks/test_failed_dependency_propagation.py
@@ -234,6 +234,63 @@ class TestTaskStoreFailurePropagation:
         await store.cancel("A", "operator stopped it")
         assert dependent.status is TaskStatus.BLOCKED_BY_FAILED_DEP
 
+    async def test_cancel_cascade_propagates_to_an_in_progress_dependent(self, tmp_path: Path) -> None:
+        """#4247: the cascade transitions inline, so it used to skip propagation.
+
+        An already-CLAIMED or IN_PROGRESS dependent is the case that matters:
+        it never passes through ``claim_next`` again, so the backstop there
+        cannot rescue it and it would keep running against a dependency that
+        can never complete.
+        """
+        store = _store(tmp_path)
+        await _insert(store, "P", status=TaskStatus.IN_PROGRESS)
+        await _insert(store, "S", status=TaskStatus.IN_PROGRESS, parent_task_id="P")
+        dependent = await _insert(store, "D", status=TaskStatus.IN_PROGRESS, depends_on=["S"])
+
+        await store.cancel_cascade("P", "operator stopped the tree")
+
+        assert dependent.status is TaskStatus.BLOCKED_BY_FAILED_DEP
+        assert dependent.metadata["blocking_task_id"] == "S"
+
+    async def test_cancel_cascade_propagates_transitively(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _insert(store, "P", status=TaskStatus.IN_PROGRESS)
+        d1 = await _insert(store, "D1", status=TaskStatus.IN_PROGRESS, depends_on=["P"])
+        d2 = await _insert(store, "D2", depends_on=["D1"])
+
+        await store.cancel_cascade("P", "operator stopped the tree")
+
+        assert d1.status is TaskStatus.BLOCKED_BY_FAILED_DEP
+        assert d2.status is TaskStatus.BLOCKED_BY_FAILED_DEP
+        assert d2.metadata["blocking_task_id"] == "D1"
+
+    async def test_cancel_cascade_still_cancels_a_descendant_that_also_depends_on_the_root(
+        self, tmp_path: Path
+    ) -> None:
+        """A subtask must end CANCELLED, not BLOCKED_BY_FAILED_DEP.
+
+        Propagation runs after the whole subtree is cancelled for exactly this
+        case: marking the dependent first would leave it in a status the
+        cascade's ``cancellable`` set does not cover, and it would never be
+        cancelled at all.
+        """
+        store = _store(tmp_path)
+        await _insert(store, "P", status=TaskStatus.IN_PROGRESS)
+        both = await _insert(store, "S", status=TaskStatus.IN_PROGRESS, parent_task_id="P", depends_on=["P"])
+
+        await store.cancel_cascade("P", "operator stopped the tree")
+
+        assert both.status is TaskStatus.CANCELLED
+
+    async def test_cancel_cascade_leaves_an_unrelated_task_alone(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _insert(store, "P", status=TaskStatus.IN_PROGRESS)
+        untouched = await _insert(store, "U", status=TaskStatus.IN_PROGRESS)
+
+        await store.cancel_cascade("P", "operator stopped the tree")
+
+        assert untouched.status is TaskStatus.IN_PROGRESS
+
     async def test_a_live_sibling_dependency_does_not_keep_the_dependent_claimable(self, tmp_path: Path) -> None:
         store = _store(tmp_path)
         await _insert(store, "A", status=TaskStatus.IN_PROGRESS)


### PR DESCRIPTION
Closes #4247.

## Symptom

A task that `depends_on` something cancelled *through the cascade* kept running against a dependency that could never complete, and nothing moved it to `BLOCKED_BY_FAILED_DEP`.

Reachable from the REST cancel route (`core/routes/task_crud.py`), which is the operator-facing way to abort a subtree.

## Root cause

`cancel_cascade()` walks the `parent_task_id` tree and transitions each descendant to `CANCELLED` inline rather than by calling `cancel()`. The dependency-failure propagation added in #4243 hangs off the four terminal transitions — `fail()`, `fail_contract_violation()`, `refuse()`, `cancel()` — so the cascade never reached it.

The `claim_next` backstop does not rescue this case. It only sees a candidate *before* it is claimed, and a dependent that is already `CLAIMED` or `IN_PROGRESS` never passes through `claim_next` again.

## Fix

Propagation runs once after the cancel loop, seeded with every id the cascade cancelled.

**Why after the loop, not inside it.** A dependent that is *also* a descendant has to be cancelled by the walk first. The cascade's `cancellable` set does not include `BLOCKED_BY_FAILED_DEP`, so marking it blocked mid-loop would make the walk skip it and a subtask would end in the wrong terminal status. `test_cancel_cascade_still_cancels_a_descendant_that_also_depends_on_the_root` pins that.

**Why one seeded walk, not one walk per id.** A task depending on two cancelled tasks records a single nearest cause rather than whichever walk reached it last, and the store is scanned once instead of once per cancelled task.

`_cascade_failed_dependency` takes a variadic seed for this. The four existing call sites pass one id and are unchanged.

## Tests

| Test | Asserts |
|---|---|
| `test_cancel_cascade_propagates_to_an_in_progress_dependent` | the case the backstop cannot reach |
| `test_cancel_cascade_propagates_transitively` | the next ring, with the nearest cause recorded |
| `test_cancel_cascade_still_cancels_a_descendant_that_also_depends_on_the_root` | a subtask ends `CANCELLED`, not blocked |
| `test_cancel_cascade_leaves_an_unrelated_task_alone` | no over-reach |

The first two fail against `main`.

Full run: `tests/unit/tasks/`, `test_task_store.py`, `test_task_lifecycle.py`, `test_task_lifecycle_state_machine.py`, `test_task_release_receipt.py`, `test_task_release_requeue.py`, `test_task_grace_period.py` — 639 passed.

## Not in this PR

The cancel route publishes an SSE `task_update` for every cancelled task, but a dependent moved to `BLOCKED_BY_FAILED_DEP` gets no event, so a dashboard shows it as still running until the next poll. That is not specific to the cascade — it is true of every propagation path #4243 introduced, since the store has no bus — so it is filed separately rather than widened into this fix.
