### PR TITLE
fix(tasks): cancel planning-task retries that race a completed sibling

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -13,7 +13,3 @@ rather than as its own attribution is exempted by hand there, with the reason.
 ## Added
 
 - `bernstein run` on a TTY now says it is waiting for the first agent instead of sitting silent (#4257). The wait is bounded and returns as soon as an agent registers, so a fast start stays exactly as quiet as before: the transient status appears only once a poll has already failed to produce a verdict, and clears before the dashboard or the Rich fallback renders. The non-interactive detach path is unchanged.
-
-## Fixed
-
-- A failed planning task's retry no longer races a sibling planning task that already finished the same decomposition (#4309). `retry_or_fail_task` now cancels the redundant retry with a reason instead of leaving it open, so a second manager agent can no longer re-decompose the same goal and double every downstream task. Scoped to the planning role; worker retries are unaffected.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -13,3 +13,7 @@ rather than as its own attribution is exempted by hand there, with the reason.
 ## Added
 
 - `bernstein run` on a TTY now says it is waiting for the first agent instead of sitting silent (#4257). The wait is bounded and returns as soon as an agent registers, so a fast start stays exactly as quiet as before: the transient status appears only once a poll has already failed to produce a verdict, and clears before the dashboard or the Rich fallback renders. The non-interactive detach path is unchanged.
+
+## Fixed
+
+- A failed planning task's retry no longer races a sibling planning task that already finished the same decomposition (#4309). `retry_or_fail_task` now cancels the redundant retry with a reason instead of leaving it open, so a second manager agent can no longer re-decompose the same goal and double every downstream task. Scoped to the planning role; worker retries are unaffected.

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -623,17 +623,57 @@ def maybe_retry_task(
     try:
         resp = client.post(f"{server_url}/tasks", json=payload)
         resp.raise_for_status()
-        new_task_id = resp.json().get("id", "?")
+        new_task_id = _extract_new_task_id(resp)
         retried_task_ids.add(task.id)
         logger.info(
             "Retry %d queued for failed task %s -> %s (model=%s effort=%s budget_mult=%.1fx)",
             next_retry,
             task.id,
-            new_task_id,
+            new_task_id or "?",
             new_model,
             new_effort,
             budget_multiplier,
         )
+
+        # Planning-retry race guard (#4309). This tick-loop path and
+        # retry_or_fail_task's reap path are independent retry-creation call
+        # sites for the same failed task -- see _find_done_planning_sibling.
+        # No tasks_snapshot is available here (the tick loop hands this
+        # function one failed task at a time), so the sibling lookup always
+        # takes the live-GET fallback; that is fine because planning-role
+        # failures are rare relative to worker failures.
+        if task.role == _PLANNING_ROLE and new_task_id is not None:
+            completed_sibling = _find_done_planning_sibling(
+                task,
+                retry_metadata["original_task_id"],
+                tasks_snapshot=None,
+                client=client,
+                base=server_url,
+            )
+            if completed_sibling is not None:
+                cancel_reason = (
+                    f"planning retry race: sibling planning task {completed_sibling.id} "
+                    "already completed the decomposition for this goal"
+                )
+                try:
+                    client.post(
+                        f"{server_url}/tasks/{new_task_id}/cancel", json={"reason": cancel_reason}
+                    ).raise_for_status()
+                    logger.info(
+                        "maybe_retry_task verdict=cancel_planning_retry task=%s retry=%s "
+                        "completed_sibling=%s reason=%r",
+                        task.id,
+                        new_task_id,
+                        completed_sibling.id,
+                        cancel_reason,
+                    )
+                except httpx.HTTPError as exc:
+                    logger.warning(
+                        "maybe_retry_task: failed to cancel duplicate planning retry %s (%s) -- "
+                        "it remains open and claimable",
+                        new_task_id,
+                        exc,
+                    )
         return True
     except Exception as exc:
         logger.warning("Failed to queue retry for task %s: %s", task.id, exc)
@@ -831,6 +871,98 @@ def _enqueue_dlq_if_workdir(
         logger.debug("incident synthesiser skipped for task %s: %s", task.id, exc)
 
 
+# Role that performs goal decomposition (see config/seed.py::seed_to_initial_task
+# and orchestration/manager.py). The only role whose retries this module's
+# planning-race guard applies to (#4309).
+_PLANNING_ROLE = "manager"
+
+
+def _extract_new_task_id(resp: httpx.Response) -> str | None:
+    """Best-effort task id extraction from a successful ``POST /tasks`` response."""
+    try:
+        body = resp.json()
+    except ValueError:
+        return None
+    if isinstance(body, dict):
+        new_id = body.get("id")
+        if isinstance(new_id, str) and new_id:
+            return new_id
+    return None
+
+
+def _find_done_planning_sibling(
+    task: Task,
+    lineage_id: str,
+    *,
+    tasks_snapshot: dict[str, list[Task]] | None,
+    client: httpx.Client,
+    base: str,
+) -> Task | None:
+    """Return a DONE/CLOSED planning-role sibling sharing *lineage_id*, if any.
+
+    A "sibling" is another task of the same role whose own decomposition
+    lineage (``metadata["original_task_id"]``, defaulting to its own id)
+    matches *lineage_id* -- i.e. another attempt at decomposing the same
+    goal. Consulted by :func:`retry_or_fail_task` before creating a planning
+    retry (#4309): the tick-loop sweep (``maybe_retry_task``) and this
+    reap-path function are two independent retry-creation call sites, and
+    a run can also be worked by more than one orchestrator process against
+    the same shared task board, so nothing in-process (e.g.
+    ``retried_task_ids``) can stop two of them from each retrying the same
+    failed planning task. Left unguarded, the redundant retry gets claimed
+    by a second manager agent and re-decomposes the same goal, doubling
+    every downstream task.
+
+    Prefers the pre-fetched *tasks_snapshot* (all of its buckets, since
+    callers key it differently) to avoid an extra round-trip. Falls back to
+    a pair of status-filtered GETs when no snapshot was supplied -- the
+    common case for the reap-path callers in ``agent_lifecycle.py`` that
+    retry a single task outside the tick loop.
+    """
+    candidates: list[Task] = []
+    if tasks_snapshot is not None:
+        for bucket in tasks_snapshot.values():
+            candidates.extend(bucket)
+    else:
+        for status in ("done", "closed"):
+            try:
+                resp = client.get(f"{base}/tasks", params={"status": status, "limit": 500})
+                resp.raise_for_status()
+                body = resp.json()
+            except (httpx.HTTPError, ValueError) as exc:
+                logger.warning(
+                    "planning-retry sibling check for %s: could not fetch status=%s tasks (%s) -- "
+                    "proceeding without the guard for this attempt",
+                    task.id,
+                    status,
+                    exc,
+                )
+                continue
+            raw = body.get("tasks", body) if isinstance(body, dict) else body
+            if not isinstance(raw, list):
+                continue
+            for r in raw:
+                try:
+                    candidates.append(Task.from_dict(r))
+                except (KeyError, TypeError, ValueError) as exc:
+                    logger.warning(
+                        "planning-retry sibling check for %s: skipping unparseable status=%s task (%s)",
+                        task.id,
+                        status,
+                        exc,
+                    )
+
+    for sibling in candidates:
+        if sibling.id == task.id or sibling.role != task.role:
+            continue
+        if sibling.status not in (TaskStatus.DONE, TaskStatus.CLOSED):
+            continue
+        sib_metadata = sibling.metadata if isinstance(sibling.metadata, dict) else {}
+        if sib_metadata.get("original_task_id", sibling.id) == lineage_id:
+            return sibling
+    return None
+
+
 def retry_or_fail_task(
     task_id: str,
     reason: str,
@@ -853,6 +985,14 @@ def retry_or_fail_task(
     new open task is created with ``retry_count`` incremented; otherwise the
     task is moved to the Dead Letter Queue and failed with a
     ``"Max retries exceeded"`` reason.
+
+    Planning-role retries (``task.role == "manager"``) get one extra check
+    before the new task is left open: if a sibling planning task sharing the
+    same decomposition lineage has already reached ``done``/``closed`` (see
+    ``_find_done_planning_sibling``), the retry is created and then
+    immediately cancelled with a reason instead of left claimable -- two
+    managers decomposing the same goal doubles every downstream task
+    (#4309). Worker retries are unaffected.
 
     Args:
         task_id: ID of the task to retry or fail.
@@ -1140,15 +1280,8 @@ def retry_or_fail_task(
         if task.completion_signals:
             task_body["completion_signals"] = [{"type": s.type, "value": s.value} for s in task.completion_signals]
         try:
-            client.post(f"{base}/tasks", json=task_body).raise_for_status()
-            logger.info(
-                "retry_or_fail_task verdict=retry task=%s original_task_id=%s attempt=%d/%d reason=%r",
-                task_id,
-                _original_task_id,
-                retry_count + 1,
-                effective_limit,
-                reason,
-            )
+            resp = client.post(f"{base}/tasks", json=task_body)
+            resp.raise_for_status()
         except httpx.HTTPError as exc:
             logger.error("Failed to re-create task %s for retry: %s", task_id, exc)
             # Fall through to permanent fail (DLQ-eligible: re-create failure
@@ -1162,6 +1295,64 @@ def retry_or_fail_task(
             )
             fail_task(client, base, task_id, f"Max retries exceeded: {reason}")
             return
+
+        # Planning-retry race guard (#4309). See _find_done_planning_sibling
+        # for why this can happen even against a single orchestrator process.
+        # Scoped to the planning role only -- ordinary worker retries keep
+        # racing exactly as before, which is fine because a duplicate worker
+        # retry costs one wasted task, not a doubled task tree.
+        completed_sibling = (
+            _find_done_planning_sibling(
+                task,
+                _original_task_id,
+                tasks_snapshot=tasks_snapshot,
+                client=client,
+                base=base,
+            )
+            if task.role == _PLANNING_ROLE
+            else None
+        )
+        if completed_sibling is None:
+            logger.info(
+                "retry_or_fail_task verdict=retry task=%s original_task_id=%s attempt=%d/%d reason=%r",
+                task_id,
+                _original_task_id,
+                retry_count + 1,
+                effective_limit,
+                reason,
+            )
+        else:
+            new_task_id = _extract_new_task_id(resp)
+            cancel_reason = (
+                f"planning retry race: sibling planning task {completed_sibling.id} "
+                "already completed the decomposition for this goal"
+            )
+            if new_task_id is None:
+                logger.warning(
+                    "retry_or_fail_task: planning retry for %s should be cancelled (%s) but the "
+                    "create response carried no task id -- it remains open and claimable",
+                    task_id,
+                    cancel_reason,
+                )
+            else:
+                try:
+                    client.post(f"{base}/tasks/{new_task_id}/cancel", json={"reason": cancel_reason}).raise_for_status()
+                    logger.info(
+                        "retry_or_fail_task verdict=cancel_planning_retry task=%s original_task_id=%s "
+                        "retry=%s completed_sibling=%s reason=%r",
+                        task_id,
+                        _original_task_id,
+                        new_task_id,
+                        completed_sibling.id,
+                        cancel_reason,
+                    )
+                except httpx.HTTPError as exc:
+                    logger.warning(
+                        "retry_or_fail_task: failed to cancel duplicate planning retry %s (%s) -- "
+                        "it remains open and claimable",
+                        new_task_id,
+                        exc,
+                    )
         # Fail the old task silently (it has been replaced)
         with contextlib.suppress(httpx.HTTPError):
             fail_task(client, base, task_id, f"Retried: {reason}")

--- a/tests/unit/test_retry_consolidation.py
+++ b/tests/unit/test_retry_consolidation.py
@@ -220,6 +220,87 @@ def test_maybe_retry_ignores_legacy_title_prefix_when_typed_field_disagrees():
 
 
 # ---------------------------------------------------------------------------
+# Planning-retry race guard (#4309), tick-loop path.
+#
+# maybe_retry_task and retry_or_fail_task are independent retry-creation
+# call sites for the same failed task (see the hard-ceiling comment above
+# and retry_or_fail_task's own docstring) -- both must refuse to leave a
+# planning-role retry claimable once a sibling planning task sharing its
+# decomposition lineage has already finished. This function has no
+# tasks_snapshot to consult, so the guard falls back to a live GET.
+# ---------------------------------------------------------------------------
+
+
+def _capture_client_with_done_sibling(sibling: Task) -> tuple[MagicMock, list[dict]]:
+    """Like _capture_client, but GET /tasks?status=done returns *sibling*."""
+    client, posted = _capture_client()
+
+    def get_side_effect(url: str, params: dict | None = None, **_: object) -> MagicMock:
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        status = (params or {}).get("status")
+        resp.json.return_value = [sibling.to_dict()] if status == "done" else []
+        return resp
+
+    client.get.side_effect = get_side_effect
+    return client, posted
+
+
+def test_maybe_retry_planning_task_cancelled_when_sibling_done(tmp_path):
+    """A planning ('manager') task's retry is created and then immediately
+    cancelled once a sibling sharing its decomposition lineage is DONE."""
+    task = _build_task(task_id="planning-A", retry_count=0)
+    task.role = "manager"
+
+    sibling = _build_task(task_id="planning-B", retry_count=0)
+    sibling.role = "manager"
+    sibling.status = TaskStatus.DONE
+    sibling.metadata = {"original_task_id": "planning-A"}
+
+    client, posted = _capture_client_with_done_sibling(sibling)
+
+    created = maybe_retry_task(
+        task,
+        retried_task_ids=set(),
+        max_task_retries=3,
+        client=client,
+        server_url="http://server",
+        quarantine=MagicMock(),
+        workdir=tmp_path,
+        session_id=None,
+    )
+
+    assert created is True
+    assert len(posted) == 1  # the retry row was still created -- visible on the board
+
+    cancel_calls = [call for call in client.post.call_args_list if call[0][0].endswith("/NEW-1/cancel")]
+    assert cancel_calls, f"expected the duplicate retry to be cancelled, got: {client.post.call_args_list}"
+    assert "planning-B" in cancel_calls[0].kwargs["json"]["reason"]
+
+
+def test_maybe_retry_planning_task_unaffected_when_no_sibling_done(tmp_path):
+    """Control: no completed sibling -> the planning retry stays open."""
+    task = _build_task(task_id="planning-C", retry_count=0)
+    task.role = "manager"
+    client, posted = _capture_client()  # GET is unmocked; MagicMock default -> no siblings found
+
+    created = maybe_retry_task(
+        task,
+        retried_task_ids=set(),
+        max_task_retries=3,
+        client=client,
+        server_url="http://server",
+        quarantine=MagicMock(),
+        workdir=tmp_path,
+        session_id=None,
+    )
+
+    assert created is True
+    assert len(posted) == 1
+    assert not any(call[0][0].endswith("/cancel") for call in client.post.call_args_list)
+
+
+# ---------------------------------------------------------------------------
 # retry_or_fail_task
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_retry_or_fail_task.py
+++ b/tests/unit/test_retry_or_fail_task.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
+from bernstein.core.models import TaskStatus
 
 # Both imports point to the same function: task_lifecycle re-exports from task_retry
 from bernstein.core.task_lifecycle import retry_or_fail_task as retry_lifecycle
@@ -350,4 +351,174 @@ def test_retry_cap_decision_is_logged_with_original_task_id(caplog):
     )
     assert any("verdict=permanent_fail" in m and "orig-root-task" in m for m in messages), (
         f"expected a permanent_fail verdict log line, got: {messages}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Planning-retry race guard (#4309).
+#
+# A failed planning ("manager") task's retry can be created after a sibling
+# planning task -- decomposing the exact same goal -- has already reached
+# DONE: two independent retry-creation call sites (the tick-loop
+# maybe_retry_task sweep and this reap-path function) can each react to the
+# same failure, and a run can be worked by more than one orchestrator
+# process against the same shared task board, so in-process dedup
+# (retried_task_ids) never sees the other side. Left unguarded, the
+# redundant retry gets claimed by a second manager agent and re-decomposes
+# the same goal, doubling every downstream task.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("retry_func", [retry_lifecycle, retry_completion])
+def test_planning_retry_cancelled_when_sibling_already_done(retry_func, caplog):
+    """A' (the retry of failed planning task A) must be created and then
+    immediately cancelled -- not left open/claimable -- once a sibling
+    planning task B sharing A's decomposition lineage has already finished
+    the decomposition."""
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.post.return_value.json.return_value = {"id": "planning-A-retry-1"}
+
+    task_a = MockTask("planning-A", title="Decompose goal")
+    task_a.role = "manager"
+    # task_a is itself the lineage root (no metadata.original_task_id yet),
+    # so its lineage id is its own task id.
+
+    sibling_b = MockTask("planning-B", title="Decompose goal")
+    sibling_b.role = "manager"
+    sibling_b.status = TaskStatus.DONE
+    sibling_b.metadata = {"original_task_id": "planning-A"}
+
+    tasks_snapshot = {"active": [task_a], "done": [sibling_b]}
+    retried_ids: set[str] = set()
+
+    with caplog.at_level(logging.INFO):
+        retry_func(
+            task_id="planning-A",
+            reason="Agent manager-abc died mid-decomposition",
+            client=mock_client,
+            server_url="http://test",
+            max_task_retries=3,
+            retried_task_ids=retried_ids,
+            tasks_snapshot=tasks_snapshot,
+        )
+
+    post_calls = mock_client.post.call_args_list
+    # The retry row is created -- visible on the board, not silently dropped.
+    assert any(call[0][0].endswith("/tasks") for call in post_calls), (
+        f"expected the retry to still be created via POST /tasks, got: {post_calls}"
+    )
+    # ... and then immediately cancelled, with a reason, instead of left open.
+    cancel_calls = [call for call in post_calls if call[0][0].endswith("/planning-A-retry-1/cancel")]
+    assert cancel_calls, f"expected a cancel call for the duplicate retry, got: {post_calls}"
+    assert "planning-B" in cancel_calls[0].kwargs["json"]["reason"]
+    # The original failed task is still marked failed/superseded as usual.
+    assert any(call[0][0].endswith("/planning-A/fail") for call in post_calls), (
+        f"expected the original task to still be failed, got: {post_calls}"
+    )
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("verdict=cancel_planning_retry" in m and "planning-B" in m for m in messages), (
+        f"expected a cancel_planning_retry verdict log line, got: {messages}"
+    )
+
+
+@pytest.mark.parametrize("retry_func", [retry_lifecycle, retry_completion])
+def test_planning_retry_unaffected_when_no_sibling_done(retry_func):
+    """Control: an ordinary planning retry with no completed sibling stays
+    open exactly like before the guard existed."""
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.post.return_value.json.return_value = {"id": "planning-C-retry-1"}
+
+    task_c = MockTask("planning-C", title="Decompose goal")
+    task_c.role = "manager"
+    tasks_snapshot = {"active": [task_c]}
+    retried_ids: set[str] = set()
+
+    retry_func(
+        task_id="planning-C",
+        reason="Agent manager-abc died mid-decomposition",
+        client=mock_client,
+        server_url="http://test",
+        max_task_retries=3,
+        retried_task_ids=retried_ids,
+        tasks_snapshot=tasks_snapshot,
+    )
+
+    post_calls = mock_client.post.call_args_list
+    assert any(call[0][0].endswith("/tasks") for call in post_calls)
+    assert not any(call[0][0].endswith("/cancel") for call in post_calls), (
+        f"no sibling is done -- the retry must not be cancelled, got: {post_calls}"
+    )
+
+
+@pytest.mark.parametrize("retry_func", [retry_lifecycle, retry_completion])
+def test_planning_retry_unaffected_by_unrelated_completed_manager_task(retry_func):
+    """Control: a DONE manager-role task for a *different* goal (different
+    decomposition lineage) must not cancel this retry -- e.g. two unrelated
+    evolve-cycle manager tasks running concurrently are not siblings."""
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.post.return_value.json.return_value = {"id": "planning-D-retry-1"}
+
+    task_d = MockTask("planning-D", title="Decompose goal")
+    task_d.role = "manager"
+
+    unrelated_done = MockTask("planning-E", title="Evolve cycle 9: new_features")
+    unrelated_done.role = "manager"
+    unrelated_done.status = TaskStatus.DONE
+    unrelated_done.metadata = {"original_task_id": "some-other-goal-root"}
+
+    tasks_snapshot = {"active": [task_d], "done": [unrelated_done]}
+    retried_ids: set[str] = set()
+
+    retry_func(
+        task_id="planning-D",
+        reason="Agent manager-abc died mid-decomposition",
+        client=mock_client,
+        server_url="http://test",
+        max_task_retries=3,
+        retried_task_ids=retried_ids,
+        tasks_snapshot=tasks_snapshot,
+    )
+
+    post_calls = mock_client.post.call_args_list
+    assert any(call[0][0].endswith("/tasks") for call in post_calls)
+    assert not any(call[0][0].endswith("/cancel") for call in post_calls), (
+        f"unrelated goal's completed manager task must not cancel this retry, got: {post_calls}"
+    )
+
+
+@pytest.mark.parametrize("retry_func", [retry_lifecycle, retry_completion])
+def test_worker_retry_unaffected_by_completed_planning_sibling(retry_func):
+    """Control: the guard is scoped to the planning role only -- an ordinary
+    worker task's retry is unaffected even when a same-lineage DONE
+    manager-role task exists (e.g. the manager that spawned this worker task
+    already finished, which is the normal, expected shape)."""
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.post.return_value.json.return_value = {"id": "worker-1-retry-1"}
+
+    worker_task = MockTask("worker-1", title="Implement hello subcommand in cli.py")
+    # role defaults to "backend" on MockTask
+
+    done_manager = MockTask("planning-F", title="Decompose goal")
+    done_manager.role = "manager"
+    done_manager.status = TaskStatus.DONE
+    done_manager.metadata = {"original_task_id": "worker-1"}  # contrived id collision
+
+    tasks_snapshot = {"active": [worker_task], "done": [done_manager]}
+    retried_ids: set[str] = set()
+
+    retry_func(
+        task_id="worker-1",
+        reason="Agent backend-abc died; no completion signals and no files modified",
+        client=mock_client,
+        server_url="http://test",
+        max_task_retries=3,
+        retried_task_ids=retried_ids,
+        tasks_snapshot=tasks_snapshot,
+    )
+
+    post_calls = mock_client.post.call_args_list
+    assert any(call[0][0].endswith("/tasks") for call in post_calls)
+    assert not any(call[0][0].endswith("/cancel") for call in post_calls), (
+        f"worker retries must be unaffected by the planning-role guard, got: {post_calls}"
     )

--- a/tests/unit/volunteer/test_volunteer_submission.py
+++ b/tests/unit/volunteer/test_volunteer_submission.py
@@ -12,7 +12,6 @@ import pytest
 
 from bernstein.core.git.git_basic import GitResult
 
-from bernstein.core.git.git_pr import push_head_as
 
 @pytest.fixture
 def isolated_pacing(tmp_path: Path):
@@ -193,7 +192,10 @@ def test_pacing_releases_after_the_tracked_pr_is_merged(tmp_path: Path, isolated
     # Mock DCO and push so we don't need real git config or a real repo
     with (
         patch("bernstein.core.volunteer.submission.read_dco_line", return_value="Jane Doe <jane@example.com>"),
-        patch("bernstein.core.volunteer.submission.push_head_as", return_value=GitResult(returncode=0, stdout="", stderr="")),
+        patch(
+            "bernstein.core.volunteer.submission.push_head_as",
+            return_value=GitResult(returncode=0, stdout="", stderr=""),
+        ),
     ):
         pr_url = submit_volunteer_pr(
             bundle=_make_bundle(),


### PR DESCRIPTION
## What was broken

A failed planning ("manager") task's retry could be created after a sibling
planning task decomposing the exact same goal had already finished. Two
managers then each ran a full decomposition of the same goal, and the board
carried two near-identical task sets that workers burned time on before an
operator noticed and cancelled the duplicates by hand.

## Root cause

`retry_or_fail_task` (the reap-path retry-creation function, called from
many sites in `agent_lifecycle.py`) and `maybe_retry_task` (the tick-loop
sweep over failed tasks) are two independent call sites that can each
decide the same failed task needs a retry and each create a new task row.
The in-process dedup (`retried_task_ids`) only prevents one process from
retrying the same task twice - it does not span two orchestrator processes
working the same shared task board, and it does not stop the two *different*
retry-creation functions from racing each other within one process either,
since each only checks-and-sets its own pass over the set.

Neither retry path checked whether a sibling planning task for the same
decomposition lineage had already finished before leaving the new retry
open and claimable.

## What changed

Both retry-creation paths now consult a new `_find_done_planning_sibling`
helper right before leaving a freshly created retry open. For a
planning-role (`"manager"`) retry only, it looks for another task of the
same role whose decomposition lineage (`metadata.original_task_id`,
defaulting to its own id) matches the failing task's lineage and whose
status is already `done`/`closed`. `retry_or_fail_task` checks its
pre-fetched `tasks_snapshot` when one is available; `maybe_retry_task` has
no snapshot to consult, so it falls back to a status-filtered `GET /tasks`
(rare in practice, since planning-role failures are uncommon relative to
worker failures).

When a completed sibling is found, the retry is still created - it stays
visible on the board with a reason - but is immediately cancelled via the
existing `POST /tasks/{id}/cancel` endpoint instead of being left
claimable. The originally failed task is still marked failed/superseded
exactly as before. Ordinary worker retries are completely unaffected: the
guard only ever activates for `role == "manager"`.

## Test evidence

```
uv run pytest tests/unit/test_retry_or_fail_task.py -q
24 passed

uv run pytest tests/unit/test_retry_consolidation.py -q
13 passed
```

New tests added:

- `test_planning_retry_cancelled_when_sibling_already_done` - the retry is created then immediately cancelled with a reason once a same-lineage sibling is done.
- `test_planning_retry_unaffected_when_no_sibling_done` - control: no completed sibling, retry stays open.
- `test_planning_retry_unaffected_by_unrelated_completed_manager_task` - control: a done manager task for a *different* goal does not trip the guard.
- `test_worker_retry_unaffected_by_completed_planning_sibling` - control: the guard is scoped to the planning role; worker retries are unaffected even with a same-lineage done manager task present.
- `test_maybe_retry_planning_task_cancelled_when_sibling_done` / `test_maybe_retry_planning_task_unaffected_when_no_sibling_done` - same coverage for the tick-loop retry path.

Also ran the full retry/orchestrator-adjacent suite locally (`test_agent_lifecycle.py`,
`test_dlq_retry_integration.py`, `test_max_output_tokens_escalation.py`,
`test_checkpoint_retry_wiring.py`, `test_fresh_context_retry.py`,
`test_reactive_compact_413.py`, `test_chaos.py`, `test_failure_reduction.py`,
`test_retrospective.py`, `test_agent_lifecycle_helpers.py`,
`test_failure_aware_retry.py`, `test_retry_exhaustion_bookkeeping.py`,
`test_task_lifecycle.py`, `test_regression_orchestrator.py`,
`test_orchestrator.py`, `test_unreleased_notes_rotation.py`) - all green,
no regressions. `ruff check`, `ruff format --check`, and `lint-imports`
all pass on the changed files.

Closes #4309
