### PR TITLE
fix(store): role-gate claim_batch on the PostgreSQL backend

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -13,3 +13,7 @@ rather than as its own attribution is exempted by hand there, with the reason.
 ## Added
 
 - `bernstein run` on a TTY now says it is waiting for the first agent instead of sitting silent (#4257). The wait is bounded and returns as soon as an agent registers, so a fast start stays exactly as quiet as before: the transient status appears only once a poll has already failed to produce a verdict, and clears before the dashboard or the Rich fallback renders. The non-interactive detach path is unchanged.
+
+## Fixed
+
+- The PostgreSQL backend ignored the claiming agent's role in `claim_batch`: the parameter was accepted but never reached either UPDATE (#4323), which filtered on id and `status = 'open'` only. A worker registered as one role could therefore claim another role's tasks in a batch, while the in-memory store rejected exactly that claim and `claim_next` gated on role in its own SQL. The role predicate is now folded into the statement the same way the tenant scope already was, so the check is atomic with the claim on both backends.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -13,7 +13,3 @@ rather than as its own attribution is exempted by hand there, with the reason.
 ## Added
 
 - `bernstein run` on a TTY now says it is waiting for the first agent instead of sitting silent (#4257). The wait is bounded and returns as soon as an agent registers, so a fast start stays exactly as quiet as before: the transient status appears only once a poll has already failed to produce a verdict, and clears before the dashboard or the Rich fallback renders. The non-interactive detach path is unchanged.
-
-## Fixed
-
-- The PostgreSQL backend ignored the claiming agent's role in `claim_batch`: the parameter was accepted but never reached either UPDATE (#4323), which filtered on id and `status = 'open'` only. A worker registered as one role could therefore claim another role's tasks in a batch, while the in-memory store rejected exactly that claim and `claim_next` gated on role in its own SQL. The role predicate is now folded into the statement the same way the tenant scope already was, so the check is atomic with the claim on both backends.

--- a/src/bernstein/core/persistence/store_postgres.py
+++ b/src/bernstein/core/persistence/store_postgres.py
@@ -496,40 +496,35 @@ class PostgresTaskStore(BaseTaskStore):
         When ``tenant_id`` is provided the tenant scope check is folded
         into the same UPDATE statement so tasks outside the scope are
         reported as failed rather than silently claimed, even under
-        concurrent tenant rewrites.
+        concurrent tenant rewrites.  ``agent_role`` is folded in the same
+        way, so role-locked claiming holds here exactly as it does in
+        ``claim_next`` - a task belonging to another role is reported as
+        failed instead of being claimed.
         """
         claimed: list[str] = []
         failed: list[str] = []
         assert self._pool is not None
         async with self._pool.acquire() as conn, conn.transaction():
             for task_id in task_ids:
-                if tenant_id is None:
-                    row = await conn.fetchrow(
-                        """
-                            UPDATE tasks
-                            SET    status         = 'claimed',
-                                   assigned_agent = $2,
-                                   version        = version + 1
-                            WHERE  id = $1 AND status = 'open'
-                            RETURNING id
-                            """,
-                        task_id,
-                        agent_id,
-                    )
-                else:
-                    row = await conn.fetchrow(
-                        """
-                            UPDATE tasks
-                            SET    status         = 'claimed',
-                                   assigned_agent = $2,
-                                   version        = version + 1
-                            WHERE  id = $1 AND status = 'open' AND tenant_id = $3
-                            RETURNING id
-                            """,
-                        task_id,
-                        agent_id,
-                        tenant_id,
-                    )
+                params: list[Any] = [task_id, agent_id]
+                predicates = ["id = $1", "status = 'open'"]
+                if tenant_id is not None:
+                    params.append(tenant_id)
+                    predicates.append(f"tenant_id = ${len(params)}")
+                if agent_role is not None:
+                    params.append(agent_role)
+                    predicates.append(f"role = ${len(params)}")
+                row = await conn.fetchrow(
+                    f"""
+                        UPDATE tasks
+                        SET    status         = 'claimed',
+                               assigned_agent = $2,
+                               version        = version + 1
+                        WHERE  {" AND ".join(predicates)}
+                        RETURNING id
+                        """,
+                    *params,
+                )
                 if row is not None:
                     claimed.append(task_id)
                 else:

--- a/tests/unit/test_store_postgres.py
+++ b/tests/unit/test_store_postgres.py
@@ -439,3 +439,110 @@ def test_postgres_count_tasks_executes_select_count(monkeypatch: pytest.MonkeyPa
     assert count == 42
     assert conn.executed_query == "SELECT COUNT(*) FROM tasks WHERE status = $1 AND cell_id = $2 AND tenant_id = $3"
     assert conn.executed_params == ("done", "cell-1", "tenant-a")
+
+
+class _ClaimBatchConn(_TxAware):
+    """Fake connection that evaluates ``claim_batch``'s UPDATE predicates.
+
+    Mimics PostgreSQL closely enough for the claim gate: a row is returned
+    only when every predicate the query actually carries matches the stored
+    row.  A predicate the query omits is therefore invisible here - which is
+    exactly what a missing role gate looks like to a caller.
+    """
+
+    def __init__(self, rows: dict[str, dict[str, object]]) -> None:
+        self.rows = rows
+        self.queries: list[tuple[str, tuple[object, ...]]] = []
+
+    async def fetchrow(self, query: str, *args: object) -> object | None:
+        await asyncio.sleep(0)  # Async interface requirement
+        self.queries.append((query, args))
+        task_id = args[0]
+        # $1 is the id and $2 the agent; the optional predicates bind the
+        # remaining params in the order they appear in the statement.
+        optional = [name for name in ("tenant_id", "role") if f"{name} = $" in query]
+        optional.sort(key=lambda name: query.index(f"{name} = $"))
+        bound = dict(zip(optional, args[2:], strict=True))
+
+        row = self.rows.get(cast("str", task_id))
+        if row is None or row["status"] != "open":
+            return None
+        if any(row[name] != value for name, value in bound.items()):
+            return None
+        return {"id": task_id}
+
+
+def test_claim_batch_rejects_role_mismatched_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``claim_batch`` must honor ``agent_role`` like the in-memory store.
+
+    Without a role predicate in the UPDATE, a worker registered as one role
+    could claim another role's task on the PostgreSQL backend - bypassing
+    the role-locked claiming ``claim_next`` enforces via ``_CLAIM_NEXT_SQL``.
+    """
+    monkeypatch.setattr(store_postgres, "_ASYNCPG_AVAILABLE", True)
+
+    conn = _ClaimBatchConn(
+        {
+            "task-backend": {"status": "open", "role": "backend", "tenant_id": None},
+            "task-qa": {"status": "open", "role": "qa", "tenant_id": None},
+        }
+    )
+    store = store_postgres.PostgresTaskStore("postgresql://example")
+    cast("Any", store)._pool = _FakePool(conn)
+
+    claimed, failed = asyncio.run(store.claim_batch(["task-backend", "task-qa"], "agent-1", agent_role="backend"))
+
+    assert claimed == ["task-backend"]
+    assert failed == ["task-qa"]
+    assert all("role = $" in query for query, _ in conn.queries)
+
+
+def test_claim_batch_rejects_role_mismatch_within_tenant_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The tenant-scoped variant carries the role gate too.
+
+    Both predicates apply together: a task inside the tenant scope but owned
+    by another role stays unclaimed.
+    """
+    monkeypatch.setattr(store_postgres, "_ASYNCPG_AVAILABLE", True)
+
+    conn = _ClaimBatchConn(
+        {
+            "task-backend": {"status": "open", "role": "backend", "tenant_id": "tenant-a"},
+            "task-qa": {"status": "open", "role": "qa", "tenant_id": "tenant-a"},
+            "task-other-tenant": {"status": "open", "role": "backend", "tenant_id": "tenant-b"},
+        }
+    )
+    store = store_postgres.PostgresTaskStore("postgresql://example")
+    cast("Any", store)._pool = _FakePool(conn)
+
+    claimed, failed = asyncio.run(
+        store.claim_batch(
+            ["task-backend", "task-qa", "task-other-tenant"],
+            "agent-1",
+            agent_role="backend",
+            tenant_id="tenant-a",
+        )
+    )
+
+    assert claimed == ["task-backend"]
+    assert failed == ["task-qa", "task-other-tenant"]
+
+
+def test_claim_batch_without_role_claims_any_open_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``agent_role=None`` keeps the pre-existing unrestricted behavior."""
+    monkeypatch.setattr(store_postgres, "_ASYNCPG_AVAILABLE", True)
+
+    conn = _ClaimBatchConn(
+        {
+            "task-backend": {"status": "open", "role": "backend", "tenant_id": None},
+            "task-qa": {"status": "open", "role": "qa", "tenant_id": None},
+        }
+    )
+    store = store_postgres.PostgresTaskStore("postgresql://example")
+    cast("Any", store)._pool = _FakePool(conn)
+
+    claimed, failed = asyncio.run(store.claim_batch(["task-backend", "task-qa"], "agent-1"))
+
+    assert claimed == ["task-backend", "task-qa"]
+    assert failed == []
+    assert all("role = $" not in query for query, _ in conn.queries)

--- a/tests/unit/volunteer/test_volunteer_submission.py
+++ b/tests/unit/volunteer/test_volunteer_submission.py
@@ -12,7 +12,6 @@ import pytest
 
 from bernstein.core.git.git_basic import GitResult
 
-from bernstein.core.git.git_pr import push_head_as
 
 @pytest.fixture
 def isolated_pacing(tmp_path: Path):
@@ -193,7 +192,10 @@ def test_pacing_releases_after_the_tracked_pr_is_merged(tmp_path: Path, isolated
     # Mock DCO and push so we don't need real git config or a real repo
     with (
         patch("bernstein.core.volunteer.submission.read_dco_line", return_value="Jane Doe <jane@example.com>"),
-        patch("bernstein.core.volunteer.submission.push_head_as", return_value=GitResult(returncode=0, stdout="", stderr="")),
+        patch(
+            "bernstein.core.volunteer.submission.push_head_as",
+            return_value=GitResult(returncode=0, stdout="", stderr=""),
+        ),
     ):
         pr_url = submit_volunteer_pr(
             bundle=_make_bundle(),


### PR DESCRIPTION
Closes #4323.

`PostgresTaskStore.claim_batch` accepted `agent_role` and dropped it. Both UPDATE variants — plain and tenant-scoped — filtered on `id` and `status = 'open'` only, so on a PostgreSQL deployment a worker could claim a batch containing tasks that belong to another role. The in-memory store rejects exactly that claim, `claim_next` gates on role inside `_CLAIM_NEXT_SQL`, and `BaseTaskStore.claim_batch` already documents mismatched roles as landing in `failed_ids` — so the PostgreSQL implementation contradicted both its sibling and its own base class.

## Change

The role predicate is folded into the statement that performs the claim, the way the tenant scope already was, so the authorization decision stays atomic with the claim instead of becoming a client-side pre-check a concurrent role rewrite could invalidate. Predicates are assembled per task the same way `update()` in this file assembles its SET clause, which keeps the parameter numbering correct as optional predicates are added:

```sql
WHERE id = $1 AND status = 'open' [AND tenant_id = $n] [AND role = $n]
```

`agent_role=None` keeps the previous unrestricted behaviour unchanged — covered by a test.

## Tests

`uv run pytest tests/unit/test_store_postgres.py -q` → 13 passed, including three new regression tests: role mismatch, role mismatch inside a tenant scope, and the no-role path. The fake connection evaluates whichever predicates the query actually carries, so a dropped gate is invisible to it exactly as it is to a caller — the tests fail against the old code.

`uv run pytest tests/unit/test_claim_role_matching.py tests/unit/test_claim_by_id_double_claim.py tests/unit/test_claim_next.py tests/unit/test_claim_dependency_property.py tests/unit/test_batch_api.py tests/unit/test_unreleased_notes_rotation.py -q` → 40 passed, unaffected.

## Note for reviewers

#4320 rewrites these same two queries into module-level constants to add dependency gating. Whichever lands second adds its predicate to the other's structure; the two gates are independent.
