### PR TITLE
feat(agents): classify a zero-token fast clean exit as a transport failure

### DIFF
--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -1523,7 +1523,15 @@ def _probe_fast_exit(
         A dict (never a bare bool) with keys: ``suspicious`` (bool),
         ``runtime_s`` (float), ``exit_code`` (int | None), ``manifest_path``
         (str | None), ``log_path`` (str | None), ``log_tail`` (list[str]),
-        ``session_id`` (str), ``task_id`` (str).
+        ``session_id`` (str), ``task_id`` (str), ``tokens_used`` (int) and
+        ``no_session_activity`` (bool).
+
+        ``no_session_activity`` is the transport-failure signal: the agent
+        exited without consuming a single token, so it never exchanged
+        anything with the model. That is a different fault from an agent that
+        ran, spent tokens and produced nothing, and it needs a different
+        response - retrying a transport failure is reasonable, while retrying
+        a genuinely empty deliverable just burns the budget again.
     """
     runtime_s = time.time() - session.spawn_ts if session.spawn_ts > 0 else -1.0
     suspicious = 0 <= runtime_s < _FAST_EXIT_THRESHOLD_S
@@ -1556,6 +1564,15 @@ def _probe_fast_exit(
                 if candidate.exists():
                     manifest_path = str(candidate)
 
+    # Callers reach this probe only after no files, no commits and no
+    # completion signals were found, so the deliverable side is already known
+    # to be empty. The one thing still unanswered is whether the agent talked
+    # to the model at all, and tokens_used answers exactly that on its own -
+    # no corroborating signal would add information the caller does not
+    # already have.
+    tokens_used = int(getattr(session, "tokens_used", 0) or 0)
+    no_session_activity = tokens_used == 0
+
     result: dict[str, Any] = {
         "suspicious": suspicious,
         "runtime_s": round(runtime_s, 2),
@@ -1565,6 +1582,8 @@ def _probe_fast_exit(
         "log_tail": log_tail,
         "session_id": session.id,
         "task_id": task_id,
+        "tokens_used": tokens_used,
+        "no_session_activity": no_session_activity,
     }
 
     if suspicious:
@@ -1936,18 +1955,41 @@ def _handle_orphan_no_signals(
             )
             return _try_auto_complete(orch, task_id, base, summary, log_msg, session=session, start_ts=start_ts)
 
-        logger.warning(
-            "SUSPICIOUS clean exit: agent %s exited cleanly (exit code 0) after only %.1fs "
-            "with no files modified, no commits, and no completion signals -- NOT "
-            "auto-completing task %s; failing it as unverified. A fast empty clean exit is a "
-            "defect signal, not health. See preserved logs under .sdd/runtime/agent_logs/%s/ "
-            "for the full transcript (manifest=%s).",
-            session.id,
-            _probe_result.get("runtime_s"),
-            task_id,
-            session.id,
-            _probe_result.get("manifest_path") or "<none preserved>",
-        )
+        if _probe_result.get("no_session_activity"):
+            # Zero tokens means the agent never exchanged anything with the
+            # model: nothing was asked and nothing was answered. That is a
+            # transport failure, not an agent that ran and produced nothing,
+            # and reporting it as an unverified deliverable sends whoever
+            # reads it to inspect a transcript that does not exist. ERROR
+            # rather than WARNING because a spawn that never reached the
+            # provider is an infrastructure fault, not an agent outcome.
+            logger.error(
+                "TRANSPORT FAILURE (zero-token clean exit): agent %s exited cleanly (exit code 0) "
+                "after only %.1fs having consumed 0 tokens -- it never exchanged anything with the "
+                "model, so there is no transcript to inspect and no deliverable was ever possible. "
+                "NOT auto-completing task %s. This is a spawn/transport fault, not an empty "
+                "deliverable. See preserved logs under .sdd/runtime/agent_logs/%s/ (manifest=%s).",
+                session.id,
+                _probe_result.get("runtime_s"),
+                task_id,
+                session.id,
+                _probe_result.get("manifest_path") or "<none preserved>",
+            )
+        else:
+            logger.warning(
+                "SUSPICIOUS clean exit: agent %s exited cleanly (exit code 0) after only %.1fs "
+                "with no files modified, no commits, and no completion signals -- NOT "
+                "auto-completing task %s; failing it as unverified. A fast empty clean exit is a "
+                "defect signal, not health. It consumed %s tokens, so it did reach the model. "
+                "See preserved logs under .sdd/runtime/agent_logs/%s/ "
+                "for the full transcript (manifest=%s).",
+                session.id,
+                _probe_result.get("runtime_s"),
+                task_id,
+                _probe_result.get("tokens_used"),
+                session.id,
+                _probe_result.get("manifest_path") or "<none preserved>",
+            )
         try:
             retry_or_fail_task(
                 task_id,

--- a/tests/unit/agents/test_agent_lifecycle_helpers.py
+++ b/tests/unit/agents/test_agent_lifecycle_helpers.py
@@ -445,6 +445,10 @@ def test_suspicious_clean_exit_is_failed_not_auto_completed(
 
     session = _session(exit_code=0)
     session.spawn_ts = _time.time() - 3.0
+    # Tokens were spent, so the agent did reach the model and this is the
+    # empty-deliverable case this test is about - not a transport failure,
+    # which is covered separately below.
+    session.tokens_used = 2048
     with caplog.at_level(logging.WARNING):
         success, error_type = al._handle_orphan_no_signals(
             _orphan_orch(tmp_path), MagicMock(), "T-1", session, "http://srv", _time.time()
@@ -457,6 +461,51 @@ def test_suspicious_clean_exit_is_failed_not_auto_completed(
     warning = next(r for r in caplog.records if "SUSPICIOUS clean exit" in r.message)
     assert "A-1" in warning.message
     assert "agent_logs" in warning.message
+
+
+def test_zero_token_clean_exit_is_reported_as_a_transport_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An agent that spent no tokens never reached the model.
+
+    Same routing as any other suspicious fast exit - the task is still failed
+    rather than auto-completed - but the operator-facing signal must say
+    transport failure, not unverified deliverable. Reporting it as the latter
+    sends whoever reads it to inspect a transcript that does not exist.
+    """
+    import logging
+    import time as _time
+
+    import bernstein.core.agents.agent_lifecycle as al
+
+    monkeypatch.setattr(al, "collect_completion_data", lambda workdir, session: {"files_modified": []})
+    completed: list[str] = []
+    monkeypatch.setattr(al, "complete_task", lambda client, base, task_id, summary: completed.append(task_id))
+    failed: list[tuple[str, str]] = []
+    monkeypatch.setattr(al, "retry_or_fail_task", lambda task_id, reason, **kw: failed.append((task_id, reason)))
+
+    session = _session(exit_code=0)
+    session.spawn_ts = _time.time() - 3.0
+    session.tokens_used = 0
+
+    with caplog.at_level(logging.WARNING):
+        success, error_type = al._handle_orphan_no_signals(
+            _orphan_orch(tmp_path), MagicMock(), "T-1", session, "http://srv", _time.time()
+        )
+
+    # Routing is unchanged: still failed, never auto-completed.
+    assert success is False
+    assert error_type == "clean_exit_unverified"
+    assert completed == []
+    assert failed and failed[0][0] == "T-1"
+
+    # ...but the signal is distinguishable, and raised to ERROR.
+    record = next(r for r in caplog.records if "TRANSPORT FAILURE" in r.message)
+    assert record.levelno == logging.ERROR
+    assert "0 tokens" in record.message
+    assert not any("SUSPICIOUS clean exit" in r.message for r in caplog.records)
 
 
 def test_long_lived_clean_exit_auto_complete_does_not_warn(

--- a/tests/unit/test_agent_lifecycle.py
+++ b/tests/unit/test_agent_lifecycle.py
@@ -577,6 +577,54 @@ def test_probe_fast_exit_not_suspicious_for_long_lived_agent(tmp_path: Path) -> 
     assert result["manifest_path"] is None
 
 
+def _fast_exit_session(session_id: str, tokens_used: int) -> AgentSession:
+    """A clean, fast exit differing only in whether any tokens were spent."""
+    session = AgentSession(
+        id=session_id,
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=["T-1"],
+        exit_code=0,
+    )
+    session.spawn_ts = __import__("time").time() - 2.0
+    session.tokens_used = tokens_used
+    return session
+
+
+def test_probe_fast_exit_flags_zero_token_exit_as_no_session_activity(tmp_path: Path) -> None:
+    """Zero tokens means the agent never reached the model - a transport fault.
+
+    An agent that spent nothing produced nothing because it never exchanged
+    anything, which is a different fault from one that ran, spent tokens and
+    still produced no deliverable. Both used to be reported identically.
+    """
+    orch = SimpleNamespace()
+    orch._workdir = tmp_path
+    orch._spawner = MagicMock()
+    orch._spawner.get_worktree_path.return_value = None
+
+    result = _probe_fast_exit(orch, _fast_exit_session("sess-zero", 0), "T-1")
+
+    assert result["suspicious"] is True
+    assert result["tokens_used"] == 0
+    assert result["no_session_activity"] is True
+
+
+def test_probe_fast_exit_does_not_flag_a_fast_exit_that_spent_tokens(tmp_path: Path) -> None:
+    """Same fast clean exit, but it did reach the model: not a transport fault."""
+    orch = SimpleNamespace()
+    orch._workdir = tmp_path
+    orch._spawner = MagicMock()
+    orch._spawner.get_worktree_path.return_value = None
+
+    result = _probe_fast_exit(orch, _fast_exit_session("sess-spent", 4321), "T-1")
+
+    assert result["suspicious"] is True
+    assert result["tokens_used"] == 4321
+    assert result["no_session_activity"] is False
+
+
 def test_probe_fast_exit_falls_back_to_worktree_manifest(tmp_path: Path) -> None:
     """When no preserved manifest exists, fall back to the (still-live) worktree copy."""
     session = AgentSession(


### PR DESCRIPTION
Closes #4296.

## Change

`_probe_fast_exit` returns two new keys, `tokens_used` and `no_session_activity`, so the classification is available to callers without re-deriving it (acceptance criterion 2). The suspicious branch in `_handle_orphan_no_signals` then splits:

- **zero tokens** → `ERROR`, `"TRANSPORT FAILURE (zero-token clean exit)"`, saying explicitly that nothing was exchanged with the model and there is no transcript to inspect.
- **nonzero tokens** → the existing `WARNING`, now also reporting the token count so the two read differently at a glance.

`ERROR` rather than `WARNING` for the zero-token case because a spawn that never reached the provider is an infrastructure fault, not an agent outcome.

## The decision the issue left open

**`tokens_used == 0` alone**, with no corroborating signal.

This path is only reached after no files, no commits and no completion signals were found — the deliverable side is *already* known to be empty, and that is the precondition of the whole branch. The single open question is whether the agent reached the model at all, and `tokens_used` answers exactly that. Adding `files_changed` or similar would re-assert something the caller already established, so it would narrow the classification without adding information.

## Routing is unchanged

Both branches still fail the task rather than auto-complete it — asserted in both tests. Acting differently on the classification (e.g. not charging retry budget) is #4297, the dependent issue.

## One existing test changed, and why

`test_suspicious_clean_exit_is_failed_not_auto_completed` used `_session()`, whose `tokens_used` defaults to `0` — so under this change it took the new transport-failure branch and failed on its `"SUSPICIOUS clean exit"` assertion.

That is the test telling the truth: its scenario *was* the zero-token case, while its name and docstring (#2810/#2806, "produced no deliverable") describe the empty-deliverable case. I gave it `tokens_used = 2048` so it tests what it says it does, and added the zero-token case as its own test. Every behavioural assertion in it — not completed, failed, `clean_exit_unverified` — is untouched; only the log line it looks for changed.

## Testing

Four tests:

- `_probe_fast_exit` flags a zero-token fast exit as `no_session_activity` / does **not** flag one that spent 4321 tokens — same fast clean exit otherwise, so the token count is the only variable.
- `test_zero_token_clean_exit_is_reported_as_a_transport_failure` — asserts the `ERROR` level, `"0 tokens"` in the message, that `"SUSPICIOUS clean exit"` is *absent*, and that routing is still fail-not-complete.
- the amended empty-deliverable test, covering the other side.

Confirmed the new test is red on unmodified source:

```
FAILED tests/unit/agents/test_agent_lifecycle_helpers.py::test_zero_token_clean_exit_is_reported_as_a_transport_failure
```

```
uv run python scripts/run_tests.py tests/unit/agents/test_agent_lifecycle_helpers.py tests/unit/test_agent_lifecycle.py   # 2 files passed
uv run ruff check <changed files>    # All checks passed
uv run ruff format --check src/      # clean
```
