### PR TITLE
chore(ci): ratchet coverage baseline up to 84.02%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
   "diff_coverage_floor_percent": 87,
-  "head_sha": "f5400a3a180407e87f29e09ff1305678ca340057",
-  "line_rate": 0.8401,
-  "run_id": "32465216644",
-  "total_coverage_percent": 84.01,
-  "updated_at": "2026-08-21T10:51:23+00:00"
+  "head_sha": "251a541889cfdfdfa91c8b67195ecdce7890f0af",
+  "line_rate": 0.8402,
+  "run_id": "32469233688",
+  "total_coverage_percent": 84.02,
+  "updated_at": "2026-08-21T11:34:05+00:00"
 }


### PR DESCRIPTION
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **84.02%**.

Measured on `251a541889cfdfdfa91c8b67195ecdce7890f0af` from the
`coverage-report` artifact of CI run
[32469233688](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/32469233688).
Those, and the raw Cobertura `line-rate` the percentage was
rounded from, are recorded in the baseline, so the number in the
diff can be re-derived from the file itself:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.