### PR TITLE
fix(cli): show transient status spinner during TTY first agent spawn wait (#4257)

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -28,6 +28,7 @@ rather than as its own attribution is exempted by hand there, with the reason.
 - `PostgresTaskStore.list_tasks()` now issues a bounded query even when the caller omits `limit` (#3813). The `limit`/`offset` support from #4157 still left the SQL unbounded by default, so a caller that forgot to pass `limit` fetched and constructed a `Task` for every row in the table. A missing `limit` now falls back to a documented default (`_LIST_TASKS_DEFAULT_LIMIT`); a caller that genuinely needs the full table pages through it by advancing `offset`.
 - Wire weekly SOC 2 evidence pack workflow export step to sink backend via `SOC2_EVIDENCE_SINK` secret (#4149).
 - Wave 2 of README translations adds 16 languages (`es`, `pt`, `de`, `fr`, `it`, `nl`, `pl`, `sv`, `fi`, `uk`, `tr`, `ar`, `he`, `id`, `vi`, `th`) under the hash-binding drift gate, bringing translated README coverage to 23 languages alongside the English source. Docs: [`docs/playbooks/readme-l10n.md`](../playbooks/readme-l10n.md).
+- Displays a transient status spinner while TTY first-agent spawn polling takes longer than a single poll interval (#4257).
 
 ## Security
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1677,6 +1677,7 @@ def _await_first_spawn_outcome(
     *,
     timeout_s: float = _FIRST_SPAWN_WAIT_S,
     poll_interval_s: float = _FIRST_SPAWN_POLL_S,
+    show_status: bool = False,
 ) -> tuple[str, str | None]:
     """Briefly poll the task server for the outcome of the first agent spawn.
 
@@ -1692,6 +1693,8 @@ def _await_first_spawn_outcome(
     Args:
         timeout_s: Maximum total time to wait for a verdict.
         poll_interval_s: Delay between polls.
+        show_status: When True, displays a transient terminal spinner while
+            polling takes longer than a single poll interval (gh-4257).
 
     Returns:
         ``("spawned", None)`` once at least one agent is live,
@@ -1702,35 +1705,50 @@ def _await_first_spawn_outcome(
     deadline = time.time() + timeout_s
     transient_reason: str | None = None
     unreachable_polls = 0
-    while True:
-        health = server_get("/health")
-        if not isinstance(health, dict):
-            unreachable_polls += 1
-            if unreachable_polls >= _FIRST_SPAWN_MAX_UNREACHABLE:
-                return "unknown", None
-        else:
-            unreachable_polls = 0
-            if int(health.get("agent_count", 0) or 0) > 0:
-                return "spawned", None
-            failed_page: Any = server_get("/tasks?status=failed&limit=50")
-            entries = failed_page.get("tasks", []) if isinstance(failed_page, dict) else []
-            for entry in entries:
-                if not isinstance(entry, dict):
-                    continue
-                reason = str(entry.get("result_summary") or "")
-                if not reason.startswith("Spawn failed"):
-                    continue
-                completed_at = float(entry.get("completed_at") or 0.0)
-                if completed_at < time.time() - _FIRST_SPAWN_FRESHNESS_S:
-                    continue
-                if "(transient" in reason:
-                    # A retry may still succeed - keep polling until deadline.
-                    transient_reason = reason
-                    continue
-                return "refused", reason
-        if time.time() >= deadline:
-            break
-        time.sleep(poll_interval_s)
+    poll_count = 0
+    status_cm: Any = None
+
+    try:
+        while True:
+            poll_count += 1
+            if show_status and poll_count == 2 and status_cm is None:
+                from bernstein.cli.helpers import console
+
+                status_cm = console.status("[dim]Waiting for first agent to spawn...[/dim]")
+                status_cm.__enter__()
+
+            health = server_get("/health")
+            if not isinstance(health, dict):
+                unreachable_polls += 1
+                if unreachable_polls >= _FIRST_SPAWN_MAX_UNREACHABLE:
+                    return "unknown", None
+            else:
+                unreachable_polls = 0
+                if int(health.get("agent_count", 0) or 0) > 0:
+                    return "spawned", None
+                failed_page: Any = server_get("/tasks?status=failed&limit=50")
+                entries = failed_page.get("tasks", []) if isinstance(failed_page, dict) else []
+                for entry in entries:
+                    if not isinstance(entry, dict):
+                        continue
+                    reason = str(entry.get("result_summary") or "")
+                    if not reason.startswith("Spawn failed"):
+                        continue
+                    completed_at = float(entry.get("completed_at") or 0.0)
+                    if completed_at < time.time() - _FIRST_SPAWN_FRESHNESS_S:
+                        continue
+                    if "(transient" in reason:
+                        # A retry may still succeed - keep polling until deadline.
+                        transient_reason = reason
+                        continue
+                    return "refused", reason
+            if time.time() >= deadline:
+                break
+            time.sleep(poll_interval_s)
+    finally:
+        if status_cm is not None:
+            status_cm.__exit__(None, None, None)
+
     if transient_reason is not None:
         return "refused", transient_reason
     return "unknown", None

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -604,7 +604,7 @@ def _make_profile_ctx(profile: bool, workdir: Path) -> contextlib.AbstractContex
     return contextlib.nullcontext()
 
 
-def _raise_if_no_plan_after_spawn() -> None:
+def _raise_if_no_plan_after_spawn(*, show_status: bool = False) -> None:
     """Diagnose a spawned-then-dead agent before a display branch's own wait.
 
     The non-interactive detach path (issue #3528, #4246) briefly confirms the
@@ -632,7 +632,7 @@ def _raise_if_no_plan_after_spawn() -> None:
     from bernstein.cli.run_bootstrap import _await_first_spawn_outcome, _poll_no_plan_after_spawn
     from bernstein.core.errors import BernsteinFirstRunError, ErrorCategory
 
-    outcome, _reason = _await_first_spawn_outcome()
+    outcome, _reason = _await_first_spawn_outcome(show_status=show_status)
     if outcome == "spawned" and _poll_no_plan_after_spawn() is not None:
         raise BernsteinFirstRunError(
             "Spawned agent exited before producing a work plan",
@@ -709,7 +709,7 @@ def _finalize_run_output(*, quiet: bool) -> None:
         caps = detect_capabilities()
 
         if caps.supports_textual:
-            _raise_if_no_plan_after_spawn()
+            _raise_if_no_plan_after_spawn(show_status=True)
             try:
                 from bernstein.cli.dashboard import BernsteinApp as DashboardApp
 
@@ -728,7 +728,7 @@ def _finalize_run_output(*, quiet: bool) -> None:
             _exit_nonzero_on_unhealthy_run(_poll_quiescent_status())
         elif caps.is_tty:
             # TTY but Textual not supported -- use Rich fallback (TUI-003)
-            _raise_if_no_plan_after_spawn()
+            _raise_if_no_plan_after_spawn(show_status=True)
             _try_fallback_display()
             _exit_nonzero_on_unhealthy_run(_poll_quiescent_status())
         else:

--- a/tests/unit/cli/test_first_spawn_status_indicator.py
+++ b/tests/unit/cli/test_first_spawn_status_indicator.py
@@ -1,0 +1,83 @@
+"""Unit tests for transient TTY status spinner during first agent spawn polling (#4257).
+
+Asserts that ``_await_first_spawn_outcome`` with ``show_status=True`` displays a
+transient status indicator when polling takes longer than a single poll interval,
+and stays quiet when the first poll succeeds immediately.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from bernstein.cli.run_bootstrap import _await_first_spawn_outcome
+
+
+def _server_get_factory(responses: list[dict[str, Any] | None]) -> Any:
+    iterator = iter(responses)
+
+    def _server_get(path: str) -> Any:
+        if path.startswith("/health"):
+            try:
+                return next(iterator)
+            except StopIteration:
+                return {"agent_count": 1}
+        if path.startswith("/tasks?status=failed"):
+            return {"tasks": [], "total": 0, "limit": 50, "offset": 0}
+        return None
+
+    return _server_get
+
+
+def test_first_poll_spawned_prints_nothing() -> None:
+    """Fast start: first poll returns agent_count > 0, so status spinner is not shown."""
+    stub = _server_get_factory([{"agent_count": 1}])
+    with (
+        patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub),
+        patch("bernstein.cli.helpers.console.status") as mock_status,
+    ):
+        outcome, reason = _await_first_spawn_outcome(
+            timeout_s=1.0,
+            poll_interval_s=0.01,
+            show_status=True,
+        )
+    assert outcome == "spawned"
+    assert reason is None
+    assert not mock_status.called
+
+
+def test_subsequent_poll_spawned_shows_and_clears_status() -> None:
+    """Slow start: first poll returns 0 agents, second poll returns 1 -> status shown and cleared."""
+    stub = _server_get_factory([{"agent_count": 0}, {"agent_count": 1}])
+    mock_cm = MagicMock()
+    with (
+        patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub),
+        patch("bernstein.cli.helpers.console.status", return_value=mock_cm) as mock_status,
+    ):
+        outcome, reason = _await_first_spawn_outcome(
+            timeout_s=1.0,
+            poll_interval_s=0.01,
+            show_status=True,
+        )
+    assert outcome == "spawned"
+    assert reason is None
+    mock_status.assert_called_once_with("[dim]Waiting for first agent to spawn...[/dim]")
+    assert mock_cm.__enter__.called
+    assert mock_cm.__exit__.called
+
+
+def test_show_status_false_does_not_call_status() -> None:
+    """Non-interactive / quiet mode: show_status=False never triggers status spinner."""
+    stub = _server_get_factory([{"agent_count": 0}, {"agent_count": 1}])
+    with (
+        patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub),
+        patch("bernstein.cli.helpers.console.status") as mock_status,
+    ):
+        outcome, reason = _await_first_spawn_outcome(
+            timeout_s=1.0,
+            poll_interval_s=0.01,
+            show_status=False,
+        )
+    assert outcome == "spawned"
+    assert reason is None
+    assert not mock_status.called


### PR DESCRIPTION
Closes #4257.

### Summary of Changes

1. **Transient TTY Status Spinner**:
   - Updated `_await_first_spawn_outcome` in `src/bernstein/cli/run_bootstrap.py` to support an optional `show_status` flag.
   - When `show_status=True`, if the first poll interval (0.5s) does not immediately return a live agent, a transient Rich `console.status("[dim]Waiting for first agent to spawn...[/dim]")` spinner is displayed on TTY.
   - Fast starts (first poll succeeds) stay completely quiet with zero output printed.
   - When the agent registers or timeout occurs, the spinner is automatically cleared without leaving any residue in the scrollback before the dashboard or fallback display renders.
   - Updated `_raise_if_no_plan_after_spawn` and TTY branches in `src/bernstein/cli/run_preflight.py` to pass `show_status=True`. The non-interactive branch remains unchanged.

2. **Automated Unit Tests**:
   - Added `tests/unit/cli/test_first_spawn_status_indicator.py` covering:
     - Fast start: immediate `agent_count > 0` does not trigger `console.status`.
     - Slow start: subsequent poll triggers, enters, and exits `console.status`.
     - Non-interactive mode: `show_status=False` never triggers `console.status`.

### Verification

- Verified all 31 unit tests pass: `python -m pytest tests/unit/cli/test_first_spawn_status_indicator.py tests/unit/test_detached_run_visibility.py tests/unit/test_no_plan_after_spawn_diagnosis.py -v`.
- Ran `ruff check` and `ruff format --check` cleanly.
