### PR TITLE
fix(agents): idle recycler defers to heartbeat_escalation's liveness signal

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -13,3 +13,7 @@ rather than as its own attribution is exempted by hand there, with the reason.
 ## Added
 
 - `bernstein run` on a TTY now says it is waiting for the first agent instead of sitting silent (#4257). The wait is bounded and returns as soon as an agent registers, so a fast start stays exactly as quiet as before: the transient status appears only once a poll has already failed to produce a verdict, and clears before the dashboard or the Rich fallback renders. The non-interactive detach path is unchanged.
+
+## Fixed
+
+- The idle-agent recycler now checks the same log/git liveness grace the heartbeat escalation ladder checks before recycling on stale heartbeat-file age (#4314). The two used to disagree about the same agent - heartbeat escalation would decline to escalate a session with a fresh runner log while the recycler SIGKILL'd it seconds later for the raw heartbeat-file age alone, killing agents mid-edit.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -13,7 +13,3 @@ rather than as its own attribution is exempted by hand there, with the reason.
 ## Added
 
 - `bernstein run` on a TTY now says it is waiting for the first agent instead of sitting silent (#4257). The wait is bounded and returns as soon as an agent registers, so a fast start stays exactly as quiet as before: the transient status appears only once a poll has already failed to produce a verdict, and clears before the dashboard or the Rich fallback renders. The non-interactive detach path is unchanged.
-
-## Fixed
-
-- The idle-agent recycler now checks the same log/git liveness grace the heartbeat escalation ladder checks before recycling on stale heartbeat-file age (#4314). The two used to disagree about the same agent - heartbeat escalation would decline to escalate a session with a fresh runner log while the recycler SIGKILL'd it seconds later for the raw heartbeat-file age alone, killing agents mid-edit.

--- a/src/bernstein/core/agents/agent_recycling.py
+++ b/src/bernstein/core/agents/agent_recycling.py
@@ -158,9 +158,33 @@ def _detect_idle_reason(
     # Case 2: stale heartbeat
     hb = orch._signal_mgr.read_heartbeat(session.id)
     if hb is not None and (now - hb.timestamp) >= hb_idle_s:
+        hb_age = now - hb.timestamp
         pid = session.pid
-        if pid is not None and _is_process_alive(pid) and (now - hb.timestamp) < _IDLE_LIVENESS_EXTENSION_S:
+        if pid is not None and _is_process_alive(pid) and hb_age < _IDLE_LIVENESS_EXTENSION_S:
             return None  # still alive, within extended window
+
+        # Liveness gate (issue #4314): a stale heartbeat FILE must not
+        # out-vote heartbeat_escalation's own liveness verdict for the same
+        # agent. heartbeat.py's _escalate_heartbeat declines to SIGTERM a
+        # stuck agent whose log/git tree changed within the grace window;
+        # this recycler used to ignore that signal entirely and SIGKILL the
+        # SAME agent seconds later for heartbeat-file age alone, so whichever
+        # of the two disagreeing subsystems was harsher always won - agents
+        # got killed mid-edit. Reuse the exact verdict heartbeat_escalation
+        # uses so the two paths can no longer disagree.
+        # _agent_has_fresh_liveness_signal always logs the per-signal ages it
+        # checked (its own "liveness_judgment" line), so a recycle decision
+        # here is diagnosable the same way a deferred escalation already is.
+        has_fresh_liveness = heartbeat_protocol._agent_has_fresh_liveness_signal(orch, session)
+        if has_fresh_liveness and heartbeat_protocol._liveness_signal_may_defer(hb_age):
+            logger.info(
+                "agent_recycling: NOT recycling agent %s despite heartbeat age %.0fs -- "
+                "fresh log/git liveness signal within grace window (same verdict "
+                "heartbeat_escalation uses)",
+                session.id,
+                hb_age,
+            )
+            return None
         return f"no_heartbeat_{int(hb_idle_s)}s"
 
     # Case 3: no assigned tasks and role queue empty

--- a/tests/unit/agents/test_agent_recycling_paths.py
+++ b/tests/unit/agents/test_agent_recycling_paths.py
@@ -122,6 +122,53 @@ def test_detect_idle_reason_stale_heartbeat() -> None:
     assert reason == "no_heartbeat_300s"
 
 
+def test_detect_idle_reason_defers_when_heartbeat_escalation_reports_fresh_liveness() -> None:
+    """Issue #4314: the recycler must consult the SAME liveness verdict
+    heartbeat_escalation uses before recycling on stale heartbeat-file age
+    alone - agents were getting SIGKILL'd here seconds after
+    heartbeat_escalation had declined to SIGTERM the identical agent for the
+    identical reason (fresh log/git liveness).
+    """
+    orch = _orch_for_detect(hb_ts=600.0)  # age 400 > 300, past hb_idle_s
+    with (
+        patch.object(ar.heartbeat_protocol, "_agent_has_fresh_liveness_signal", return_value=True),
+        patch.object(ar.heartbeat_protocol, "_liveness_signal_may_defer", return_value=True),
+    ):
+        reason = _detect_idle_reason(
+            orch, _session(task_ids=["TX"]), 1000.0, 300.0, set(), {"backend": 1}, {"backend": 1}
+        )
+    assert reason is None
+
+
+def test_detect_idle_reason_recycles_when_no_fresh_liveness_signal() -> None:
+    """Without a fresh log/git liveness signal, stale heartbeat-file age
+    still recycles the agent - the gate defers, it does not exempt."""
+    orch = _orch_for_detect(hb_ts=600.0)
+    with (
+        patch.object(ar.heartbeat_protocol, "_agent_has_fresh_liveness_signal", return_value=False),
+        patch.object(ar.heartbeat_protocol, "_liveness_signal_may_defer", return_value=True),
+    ):
+        reason = _detect_idle_reason(
+            orch, _session(task_ids=["TX"]), 1000.0, 300.0, set(), {"backend": 1}, {"backend": 1}
+        )
+    assert reason == "no_heartbeat_300s"
+
+
+def test_detect_idle_reason_recycles_past_suppression_cap_even_if_fresh() -> None:
+    """A fresh log/git signal cannot defer past the suppression cap (#3058) -
+    a heartbeat silent long enough always recycles, even with log activity.
+    """
+    orch = _orch_for_detect(hb_ts=600.0)
+    with (
+        patch.object(ar.heartbeat_protocol, "_agent_has_fresh_liveness_signal", return_value=True),
+        patch.object(ar.heartbeat_protocol, "_liveness_signal_may_defer", return_value=False),
+    ):
+        reason = _detect_idle_reason(
+            orch, _session(task_ids=["TX"]), 1000.0, 300.0, set(), {"backend": 1}, {"backend": 1}
+        )
+    assert reason == "no_heartbeat_300s"
+
+
 def test_detect_idle_reason_role_queue_empty_no_tasks() -> None:
     """An agent with no tasks and an empty role queue is idle."""
     orch = _orch_for_detect(None)

--- a/tests/unit/test_idle_agent_recycling.py
+++ b/tests/unit/test_idle_agent_recycling.py
@@ -33,6 +33,8 @@ from bernstein.core.models import (
     TaskType,
 )
 
+from bernstein.core.defaults import AGENT
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -326,6 +328,81 @@ def test_fresh_heartbeat_agent_not_recycled(tmp_path: Path) -> None:
 
     orch._signal_mgr.write_shutdown.assert_not_called()
     orch._spawner.kill.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Liveness gate (#4314): recycler must honor heartbeat_escalation's own
+# log/git freshness verdict instead of recycling on heartbeat-file age alone
+# ---------------------------------------------------------------------------
+
+
+def test_stale_heartbeat_file_defers_to_fresh_log_mtime(tmp_path: Path) -> None:
+    """A stale heartbeat FILE plus a fresh runner-log mtime must survive the
+    recycler sweep - matching heartbeat_escalation's own decision to decline
+    a SIGTERM for the identical signal (evidence in #4314: heartbeat_escalation
+    logged "NOT escalating ... fresh log/git liveness signal" for an agent
+    that agent_recycling SIGKILL'd 3 seconds later).
+    """
+    orch = _make_orch(tmp_path)
+    session = _make_session(["T-live-1"], session_id="s-live-01")
+    orch._agents["s-live-01"] = session
+
+    # Past both the heartbeat threshold (300s) and the coarse PID-liveness
+    # extension (600s), so only the new log/git liveness gate can defer.
+    stale_ts = time.time() - (_IDLE_LIVENESS_EXTENSION_S + 5)
+    orch._signal_mgr.read_heartbeat.return_value = AgentHeartbeat(timestamp=stale_ts)
+
+    # Runner log was written moments ago - the agent is demonstrably still
+    # working (e.g. mid-edit), same signal heartbeat_escalation checks.
+    log_path = tmp_path / ".sdd" / "runtime" / f"{session.id}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("still working\n")
+
+    tasks_snapshot = {
+        "done": [],
+        "failed": [],
+        "open": [_make_task(id="T-live-1", status="open")],
+        "claimed": [],
+        "blocked": [],
+    }
+
+    recycle_idle_agents(orch, tasks_snapshot)
+
+    orch._signal_mgr.write_shutdown.assert_not_called()
+    orch._spawner.kill.assert_not_called()
+
+
+def test_stale_heartbeat_recycles_past_suppression_cap_despite_fresh_log(tmp_path: Path) -> None:
+    """The log/git liveness defer is bounded, not a permanent exemption
+    (mirrors heartbeat.py issue #3058): once the heartbeat has been silent
+    past the suppression cap the recycler must recycle even with a fresh log
+    mtime - otherwise a stuck agent whose log keeps absorbing provider retry
+    chatter would hold its worker slot forever.
+    """
+    orch = _make_orch(tmp_path)
+    session = _make_session(["T-stuck-1"], session_id="s-stuck-01")
+    orch._agents["s-stuck-01"] = session
+
+    stale_ts = time.time() - (AGENT.liveness_suppression_cap_s + 5)
+    orch._signal_mgr.read_heartbeat.return_value = AgentHeartbeat(timestamp=stale_ts)
+
+    log_path = tmp_path / ".sdd" / "runtime" / f"{session.id}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("noise\n")
+
+    tasks_snapshot = {
+        "done": [],
+        "failed": [],
+        "open": [_make_task(id="T-stuck-1", status="open")],
+        "claimed": [],
+        "blocked": [],
+    }
+
+    recycle_idle_agents(orch, tasks_snapshot)
+
+    orch._signal_mgr.write_shutdown.assert_called_once()
+    call_args = orch._signal_mgr.write_shutdown.call_args
+    assert "no_heartbeat_" in call_args.kwargs["reason"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/volunteer/test_volunteer_submission.py
+++ b/tests/unit/volunteer/test_volunteer_submission.py
@@ -12,7 +12,6 @@ import pytest
 
 from bernstein.core.git.git_basic import GitResult
 
-from bernstein.core.git.git_pr import push_head_as
 
 @pytest.fixture
 def isolated_pacing(tmp_path: Path):
@@ -193,7 +192,10 @@ def test_pacing_releases_after_the_tracked_pr_is_merged(tmp_path: Path, isolated
     # Mock DCO and push so we don't need real git config or a real repo
     with (
         patch("bernstein.core.volunteer.submission.read_dco_line", return_value="Jane Doe <jane@example.com>"),
-        patch("bernstein.core.volunteer.submission.push_head_as", return_value=GitResult(returncode=0, stdout="", stderr="")),
+        patch(
+            "bernstein.core.volunteer.submission.push_head_as",
+            return_value=GitResult(returncode=0, stdout="", stderr=""),
+        ),
     ):
         pr_url = submit_volunteer_pr(
             bundle=_make_bundle(),


### PR DESCRIPTION
## What was broken

`agent_recycling.recycle_idle_agents` killed actively-working agents for
`no_heartbeat_300s` while, in the same seconds, `heartbeat.check_stale_agents`
(the heartbeat escalation ladder) checked the identical agent's log/git
liveness and explicitly declined to escalate it. The two subsystems
disagreed about the same liveness question and the harsher one always won:
a live agent mid-edit got SIGTERM'd/SIGKILL'd.

Evidence from the issue (`spawner.log`, same agent, 3 seconds apart):

```
12:12:51 heartbeat: NOT escalating agent docs-80f8f907 despite heartbeat age 632s -- fresh log/git liveness signal within grace window
12:12:54 agent_recycling: Recycled idle agent docs-80f8f907 (no_heartbeat_300s - no exit after 30s SHUTDOWN grace)
```

## Root cause

`heartbeat.py`'s `_escalate_heartbeat` checks `_agent_has_fresh_liveness_signal`
(log/git mtime within `AGENT.liveness_grace_s`, bounded by
`AGENT.liveness_suppression_cap_s`) before it will SIGTERM a stale-heartbeat
agent. `agent_recycling.py`'s `_detect_idle_reason` never consulted that
signal at all - it only checked the raw heartbeat-file age plus a coarser,
unrelated PID-alive extension window (`_IDLE_LIVENESS_EXTENSION_S`, 600s).
Once heartbeat age passed that 600s extension, the recycler had no further
gate and killed on file age alone, regardless of what the escalation ladder
had just decided about the same agent.

## What changed

`_detect_idle_reason`'s stale-heartbeat case (Case 2) now reuses
`heartbeat._agent_has_fresh_liveness_signal` and
`heartbeat._liveness_signal_may_defer` - the exact same functions
`heartbeat_escalation` uses - before returning a recycle reason. If the
agent has a fresh log/git signal within grace (and the heartbeat hasn't been
silent long enough to exceed the suppression cap), the recycler defers and
logs why, instead of recycling. Past the cap the defer stops applying, same
as the escalation ladder: this is a bounded grace, not a permanent
exemption.

## Test evidence

```
tests/unit/agents/test_agent_recycling_paths.py::test_detect_idle_reason_defers_when_heartbeat_escalation_reports_fresh_liveness PASSED
tests/unit/agents/test_agent_recycling_paths.py::test_detect_idle_reason_recycles_when_no_fresh_liveness_signal PASSED
tests/unit/agents/test_agent_recycling_paths.py::test_detect_idle_reason_recycles_past_suppression_cap_even_if_fresh PASSED
tests/unit/test_idle_agent_recycling.py::test_stale_heartbeat_file_defers_to_fresh_log_mtime PASSED
tests/unit/test_idle_agent_recycling.py::test_stale_heartbeat_recycles_past_suppression_cap_despite_fresh_log PASSED
```

Also ran the full existing suites for every module this PR touches or relies
on, plus the changelog-rotation guard - all green, no regressions:

```
uv run pytest tests/unit/agents/test_agent_recycling_paths.py \
  tests/unit/test_idle_agent_recycling.py \
  tests/unit/test_heartbeat_escalation.py \
  tests/unit/test_heartbeat.py \
  tests/unit/test_heartbeat_liveness_gate.py \
  tests/unit/agents/test_heartbeat_paths.py \
  tests/unit/test_unreleased_notes_rotation.py -q
124 passed
```

`ruff check`, `ruff format --check`, and `pyright src/` (full project) are
clean for every file this PR touches.

Closes #4314
