### PR TITLE
fix(cli): narrate the first-agent wait on TTY runs

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -10,4 +10,6 @@ holds the page to that — an entry naming an issue or PR a tagged release page
 already documents fails the build. An entry that cites released work as context
 rather than as its own attribution is exempted by hand there, with the reason.
 
-Nothing yet: v3.17.0 was cut from this page.
+## Added
+
+- `bernstein run` on a TTY now says it is waiting for the first agent instead of sitting silent (#4257). The wait is bounded and returns as soon as an agent registers, so a fast start stays exactly as quiet as before: the transient status appears only once a poll has already failed to produce a verdict, and clears before the dashboard or the Rich fallback renders. The non-interactive detach path is unchanged.

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1677,6 +1677,7 @@ def _await_first_spawn_outcome(
     *,
     timeout_s: float = _FIRST_SPAWN_WAIT_S,
     poll_interval_s: float = _FIRST_SPAWN_POLL_S,
+    narrate_wait: bool = False,
 ) -> tuple[str, str | None]:
     """Briefly poll the task server for the outcome of the first agent spawn.
 
@@ -1692,6 +1693,13 @@ def _await_first_spawn_outcome(
     Args:
         timeout_s: Maximum total time to wait for a verdict.
         poll_interval_s: Delay between polls.
+        narrate_wait: When True and the first poll does not already produce a
+            verdict, show a transient Rich status ("waiting for the first
+            agent") while the remaining polls run, clearing it before the
+            caller renders its own surface. A fast start -- the first poll
+            already reports an agent -- stays silent. Off by default so the
+            non-interactive detach branch and ``--quiet`` keep today's
+            chatter-free behaviour.
 
     Returns:
         ``("spawned", None)`` once at least one agent is live,
@@ -1702,38 +1710,64 @@ def _await_first_spawn_outcome(
     deadline = time.time() + timeout_s
     transient_reason: str | None = None
     unreachable_polls = 0
-    while True:
+
+    def _poll_once() -> tuple[str, str | None] | None:
+        nonlocal unreachable_polls, transient_reason
         health = server_get("/health")
         if not isinstance(health, dict):
             unreachable_polls += 1
             if unreachable_polls >= _FIRST_SPAWN_MAX_UNREACHABLE:
                 return "unknown", None
-        else:
-            unreachable_polls = 0
-            if int(health.get("agent_count", 0) or 0) > 0:
-                return "spawned", None
-            failed_page: Any = server_get("/tasks?status=failed&limit=50")
-            entries = failed_page.get("tasks", []) if isinstance(failed_page, dict) else []
-            for entry in entries:
-                if not isinstance(entry, dict):
-                    continue
-                reason = str(entry.get("result_summary") or "")
-                if not reason.startswith("Spawn failed"):
-                    continue
-                completed_at = float(entry.get("completed_at") or 0.0)
-                if completed_at < time.time() - _FIRST_SPAWN_FRESHNESS_S:
-                    continue
-                if "(transient" in reason:
-                    # A retry may still succeed - keep polling until deadline.
-                    transient_reason = reason
-                    continue
-                return "refused", reason
-        if time.time() >= deadline:
-            break
-        time.sleep(poll_interval_s)
-    if transient_reason is not None:
-        return "refused", transient_reason
-    return "unknown", None
+            return None
+        unreachable_polls = 0
+        if int(health.get("agent_count", 0) or 0) > 0:
+            return "spawned", None
+        failed_page: Any = server_get("/tasks?status=failed&limit=50")
+        entries = failed_page.get("tasks", []) if isinstance(failed_page, dict) else []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            reason = str(entry.get("result_summary") or "")
+            if not reason.startswith("Spawn failed"):
+                continue
+            completed_at = float(entry.get("completed_at") or 0.0)
+            if completed_at < time.time() - _FIRST_SPAWN_FRESHNESS_S:
+                continue
+            if "(transient" in reason:
+                # A retry may still succeed - keep polling until deadline.
+                transient_reason = reason
+                continue
+            return "refused", reason
+        return None
+
+    # The first poll runs before any narration, so a fast start (the first
+    # poll already reports an agent) stays exactly as quiet as it is today.
+    first = _poll_once()
+    if first is not None:
+        return first
+    if time.time() >= deadline:
+        if transient_reason is not None:
+            return "refused", transient_reason
+        return "unknown", None
+
+    def _finish_waiting() -> tuple[str, str | None]:
+        while True:
+            time.sleep(poll_interval_s)
+            result = _poll_once()
+            if result is not None:
+                return result
+            if time.time() >= deadline:
+                break
+        if transient_reason is not None:
+            return "refused", transient_reason
+        return "unknown", None
+
+    if narrate_wait:
+        # Only now is the wait real: tell the operator we are still waiting
+        # for the first agent, and clear the indicator before returning.
+        with console.status("Waiting for the first agent to register..."):
+            return _finish_waiting()
+    return _finish_waiting()
 
 
 def exec_restart() -> None:

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -604,7 +604,7 @@ def _make_profile_ctx(profile: bool, workdir: Path) -> contextlib.AbstractContex
     return contextlib.nullcontext()
 
 
-def _raise_if_no_plan_after_spawn() -> None:
+def _raise_if_no_plan_after_spawn(*, narrate_wait: bool = True) -> None:
     """Diagnose a spawned-then-dead agent before a display branch's own wait.
 
     The non-interactive detach path (issue #3528, #4246) briefly confirms the
@@ -628,11 +628,17 @@ def _raise_if_no_plan_after_spawn() -> None:
     message. A spawn refusal is left untouched here; each branch's existing
     terminal-state check already accounts for it once the refused task
     reaches a terminal status.
+
+    Args:
+        narrate_wait: When True, the first-spawn wait shows a transient Rich
+            status ("waiting for the first agent") while it polls, so a slow
+            start reads as progress instead of a hang. ``--quiet`` passes
+            False to keep its promise of no progress chatter.
     """
     from bernstein.cli.run_bootstrap import _await_first_spawn_outcome, _poll_no_plan_after_spawn
     from bernstein.core.errors import BernsteinFirstRunError, ErrorCategory
 
-    outcome, _reason = _await_first_spawn_outcome()
+    outcome, _reason = _await_first_spawn_outcome(narrate_wait=narrate_wait)
     if outcome == "spawned" and _poll_no_plan_after_spawn() is not None:
         raise BernsteinFirstRunError(
             "Spawned agent exited before producing a work plan",
@@ -698,7 +704,7 @@ def _finalize_run_output(*, quiet: bool) -> None:
             # the run produced nothing" -- run the same fast diagnosis every
             # other branch runs before falling back to the slower, general
             # terminal-state wait below (issue #3528).
-            _raise_if_no_plan_after_spawn()
+            _raise_if_no_plan_after_spawn(narrate_wait=False)
             final_status = _wait_for_run_completion()
             _show_run_summary()
             _exit_nonzero_on_unhealthy_run(final_status)

--- a/tests/unit/test_first_spawn_wait_narration.py
+++ b/tests/unit/test_first_spawn_wait_narration.py
@@ -1,0 +1,96 @@
+"""Regression tests for issue #4257: the first-agent wait must not be silent.
+
+On a TTY, ``bernstein run`` prints nothing between bootstrap and the
+dashboard opening. When the first agent takes a couple of seconds to register,
+the terminal just sits there, and the operator cannot tell whether the run is
+starting, hung, or broken. The wait itself is correctly bounded -- it returns
+as soon as ``agent_count > 0`` -- so the fix is to narrate it, not remove it.
+
+``_await_first_spawn_outcome`` polls ``/health`` every ``_FIRST_SPAWN_POLL_S``.
+The narration is opt-in (``narrate_wait=True``): the first poll runs before any
+status is shown, so a fast start stays silent; only when a poll fails to
+produce a verdict does a transient Rich status appear and clear on exit.
+
+These tests assert on captured output only -- never on timing.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import io
+from typing import Any
+from unittest.mock import patch
+
+from rich.console import Console
+
+from bernstein.cli.run_bootstrap import _await_first_spawn_outcome
+
+_STATUS_TEXT = "Waiting for the first agent to register"
+
+
+def _captured_console() -> tuple[Console, io.StringIO]:
+    """A terminal-forced console writing to an in-memory buffer."""
+    buffer = io.StringIO()
+    return Console(file=buffer, force_terminal=True, color_system=None, width=80, height=24), buffer
+
+
+def test_fast_start_prints_nothing() -> None:
+    """When the first poll already reports an agent, no status is shown."""
+    console, buffer = _captured_console()
+
+    def _server_get(path: str) -> Any:
+        if path.startswith("/health"):
+            return {"agent_count": 1}
+        return None
+
+    with (
+        patch("bernstein.cli.run_bootstrap.server_get", side_effect=_server_get),
+        patch("bernstein.cli.run_bootstrap.console", console),
+    ):
+        outcome, reason = _await_first_spawn_outcome(narrate_wait=True, timeout_s=1.0, poll_interval_s=0.01)
+
+    assert outcome == "spawned"
+    assert reason is None
+    assert _STATUS_TEXT not in buffer.getvalue()
+
+
+def test_slow_start_shows_waiting_status() -> None:
+    """When a later poll reports the agent, the wait is narrated and cleared."""
+    console, buffer = _captured_console()
+    healths = iter([{"agent_count": 0}, {"agent_count": 0}, {"agent_count": 1}])
+
+    def _server_get(path: str) -> Any:
+        if path.startswith("/health"):
+            return next(healths)
+        return None
+
+    with (
+        patch("bernstein.cli.run_bootstrap.server_get", side_effect=_server_get),
+        patch("bernstein.cli.run_bootstrap.console", console),
+    ):
+        outcome, reason = _await_first_spawn_outcome(narrate_wait=True, timeout_s=1.0, poll_interval_s=0.01)
+
+    assert outcome == "spawned"
+    assert reason is None
+    assert _STATUS_TEXT in buffer.getvalue()
+
+
+def test_narration_disabled_stays_silent() -> None:
+    """The non-interactive and ``--quiet`` paths (``narrate_wait=False``) stay quiet."""
+    console, buffer = _captured_console()
+    healths = iter([{"agent_count": 0}, {"agent_count": 0}, {"agent_count": 1}])
+
+    def _server_get(path: str) -> Any:
+        if path.startswith("/health"):
+            return next(healths)
+        return None
+
+    with (
+        patch("bernstein.cli.run_bootstrap.server_get", side_effect=_server_get),
+        patch("bernstein.cli.run_bootstrap.console", console),
+    ):
+        outcome, _reason = _await_first_spawn_outcome(narrate_wait=False, timeout_s=1.0, poll_interval_s=0.01)
+
+    assert outcome == "spawned"
+    assert _STATUS_TEXT not in buffer.getvalue()


### PR DESCRIPTION
## Summary

`bernstein run` on a TTY prints nothing between bootstrap and the dashboard opening. When the first agent takes a couple of seconds to register, the terminal sits there and the operator can't tell whether the run is starting, hung, or broken. The wait itself is correctly bounded and must stay (issue #3528); this narrates it instead of removing it.

## Change

- `_await_first_spawn_outcome()` gains an opt-in `narrate_wait` flag. The first poll runs before any status is shown, so a fast start (first poll already reports an agent) stays exactly as quiet as today. Only when a poll fails to produce a verdict does a transient Rich `console.status("Waiting for the first agent to register...")` appear around the remaining polls, and it clears before the caller renders.
- `_raise_if_no_plan_after_spawn()` forwards `narrate_wait` (default `True`) to it, so the two TTY branches narrate the wait. `--quiet` passes `False`, and the non-interactive detach branch is untouched, so both keep their existing chatter-free behaviour.

## Tests

Added `tests/unit/test_first_spawn_wait_narration.py` asserting on captured output only (never timing):
- first poll returns `spawned` → nothing printed
- a later poll returns `spawned` → the status text is shown
- `narrate_wait=False` stays silent

## Verification

- `uv run python -m pytest tests/unit/test_first_spawn_wait_narration.py tests/unit/test_detached_run_visibility.py tests/unit/test_no_plan_after_spawn_diagnosis.py tests/unit/test_run_outcome_reaches_every_branch.py tests/unit/test_tui_fallback.py tests/unit/test_run_summary_issue_953.py tests/unit/test_issue_3255_plan_only_honors_plan_file.py tests/unit/test_run_cmd_track_b.py` → 108 passed
- `uv run ruff check src/bernstein/cli/run_bootstrap.py src/bernstein/cli/run_preflight.py tests/unit/test_first_spawn_wait_narration.py` → all checks passed
- `uv run ruff format --check ...` → 3 files already formatted

Closes #4257