### PR TITLE
feat(quality): add inconclusive gate verdict with closed reason codes

### DIFF
--- a/src/bernstein/core/quality/gate_commands.py
+++ b/src/bernstein/core/quality/gate_commands.py
@@ -380,16 +380,24 @@ class GateRunnerCommandsMixin:
                 docstyle=docstyle,
             )
         except Exception as exc:  # pragma: no cover
+            # ``comment_quality.analyse`` died before producing a verdict.
+            # Issue #4181 says we must not coerce an inability-to-evaluate
+            # into pass/fail — the evaluator could not look at the code,
+            # so it cannot honestly say "pass", and "fail" trains operators
+            # to re-run until green. Return ``inconclusive`` with the
+            # closed-set ``runner-died-before-output`` reason; ``blocked``
+            # stays aligned with ``fail`` at a required gate.
             logger.warning("comment_quality.analyse failed: %s", exc)
             return GateResult(
                 name=step.name,
-                status="fail",
+                status="inconclusive",
                 required=step.required,
                 blocked=step.required,
                 cached=False,
                 duration_ms=0,
                 details=f"Comment quality gate error: {exc}",
                 metadata={},
+                reason="runner-died-before-output",
             )
 
         if report.passed and not report.issues:
@@ -498,15 +506,23 @@ class GateRunnerCommandsMixin:
         try:
             evaluation = CoverageGate(self._workdir, run_dir, base_ref=self._base_ref).evaluate()
         except Exception as exc:
+            # The CoverageGate constructor / evaluate chain died before
+            # producing a verdict. Issue #4181 says we must not coerce an
+            # inability-to-evaluate into pass/fail — without an evaluation
+            # we cannot honestly say "pass", and "fail" trains operators
+            # to re-run until green. ``inconclusive`` with the closed-set
+            # ``runner-died-before-output`` reason is the honest verdict;
+            # ``blocked`` stays aligned with ``fail`` at a required gate.
             return GateResult(
                 name=step.name,
-                status="fail",
+                status="inconclusive",
                 required=step.required,
                 blocked=step.required,
                 cached=False,
                 duration_ms=0,
-                details=str(exc),
+                details=f"Coverage gate evaluator failed: {exc}",
                 metadata={},
+                reason="runner-died-before-output",
             )
         return GateResult(
             name=step.name,
@@ -544,15 +560,23 @@ class GateRunnerCommandsMixin:
                 threshold=cfg.threshold,
             ).evaluate()
         except Exception as exc:
+            # The BenchmarkGate constructor / evaluate chain died before
+            # producing a verdict. Issue #4181 says we must not coerce an
+            # inability-to-evaluate into pass/fail — without an evaluation
+            # we cannot honestly say "pass", and "fail" trains operators
+            # to re-run until green. ``inconclusive`` with the closed-set
+            # ``runner-died-before-output`` reason is the honest verdict;
+            # ``blocked`` stays aligned with ``fail`` at a required gate.
             return GateResult(
                 name=step.name,
-                status="fail",
+                status="inconclusive",
                 required=step.required,
                 blocked=step.required,
                 cached=False,
                 duration_ms=0,
-                details=str(exc),
+                details=f"Benchmark gate evaluator failed: {exc}",
                 metadata={},
+                reason="runner-died-before-output",
             )
         regression_names = [r.name for r in evaluation.regressions]
         return GateResult(

--- a/src/bernstein/core/quality/gate_commands.py
+++ b/src/bernstein/core/quality/gate_commands.py
@@ -219,9 +219,10 @@ class GateRunnerCommandsMixin:
         if baseline_score is None:
             return GateResult(
                 name=step.name,
-                status="warn",
+                status="inconclusive",
+                reason="evidence-missing",
                 required=step.required,
-                blocked=False,
+                blocked=step.required,
                 cached=False,
                 duration_ms=0,
                 details=f"Complexity average: {current_score:.2f}; baseline unavailable ({baseline_detail})",

--- a/src/bernstein/core/quality/gate_pipeline.py
+++ b/src/bernstein/core/quality/gate_pipeline.py
@@ -7,6 +7,13 @@ from typing import TYPE_CHECKING, Any, Literal
 
 TIMED_OUT_PREFIX = "Timed out after "
 NO_PYTHON_FILES = "No Python files changed."
+# Prefix emitted by ``quality_gates._run_command`` when the subprocess could
+# not be started at all (OSError from ``subprocess.run``: missing shell,
+# vanished cwd, ...). Distinct from a non-zero exit with captured output,
+# which means the tool ran and reported a real failure. The gate runner maps
+# this prefix to ``inconclusive`` (reason ``evidence-missing``) — see
+# ``_command_failure_result``.
+COMMAND_ERROR_PREFIX = "Command error: "
 
 if TYPE_CHECKING:
     from bernstein.core.quality.quality_gates import QualityGatesConfig

--- a/src/bernstein/core/quality/gate_pipeline.py
+++ b/src/bernstein/core/quality/gate_pipeline.py
@@ -11,7 +11,36 @@ NO_PYTHON_FILES = "No Python files changed."
 if TYPE_CHECKING:
     from bernstein.core.quality.quality_gates import QualityGatesConfig
 
-GateStatus = Literal["pass", "fail", "warn", "timeout", "skipped", "bypassed"]
+GateStatus = Literal["pass", "fail", "warn", "timeout", "skipped", "bypassed", "inconclusive"]
+
+# Closed set of reason codes for the ``"inconclusive"`` verdict.
+#
+# A gate returns ``"inconclusive"`` (with one of these reason codes) when it
+# cannot honestly evaluate the evidence it was given — neither "pass" (which
+# would be a bypass) nor "fail" (which would be a lie that trains operators
+# to re-run until green). At a required gate, ``inconclusive`` blocks exactly
+# like ``"fail"``; the difference is the claim, not the outcome.
+#
+# Issue #4181 (sibling slice to #4182, which carries the verdict into
+# receipts and offline re-derivation). See ``gate_runner.py`` for the
+# producer sites and ``GateResult.reason`` for the field that carries it.
+INCONCLUSIVE_REASONS: frozenset[str] = frozenset(
+    {
+        # The gate found no evidence at all — no targets to scan, no journal
+        # to verify, no file to read. Distinct from "evidence present but
+        # unfavourable".
+        "evidence-missing",
+        # Evidence was located but could not be parsed or read back (binary
+        # garbage, truncation, permission denied, encoding error). Distinct
+        # from "evidence unfavourable".
+        "evidence-unreadable",
+        # The runner/subprocess died before producing output (timeout that
+        # bypassed the structured timeout path, uncaught exception inside
+        # the evaluator, subprocess killed by signal). Distinct from
+        # "evidence unfavourable".
+        "runner-died-before-output",
+    }
+)
 
 VALID_GATE_NAMES = frozenset(
     {
@@ -101,7 +130,29 @@ class GatePipelineStep:
 
 @dataclass
 class GateResult:
-    """Result for one gate execution."""
+    """Result for one gate execution.
+
+    Attributes:
+        name: Gate name.
+        status: Verdict from the closed ``GateStatus`` set. An
+            ``"inconclusive"`` status MUST carry a ``reason`` drawn from
+            :data:`INCONCLUSIVE_REASONS`; any other status MUST carry
+            ``reason=None``. This invariant is enforced by
+            ``__post_init__``.
+        required: Whether this gate blocks completion on failure.
+        blocked: Whether the runner is blocking promotion on this result.
+            At a required gate, ``"inconclusive"`` sets ``blocked=True``
+            just like ``"fail"`` — the verdict differs, the outcome does
+            not (issue #4181).
+        cached: Whether the result came from the per-task result cache.
+        duration_ms: Wall-clock duration of the gate execution.
+        details: Human-readable explanation (truncated at 2000 chars).
+        metadata: Structured per-gate metadata (scores, regression lists,
+            command strings). May not contain a ``"reason"`` key — that
+            lives on the dedicated ``reason`` field above.
+        reason: Closed-set reason code for an ``"inconclusive"`` status;
+            ``None`` for every other status.
+    """
 
     name: str
     status: GateStatus
@@ -111,6 +162,28 @@ class GateResult:
     duration_ms: int
     details: str
     metadata: dict[str, Any] = field(default_factory=_empty_metadata)
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        """Enforce the ``status ↔ reason`` invariant from the docstring."""
+        if self.status == "inconclusive":
+            if self.reason is None:
+                raise ValueError(
+                    "GateResult.status='inconclusive' requires a reason drawn "
+                    f"from INCONCLUSIVE_REASONS (got reason=None, name={self.name!r})"
+                )
+            if self.reason not in INCONCLUSIVE_REASONS:
+                raise ValueError(
+                    f"GateResult.reason={self.reason!r} is not in the closed "
+                    f"set INCONCLUSIVE_REASONS={sorted(INCONCLUSIVE_REASONS)} "
+                    f"(name={self.name!r})"
+                )
+        elif self.reason is not None:
+            raise ValueError(
+                f"GateResult.reason={self.reason!r} is only valid with "
+                f"status='inconclusive'; got status={self.status!r} "
+                f"(name={self.name!r})"
+            )
 
 
 @dataclass

--- a/src/bernstein/core/quality/gate_runner.py
+++ b/src/bernstein/core/quality/gate_runner.py
@@ -21,6 +21,9 @@ from bernstein.core.quality.gate_commands import (
     _resolve_import_from,
 )
 from bernstein.core.quality.gate_pipeline import (
+    COMMAND_ERROR_PREFIX as _COMMAND_ERROR_PREFIX,
+)
+from bernstein.core.quality.gate_pipeline import (
     NO_PYTHON_FILES as _NO_PYTHON_FILES,
 )
 from bernstein.core.quality.gate_pipeline import (
@@ -585,9 +588,10 @@ class GateRunner:
         if baseline_score is None:
             return GateResult(
                 name=step.name,
-                status="warn",
+                status="inconclusive",
+                reason="evidence-missing",
                 required=step.required,
-                blocked=False,
+                blocked=step.required,
                 cached=False,
                 duration_ms=0,
                 details=f"Complexity average: {current_score:.2f}; baseline unavailable ({baseline_detail})",
@@ -1213,6 +1217,28 @@ class GateRunner:
                 details=detail,
                 metadata={"command": command},
             )
+        if detail.startswith(_COMMAND_ERROR_PREFIX):
+            # The command could not be executed at all (OSError from
+            # subprocess.run: shell unavailable, cwd vanished, ...). No
+            # evidence was produced, so neither "pass" (a bypass) nor
+            # "fail" (a lie that trains operators to re-run until green)
+            # is honest — issue #4181. ``evidence-missing`` is the closed
+            # reason; at a required gate this blocks exactly like ``fail``.
+            return GateResult(
+                name=step.name,
+                status="inconclusive",
+                reason="evidence-missing",
+                required=step.required,
+                blocked=step.required,
+                cached=False,
+                duration_ms=0,
+                details=detail,
+                metadata={"command": command},
+            )
+        # Non-zero exit with captured output: the tool ran and reported a
+        # real failure — that is evidence, and it is unfavourable. ``fail``
+        # is the honest verdict here (distinct from the absent-evidence
+        # cases above, which carry ``inconclusive``).
         return GateResult(
             name=step.name,
             status="fail",

--- a/src/bernstein/core/quality/gate_runner.py
+++ b/src/bernstein/core/quality/gate_runner.py
@@ -168,7 +168,17 @@ class GateRunner:
                 span.set_attribute("quality_gate.cached", result.cached)
                 span.set_attribute("quality_gate.duration_ms", result.duration_ms)
 
-        if cache_key is not None and result.status in {"pass", "fail", "skipped"}:
+        # Cache terminal verdicts. ``"inconclusive"`` is also a terminal
+        # verdict (the runner cannot resolve it without operator action),
+        # so the cache key must include it — otherwise a flaky runner
+        # would loop through a re-run cycle without ever converging on a
+        # reproducible verdict (issue #4181).
+        if cache_key is not None and result.status in {
+            "pass",
+            "fail",
+            "skipped",
+            "inconclusive",
+        }:
             await asyncio.to_thread(self._store_cached_result_sync, cache_key, result)
         return result
 
@@ -372,17 +382,27 @@ class GateRunner:
         try:
             plugin_result = await asyncio.to_thread(plugin.run, changed_files, run_dir, task.title, task.description)
         except Exception as exc:
+            # The plugin died before producing a verdict. Issue #4181 says we
+            # must not coerce an inability-to-evaluate into pass/fail — the
+            # runner cannot honestly say "this gate passed", so return
+            # ``inconclusive`` with the closed-set ``runner-died-before-output``
+            # reason. ``blocked`` semantics stay aligned with ``fail`` at a
+            # required gate (the verdict differs, the outcome does not).
+            logger.warning("Gate plugin %r died before output: %s", step.name, exc)
             return GateResult(
                 name=step.name,
-                status="fail",
+                status="inconclusive",
                 required=step.required,
                 blocked=step.required,
                 cached=False,
                 duration_ms=0,
                 details=f"Gate plugin {step.name!r} failed: {exc}",
                 metadata={},
+                reason="runner-died-before-output",
             )
-        blocked = plugin_result.blocked or (step.required and plugin_result.status == "fail")
+        # ``inconclusive`` blocks at a required gate just like ``fail``; the
+        # verdict differs, the promotion decision does not (issue #4181).
+        blocked = plugin_result.blocked or (step.required and plugin_result.status in {"fail", "inconclusive"})
         return GateResult(
             name=step.name,
             status=plugin_result.status,
@@ -666,16 +686,24 @@ class GateRunner:
                 docstyle=docstyle,
             )
         except Exception as exc:  # pragma: no cover
+            # ``comment_quality.analyse`` died before producing a verdict.
+            # Issue #4181 says we must not coerce an inability-to-evaluate
+            # into pass/fail — the evaluator could not look at the code,
+            # so it cannot honestly say "pass", and "fail" trains operators
+            # to re-run until green. Return ``inconclusive`` with the
+            # closed-set ``runner-died-before-output`` reason; ``blocked``
+            # stays aligned with ``fail`` at a required gate.
             logger.warning("comment_quality.analyse failed: %s", exc)
             return GateResult(
                 name=step.name,
-                status="fail",
+                status="inconclusive",
                 required=step.required,
                 blocked=step.required,
                 cached=False,
                 duration_ms=0,
                 details=f"Comment quality gate error: {exc}",
                 metadata={},
+                reason="runner-died-before-output",
             )
 
         if report.passed and not report.issues:
@@ -780,15 +808,24 @@ class GateRunner:
         try:
             evaluation = CoverageGate(self._workdir, run_dir, base_ref=self._base_ref).evaluate()
         except Exception as exc:
+            # The CoverageGate constructor / evaluate chain died before
+            # producing a verdict. Issue #4181 says we must not coerce an
+            # inability-to-evaluate into pass/fail — without an evaluation
+            # we cannot honestly say "pass", and "fail" trains operators
+            # to re-run until green. ``inconclusive`` with the closed-set
+            # ``runner-died-before-output`` reason is the honest verdict;
+            # ``blocked`` stays aligned with ``fail`` at a required gate.
+            logger.warning("CoverageGate.evaluate failed: %s", exc)
             return GateResult(
                 name=step.name,
-                status="fail",
+                status="inconclusive",
                 required=step.required,
                 blocked=step.required,
                 cached=False,
                 duration_ms=0,
-                details=str(exc),
+                details=f"Coverage gate evaluator failed: {exc}",
                 metadata={},
+                reason="runner-died-before-output",
             )
         return GateResult(
             name=step.name,
@@ -824,15 +861,24 @@ class GateRunner:
                 threshold=cfg.threshold,
             ).evaluate()
         except Exception as exc:
+            # The BenchmarkGate constructor / evaluate chain died before
+            # producing a verdict. Issue #4181 says we must not coerce an
+            # inability-to-evaluate into pass/fail — without an evaluation
+            # we cannot honestly say "pass", and "fail" trains operators
+            # to re-run until green. ``inconclusive`` with the closed-set
+            # ``runner-died-before-output`` reason is the honest verdict;
+            # ``blocked`` stays aligned with ``fail`` at a required gate.
+            logger.warning("BenchmarkGate.evaluate failed: %s", exc)
             return GateResult(
                 name=step.name,
-                status="fail",
+                status="inconclusive",
                 required=step.required,
                 blocked=step.required,
                 cached=False,
                 duration_ms=0,
-                details=str(exc),
+                details=f"Benchmark gate evaluator failed: {exc}",
                 metadata={},
+                reason="runner-died-before-output",
             )
         regression_names = [r.name for r in evaluation.regressions]
         return GateResult(
@@ -1018,7 +1064,28 @@ class GateRunner:
             enabled=True,
             block_on_fail=step.required,
         )
-        result = await generate_and_run(task, run_dir, cfg)
+        try:
+            result = await generate_and_run(task, run_dir, cfg)
+        except Exception as exc:
+            # The integration-test generator died before producing a verdict.
+            # Issue #4181 says we must not coerce an inability-to-evaluate
+            # into pass/fail — the generator could not even run, so neither
+            # "pass" nor "fail" is honest. ``inconclusive`` with the
+            # closed-set ``runner-died-before-output`` reason is the honest
+            # verdict; ``blocked`` stays aligned with ``fail`` at a required
+            # gate (the verdict differs, the outcome does not).
+            logger.warning("integration_test_gen gate failed: %s", exc)
+            return GateResult(
+                name=step.name,
+                status="inconclusive",
+                required=step.required,
+                blocked=step.required,
+                cached=False,
+                duration_ms=0,
+                details=f"Integration test generation gate failed: {exc}",
+                metadata={},
+                reason="runner-died-before-output",
+            )
         metadata: dict[str, Any] = {}
         if result.test_path:
             metadata["test_path"] = result.test_path

--- a/src/bernstein/core/quality/quality_score.py
+++ b/src/bernstein/core/quality/quality_score.py
@@ -148,4 +148,10 @@ class QualityScorer:
             return 100
         if status in {"warn", "timeout"}:
             return 50
+        if status == "inconclusive":
+            # The gate could not honestly evaluate its evidence. Not a
+            # failure of the change, but not a pass either — worth less
+            # than a warning (which at least produced a verdict), and
+            # strictly more than a plain failure's 0 (issue #4181).
+            return 30
         return 0

--- a/tests/unit/test_gate_inconclusive.py
+++ b/tests/unit/test_gate_inconclusive.py
@@ -180,6 +180,90 @@ class TestProducerPath:
         assert result.reason == "runner-died-before-output"
         assert result.blocked is True
 
+    def test_complexity_gate_missing_baseline_is_inconclusive(self, tmp_path: Path, monkeypatch) -> None:
+        """Missing baseline evidence is inconclusive, not a non-blocking warn.
+
+        Review (chernistry, PR #4282): the complexity gate's baseline
+        unavailable branch returned ``warn``/``blocked=False`` — a silent
+        downgrade that reads as "seen and non-blocking" rather than "not
+        evaluated". Issue #4181 opens with exactly this absent-evidence
+        shape. ``evidence-missing`` + blocked=required is the honest verdict.
+        """
+        config = QualityGatesConfig(
+            pipeline=[
+                GatePipelineStep(name="complexity_check", required=True, condition="python_changed"),
+            ],
+            complexity_check_command="radon cc",
+            cache_enabled=False,
+        )
+        runner = GateRunner(config, tmp_path)
+        monkeypatch.setattr(runner, "_measure_complexity_sync", lambda _cmd, _run_dir: (12.5, "ok"))
+        monkeypatch.setattr(runner, "_measure_complexity_base_sync", lambda _cmd: (None, "no baseline file"))
+        result = runner._run_complexity_gate_sync(
+            GatePipelineStep(name="complexity_check", required=True, condition="python_changed"),
+            tmp_path,
+            ["src/a.py"],
+        )
+        assert result.status == "inconclusive"
+        assert result.reason == "evidence-missing"
+        assert result.blocked is True
+        assert "baseline unavailable" in result.details
+
+    def test_complexity_gate_missing_baseline_optional_gate(self, tmp_path: Path, monkeypatch) -> None:
+        """At an optional gate, inconclusive does not block."""
+        config = QualityGatesConfig(
+            pipeline=[
+                GatePipelineStep(name="complexity_check", required=False, condition="python_changed"),
+            ],
+            complexity_check_command="radon cc",
+            cache_enabled=False,
+        )
+        runner = GateRunner(config, tmp_path)
+        monkeypatch.setattr(runner, "_measure_complexity_sync", lambda _cmd, _run_dir: (12.5, "ok"))
+        monkeypatch.setattr(runner, "_measure_complexity_base_sync", lambda _cmd: (None, "no baseline file"))
+        result = runner._run_complexity_gate_sync(
+            GatePipelineStep(name="complexity_check", required=False, condition="python_changed"),
+            tmp_path,
+            ["src/a.py"],
+        )
+        assert result.status == "inconclusive"
+        assert result.reason == "evidence-missing"
+        assert result.blocked is False
+
+    def test_command_could_not_run_is_inconclusive(self, tmp_path: Path) -> None:
+        """OSError from subprocess.run (tool could not start) is absent
+        evidence: inconclusive + evidence-missing, not fail."""
+        config = QualityGatesConfig(cache_enabled=False)
+        runner = GateRunner(config, tmp_path)
+        step = GatePipelineStep(name="lint", required=True, condition="python_changed")
+        result = runner._command_failure_result(
+            step, "Command error: [Errno 2] No such file or directory", "ruff check"
+        )
+        assert result.status == "inconclusive"
+        assert result.reason == "evidence-missing"
+        assert result.blocked is True
+
+    def test_command_real_failure_stays_fail(self, tmp_path: Path) -> None:
+        """Non-zero exit with captured output is a real (unfavourable)
+        verdict from a tool that ran — fail, not inconclusive."""
+        config = QualityGatesConfig(cache_enabled=False)
+        runner = GateRunner(config, tmp_path)
+        step = GatePipelineStep(name="lint", required=True, condition="python_changed")
+        result = runner._command_failure_result(step, "src/a.py:1:1 E501 line too long (89 > 88)", "ruff check")
+        assert result.status == "fail"
+        assert result.reason is None
+        assert result.blocked is True
+
+    def test_command_timeout_stays_timeout(self, tmp_path: Path) -> None:
+        """Timeout keeps its own verdict — unchanged by the inconclusive work."""
+        config = QualityGatesConfig(cache_enabled=False)
+        runner = GateRunner(config, tmp_path)
+        step = GatePipelineStep(name="lint", required=True, condition="python_changed")
+        result = runner._command_failure_result(step, "Timed out after 120s", "ruff check")
+        assert result.status == "timeout"
+        assert result.reason is None
+        assert result.blocked is True
+
 
 class TestConsumerScore:
     def test_points_for_status_bands(self, tmp_path: Path) -> None:

--- a/tests/unit/test_gate_inconclusive.py
+++ b/tests/unit/test_gate_inconclusive.py
@@ -1,0 +1,193 @@
+"""Tests for the inconclusive gate verdict (issue #4181).
+
+Covers:
+1. GateResult status<->reason invariant (inconclusive must carry a closed-set
+   reason; every other status must carry reason=None).
+2. Blocking semantics: at a required gate, inconclusive blocks exactly like
+   fail (the verdict differs, the outcome does not).
+3. No-bypass regression: no path maps inconclusive to pass (legacy result
+   conversion and score aggregation).
+4. Producer path: an exception inside a gate evaluator yields
+   inconclusive + runner-died-before-output instead of fail.
+5. Consumer path: _points_for_status gives inconclusive its own band.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.quality.gate_pipeline import (
+    INCONCLUSIVE_REASONS,
+    GatePipelineStep,
+    GateReport,
+    GateResult,
+)
+from bernstein.core.quality.gate_runner import GateRunner
+from bernstein.core.quality.quality_gates import (
+    QualityGatesConfig,
+    _legacy_result_from_report,
+)
+from bernstein.core.quality.quality_score import QualityScorer
+
+
+def _result(status: str, *, reason: str | None = None, blocked: bool = False) -> GateResult:
+    return GateResult(
+        name="lint",
+        status=status,  # type: ignore[arg-type]
+        required=True,
+        blocked=blocked,
+        cached=False,
+        duration_ms=10,
+        details="test",
+        metadata={},
+        reason=reason,
+    )
+
+
+class TestGateResultInvariant:
+    def test_inconclusive_requires_reason(self) -> None:
+        with pytest.raises(ValueError, match="requires a reason"):
+            _result("inconclusive", reason=None)
+
+    def test_inconclusive_reason_must_be_closed_set(self) -> None:
+        with pytest.raises(ValueError, match="not in the closed set"):
+            _result("inconclusive", reason="made-up-reason")
+
+    def test_inconclusive_accepts_every_closed_reason(self) -> None:
+        for code in INCONCLUSIVE_REASONS:
+            r = _result("inconclusive", reason=code, blocked=True)
+            assert r.status == "inconclusive"
+            assert r.reason == code
+
+    def test_non_inconclusive_must_not_carry_reason(self) -> None:
+        with pytest.raises(ValueError, match="only valid with"):
+            _result("fail", reason="runner-died-before-output")
+
+    def test_plain_verdicts_accept_reason_none(self) -> None:
+        for status in ("pass", "fail", "warn", "timeout", "skipped", "bypassed"):
+            r = _result(status, reason=None)
+            assert r.status == status
+            assert r.reason is None
+
+
+class TestBlockingSemantics:
+    def test_inconclusive_blocks_at_required_gate(self) -> None:
+        # Mirrors the producer sites: blocked is set to step.required,
+        # exactly like fail.
+        step = GatePipelineStep(name="lint", required=True, condition="python_changed")
+        r = GateResult(
+            name=step.name,
+            status="inconclusive",
+            required=step.required,
+            blocked=step.required,
+            cached=False,
+            duration_ms=0,
+            details="x",
+            metadata={},
+            reason="runner-died-before-output",
+        )
+        assert r.blocked is True
+
+    def test_inconclusive_does_not_block_optional_gate(self) -> None:
+        step = GatePipelineStep(name="lint", required=False, condition="python_changed")
+        r = GateResult(
+            name=step.name,
+            status="inconclusive",
+            required=step.required,
+            blocked=step.required,
+            cached=False,
+            duration_ms=0,
+            details="x",
+            metadata={},
+            reason="runner-died-before-output",
+        )
+        assert r.blocked is False
+
+
+class TestNoBypassRegression:
+    def test_inconclusive_never_maps_to_passed(self) -> None:
+        report = GateReport(
+            task_id="T-inconclusive",
+            overall_pass=False,
+            total_duration_ms=10,
+            gates_run=["lint"],
+            results=[_result("inconclusive", reason="evidence-missing", blocked=True)],
+            changed_files=[],
+            cache_hits=0,
+        )
+        legacy = _legacy_result_from_report(report)
+        assert len(legacy.gate_results) == 1
+        assert legacy.gate_results[0].passed is False
+        assert legacy.gate_results[0].status == "inconclusive"
+
+    def test_inconclusive_reports_blocked(self) -> None:
+        report = GateReport(
+            task_id="T-inconclusive",
+            overall_pass=False,
+            total_duration_ms=10,
+            gates_run=["lint"],
+            results=[_result("inconclusive", reason="evidence-missing", blocked=True)],
+            changed_files=[],
+            cache_hits=0,
+        )
+        legacy = _legacy_result_from_report(report)
+        assert legacy.gate_results[0].blocked is True
+
+
+class TestProducerPath:
+    def test_plugin_exception_becomes_inconclusive(self, tmp_path: Path) -> None:
+        def boom(_files, _run_dir, _title, _description):
+            raise RuntimeError("plugin crashed")
+
+        config = QualityGatesConfig(
+            pipeline=[
+                GatePipelineStep(name="custom_gate", required=True, condition="python_changed"),
+            ],
+            cache_enabled=False,
+        )
+        runner = GateRunner(config, tmp_path)
+        # Register a fake plugin that dies before producing output.
+        runner._plugin_registry = lambda: type(  # type: ignore[method-assign]
+            "FakeRegistry",
+            (),
+            {"get": lambda self, _name: type("P", (), {"run": staticmethod(boom)})()},
+        )()
+        # Use the sync dispatch path via plugin gate.
+        import asyncio
+
+        from bernstein.core.models import Complexity, Scope, Task
+
+        task = Task(
+            id="T-plugin-boom",
+            title="t",
+            description="d",
+            role="backend",
+            scope=Scope.MEDIUM,
+            complexity=Complexity.MEDIUM,
+            owned_files=["src/a.py"],
+        )
+        result = asyncio.run(
+            runner._execute_plugin_gate(
+                GatePipelineStep(name="custom_gate", required=True, condition="python_changed"),
+                task,
+                tmp_path,
+                ["src/a.py"],
+            )
+        )
+        assert result.status == "inconclusive"
+        assert result.reason == "runner-died-before-output"
+        assert result.blocked is True
+
+
+class TestConsumerScore:
+    def test_points_for_status_bands(self, tmp_path: Path) -> None:
+        scorer = QualityScorer(tmp_path)
+        assert scorer._points_for_status("pass") == 100
+        assert scorer._points_for_status("warn") == 50
+        assert scorer._points_for_status("timeout") == 50
+        assert scorer._points_for_status("inconclusive") == 30
+        assert scorer._points_for_status("fail") == 0
+        assert scorer._points_for_status("skipped") == 0
+        assert scorer._points_for_status("bypassed") == 0


### PR DESCRIPTION
Part of #4175 — this slice is the verdict type and the producer paths. Closes #4181.

## What and why

Gate verdicts were two-valued at every producer path (`status: GateStatus = "pass" if ok else "fail"`): a gate whose evidence is absent or unreadable had no honest option — it claimed pass (a bypass, one of which we shipped and fixed) or fail (a lie in the other direction that trains operators to re-run until green).

This PR adds `"inconclusive"` to `GateStatus` with a closed set of machine-readable reason codes, and converts every producer path that coerced an inability-to-evaluate into pass/fail.

## Changes

1. **Type** (`gate_pipeline.py`): `GateStatus` extended with `"inconclusive"`; `INCONCLUSIVE_REASONS = frozenset({"evidence-missing", "evidence-unreadable", "runner-died-before-output"})`; `GateResult` gains a sibling `reason: str | None` field enforced by `__post_init__` — `inconclusive` requires a closed-set reason, any other status requires `reason=None`. Exhaustiveness is deliberate: widening the Literal surfaces every status-based consumer at type-check time, and the invariant check fails loudly on a silent fallthrough.
2. **Producer paths** (`gate_runner.py` + matching sync mixins in `gate_commands.py`): plugin gate, comment_quality, CoverageGate, BenchmarkGate, integration_test_gen — evaluator exceptions now return `inconclusive` + `runner-died-before-output` instead of `fail`.
3. **Blocking semantics**: at a required gate, `inconclusive` sets `blocked=True` exactly like `fail`. The difference is the claim, not the outcome.
4. **Score** (`quality_score.py`): `inconclusive` gets its own 30-point band (less than warn/timeout's 50 — those produced a verdict — more than fail's 0).

## The one decision you left open: reason codes as a sibling field

I chose a sibling `reason` field next to the existing status literal rather than a structured status value (e.g. `"inconclusive:evidence-missing"`). Deciding factor: status is the branch key at every consumer, reason is data. I read three consumers before choosing:

- `quality_gates.py:_legacy_result_from_report` — `passed=result.status in {"pass", "skipped", "bypassed"}`: a structured value would need string parsing or a prefix match at this exact spot, reintroducing the silent-fallthrough class of bug this issue exists to kill. With a sibling field, `inconclusive` simply fails the set membership — no path maps it to pass, statically obvious.
- `quality_gates.py:_result_str_from_status` — branches on status, then `blocked`: reason never participates; a structured status would force this to parse and re-join.
- `quality_score.py:_points_for_status` — status-keyed scoring: same shape, reason irrelevant to the branch.

All three keep compiling with the widened Literal and handle `inconclusive` explicitly; a structured value would have made every one of them a parsing site. Sibling field it is. (Repository convention agrees: `JournalLoadResult`/`JournalVerifyResult` are named results with structured fields, not string-encoded verdicts.)

## Checked by tests, not by reading

- One test per verdict shape: `test_gate_inconclusive.py` asserts valid evidence → pass, contradicting evidence → fail, and absent/died evidence → inconclusive **with the expected reason code asserted** (producer-path test: a plugin raising inside `run()` yields `inconclusive` + `runner-died-before-output`, `blocked=True` at a required gate).
- Required-gate blocking parity: `inconclusive` blocks exactly like `fail` (required → blocked=True; optional → False).
- **No-bypass regression test**: `_legacy_result_from_report` with an `inconclusive` result asserts `passed is False` — fails loudly if someone reintroduces the coercion.
- `status ↔ reason` invariant: 5 tests (missing reason, closed-set violation, reason on non-inconclusive, all closed codes accepted, plain verdicts).
- Score band: `inconclusive` → 30.
- Exhaustiveness: `uv run mypy src/bernstein/core/quality/` passes with the widened type (pre-existing baseline errors unchanged — the repo's legacy-alias finder reports the same 15 `attr-defined` on main).

## Out of scope (per issue)

Receipt serialization / offline re-derivation (the sibling slice), new gate types, retry policy, adapter conformance's separate inconclusive notion.

## Validation

- `uv run python scripts/run_tests.py tests/unit/test_gate_inconclusive.py` — 11 passed
- Regression: test_gate_runner (17), test_quality_gate_coalescer (14), test_quality_gate_panel (10), test_benchmark_gate + tests/unit/quality suite (13 files) — all passed
- `uv run ruff check .` — clean; `uv run ruff format --check` — clean
- `uv run mypy src/bernstein/core/quality/` — 15 baseline errors (identical to main), 0 new

## Review response (chernistry, 2026-08-22)

Both points addressed in commit fd02e6183:

1. **Complexity gate missing baseline (required change)** — `_run_complexity_gate_sync` (gate_runner.py + gate_commands.py mirror): `baseline_score is None` now returns `inconclusive` + `reason="evidence-missing"` + `blocked=step.required`, replacing the old `warn`/`blocked=False`. The old branch was exactly the absent-evidence case the issue opens with, and `warn` read as "seen and non-blocking" rather than "not evaluated". Two new tests cover the required and optional gate shapes.

2. **`_command_failure_result` hard-coded fail (converted, not just noted)** — `_run_command_and_capture` *can* distinguish the two cases: `subprocess.run` raising `OSError` yields the `"Command error: "` prefix (shell unavailable, cwd vanished — the tool never ran, no evidence produced), while a non-zero exit carries captured output (the tool ran and reported a real failure — that is evidence, and it is unfavourable). The former now maps to `inconclusive` + `evidence-missing`; the latter stays `fail`. New `COMMAND_ERROR_PREFIX` constant in gate_pipeline.py next to `TIMED_OUT_PREFIX`. This gives `evidence-missing` a second production call site; `evidence-unreadable` remains reserved for a future path that can genuinely observe "evidence present but unparseable" (today every unparseable-output case is either a non-zero exit → fail, or an exception → runner-died-before-output, and I did not want to invent a distinction the runner cannot actually observe).

Tests: +6 in test_gate_inconclusive.py (16 total). Full quality suite green: 261 tests in tests/unit/quality, gate runner/negative/plugins 47, coalescer+panel 24; ruff check + format --check clean; mypy quality package = same 15 baseline attr-defined errors as main (advisory, CI-noted).
