### PR TITLE
fix(mcp): point the MCP bridge spec at a runnable entrypoint

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -13,3 +13,7 @@ rather than as its own attribution is exempted by hand there, with the reason.
 ## Added
 
 - `bernstein run` on a TTY now says it is waiting for the first agent instead of sitting silent (#4257). The wait is bounded and returns as soon as an agent registers, so a fast start stays exactly as quiet as before: the transient status appears only once a poll has already failed to produce a verdict, and clears before the dashboard or the Rich fallback renders. The non-interactive detach path is unchanged.
+
+## Fixed
+
+- The `bernstein` MCP bridge injected into every agent spawn pointed at `python -m bernstein.mcp.server`, a module with no `__main__` guard: running it imported the module and exited 0 without ever answering the MCP handshake (#4313). Every spawned agent's init event showed the `bernstein` server as disconnected and never received the bridge tools (`bernstein_post_message`, `bernstein_claim`, `bernstein_complete`, and the rest), so anything downstream that depends on agent-posted progress signals starved silently. The spawn spec now points at the package's own stdio entrypoint, `python -m bernstein.mcp` (`bernstein/mcp/__main__.py` -> `run_stdio()`), and `bernstein/mcp/server.py` gained a `__main__` guard calling the same `run_stdio()` directly, so the previously-specced module path answers too.

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -881,11 +881,12 @@ class ClaudeCodeAdapter(CLIAdapter):
         self._inject_hooks_config(workdir, session_id)
 
         # Inject Bernstein MCP bridge so agents can report progress, check
-        # sibling status, and read the bulletin board.  Uses the existing
-        # bernstein.mcp.server module in stdio transport mode.
+        # sibling status, and read the bulletin board.  Uses the bernstein.mcp
+        # package's stdio entrypoint (bernstein/mcp/__main__.py -> run_stdio()).
+        # bernstein.mcp.server has no __main__ guard on its own - see #4313.
         bridge_server: dict[str, Any] = {
             "command": sys.executable,
-            "args": ["-m", "bernstein.mcp.server"],
+            "args": ["-m", "bernstein.mcp"],
         }
         effective_mcp: dict[str, Any] = {}
         if mcp_config:

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -2405,3 +2405,11 @@ def run_sse(
     import uvicorn
 
     uvicorn.run(mcp.sse_app(), host=host, port=port)
+
+
+if __name__ == "__main__":
+    # bernstein/mcp/__main__.py is the documented ``python -m bernstein.mcp``
+    # entrypoint and already calls run_stdio() unconditionally. This guard
+    # covers the same invocation via ``python -m bernstein.mcp.server``
+    # directly, which has no __main__ guard of its own - see #4313.
+    run_stdio()

--- a/tests/unit/test_adapter_claude.py
+++ b/tests/unit/test_adapter_claude.py
@@ -210,6 +210,60 @@ class TestSpawnCommandArgs:
         parsed = json.loads(cmd[cmd.index("--mcp-config") + 1])
         assert "bernstein" in parsed["mcpServers"]
 
+    def test_bernstein_bridge_targets_the_package_entrypoint(self, tmp_path: Path) -> None:
+        """The bridge spec must spawn a module that actually answers stdio (#4313).
+
+        ``bernstein.mcp.server`` has no ``__main__`` guard, so ``-m
+        bernstein.mcp.server`` imports it and exits 0 without ever starting
+        the server. ``bernstein.mcp`` (``__main__.py``) is the entrypoint
+        that calls ``run_stdio()``.
+        """
+        cmd, _, __ = self._spawn(tmp_path, mcp_config=None)
+        parsed = json.loads(cmd[cmd.index("--mcp-config") + 1])
+        bridge = parsed["mcpServers"]["bernstein"]
+        assert bridge["args"] == ["-m", "bernstein.mcp"]
+
+    def test_bernstein_bridge_spec_answers_initialize_over_stdio(self, tmp_path: Path) -> None:
+        """Regression for #4313: subprocess round-trip, no orchestrator involved.
+
+        Spawns the exact command+args the adapter injects for the bridge
+        server as a real subprocess and checks it answers an ``initialize``
+        request. This is what actually broke: the previous spec started a
+        process that exited 0 without ever answering the handshake, so
+        every agent's ``bernstein`` MCP server showed as disconnected.
+        """
+        cmd, _, __ = self._spawn(tmp_path, mcp_config=None)
+        parsed = json.loads(cmd[cmd.index("--mcp-config") + 1])
+        bridge = parsed["mcpServers"]["bernstein"]
+
+        request = (
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "clientInfo": {"name": "regression-test", "version": "1"},
+                    },
+                }
+            )
+            + "\n"
+        )
+        proc = subprocess.run(
+            [bridge["command"], *bridge["args"]],
+            input=request,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert proc.stdout.strip(), f"bridge server produced no stdout; stderr={proc.stderr}"
+        response = json.loads(proc.stdout.splitlines()[0])
+        assert response["id"] == 1
+        assert response["result"]["serverInfo"]["name"] == "bernstein"
+
 
 # ---------------------------------------------------------------------------
 # spawn() - two-process pipeline wiring

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1335,3 +1335,45 @@ def test_cancel_has_an_explicit_standard_tier_entry() -> None:
     from bernstein.core.protocols.mcp.tool_tiers import TOOL_TIERS
 
     assert TOOL_TIERS["bernstein_cancel"] == "standard"
+
+
+def test_server_module_has_a_main_guard_that_answers_initialize() -> None:
+    """Regression for #4313: ``python -m bernstein.mcp.server`` must answer stdio.
+
+    The module previously had no ``__main__`` guard, so running it directly
+    imported the module and exited 0 without ever starting the server. The
+    MCP bridge spec injected into every agent spawn pointed at exactly this
+    module path, so every agent's ``bernstein`` bridge silently failed to
+    connect. This spawns the module directly, the same way the broken spec
+    did, and checks it now answers ``initialize`` over stdio.
+    """
+    import subprocess
+    import sys
+
+    request = (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "regression-test", "version": "1"},
+                },
+            }
+        )
+        + "\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-m", "bernstein.mcp.server"],
+        input=request,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert proc.stdout.strip(), f"server module produced no stdout; stderr={proc.stderr}"
+    response = json.loads(proc.stdout.splitlines()[0])
+    assert response["id"] == 1
+    assert response["result"]["serverInfo"]["name"] == "bernstein"


### PR DESCRIPTION
## What was broken

The `bernstein` MCP bridge injected into every agent spawn (`src/bernstein/adapters/claude.py`, `bridge_server` spec) pointed at:

```python
"args": ["-m", "bernstein.mcp.server"]
```

`bernstein/mcp/server.py` has no `__main__` guard, so `python -m bernstein.mcp.server` imports the module and exits 0 without ever answering the MCP handshake. Every spawned agent's init event showed the `bernstein` server as `disconnected`, and the agent never received the bridge tools (`bernstein_post_message`, `bernstein_claim`, `bernstein_complete`, ...). Anything downstream that depends on agent-posted progress signals starved silently.

## Root cause

The spec assumed the module itself was directly runnable via `-m`. The actual stdio entrypoint is the package: `bernstein/mcp/__main__.py` → `run_stdio()` (i.e. `python -m bernstein.mcp`, not `python -m bernstein.mcp.server`).

## What changed

Both sides, per the issue's "cheapest insurance" note:

- `src/bernstein/adapters/claude.py`: `bridge_server["args"]` now targets `-m bernstein.mcp`.
- `src/bernstein/mcp/server.py`: gained its own `if __name__ == "__main__": run_stdio()` guard, so the previously-specced module path (`bernstein.mcp.server`) also answers directly.

As a side effect, this also repairs the `.claude/mcp.json` entry written by the auto-discovery bootstrap path (`_register_mcp_discovery` in `src/bernstein/core/orchestration/bootstrap.py`), which independently writes `["-m", "bernstein.mcp.server"]`. That call site is untouched and stays pinned by its existing test (`tests/unit/test_mcp_discovery.py`) — it now works because the module it names is runnable, not because its args changed.

## Tests

Added (real subprocess round-trip over stdio, no orchestrator involved):

- `tests/unit/test_adapter_claude.py::TestSpawnCommandArgs::test_bernstein_bridge_targets_the_package_entrypoint`
- `tests/unit/test_adapter_claude.py::TestSpawnCommandArgs::test_bernstein_bridge_spec_answers_initialize_over_stdio`
- `tests/unit/test_mcp_server.py::test_server_module_has_a_main_guard_that_answers_initialize`

All three were verified to fail against the pre-fix source (reverted the two source files, reran, confirmed failure) and pass with the fix applied.

```
$ uv run pytest tests/unit/test_adapter_claude.py tests/unit/test_mcp_server.py tests/unit/test_mcp_discovery.py tests/unit/test_unreleased_notes_rotation.py -q
207 passed, 290 warnings in 21.55s
```

Also clean: `uv run ruff check`, `uv run ruff format --check`, `uv run lint-imports` on the touched files. `uv run pyright` on the two touched source files reports the same 131 pre-existing errors with and without this diff (confirmed via git stash comparison) — none introduced by this change.

Closes #4313
