### PR TITLE
fix(observability): keep a failed target's metric lines for the next flush

### DIFF
--- a/src/bernstein/core/observability/metric_collector.py
+++ b/src/bernstein/core/observability/metric_collector.py
@@ -974,6 +974,10 @@ class MetricsCollector:
         for directory, filename, line in batch:
             by_file.setdefault((directory, filename), []).append(line)
 
+        # Lines whose target write failed. Collected rather than re-queued
+        # inline so the remaining targets in this batch are still attempted.
+        failed: list[tuple[AnchoredDir, str, str]] = []
+
         for (directory, filename), lines in by_file.items():
             try:
                 # Bound per-file growth: rotate *before* appending so the new
@@ -995,6 +999,26 @@ class MetricsCollector:
                     f.write("\n".join(lines) + "\n")
             except OSError:
                 logger.exception("Failed to flush metrics to %s", directory.path / filename)
+                failed.extend((directory, filename, line) for line in lines)
+
+        if failed:
+            # Put the failed target's lines back so a later flush() can retry
+            # them. They were drained before any write was attempted, so
+            # without this a transient ENOSPC or a briefly unwritable tenant
+            # directory silently destroyed that target's copy while the shared
+            # copy survived - a divergence nothing downstream could detect.
+            #
+            # Prepended, not appended: anything enqueued while this flush was
+            # writing is newer, so putting the retries in front keeps each
+            # target's lines in the order they were recorded. Only the failed
+            # target's lines come back, so a target that wrote successfully is
+            # neither undone nor duplicated.
+            #
+            # Deliberately unbounded here: capping retries for a permanently
+            # failing target is a separate concern, and dropping data by
+            # default is the behaviour this is fixing.
+            with self._lock:
+                self._buffer[:0] = failed
 
     def flush(self) -> None:
         """Flush the write buffer to disk. Call this each orchestrator tick."""

--- a/tests/unit/test_metrics_batching.py
+++ b/tests/unit/test_metrics_batching.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 import json
 import threading
 import time
-from typing import TYPE_CHECKING
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from bernstein.core.metrics import MetricsCollector, MetricType
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 @pytest.fixture
@@ -185,3 +183,82 @@ def test_accepted_tenant_label_queues_both_destinations(collector: MetricsCollec
 
     assert len(collector._buffer) == 2
     assert len({directory for directory, _, _ in collector._buffer}) == 2
+
+
+# ---------------------------------------------------------------------------
+# A failed target's lines survive the flush that failed to write them
+# ---------------------------------------------------------------------------
+
+
+def _fail_writes_under(tenant_segment: str):
+    """Wrap ``anchored_append`` so only the tenant target raises OSError."""
+    import bernstein.core.observability.metric_collector as mc
+
+    real = mc.anchored_append
+
+    def _appender(directory, filename, *args, **kwargs):
+        if tenant_segment in str(directory.path):
+            raise OSError("simulated: tenant volume unwritable")
+        return real(directory, filename, *args, **kwargs)
+
+    return _appender
+
+
+def _lines_in(path: Path) -> list[str]:
+    return [line for line in path.read_text().splitlines() if line]
+
+
+def test_failed_target_write_does_not_discard_its_lines(collector: MetricsCollector, tmp_path: Path) -> None:
+    """A transient write failure must not destroy that target's copy.
+
+    ``_flush_buffer`` drains the buffer before attempting any write, so a
+    target whose write raised had its lines already removed with nowhere to
+    go. The shared copy survived and the tenant copy did not, leaving the two
+    views permanently divergent with nothing downstream able to notice.
+    """
+    collector._write_metric_point(MetricType.API_USAGE, 1.0, {"tenant_id": "team-a"})
+    assert len(collector._buffer) == 2
+
+    shared_file = tmp_path / "metrics" / f"api_usage_{time.strftime('%Y-%m-%d')}.jsonl"
+    tenant_file = tmp_path / "team-a" / "metrics" / shared_file.name
+
+    with patch(
+        "bernstein.core.observability.metric_collector.anchored_append",
+        _fail_writes_under("team-a"),
+    ):
+        collector.flush()
+
+    # The healthy target was written, and the failed one is still pending.
+    assert len(_lines_in(shared_file)) == 1
+    assert not tenant_file.exists() or _lines_in(tenant_file) == []
+    assert len(collector._buffer) == 1
+
+    # The volume comes back; the next flush lands the line it could not write.
+    collector.flush()
+
+    assert len(_lines_in(tenant_file)) == 1
+    assert collector._buffer == []
+
+    # ...and the target that already succeeded was not written a second time.
+    assert len(_lines_in(shared_file)) == 1
+    assert _lines_in(shared_file) == _lines_in(tenant_file)
+
+
+def test_retried_lines_keep_their_recorded_order(collector: MetricsCollector, tmp_path: Path) -> None:
+    """Retries go in front of whatever was enqueued while the flush ran."""
+    collector._write_metric_point(MetricType.API_USAGE, 1.0, {"tenant_id": "team-a"})
+
+    with patch(
+        "bernstein.core.observability.metric_collector.anchored_append",
+        _fail_writes_under("team-a"),
+    ):
+        collector.flush()
+
+    # A newer point for the same tenant arrives after the failed flush.
+    collector._write_metric_point(MetricType.API_USAGE, 2.0, {"tenant_id": "team-a"})
+    collector.flush()
+
+    tenant_file = tmp_path / "team-a" / "metrics" / f"api_usage_{time.strftime('%Y-%m-%d')}.jsonl"
+    values = [json.loads(line)["value"] for line in _lines_in(tenant_file)]
+
+    assert values == [1.0, 2.0], "the retried line must precede the one recorded after it"


### PR DESCRIPTION
Closes #4305. Part of #3710.

## Change

`_flush_buffer` collects the lines of any target whose write raised, and puts them back on the buffer:

```python
        if failed:
            with self._lock:
                self._buffer[:0] = failed
```

Nothing else in the method moves — the drain-under-lock batching, the `by_file` grouping, the rotate-then-append order and the per-target `except OSError` are all left intact, and `_write_metric_point`'s target-resolution-before-enqueue ordering is untouched.

## The two decisions the issue left open

**Where retry state lives:** refilling the same `self._buffer`, not a separate per-target structure. It reuses the existing `list[tuple[AnchoredDir, str, str]]` shape, so `flush()` needs no new path and there is no second thing to keep consistent — the retry mechanism is "the lines are still in the buffer", which is what a reader would assume anyway.

**Ordering:** failed lines are **prepended**, and per-target order survives a retry. Anything enqueued while the flush was writing (the lock is not held then, by design) is strictly newer, so putting the retries in front keeps each target's lines in the order they were recorded. This is asserted, not just claimed — see the second test.

Only the failed target's lines come back, so a target that wrote successfully is neither undone nor duplicated.

## Failing-first

Both tests are red on unmodified `main`:

```
test_failed_target_write_does_not_discard_its_lines
    assert len(collector._buffer) == 1
E   assert 0 == 1
```

The buffer is empty — the lines are gone, which is the defect.

```
test_retried_lines_keep_their_recorded_order
    assert values == [1.0, 2.0]
E   assert [2.0] == [1.0, 2.0]
```

The first point was silently lost; only the one recorded after the failed flush ever reached the file.

The first test also pins the no-duplication half: after the tenant volume "recovers" and a second `flush()` lands the retried line, the shared file still carries each line exactly once, and both files end up with identical content.

Only the tenant write is made to fail (a wrapper around `anchored_append` that raises for that directory), so the shared write in the same batch succeeds — which is the divergence case the issue describes, not a blanket "all writes fail".

## Explicitly not in this PR

No retention bound or drop-after-N policy — that is the companion sub-issue, and it builds on the retry mechanism this introduces. Retries are unbounded here on purpose: dropping data by default is the behaviour being fixed. A permanently failing target will keep its lines buffered and keep triggering the size-based flush check, which is exactly the pressure the bound issue exists to relieve.

This also does not make writes mandatory — a dead disk still never blocks the caller; the buffer stays best-effort.

## Verification

```
uv run python scripts/run_tests.py tests/unit/test_metrics_batching.py tests/unit/test_metric_collector.py tests/unit/test_metrics.py   # 3 files passed
uv run ruff format --check src/                                        # clean
uv run ruff check <changed files>                                      # All checks passed
uv run mypy src/bernstein/core/observability/metric_collector.py       # 1 error, pre-existing on main (PluginManager.hook), unrelated
```
