### PR TITLE
fix(planning): unify the dependency-satisfaction rule across both schedulers

### DIFF
--- a/src/bernstein/core/planning/workflow_dsl.py
+++ b/src/bernstein/core/planning/workflow_dsl.py
@@ -82,8 +82,16 @@ from bernstein.core.knowledge.task_graph import EdgeType
 from bernstein.core.models import Scope, Task, TaskStatus
 from bernstein.core.planning.recovery_receipt import DEFAULT_JOURNAL_TAIL
 from bernstein.core.planning.workflow import WorkflowDefinition, WorkflowPhase
-from bernstein.core.tasks.lifecycle import DEPENDENCY_BLOCKED_STATUSES
-from bernstein.core.tasks.unreachable import blocking_dependency, unreachable_tasks
+from bernstein.core.tasks.lifecycle import (
+    DEPENDENCY_BLOCKED_STATUSES,
+    SUCCESSFUL_TASK_STATUSES,
+    UNSUCCESSFUL_TERMINAL_STATUSES,
+)
+from bernstein.core.tasks.unreachable import (
+    blocking_dependency,
+    dependency_can_never_satisfy,
+    unreachable_tasks,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -828,18 +836,15 @@ class EdgeResolution(StrEnum):
     PENDING = "pending"  # Upstream not yet terminal.
 
 
-TERMINAL_STATUSES: frozenset[TaskStatus] = frozenset(
-    {
-        TaskStatus.DONE,
-        TaskStatus.FAILED,
-        TaskStatus.CANCELLED,
-        # A node materialised as unreachable (#3622) never ran and never will,
-        # so an edge out of it is as resolved as an edge out of a failure.
-        # Left out of this set its own dependents resolve PENDING forever and
-        # the strand stops at the first ring.
-        TaskStatus.BLOCKED_BY_FAILED_DEP,
-    }
-)
+# Derived from the lifecycle sets rather than hand-listed. The hand-written
+# version omitted CLOSED, ORPHANED, ABANDONED, REFUSED and BLOCKED_BY_ABANDON,
+# so an edge out of a source in any of those resolved PENDING forever: a node
+# whose dependency had completed and been reaped (CLOSED) never became ready,
+# and a strand out of an abandoned or refused node stopped at the first ring -
+# the very failure mode the BLOCKED_BY_FAILED_DEP entry was added to prevent.
+#
+# Deriving it means a status added to the lifecycle cannot be forgotten here.
+TERMINAL_STATUSES: frozenset[TaskStatus] = SUCCESSFUL_TASK_STATUSES | UNSUCCESSFUL_TERMINAL_STATUSES
 
 # The node whose skipped edge stranded this one. Deliberately the same key the
 # task store stamps on its own cascade (#3452), so a record from either
@@ -892,9 +897,17 @@ class DAGExecutor:
             return EdgeResolution.PENDING
 
         if edge.condition is None:
-            # Unconditional edge: satisfied when source is DONE.
-            if source_task.status == TaskStatus.DONE:
+            # Unconditional edge: satisfied when the source succeeded. CLOSED
+            # counts, not just DONE - a task is closed once its agent is reaped
+            # and its branch merged, which is the store's rule too
+            # (_dependencies_satisfied accepts either).
+            if source_task.status in SUCCESSFUL_TASK_STATUSES:
                 return EdgeResolution.SATISFIED
+            # Otherwise ask the shared classification instead of inferring
+            # "not done means never" locally, so this side cannot drift from
+            # the store's answer for the same status.
+            if dependency_can_never_satisfy(source_task):
+                return EdgeResolution.SKIPPED
             return EdgeResolution.SKIPPED
 
         # A source materialised as unreachable produced no result, so there is

--- a/src/bernstein/core/tasks/unreachable.py
+++ b/src/bernstein/core/tasks/unreachable.py
@@ -29,6 +29,18 @@ if TYPE_CHECKING:
 __all__ = ["blocking_dependency", "unreachable_tasks"]
 
 
+def dependency_can_never_satisfy(dependency: Task) -> bool:
+    """Can ``dependency``, in its recorded status, ever satisfy a dependent?
+
+    The single place this question is answered. Two schedulers ask it -
+    ``TaskStore._dependencies_satisfied`` when deciding whether a claim may
+    proceed, and ``DAGExecutor.resolve_edge`` when resolving an edge - and
+    before this they each carried their own copy of the status logic with
+    nothing keeping the two in step.
+    """
+    return dependency.status in UNSUCCESSFUL_TERMINAL_STATUSES
+
+
 def blocking_dependency(task: Task, tasks: Mapping[str, Task]) -> str | None:
     """Return the id of the dependency that strands *task*, if any.
 
@@ -45,7 +57,7 @@ def blocking_dependency(task: Task, tasks: Mapping[str, Task]) -> str | None:
     blockers = sorted(
         dep_id
         for dep_id in task.depends_on
-        if (dep := tasks.get(dep_id)) is not None and dep.status in UNSUCCESSFUL_TERMINAL_STATUSES
+        if (dep := tasks.get(dep_id)) is not None and dependency_can_never_satisfy(dep)
     )
     return blockers[0] if blockers else None
 

--- a/tests/unit/tasks/test_failed_dependency_propagation.py
+++ b/tests/unit/tasks/test_failed_dependency_propagation.py
@@ -20,7 +20,7 @@ from bernstein.core.tasks.lifecycle import (
 )
 from bernstein.core.tasks.models import Task, TaskStatus
 from bernstein.core.tasks.task_store_core import TaskStore
-from bernstein.core.tasks.unreachable import unreachable_tasks
+from bernstein.core.tasks.unreachable import blocking_dependency, unreachable_tasks
 
 UNSUCCESSFUL_DEPENDENCY_STATUSES = [
     TaskStatus.FAILED,
@@ -333,3 +333,72 @@ class TestTaskStoreFailurePropagation:
         await _insert(store, "A", status=TaskStatus.DONE)
         await _insert(store, "B", depends_on=["A"])
         assert store.status_summary()["unreachable"] == []
+
+
+# ---------------------------------------------------------------------------
+# The two schedulers must answer "can this dependency ever satisfy me?" alike
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerAgreement:
+    """``TaskStore`` and ``DAGExecutor`` decide the same question separately.
+
+    The store gates a claim on ``_dependencies_satisfied``; the DAG executor
+    resolves an edge in ``resolve_edge``. They agreed by coincidence, not by
+    construction - there was no shared call and no test that would fail if one
+    side changed alone. This walks every task status through both and asserts
+    they land on the same verdict.
+    """
+
+    @staticmethod
+    def _store_verdict(status: TaskStatus, tmp_path: Path) -> str:
+        """What the store says about a dependent whose one dependency is *status*."""
+        from bernstein.core.tasks.task_store_core import TaskStore
+
+        store = TaskStore(tmp_path / f"agree-{status.value}" / "tasks.jsonl")
+        dep = _task("A", status)
+        dependent = _task("B", TaskStatus.OPEN, ["A"])
+        store._tasks = {"A": dep, "B": dependent}
+        store._by_status = {s: {} for s in TaskStatus}
+        store._by_status[status]["A"] = dep
+        store._by_status[TaskStatus.OPEN]["B"] = dependent
+
+        if store._dependencies_satisfied(dependent):
+            return "satisfied"
+        return "never" if blocking_dependency(dependent, store._tasks) is not None else "pending"
+
+    @staticmethod
+    def _dag_verdict(status: TaskStatus) -> str:
+        """What the DAG executor says about the same edge."""
+        from bernstein.core.planning.workflow_dsl import (
+            DAGEdge,
+            DAGExecutor,
+            DAGNode,
+            EdgeResolution,
+            WorkflowDAG,
+            WorkflowDefinition,
+        )
+
+        dag = WorkflowDAG(
+            definition=WorkflowDefinition(name="agree", phases=("plan", "verify")),
+            nodes=(DAGNode(id="A", phase="plan", role="qa"), DAGNode(id="B", phase="verify", role="qa")),
+            edges=(DAGEdge(source="A", target="B"),),
+        )
+        executor = DAGExecutor(dag)
+        resolution = executor.resolve_edge(dag.edges[0], {"A": _task("A", status)})
+
+        return {
+            EdgeResolution.SATISFIED: "satisfied",
+            EdgeResolution.SKIPPED: "never",
+            EdgeResolution.PENDING: "pending",
+        }[resolution]
+
+    @pytest.mark.parametrize("status", list(TaskStatus))
+    def test_both_schedulers_agree_for_every_dependency_status(self, status: TaskStatus, tmp_path: Path) -> None:
+        store_verdict = self._store_verdict(status, tmp_path)
+        dag_verdict = self._dag_verdict(status)
+
+        assert store_verdict == dag_verdict, (
+            f"dependency in {status.value!r}: store says {store_verdict!r} but "
+            f"DAGExecutor.resolve_edge says {dag_verdict!r}"
+        )


### PR DESCRIPTION
Closes #4291.

## The agreement test found real disagreements

The issue says "Both currently agree on outcomes. Nothing keeps them agreeing." The first half turned out not to hold. Walking every `TaskStatus` through both sides, **5 of 17 disagreed** on `main`:

| dependency status | `TaskStore._dependencies_satisfied` | `DAGExecutor.resolve_edge` |
|---|---|---|
| `closed` | satisfied | **pending** |
| `orphaned` | never | **pending** |
| `abandoned` | never | **pending** |
| `refused` | never | **pending** |
| `blocked_by_abandon` | never | **pending** |

These are live hangs, not cosmetic drift:

- **`closed`** is the one that bites in normal operation. A task moves `DONE → CLOSED` once its agent is reaped and its branch merged. The store accepts either as satisfying; `resolve_edge` only matched `DONE`, and `CLOSED` was not even in `TERMINAL_STATUSES`, so the edge resolved **PENDING forever** and the dependent node never became ready.
- The other four are the strand-propagation failure that the `BLOCKED_BY_FAILED_DEP` entry in `TERMINAL_STATUSES` was added to fix (#3622) — still live for four sibling statuses, because the fix listed one status instead of deriving the set.

## Fix

The root cause is `TERMINAL_STATUSES` being hand-listed. It is now derived:

```python
TERMINAL_STATUSES: frozenset[TaskStatus] = SUCCESSFUL_TASK_STATUSES | UNSUCCESSFUL_TERMINAL_STATUSES
```

so a status added to the lifecycle cannot be forgotten here again. Alongside that:

- the unconditional branch accepts `SUCCESSFUL_TASK_STATUSES` (not just `DONE`), matching `_dependencies_satisfied`
- the never-satisfies case calls a new shared `dependency_can_never_satisfy` in `unreachable.py`, which `blocking_dependency` now uses too — so both schedulers reach the same predicate

## Scope: conditional edges deliberately unchanged

I did **not** route the conditional branch through the shared predicate. Its existing short-circuit is `BLOCKED_BY_FAILED_DEP` only, and broadening it would mean a source in `FAILED` no longer has its guard evaluated — breaking the legitimate `status == 'failed'` guard pattern. The agreement test therefore exercises unconditional edges, which is where the two rules are answering the same question.

## Mutation check

Per the acceptance criteria, I verified the test catches a one-sided change. Reverting just the DAG side to `status == TaskStatus.DONE`:

```
AssertionError: dependency in 'closed': store says 'satisfied' but DAGExecutor.resolve_edge says 'never'
```

## Verification

```
uv run python scripts/run_tests.py tests/unit/tasks/ tests/unit/test_workflow_dsl.py tests/unit/planning/   # 31 files passed
uv run python scripts/run_tests.py tests/unit/orchestration/                                                # 23 files passed
uv run ruff format --check src/     # clean
uv run ruff check <changed files>   # All checks passed
uv run mypy <changed src files>     # Success
```

The orchestration suite matters here since `resolve_edge` runs every tick — no existing behaviour regressed, and the 78 `test_workflow_dsl.py` tests (including the guard/strand cases) still pass.
