### PR TITLE
fix(adapters): select the openai auth type for a custom qwen base URL

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -28,6 +28,7 @@ rather than as its own attribution is exempted by hand there, with the reason.
 - `PostgresTaskStore.list_tasks()` now issues a bounded query even when the caller omits `limit` (#3813). The `limit`/`offset` support from #4157 still left the SQL unbounded by default, so a caller that forgot to pass `limit` fetched and constructed a `Task` for every row in the table. A missing `limit` now falls back to a documented default (`_LIST_TASKS_DEFAULT_LIMIT`); a caller that genuinely needs the full table pages through it by advancing `offset`.
 - Wire weekly SOC 2 evidence pack workflow export step to sink backend via `SOC2_EVIDENCE_SINK` secret (#4149).
 - Wave 2 of README translations adds 16 languages (`es`, `pt`, `de`, `fr`, `it`, `nl`, `pl`, `sv`, `fi`, `uk`, `tr`, `ar`, `he`, `id`, `vi`, `th`) under the hash-binding drift gate, bringing translated README coverage to 23 languages alongside the English source. Docs: [`docs/playbooks/readme-l10n.md`](../playbooks/readme-l10n.md).
+- The qwen adapter selects the OpenAI auth type when a custom `OPENAI_BASE_URL` is configured. The flag was sent only for a named provider, so a run pointed at a custom OpenAI-compatible endpoint on the default provider reached the CLI with no auth type selected; the CLI aborts non-interactively in that state, and the task was recorded as an agent death at zero tokens with no transcript explaining it. A bare `OPENAI_API_KEY` with no custom base URL still uses the CLI's own auth flow.
 
 ## Security
 

--- a/src/bernstein/adapters/qwen.py
+++ b/src/bernstein/adapters/qwen.py
@@ -145,7 +145,14 @@ class QwenAdapter(CLIAdapter):
         resolved = self._MODEL_MAP.get(model_name, model_name)
         cmd.extend(["--model", resolved])
 
-        if provider != "default":
+        # ``--auth-type openai`` tells the CLI to use the OpenAI-compatible key and
+        # base URL from the environment instead of its own login. Every named
+        # provider needs it, and so does the default provider once an explicit
+        # ``OPENAI_BASE_URL`` points the CLI at a custom OpenAI-compatible endpoint:
+        # without the flag the CLI aborts non-interactively with "No auth type is
+        # selected", producing a 0-token agent death with no transcript. A bare
+        # ``OPENAI_API_KEY`` with no custom base URL keeps the CLI's own auth flow.
+        if provider != "default" or settings.openai_base_url:
             cmd.extend(["--auth-type", "openai"])
 
         if mcp_config:

--- a/tests/unit/test_adapter_qwen.py
+++ b/tests/unit/test_adapter_qwen.py
@@ -192,6 +192,51 @@ class TestQwenAdapterSpawn:
         inner = _inner_cmd(popen.call_args.args[0])
         assert "--auth-type" not in inner
 
+    def test_custom_openai_base_url_gets_auth_type(self, tmp_path: Path) -> None:
+        """A custom OpenAI-compatible endpoint must still select the openai auth type.
+
+        Without ``--auth-type openai`` the Qwen CLI aborts non-interactively with
+        "No auth type is selected", so the agent dies at 0 tokens and the task is
+        recorded as an agent-reported failure with no transcript to explain it.
+        """
+        adapter = QwenAdapter()
+        proc_mock = _make_popen_mock(pid=106)
+        settings = _default_settings(
+            openai_api_key="sk-local-key",
+            openai_base_url="http://localhost:20128/v1",
+        )
+        with (
+            patch("bernstein.adapters.qwen.subprocess.Popen", return_value=proc_mock) as popen,
+            patch("bernstein.adapters.qwen.LLMSettings", return_value=settings),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="some-model", effort="high"),
+                session_id="qwen-s7",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert "--auth-type" in inner
+        assert inner[inner.index("--auth-type") + 1] == "openai"
+
+    def test_default_openai_endpoint_keeps_native_auth(self, tmp_path: Path) -> None:
+        """An API key alone (no custom base URL) keeps the CLI's own auth flow."""
+        adapter = QwenAdapter()
+        proc_mock = _make_popen_mock(pid=107)
+        settings = _default_settings(openai_api_key="sk-plain")
+        with (
+            patch("bernstein.adapters.qwen.subprocess.Popen", return_value=proc_mock) as popen,
+            patch("bernstein.adapters.qwen.LLMSettings", return_value=settings),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="qwen-max", effort="high"),
+                session_id="qwen-s8",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert "--auth-type" not in inner
+
     def test_opus_maps_to_qwen_max_on_default(self, tmp_path: Path) -> None:
         adapter = QwenAdapter()
         proc_mock = _make_popen_mock(pid=106)


### PR DESCRIPTION
## Problem

`QwenAdapter.spawn` sent `--auth-type openai` only when a named provider was selected (`adapters/qwen.py:148`). A run on the default provider pointed at a custom OpenAI-compatible endpoint via `OPENAI_BASE_URL` therefore reached the CLI with no auth type selected.

The Qwen CLI aborts non-interactively in that state with "No auth type is selected". From the operator's side that surfaces as an agent death at zero tokens with no transcript, so the failure gives no indication that the cause is a missing flag rather than the model or the prompt.

## Change

`--auth-type openai` is now also sent when `settings.openai_base_url` is set, since that is exactly the case where the CLI must use the OpenAI-compatible key and base URL from the environment instead of its own login. A bare `OPENAI_API_KEY` with no custom base URL is unchanged and still uses the CLI's own auth flow.

## Tests

`tests/unit/test_adapter_qwen.py`:
- a custom `OPENAI_BASE_URL` on the default provider puts `--auth-type openai` in the spawn argv
- an API key with no custom base URL leaves the flag off

Reverting the condition to `provider != "default"` fails the first of those, so the assertion holds the behaviour rather than restating it.

## Verification

- `tests/unit/test_adapter_qwen.py` — 47 passed
- `ruff check` / `ruff format --check` on the two changed files — clean
