### PR TITLE
feat(security): add ensure_public_http_url for third-party-derived URLs

### DIFF
--- a/src/bernstein/core/security/url_allowlist.py
+++ b/src/bernstein/core/security/url_allowlist.py
@@ -115,14 +115,7 @@ def _is_internal(address: str) -> bool:
     if mapped is not None:
         ip = mapped
 
-    return (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_reserved
-        or ip.is_multicast
-        or ip.is_unspecified
-    )
+    return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified
 
 
 def ensure_public_http_url(
@@ -181,9 +174,7 @@ def ensure_public_http_url(
     try:
         addresses = list(resolve(host))
     except OSError as exc:
-        raise UrlSchemeError(
-            _msg(source, f"host {host!r} could not be resolved: {exc}; url={url!r}")
-        ) from exc
+        raise UrlSchemeError(_msg(source, f"host {host!r} could not be resolved: {exc}; url={url!r}")) from exc
 
     if not addresses:
         raise UrlSchemeError(_msg(source, f"host {host!r} resolved to no addresses; url={url!r}"))
@@ -192,9 +183,7 @@ def ensure_public_http_url(
         try:
             internal = _is_internal(address)
         except ValueError as exc:
-            raise UrlSchemeError(
-                _msg(source, f"host {host!r} resolved to an unparseable address {address!r}")
-            ) from exc
+            raise UrlSchemeError(_msg(source, f"host {host!r} resolved to an unparseable address {address!r}")) from exc
 
         if internal:
             raise UrlSchemeError(

--- a/src/bernstein/core/security/url_allowlist.py
+++ b/src/bernstein/core/security/url_allowlist.py
@@ -148,6 +148,13 @@ def ensure_public_http_url(
     Resolution failure is a rejection, not a pass-through: an unresolvable host
     is not evidence of a safe host.
 
+    This validates the URL you pass it and nothing that URL later leads to. It
+    is a single pre-fetch check, so a public host that answers with a redirect
+    to ``127.0.0.1`` or ``169.254.169.254`` still reaches the client unchecked,
+    and a name re-resolved between this call and the connection can answer
+    differently the second time. Callers handling third-party-derived URLs must
+    therefore disable redirect following, or re-run this check on every hop.
+
     Args:
         url: The candidate URL string.
         allow_http: When True, accept ``http://`` as well as ``https://``.

--- a/src/bernstein/core/security/url_allowlist.py
+++ b/src/bernstein/core/security/url_allowlist.py
@@ -14,10 +14,17 @@ defence-in-depth check independent of the per-call-site allow-list comments.
 
 from __future__ import annotations
 
+import ipaddress
+import socket
+from collections.abc import Callable, Iterable
 from typing import Final
 from urllib.parse import urlparse
 
-__all__ = ["UrlSchemeError", "ensure_http_url"]
+__all__ = ["UrlSchemeError", "ensure_http_url", "ensure_public_http_url"]
+
+# Resolves a hostname to a list of textual IP addresses. Injectable so tests can
+# feed hostile answers without depending on DNS.
+HostResolver = Callable[[str], Iterable[str]]
 
 
 class UrlSchemeError(ValueError):
@@ -90,3 +97,112 @@ def ensure_http_url(  # NOSONAR python:S3516 - accept path returns input unchang
 def _msg(source: str, body: str) -> str:
     prefix = f"{source}: " if source else ""
     return f"{prefix}{body}"
+
+
+def _default_resolver(host: str) -> list[str]:
+    """Resolve ``host`` to every address it answers with, v4 and v6."""
+    infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    # sockaddr is (host, port) for v4 and (host, port, flowinfo, scope_id) for v6;
+    # the address is element 0 either way, but the tuple type is str | int.
+    return [str(info[4][0]) for info in infos]
+
+
+def _is_internal(address: str) -> bool:
+    """Is ``address`` an address a third party must not be able to aim us at?"""
+    ip = ipaddress.ip_address(address)
+    # ::ffff:127.0.0.1 is loopback wearing an IPv6 coat; judge the address it maps to.
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        ip = mapped
+
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def ensure_public_http_url(
+    url: str,
+    *,
+    allow_http: bool = False,
+    source: str = "",
+    resolver: HostResolver | None = None,
+) -> str:
+    """Validate ``url`` for a destination supplied by third-party content.
+
+    :func:`ensure_http_url` checks the scheme and stops there, which is the
+    right level of trust for a URL an operator configured: an operator who
+    points Bernstein at their own webhook is not attacking themselves. It is
+    the wrong level for a URL read out of *fetched content* — an entry inside a
+    catalog index we downloaded — because whoever authored that entry chooses
+    the destination. A crafted entry can name ``127.0.0.1``, a cloud metadata
+    service at ``169.254.169.254``, or any private range, and a scheme-only
+    check waves it through.
+
+    This is the strict sibling: scheme validation first (so the existing
+    behaviour and error messages are reused verbatim), then hostname
+    resolution, then rejection of loopback, private, link-local, reserved,
+    multicast and unspecified destinations.
+
+    **Every** resolved address must be public. A name answering with one public
+    and one private address is rejected, since which one the HTTP client picks
+    is not ours to decide.
+
+    Resolution failure is a rejection, not a pass-through: an unresolvable host
+    is not evidence of a safe host.
+
+    Args:
+        url: The candidate URL string.
+        allow_http: When True, accept ``http://`` as well as ``https://``.
+            Note that the loopback exemption :func:`ensure_http_url` grants to
+            plain HTTP is irrelevant here, since loopback is rejected outright.
+        source: Optional human-readable label used in the error message.
+        resolver: Optional hostname resolver, for tests. Defaults to
+            :func:`socket.getaddrinfo`.
+
+    Returns:
+        ``url`` if it passes validation.
+
+    Raises:
+        UrlSchemeError: If the scheme is not permitted, the host is missing or
+            unresolvable, or any resolved address is internal.
+    """
+    ensure_http_url(url, allow_http=allow_http, source=source)
+
+    host = (urlparse(url).hostname or "").lower()
+    if not host:
+        raise UrlSchemeError(_msg(source, f"URL has no host: {url!r}"))
+
+    resolve = resolver or _default_resolver
+    try:
+        addresses = list(resolve(host))
+    except OSError as exc:
+        raise UrlSchemeError(
+            _msg(source, f"host {host!r} could not be resolved: {exc}; url={url!r}")
+        ) from exc
+
+    if not addresses:
+        raise UrlSchemeError(_msg(source, f"host {host!r} resolved to no addresses; url={url!r}"))
+
+    for address in addresses:
+        try:
+            internal = _is_internal(address)
+        except ValueError as exc:
+            raise UrlSchemeError(
+                _msg(source, f"host {host!r} resolved to an unparseable address {address!r}")
+            ) from exc
+
+        if internal:
+            raise UrlSchemeError(
+                _msg(
+                    source,
+                    f"host {host!r} resolves to internal address {address!r}, "
+                    f"which is not a permitted destination; url={url!r}",
+                )
+            )
+
+    return url

--- a/tests/unit/security/test_url_allowlist.py
+++ b/tests/unit/security/test_url_allowlist.py
@@ -10,9 +10,15 @@ can never mask a regression that turns the guard into an always-allow.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 
-from bernstein.core.security.url_allowlist import UrlSchemeError, ensure_http_url
+from bernstein.core.security.url_allowlist import (
+    UrlSchemeError,
+    ensure_http_url,
+    ensure_public_http_url,
+)
 
 
 @pytest.mark.parametrize(
@@ -95,3 +101,102 @@ def test_schemeless_url_rejected() -> None:
 def test_error_message_includes_source_label() -> None:
     with pytest.raises(UrlSchemeError, match="jira webhook"):
         ensure_http_url("ftp://example.com", source="jira webhook")
+
+
+# --- ensure_public_http_url: the strict sibling for third-party-derived URLs ---
+#
+# The threat these pin: a URL read out of a *fetched* catalog index is chosen by
+# whoever authored that index, not by the operator. A scheme-only check lets a
+# crafted entry aim the fetcher at loopback, a cloud metadata service, or any
+# private range. Every reject case below is a real SSRF target.
+
+
+def _resolves_to(*addresses: str) -> Callable[[str], list[str]]:
+    """A resolver that answers with fixed addresses, so no DNS is needed."""
+    return lambda _host: list(addresses)
+
+
+def test_public_url_is_accepted_and_returned_unchanged() -> None:
+    url = "https://example.com/catalog/entry.json"
+    assert ensure_public_http_url(url, resolver=_resolves_to("93.184.216.34")) == url
+
+
+@pytest.mark.parametrize(
+    ("address", "what"),
+    [
+        ("127.0.0.1", "loopback"),
+        ("169.254.169.254", "link-local cloud metadata"),
+        ("10.0.0.5", "private 10/8"),
+        ("172.16.0.5", "private 172.16/12"),
+        ("192.168.1.5", "private 192.168/16"),
+        ("0.0.0.0", "unspecified"),
+        ("::1", "IPv6 loopback"),
+        ("fe80::1", "IPv6 link-local"),
+        ("fc00::1", "IPv6 unique-local"),
+        ("::ffff:127.0.0.1", "IPv4-mapped loopback"),
+    ],
+)
+def test_internal_destinations_are_rejected(address: str, what: str) -> None:
+    with pytest.raises(UrlSchemeError, match="internal address"):
+        ensure_public_http_url(
+            "https://evil.example/entry.json",
+            resolver=_resolves_to(address),
+        )
+    assert what  # label kept for readable parametrize ids
+
+
+def test_rebinding_style_answer_is_rejected_when_any_address_is_internal() -> None:
+    # One public and one private answer: which one the HTTP client picks is not
+    # ours to decide, so the whole name is refused.
+    with pytest.raises(UrlSchemeError, match="internal address"):
+        ensure_public_http_url(
+            "https://rebind.example/entry.json",
+            resolver=_resolves_to("93.184.216.34", "127.0.0.1"),
+        )
+
+
+def test_unresolvable_host_is_rejected_not_passed_through() -> None:
+    def _fails(_host: str) -> list[str]:
+        raise OSError("Name or service not known")
+
+    with pytest.raises(UrlSchemeError, match="could not be resolved"):
+        ensure_public_http_url("https://nx.example/entry.json", resolver=_fails)
+
+
+def test_host_resolving_to_nothing_is_rejected() -> None:
+    with pytest.raises(UrlSchemeError, match="resolved to no addresses"):
+        ensure_public_http_url("https://empty.example/x", resolver=_resolves_to())
+
+
+def test_scheme_rules_still_apply_before_resolution() -> None:
+    with pytest.raises(UrlSchemeError, match="scheme"):
+        ensure_public_http_url(
+            "http://example.com/entry.json",
+            resolver=_resolves_to("93.184.216.34"),
+        )
+
+
+def test_http_allowed_when_opted_in_and_host_is_public() -> None:
+    url = "http://example.com/entry.json"
+    assert (
+        ensure_public_http_url(url, allow_http=True, resolver=_resolves_to("93.184.216.34")) == url
+    )
+
+
+def test_loopback_http_exemption_does_not_leak_into_strict_mode() -> None:
+    # ensure_http_url lets plain http through for localhost; strict mode must not.
+    with pytest.raises(UrlSchemeError, match="internal address"):
+        ensure_public_http_url(
+            "http://localhost:8052/entry.json",
+            allow_http=True,
+            resolver=_resolves_to("127.0.0.1"),
+        )
+
+
+def test_source_label_appears_in_strict_rejection() -> None:
+    with pytest.raises(UrlSchemeError, match="skills_catalog.fetcher"):
+        ensure_public_http_url(
+            "https://evil.example/x",
+            source="skills_catalog.fetcher",
+            resolver=_resolves_to("127.0.0.1"),
+        )

--- a/tests/unit/security/test_url_allowlist.py
+++ b/tests/unit/security/test_url_allowlist.py
@@ -178,9 +178,7 @@ def test_scheme_rules_still_apply_before_resolution() -> None:
 
 def test_http_allowed_when_opted_in_and_host_is_public() -> None:
     url = "http://example.com/entry.json"
-    assert (
-        ensure_public_http_url(url, allow_http=True, resolver=_resolves_to("93.184.216.34")) == url
-    )
+    assert ensure_public_http_url(url, allow_http=True, resolver=_resolves_to("93.184.216.34")) == url
 
 
 def test_loopback_http_exemption_does_not_leak_into_strict_mode() -> None:


### PR DESCRIPTION
Closes #4300. Part of #4286.

## Shape

I took the **sibling function** option rather than a parameter on `ensure_http_url`. Both were allowed; a separate `ensure_public_http_url` makes "the default behaviour of the existing signature is completely unchanged" true *by construction* rather than by inspection, which matters for a guard whose failure mode is silent over-permissiveness.

Scheme validation is delegated to `ensure_http_url` verbatim, so the existing rules and error messages are reused rather than reimplemented and cannot drift.

## What it rejects

After the scheme check, the hostname is resolved and every returned address must be public. Rejected: loopback, private, link-local, reserved, multicast, unspecified.

Three decisions worth flagging:

- **All addresses must be public, not just one.** A name answering with one public and one private address is refused — which one the HTTP client dials is not ours to decide, and accepting on "some address was fine" is the rebinding hole.
- **Resolution failure is a rejection**, per the issue: an unresolvable host is not evidence of a safe host.
- **IPv4-mapped IPv6 is unwrapped before judging**, so `::ffff:127.0.0.1` cannot smuggle loopback past `is_loopback` on the v6 object.

The loopback-plain-HTTP exemption `ensure_http_url` grants is irrelevant here, since loopback is rejected outright — pinned by a test so it can't quietly start mattering.

## Residual gap: redirects

As the issue permits, this is a **single pre-fetch resolution check**. A destination that passes and then 302s to `169.254.169.254` is still reachable, because nothing here follows redirects. Closing that needs a per-hop check inside the HTTP client, which the issue puts out of scope for this slice. Recording it explicitly rather than implying the call sites are fully covered once they opt in.

## Out of scope, as specified

`skills/catalog/fetcher.py` and `mcp_catalog/fetcher.py` are **not** touched — those are the dependent sub-issues (#4301, #4302). Confirmed both still call `ensure_http_url` unchanged; the diff is two files.

## Verification

The gap, before and after — same URLs, same call site label:

```
catalog entry                             ensure_http_url   ensure_public_http_url
https://catalog.example/x  -> 127.0.0.1           ACCEPTED                 rejected
https://meta.example/x  -> 169.254.169.254        ACCEPTED                 rejected
https://intranet.example/x  -> 10.0.0.5           ACCEPTED                 rejected
```

Tests use an injectable `resolver`, so no case depends on DNS. Added: the public-URL accept path, ten internal addresses (v4, v6, unique-local, IPv4-mapped loopback), the mixed rebinding answer, resolution failure, empty answer, scheme rules still applying first, opt-in HTTP to a public host, the loopback exemption not leaking in, and the `source` label reaching the message.

```
uv run python scripts/run_tests.py tests/unit/security/test_url_allowlist.py   # 35 passed
uv run ruff check <both files>                                                 # All checks passed
uv run mypy src/bernstein/core/security/url_allowlist.py                       # Success
```

All pre-existing tests in the file pass unchanged.
