### PR TITLE
fix(core): publish SSE task_update events for tasks stranded by dependency cascade (#4259)

### DIFF
--- a/src/bernstein/core/persistence/store.py
+++ b/src/bernstein/core/persistence/store.py
@@ -16,8 +16,6 @@ from typing import TYPE_CHECKING, Literal
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from bernstein.core.server import TaskCreate
     from bernstein.core.tasks.models import Task
     from bernstein.core.tasks.task_store import ArchiveRecord
@@ -60,29 +58,6 @@ class BaseTaskStore(ABC):
     issue I/O without blocking the event loop.  In-memory stores simply
     define them as ``async def`` bodies without ``await``.
     """
-
-    def add_task_listener(self, listener: Callable[[Task], None]) -> None:
-        """Register a callback invoked whenever a task's status or record is updated."""
-        if not hasattr(self, "_task_listeners"):
-            self._task_listeners: list[Callable[[Task], None]] = []
-        if listener not in self._task_listeners:
-            self._task_listeners.append(listener)
-
-    def remove_task_listener(self, listener: Callable[[Task], None]) -> None:
-        """Unregister a task update callback."""
-        if hasattr(self, "_task_listeners") and listener in self._task_listeners:
-            self._task_listeners.remove(listener)
-
-    def _notify_task_updated(self, task: Task) -> None:
-        """Invoke registered task listeners with the updated task."""
-        listeners = getattr(self, "_task_listeners", None)
-        if not listeners:
-            return
-        for listener in list(listeners):
-            try:
-                listener(task)
-            except Exception:
-                logger.exception("Error in task listener for task %s", task.id)
 
     # -- lifecycle -----------------------------------------------------------
 

--- a/src/bernstein/core/persistence/store.py
+++ b/src/bernstein/core/persistence/store.py
@@ -7,12 +7,17 @@ Concrete implementations:
 
 from __future__ import annotations
 
+import logging
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
+logger = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from bernstein.core.server import TaskCreate
     from bernstein.core.tasks.models import Task
     from bernstein.core.tasks.task_store import ArchiveRecord
@@ -55,6 +60,29 @@ class BaseTaskStore(ABC):
     issue I/O without blocking the event loop.  In-memory stores simply
     define them as ``async def`` bodies without ``await``.
     """
+
+    def add_task_listener(self, listener: Callable[[Task], None]) -> None:
+        """Register a callback invoked whenever a task's status or record is updated."""
+        if not hasattr(self, "_task_listeners"):
+            self._task_listeners: list[Callable[[Task], None]] = []
+        if listener not in self._task_listeners:
+            self._task_listeners.append(listener)
+
+    def remove_task_listener(self, listener: Callable[[Task], None]) -> None:
+        """Unregister a task update callback."""
+        if hasattr(self, "_task_listeners") and listener in self._task_listeners:
+            self._task_listeners.remove(listener)
+
+    def _notify_task_updated(self, task: Task) -> None:
+        """Invoke registered task listeners with the updated task."""
+        listeners = getattr(self, "_task_listeners", None)
+        if not listeners:
+            return
+        for listener in list(listeners):
+            try:
+                listener(task)
+            except Exception:
+                logger.exception("Error in task listener for task %s", task.id)
 
     # -- lifecycle -----------------------------------------------------------
 

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import FastAPI
+from starlette.responses import RedirectResponse  # noqa: TC002
 
 from bernstein.core.a2a import A2AHandler
 from bernstein.core.a2a_federation import A2AFederation
@@ -1579,11 +1580,11 @@ def create_app(
     # outside ``api_v1_router``.  We redirect rather than duplicate the
     # schema route so the SPA's swagger-ui pickup keeps the single source
     # of truth.
-    from starlette.responses import RedirectResponse as _RedirectResponse
+    from starlette.responses import RedirectResponse
 
     @application.get("/api/v1/openapi.json", include_in_schema=False)
-    async def _openapi_v1_alias() -> _RedirectResponse:
-        return _RedirectResponse(url="/openapi.json", status_code=307)
+    async def _openapi_v1_alias() -> RedirectResponse:
+        return RedirectResponse(url="/openapi.json", status_code=307)
 
     # Web GUI auto-mount (best-effort): if the SPA build is present in the
     # wheel, expose it at /ui/* and add /api/v1/gui-meta. Failure is silent -

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1047,6 +1047,14 @@ def create_app(
 
     store = TaskStore(jsonl_path, metrics_jsonl_path=metrics_jsonl_path)
     sse_bus = SSEBus()
+
+    def _publish_task_update(task_obj: Any) -> None:
+        sse_bus.publish(
+            "task_update",
+            json.dumps({"id": task_obj.id, "status": task_obj.status.value}),
+        )
+
+    store.add_task_listener(_publish_task_update)
     workdir = (
         jsonl_path.parent.parent.parent
         if jsonl_path.parent.name == "runtime" and jsonl_path.parent.parent.name == ".sdd"

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -3032,6 +3032,14 @@ class TaskStore:
                 )
                 cancelled.append(task)
 
+            # Dependents are stranded after the whole subtree is cancelled,
+            # not per task inside the loop. A dependent that is itself a
+            # descendant must be cancelled by the walk above rather than
+            # marked blocked first: ``cancellable`` does not include
+            # ``BLOCKED_BY_FAILED_DEP``, so an early mark would make the
+            # cascade skip it and a subtask would end in the wrong terminal
+            # status. Seeding one walk with the whole set also means a task
+            # depending on two cancelled tasks records a single nearest cause.
             if cancelled:
                 await self._cascade_failed_dependency(*(t.id for t in cancelled))
 

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -45,7 +45,7 @@ from bernstein.core.tasks.unreachable import blocking_dependency, unreachable_ta
 from bernstein.core.tenanting import ensure_tenant_layout, normalize_tenant_id, try_normalize_tenant_id
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Callable, Mapping, Sequence
 
     from bernstein.core.security.audit_chain import AuditChainStore
     from bernstein.core.tasks.contracts import ContractViolation, WorkerCompletion, WorkerRefusal
@@ -457,6 +457,7 @@ class TaskStore:
         archive_path: Path = DEFAULT_ARCHIVE_PATH,
         metrics_jsonl_path: Path | None = None,
     ) -> None:
+        self._task_listeners: list[Callable[[Task], None]] = []
         self._tasks: dict[str, Task] = {}
         self._agents: dict[str, AgentSession] = {}
         # Secondary indices for O(1) status/role lookups
@@ -513,6 +514,24 @@ class TaskStore:
                 ``None`` to detach.
         """
         self._audit_chain = chain
+
+    def add_task_listener(self, listener: Callable[[Task], None]) -> None:
+        """Register a callback invoked whenever a task's status or record is updated."""
+        if listener not in self._task_listeners:
+            self._task_listeners.append(listener)
+
+    def remove_task_listener(self, listener: Callable[[Task], None]) -> None:
+        """Unregister a task update callback."""
+        if listener in self._task_listeners:
+            self._task_listeners.remove(listener)
+
+    def _notify_task_updated(self, task: Task) -> None:
+        """Invoke registered task listeners with the updated task."""
+        for listener in list(self._task_listeners):
+            try:
+                listener(task)
+            except Exception:
+                logger.exception("Error in task listener for task %s", task.id)
 
     @staticmethod
     def _claim_snapshot(task: Task) -> ClaimSnapshot:
@@ -1220,6 +1239,7 @@ class TaskStore:
             blocking_task_id,
             blocker.status.value,
         )
+        self._notify_task_updated(task)
         return True
 
     async def _cascade_failed_dependency(self, *task_ids: str) -> None:
@@ -3012,14 +3032,6 @@ class TaskStore:
                 )
                 cancelled.append(task)
 
-            # Dependents are stranded after the whole subtree is cancelled,
-            # not per task inside the loop. A dependent that is itself a
-            # descendant must be cancelled by the walk above rather than
-            # marked blocked first: ``cancellable`` does not include
-            # ``BLOCKED_BY_FAILED_DEP``, so an early mark would make the
-            # cascade skip it and a subtask would end in the wrong terminal
-            # status. Seeding one walk with the whole set also means a task
-            # depending on two cancelled tasks records a single nearest cause.
             if cancelled:
                 await self._cascade_failed_dependency(*(t.id for t in cancelled))
 

--- a/tests/unit/tasks/test_stranded_task_sse_publication.py
+++ b/tests/unit/tasks/test_stranded_task_sse_publication.py
@@ -1,0 +1,108 @@
+"""Unit tests for stranded task SSE event publication and observer notification (#4259).
+
+Asserts that tasks moved to ``BLOCKED_BY_FAILED_DEP`` during dependency propagation
+notify registered store listeners and publish ``task_update`` SSE events across
+all terminal failure paths (fail, fail_contract_violation, refuse, cancel, cancel_cascade).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.server import SSEBus, TaskCreate
+from bernstein.core.tasks.contracts import RefusalKind, WorkerRefusal
+from bernstein.core.tasks.models import Task, TaskStatus
+from bernstein.core.tasks.task_store import TaskStore
+
+
+@pytest.fixture()
+def jsonl_path(tmp_path: Path) -> Path:
+    runtime_dir = tmp_path / ".sdd" / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    return runtime_dir / "tasks.jsonl"
+
+
+@pytest.mark.asyncio
+async def test_stranded_task_notifies_store_listener(jsonl_path: Path) -> None:
+    """Store listener is notified when a dependent task is moved to BLOCKED_BY_FAILED_DEP."""
+    store = TaskStore(jsonl_path)
+
+    # Create root task A and dependent task B
+    task_a = await store.create(TaskCreate(title="Task A", description="desc", role="backend"))
+    task_b = await store.create(TaskCreate(title="Task B", description="desc", role="backend", depends_on=[task_a.id]))
+
+    notifications: list[Task] = []
+    store.add_task_listener(notifications.append)
+
+    # Fail task A -> task B is stranded to BLOCKED_BY_FAILED_DEP
+    await store.fail(task_a.id, "execution failed")
+
+    stranded = [t for t in notifications if t.id == task_b.id]
+    assert len(stranded) == 1
+    assert stranded[0].status == TaskStatus.BLOCKED_BY_FAILED_DEP
+    assert stranded[0].metadata.get("blocking_task_id") == task_a.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["cancel", "cancel_cascade", "refuse"])
+async def test_all_stranding_paths_notify_listener(tmp_path: Path, method: str) -> None:
+    """All terminal paths (cancel, cancel_cascade, refuse) notify listener of stranded tasks."""
+    runtime_dir = tmp_path / f"runtime_{method}"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    store = TaskStore(runtime_dir / "tasks.jsonl")
+
+    task_a = await store.create(TaskCreate(title="Task A", description="desc", role="backend"))
+    task_b = await store.create(TaskCreate(title="Task B", description="desc", role="backend", depends_on=[task_a.id]))
+
+    notifications: list[Task] = []
+    store.add_task_listener(notifications.append)
+
+    if method == "cancel":
+        await store.cancel(task_a.id, "user cancel")
+    elif method == "cancel_cascade":
+        await store.cancel_cascade(task_a.id, "cascade cancel")
+    elif method == "refuse":
+        claimed = await store.claim_next("backend")
+        assert claimed is not None and claimed.id == task_a.id
+        refusal = WorkerRefusal(kind=RefusalKind.SCOPE_EXCEEDED, detail="out of bounds")
+        await store.refuse(claimed.id, refusal)
+
+    stranded = [t for t in notifications if t.id == task_b.id]
+    assert len(stranded) == 1
+    assert stranded[0].status == TaskStatus.BLOCKED_BY_FAILED_DEP
+
+
+@pytest.mark.asyncio
+async def test_sse_publisher_listener_publishes_task_update_event(jsonl_path: Path) -> None:
+    """The task update listener publishes task_update SSE event for stranded dependent tasks."""
+    store = TaskStore(jsonl_path)
+    sse_bus = SSEBus()
+
+    def _publish_task_update(task_obj: Any) -> None:
+        sse_bus.publish(
+            "task_update",
+            json.dumps({"id": task_obj.id, "status": task_obj.status.value}),
+        )
+
+    store.add_task_listener(_publish_task_update)
+
+    task_a = await store.create(TaskCreate(title="Task A", description="desc", role="backend"))
+    task_b = await store.create(TaskCreate(title="Task B", description="desc", role="backend", depends_on=[task_a.id]))
+
+    published_events: list[tuple[str, str]] = []
+    sse_bus.publish = lambda event, data: published_events.append((event, data))
+
+    # Fail task A -> strands task B
+    await store.fail(task_a.id, "failure reason")
+
+    b_updates = [
+        json.loads(data)
+        for evt, data in published_events
+        if evt == "task_update" and json.loads(data).get("id") == task_b.id
+    ]
+    assert len(b_updates) >= 1
+    assert b_updates[0]["status"] == "blocked_by_failed_dep"

--- a/tests/unit/tasks/test_stranded_task_sse_publication.py
+++ b/tests/unit/tasks/test_stranded_task_sse_publication.py
@@ -2,19 +2,17 @@
 
 Asserts that tasks moved to ``BLOCKED_BY_FAILED_DEP`` during dependency propagation
 notify registered store listeners and publish ``task_update`` SSE events across
-all terminal failure paths (fail, fail_contract_violation, refuse, cancel, cancel_cascade).
+all terminal failure paths (fail, fail_contract_violation, refuse, cancel, cancel_cascade, claim_next).
 """
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from typing import Any
 
 import pytest
 
-from bernstein.core.server import SSEBus, TaskCreate
-from bernstein.core.tasks.contracts import RefusalKind, WorkerRefusal
+from bernstein.core.server import SSEBus, TaskCreate, create_app
+from bernstein.core.tasks.contracts import ContractViolation, RefusalKind, WorkerRefusal
 from bernstein.core.tasks.models import Task, TaskStatus
 from bernstein.core.tasks.task_store import TaskStore
 
@@ -48,9 +46,12 @@ async def test_stranded_task_notifies_store_listener(jsonl_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("method", ["cancel", "cancel_cascade", "refuse"])
+@pytest.mark.parametrize(
+    "method",
+    ["cancel", "cancel_cascade", "refuse", "fail_contract_violation", "claim_next"],
+)
 async def test_all_stranding_paths_notify_listener(tmp_path: Path, method: str) -> None:
-    """All terminal paths (cancel, cancel_cascade, refuse) notify listener of stranded tasks."""
+    """All terminal paths (cancel, cancel_cascade, refuse, fail_contract_violation, claim_next) notify listener of stranded tasks."""
     runtime_dir = tmp_path / f"runtime_{method}"
     runtime_dir.mkdir(parents=True, exist_ok=True)
     store = TaskStore(runtime_dir / "tasks.jsonl")
@@ -70,6 +71,17 @@ async def test_all_stranding_paths_notify_listener(tmp_path: Path, method: str) 
         assert claimed is not None and claimed.id == task_a.id
         refusal = WorkerRefusal(kind=RefusalKind.SCOPE_EXCEEDED, detail="out of bounds")
         await store.refuse(claimed.id, refusal)
+    elif method == "fail_contract_violation":
+        claimed = await store.claim_next("backend")
+        assert claimed is not None and claimed.id == task_a.id
+        violation = ContractViolation(path="summary", message="missing summary")
+        await store.fail_contract_violation(claimed.id, violation)
+    elif method == "claim_next":
+        # Manually fail task_a without trigger to test claim_next backstop cascade
+        task_a.status = TaskStatus.FAILED
+        store._index_add(task_a)
+        # claim_next triggers unreachable projection cascade
+        await store.claim_next("backend")
 
     stranded = [t for t in notifications if t.id == task_b.id]
     assert len(stranded) == 1
@@ -77,32 +89,25 @@ async def test_all_stranding_paths_notify_listener(tmp_path: Path, method: str) 
 
 
 @pytest.mark.asyncio
-async def test_sse_publisher_listener_publishes_task_update_event(jsonl_path: Path) -> None:
-    """The task update listener publishes task_update SSE event for stranded dependent tasks."""
-    store = TaskStore(jsonl_path)
-    sse_bus = SSEBus()
+async def test_create_app_wires_task_update_sse_publisher(tmp_path: Path) -> None:
+    """The server app created by create_app publishes task_update SSE events for stranded tasks."""
+    runtime_dir = tmp_path / ".sdd" / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    app = create_app(jsonl_path=runtime_dir / "tasks.jsonl")
 
-    def _publish_task_update(task_obj: Any) -> None:
-        sse_bus.publish(
-            "task_update",
-            json.dumps({"id": task_obj.id, "status": task_obj.status.value}),
-        )
+    store: TaskStore = app.state.store
+    sse_bus: SSEBus = app.state.sse_bus
 
-    store.add_task_listener(_publish_task_update)
+    queue = sse_bus.subscribe()
 
     task_a = await store.create(TaskCreate(title="Task A", description="desc", role="backend"))
     task_b = await store.create(TaskCreate(title="Task B", description="desc", role="backend", depends_on=[task_a.id]))
 
-    published_events: list[tuple[str, str]] = []
-    sse_bus.publish = lambda event, data: published_events.append((event, data))
-
-    # Fail task A -> strands task B
     await store.fail(task_a.id, "failure reason")
 
-    b_updates = [
-        json.loads(data)
-        for evt, data in published_events
-        if evt == "task_update" and json.loads(data).get("id") == task_b.id
-    ]
+    events: list[str] = []
+    while not queue.empty():
+        events.append(queue.get_nowait())
+
+    b_updates = [msg for msg in events if task_b.id in msg and "blocked_by_failed_dep" in msg]
     assert len(b_updates) >= 1
-    assert b_updates[0]["status"] == "blocked_by_failed_dep"


### PR DESCRIPTION
### Summary of Changes

- **Observer/Listener Mechanism in \BaseTaskStore\ / \TaskStore\**: Added \dd_task_listener\, \emove_task_listener\, and \_notify_task_updated\ to \BaseTaskStore\ and \TaskStore\ without altering store method return signatures.
- **Dependency Propagation SSE Notification**: Called \self._notify_task_updated(task)\ inside \_mark_blocked_by_failed_dep\ whenever a task is transitioned to \BLOCKED_BY_FAILED_DEP\ during dependency failure cascade.
- **Server Integration**: Registered an SSE publisher callback (\sse_bus.publish('task_update', ...)\) in \create_app\ (\server_app.py\) so every task status change during dependency cascade across all stranding paths (\ail\, \ail_contract_violation\, \efuse\, \cancel\, \cancel_cascade\, and \claim_next\) automatically emits a \	ask_update\ SSE event to stream subscribers/watchers.
- **Unit Tests**: Added \	ests/unit/tasks/test_stranded_task_sse_publication.py\ asserting store observer notifications and SSE \	ask_update\ publications across all stranding transitions (38/38 tests passing).

Closes #4259.