### PR TITLE
feat(adapters): add a session_state axis to AdapterStrategy

### DIFF
--- a/docs/adapters/capability_contract.md
+++ b/docs/adapters/capability_contract.md
@@ -9,7 +9,7 @@ stream-json for some, a plain-text signal grammar for others, and upstream
 hooks for the rest.
 
 To keep the orchestrator free of `if adapter == "X"` branches, each adapter
-declares its strategy on three typed axes. The orchestrator dispatches off
+declares its strategy on five typed axes. The orchestrator dispatches off
 the enum, so adding a new adapter is a contract-completion exercise rather
 than a hunt-and-patch across the core.
 
@@ -18,7 +18,7 @@ The enums and the declaration matrix live in
 Strategy is **declared**, not probed: Bernstein never runs the CLI at start
 just to discover its capabilities.
 
-## The four axes
+## The five axes
 
 ### Resume strategy (`ResumeStrategy`)
 
@@ -73,6 +73,21 @@ Every shipped adapter declares `git-diff` (the default), so the coding path is
 unchanged. See [../operations/artifacts.md](../operations/artifacts.md) for the
 artifact-mode completion path.
 
+### Session state (`SessionState`)
+
+Whether the adapter reaches agent-side state that outlives a single spawn.
+Every other axis describes how Bernstein *drives* a run; this one describes
+what the run leaves behind on the agent's side, which is what decides whether
+replaying the same inputs can be expected to reproduce the same outputs.
+
+| Value | Meaning |
+| --- | --- |
+| `stateless` | Each spawn starts from the inputs Bernstein supplies and nothing else. A replay of those inputs is reproducible. |
+| `persistent-agent` | The agent keeps its own state across spawns - a server-side session, a memory store, a persistent thread. A replay is **not** reproducible: inputs Bernstein never saw can influence the run. |
+
+`stateless` is the default, so every adapter that has not declared otherwise
+keeps its existing meaning.
+
 ## Declaring a strategy
 
 The canonical declaration is a row in `STRATEGY_MATRIX`, keyed by registry
@@ -95,7 +110,7 @@ Read the resolved strategy through `CLIAdapter.strategy()`, never the raw
 attribute: the resolver applies the inline override first, then the matrix
 keyed by registry name, then the conservative `DEFAULT_ADAPTER_STRATEGY`
 (no native resume, dangerous mode unsupported, text-signal channel,
-git-diff output mode).
+git-diff output mode, stateless session state).
 
 ## Conformance
 

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -567,13 +567,34 @@ class OutputMode(StrEnum):
     ARTIFACT = "artifact"
 
 
+class SessionState(StrEnum):
+    """Whether an adapter reaches agent-side state that outlives a single spawn.
+
+    Every other axis describes how Bernstein *drives* a run. This one
+    describes what the run leaves behind on the agent's side, which is what
+    decides whether a replay of the same inputs can be expected to reproduce
+    the same outputs.
+    """
+
+    #: Each spawn starts from the inputs Bernstein supplies and nothing else.
+    #: An operator may assume a replay of those inputs is reproducible: there
+    #: is no agent-side memory carried in from an earlier run.
+    STATELESS = "stateless"
+    #: The agent keeps state of its own across spawns - a server-side session,
+    #: a memory store, a persistent thread. An operator may NOT assume a replay
+    #: is reproducible, because inputs Bernstein never saw can influence the
+    #: run.
+    PERSISTENT_AGENT = "persistent-agent"
+
+
 class StrategyView(TypedDict):
-    """JSON-serialisable view of an :class:`AdapterStrategy`'s four axes."""
+    """JSON-serialisable view of an :class:`AdapterStrategy`'s five axes."""
 
     resume: str
     dangerous_mode: str
     event_channel: str
     output_mode: str
+    session_state: str
 
 
 class StrategyRow(StrategyView):
@@ -584,7 +605,7 @@ class StrategyRow(StrategyView):
 
 @dataclass(frozen=True)
 class AdapterStrategy:
-    """The declared strategy of a single adapter across all four axes."""
+    """The declared strategy of a single adapter across all five axes."""
 
     resume: ResumeStrategy = ResumeStrategy.UNSUPPORTED
     dangerous_mode: DangerousModeStrategy = DangerousModeStrategy.UNSUPPORTED
@@ -593,6 +614,9 @@ class AdapterStrategy:
     #: committing. An adapter driving a non-coding worker declares ``artifact``
     #: so the completion path reads its canonical output instead of HEAD.
     output_mode: OutputMode = OutputMode.GIT_DIFF
+    #: Defaults to ``stateless``, so every existing row keeps its meaning: an
+    #: adapter that does carry agent-side state across spawns must say so.
+    session_state: SessionState = SessionState.STATELESS
 
     def to_dict(self) -> StrategyView:
         """Return a JSON-serialisable view for operator-facing tables."""
@@ -601,6 +625,7 @@ class AdapterStrategy:
             "dangerous_mode": str(self.dangerous_mode),
             "event_channel": str(self.event_channel),
             "output_mode": str(self.output_mode),
+            "session_state": str(self.session_state),
         }
 
 

--- a/tests/unit/adapters/test_capability_enums.py
+++ b/tests/unit/adapters/test_capability_enums.py
@@ -23,6 +23,7 @@ from bernstein.adapters._contract import (
     EventChannel,
     OutputMode,
     ResumeStrategy,
+    SessionState,
     checkpoint_retry_capability,
     resume_capability,
     strategy_for,
@@ -137,12 +138,14 @@ def test_adapter_strategy_to_dict_round_trips() -> None:
         dangerous_mode=DangerousModeStrategy.ENV_VAR,
         event_channel=EventChannel.HOOKS,
         output_mode=OutputMode.ARTIFACT,
+        session_state=SessionState.PERSISTENT_AGENT,
     )
     assert strategy.to_dict() == {
         "resume": "flag",
         "dangerous_mode": "env-var",
         "event_channel": "hooks",
         "output_mode": "artifact",
+        "session_state": "persistent-agent",
     }
 
 
@@ -241,7 +244,14 @@ def test_strategy_table_rows_sorted_and_complete() -> None:
     rows = strategy_table(["gemini", "aider"])
     assert [r["adapter"] for r in rows] == ["aider", "gemini"]
     for row in rows:
-        assert set(row) == {"adapter", "resume", "dangerous_mode", "event_channel", "output_mode"}
+        assert set(row) == {
+            "adapter",
+            "resume",
+            "dangerous_mode",
+            "event_channel",
+            "output_mode",
+            "session_state",
+        }
 
 
 def test_strategy_conformance_table_covers_registry() -> None:

--- a/tests/unit/adapters/test_session_state_axis.py
+++ b/tests/unit/adapters/test_session_state_axis.py
@@ -41,9 +41,7 @@ def test_no_shipped_adapter_silently_became_persistent() -> None:
     # Every row was written before this axis existed, so all of them must still
     # read as stateless. Declaring letta_code is a separate issue under #3670.
     persistent = [
-        name
-        for name, strategy in STRATEGY_MATRIX.items()
-        if strategy.session_state is not SessionState.STATELESS
+        name for name, strategy in STRATEGY_MATRIX.items() if strategy.session_state is not SessionState.STATELESS
     ]
     assert persistent == [], f"unexpected non-stateless declarations: {persistent}"
 

--- a/tests/unit/adapters/test_session_state_axis.py
+++ b/tests/unit/adapters/test_session_state_axis.py
@@ -1,0 +1,80 @@
+"""The ``session_state`` axis on :class:`AdapterStrategy` (issue #4288).
+
+The axis exists so an adapter can declare that it reaches agent-side state
+outliving a single spawn. Every other axis says how Bernstein *drives* a run;
+this one says what the run leaves behind, which is what decides whether a
+replay of the same inputs can be expected to reproduce the same outputs.
+
+These pin the two properties the addition has to hold: every existing row
+keeps its meaning (the default is stateless), and the axis reaches the
+operator-facing view rather than being declared and then dropped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.adapters._contract import (
+    DEFAULT_ADAPTER_STRATEGY,
+    STRATEGY_MATRIX,
+    AdapterStrategy,
+    SessionState,
+)
+
+
+def test_every_declared_row_resolves_to_a_valid_session_state() -> None:
+    """The acceptance criterion: no row can carry an unrecognised value."""
+    assert STRATEGY_MATRIX, "STRATEGY_MATRIX is empty; this guard would check nothing"
+
+    for name, strategy in STRATEGY_MATRIX.items():
+        assert isinstance(strategy.session_state, SessionState), (
+            f"{name} declares a session_state that is not a SessionState member"
+        )
+
+
+def test_default_is_stateless_so_existing_rows_keep_their_meaning() -> None:
+    assert AdapterStrategy().session_state is SessionState.STATELESS
+    assert DEFAULT_ADAPTER_STRATEGY.session_state is SessionState.STATELESS
+
+
+def test_no_shipped_adapter_silently_became_persistent() -> None:
+    # Every row was written before this axis existed, so all of them must still
+    # read as stateless. Declaring letta_code is a separate issue under #3670.
+    persistent = [
+        name
+        for name, strategy in STRATEGY_MATRIX.items()
+        if strategy.session_state is not SessionState.STATELESS
+    ]
+    assert persistent == [], f"unexpected non-stateless declarations: {persistent}"
+
+
+def test_axis_reaches_the_operator_facing_view() -> None:
+    view = AdapterStrategy(session_state=SessionState.PERSISTENT_AGENT).to_dict()
+
+    assert view["session_state"] == "persistent-agent"
+    # The other four axes are still present and unchanged in shape.
+    assert set(view) == {
+        "resume",
+        "dangerous_mode",
+        "event_channel",
+        "output_mode",
+        "session_state",
+    }
+
+
+@pytest.mark.parametrize(
+    ("member", "wire"),
+    [(SessionState.STATELESS, "stateless"), (SessionState.PERSISTENT_AGENT, "persistent-agent")],
+)
+def test_wire_values_are_stable(member: SessionState, wire: str) -> None:
+    # These strings land in operator-facing tables and recorded run data, so a
+    # rename is a breaking change and should fail here first.
+    assert str(member) == wire
+    assert SessionState(wire) is member
+
+
+def test_unrecognised_value_fails_closed() -> None:
+    # Consistent with the other axes: an unknown value is a construction-time
+    # error, not a silently-tolerated string.
+    with pytest.raises(ValueError, match="not a valid SessionState"):
+        SessionState("federated-brain")


### PR DESCRIPTION
Closes #4288. Part of #3670, slice 1 of 3.

## The enum

Two values, as the issue expected — what an operator may assume from each:

| Value | An operator may assume |
| --- | --- |
| `stateless` | Each spawn starts from the inputs Bernstein supplies and nothing else, so replaying those inputs is reproducible. |
| `persistent-agent` | The agent keeps its own state across spawns (server-side session, memory store, persistent thread), so a replay is **not** reproducible — inputs Bernstein never saw can influence the run. |

The framing I used to justify the axis existing at all: every other axis describes how Bernstein *drives* a run; this one describes what the run leaves behind on the agent's side. That is what makes it the axis a replay verdict can be built on.

## Unrecognised values: fail closed

Explicitly, since you asked for it to be stated rather than implied. `SessionState` is a `StrEnum` like `ResumeStrategy`, `DangerousModeStrategy` and `EventChannel`, so `SessionState("federated-brain")` raises `ValueError` at construction — an unknown value cannot be carried as a string and interpreted later. That matches the existing axes, and it is the safe direction: the risky mistake here is treating a persistent-agent adapter as stateless, so refusing the value is better than defaulting it. Pinned by `test_unrecognised_value_fails_closed`.

## Compatibility

`session_state` defaults to `SessionState.STATELESS`, so **no existing `STRATEGY_MATRIX` row changes meaning** — asserted directly by `test_no_shipped_adapter_silently_became_persistent`, which fails if any row becomes non-stateless without the test being updated.

Two existing tests in `test_capability_enums.py` needed updating because they assert the exact key set of `to_dict()` / the strategy table rows. Those assertions did their job — the new key is a real shape change to an operator-facing view — so I extended them rather than loosening them to a subset check.

## Also updated

- `to_dict` and the `StrategyView` TypedDict (the axis is in the operator-facing view, not just the dataclass).
- `docs/adapters/capability_contract.md` — new "Session state" section with the value table, "four axes" → "five axes", and the `DEFAULT_ADAPTER_STRATEGY` description.

## Out of scope

Declaring `letta_code`'s value and wiring the evidence-bundle replay verdict are the other two slices of #3670 and build on this field, so they are left alone.

## Verification

```
uv run python scripts/run_tests.py tests/unit/adapters/ tests/unit/security/   # 54 files passed
uv run ruff check <changed files>                                              # All checks passed
uv run mypy src/bernstein/adapters/                                            # no new errors
```

On mypy: the package reports 11 errors, and I checked these are **pre-existing on `main`** — `comm` against a baseline run on a stashed tree gives an empty new-error set, so this change adds none.

New tests in `tests/unit/adapters/test_session_state_axis.py`: every `STRATEGY_MATRIX` row resolves to a valid member (with a non-empty guard so the loop can't pass vacuously), the default is stateless, no shipped adapter is non-stateless, the axis reaches `to_dict`, the wire strings are stable, and an unknown value raises.
