### PR TITLE
feat(planning): record retry exhaustion as a distinct stranding cause

### DIFF
--- a/src/bernstein/core/planning/workflow_dsl.py
+++ b/src/bernstein/core/planning/workflow_dsl.py
@@ -850,6 +850,28 @@ BLOCKING_NODE_METADATA_KEY = "blocking_task_id"
 # The inbound edges that all resolved SKIPPED, rendered "source -> target".
 SKIPPED_EDGES_METADATA_KEY = "skipped_edges"
 
+# Why the blocking node named by BLOCKING_NODE_METADATA_KEY is blocking. A second
+# key rather than a richer value under the existing one, so every reader that
+# already looks up ``blocking_task_id`` keeps working untouched.
+BLOCKING_CAUSE_METADATA_KEY = "blocking_cause"
+
+
+class BlockingCause(StrEnum):
+    """Why a stranded node's blocking dependency never let it run.
+
+    The outcome is the same either way - the dependent is stranded - but the
+    operator response is not. A node that failed once with no retry policy may
+    just need one, while a node that burned every attempt it was given is
+    saying the failure is not transient. Both looked identical on the record
+    before this existed.
+    """
+
+    #: The blocking node reached a terminal non-success state, and either
+    #: declared no retry policy or never exhausted one.
+    DEPENDENCY_FAILED = "dependency_failed"
+    #: The blocking node declared ``retry:`` and used up ``max_attempts``.
+    RETRY_EXHAUSTED = "retry_exhausted"
+
 
 class DAGExecutor:
     """Drives task scheduling through a conditional DAG.
@@ -1026,6 +1048,7 @@ class DAGExecutor:
                 if blocking_node is None:
                     continue
                 blocked.metadata[BLOCKING_NODE_METADATA_KEY] = blocking_node
+                blocked.metadata[BLOCKING_CAUSE_METADATA_KEY] = str(self._blocking_cause(blocking_node))
                 blocked.result_summary = f"dependency {blocking_node} is {tasks[blocking_node].status.value}"
                 ring[node.id] = blocked
 
@@ -1098,6 +1121,23 @@ class DAGExecutor:
             f"{edge.source} -> {edge.target}" for edge in sorted(incoming, key=lambda e: (e.source, e.target))
         ]
         return task
+
+    def _blocking_cause(self, node_id: str) -> BlockingCause:
+        """Classify why ``node_id`` is blocking its dependents.
+
+        Only a node that declared a retry policy AND used up ``max_attempts``
+        counts as exhausted. A node whose ``until`` condition was met stopped
+        deliberately with attempts to spare, which is not the same statement
+        about the failure, so it stays ``DEPENDENCY_FAILED``.
+        """
+        node = self._node_map.get(node_id)
+        if node is None or node.retry is None:
+            return BlockingCause.DEPENDENCY_FAILED
+
+        if self._retry_counts.get(node_id, 0) >= node.retry.max_attempts:
+            return BlockingCause.RETRY_EXHAUSTED
+
+        return BlockingCause.DEPENDENCY_FAILED
 
     def should_retry(self, node_id: str, task: Task) -> bool:
         """Check if a failed task should be retried per the node's retry policy.

--- a/tests/unit/test_workflow_dsl.py
+++ b/tests/unit/test_workflow_dsl.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 from bernstein.core.models import Task, TaskStatus
 from bernstein.core.workflow import WorkflowDefinition, WorkflowPhase
 from bernstein.core.workflow_dsl import (
+    BLOCKING_CAUSE_METADATA_KEY,
     BLOCKING_NODE_METADATA_KEY,
     SKIPPED_EDGES_METADATA_KEY,
     ConditionError,
@@ -1247,6 +1248,52 @@ class TestUnreachableNodes:
         # Derivable from the record alone, and the node stays off the ready list.
         assert executor.unreachable_nodes(tasks) == [("deploy", "test")]
         assert "deploy" not in executor.ready_nodes(tasks)
+
+    def test_stranding_cause_distinguishes_retry_exhaustion_from_plain_failure(self) -> None:
+        """A dependent must record WHY its blocker blocked, not just which node.
+
+        Both cases strand the dependent identically; the operator response
+        differs. A node that failed once with no retry policy may just need
+        one, while a node that burned every attempt is saying the failure is
+        not transient.
+        """
+        dag = WorkflowDAG(
+            definition=_simple_definition(),
+            nodes=(
+                DAGNode(id="test", phase="plan", role="qa", retry=RetryPolicy(max_attempts=2)),
+                DAGNode(id="deploy", phase="verify", role="manager"),
+            ),
+            edges=(DAGEdge(source="test", target="deploy", condition=ConditionExpr(raw="status == 'done'")),),
+        )
+
+        # Failed once, one attempt still available: not exhausted.
+        executor = DAGExecutor(dag)
+        tasks = {"test": _task("test", role="qa", status=TaskStatus.FAILED)}
+        executor.record_retry("test")
+        assert executor.should_retry("test", tasks["test"]) is True
+
+        assert executor.materialize_unreachable(tasks) == ["deploy"]
+        assert tasks["deploy"].metadata[BLOCKING_CAUSE_METADATA_KEY] == "dependency_failed"
+
+        # Same graph, same failure, but every attempt used up.
+        exhausted = DAGExecutor(dag)
+        tasks = {"test": _task("test", role="qa", status=TaskStatus.FAILED)}
+        exhausted.record_retry("test")
+        exhausted.record_retry("test")
+        assert exhausted.should_retry("test", tasks["test"]) is False
+
+        assert exhausted.materialize_unreachable(tasks) == ["deploy"]
+        assert tasks["deploy"].metadata[BLOCKING_CAUSE_METADATA_KEY] == "retry_exhausted"
+
+        # The existing key is untouched by the addition.
+        assert tasks["deploy"].metadata[BLOCKING_NODE_METADATA_KEY] == "test"
+
+    def test_node_without_retry_policy_is_never_retry_exhausted(self) -> None:
+        executor = DAGExecutor(self._guarded_dag("status == 'done'"))
+        tasks = {"test": _task("test", role="qa", status=TaskStatus.FAILED)}
+
+        assert executor.materialize_unreachable(tasks) == ["deploy"]
+        assert tasks["deploy"].metadata[BLOCKING_CAUSE_METADATA_KEY] == "dependency_failed"
 
     def test_all_of_several_inbound_edges_skipped(self) -> None:
         executor = DAGExecutor(self._fan_in_dag())


### PR DESCRIPTION
Closes #4292. Part of #4260.

## Shape

I went with the **second metadata key** option rather than enriching `blocking_task_id`'s value, so every existing reader of `blocking_task_id` — including the task store's own cascade, which deliberately shares the key — keeps working untouched.

```python
BLOCKING_CAUSE_METADATA_KEY = "blocking_cause"

class BlockingCause(StrEnum):
    DEPENDENCY_FAILED = "dependency_failed"
    RETRY_EXHAUSTED = "retry_exhausted"
```

An enum rather than a `retry_exhausted: bool`, because the parent issue's direction is "distinguishable cause" and a bool can only ever answer one question — #4260's other slices may want to name further causes without a second boolean.

Stamped at the same site as `blocking_task_id` (`materialize_unreachable`), so the cause is readable from exactly where the issue asked, not a side channel.

## The one judgment call

`should_retry` returns `False` for three different reasons: no retry policy, attempts exhausted, or the `until` condition matched. Only the middle one is exhaustion.

A node whose `until` was satisfied **stopped deliberately with attempts to spare** — that is not the same statement about the failure, and reporting it as `retry_exhausted` would mislead exactly the operator this axis is for. So `_blocking_cause` checks the policy and the count directly rather than reusing `should_retry`'s boolean.

## Testing

`test_stranding_cause_distinguishes_retry_exhaustion_from_plain_failure` runs the *same graph and same failure* twice, differing only in how many attempts were recorded:

- one `record_retry` on a `max_attempts=2` node → `should_retry` still `True` → cause is `dependency_failed`
- two `record_retry` calls → `should_retry` `False` → cause is `retry_exhausted`

and asserts `blocking_task_id` is unchanged by the addition. Plus `test_node_without_retry_policy_is_never_retry_exhausted` for the no-policy path.

Confirmed the test actually discriminates rather than passing on shape: neutering the exhaustion branch so the classifier always returns the plain cause gives

```
AssertionError: assert 'dependency_failed' == 'retry_exhausted'
```

```
uv run python scripts/run_tests.py tests/unit/test_workflow_dsl.py tests/unit/planning/   # 9 files passed
uv run ruff format --check src/                                                           # clean
uv run ruff check <changed files>                                                         # All checks passed
uv run mypy src/bernstein/core/planning/workflow_dsl.py                                   # Success
```
