### PR TITLE
fix(agents): worker refreshes the heartbeat the orchestrator reads

### DIFF
--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -344,6 +344,20 @@ class WaitableProcess(Protocol):
         """Wait for process completion and return its exit status."""
 
 
+#: Process-environment channel carrying the orchestrator root's heartbeat
+#: directory down to ``bernstein-worker``.
+#:
+#: Adapters derive every runtime path from the ``workdir`` they are spawned
+#: into, which under worktree isolation is the agent's own worktree -- while
+#: the orchestrator reads agent state from the project root. A heartbeat
+#: written under the worktree is therefore never observed, and the agent is
+#: killed at the stale threshold with nothing in the log pointing at why
+#: (issue #4330). The root travels through the environment, the same channel
+#: ``BERNSTEIN_RUN_ID`` uses to reach agent subprocesses, so the ~50 adapter
+#: call sites do not each have to learn the difference.
+HEARTBEAT_DIR_ENV = "BERNSTEIN_HEARTBEAT_DIR"
+
+
 def build_worker_cmd(
     cmd: list[str],
     *,
@@ -353,6 +367,7 @@ def build_worker_cmd(
     workdir: Path,
     log_path: Path,
     model: str = "",
+    heartbeat_dir: Path | None = None,
 ) -> list[str]:
     """Wrap a CLI command with bernstein-worker for process visibility.
 
@@ -367,10 +382,16 @@ def build_worker_cmd(
         workdir: Project root directory.
         log_path: Path to the agent log file.
         model: Model name for metadata display.
+        heartbeat_dir: Directory the orchestrator polls for heartbeats.
+            Defaults to whatever the orchestrator exported in
+            :data:`HEARTBEAT_DIR_ENV`; when neither is set the flag is
+            omitted and the worker falls back to ``--workdir``, which is
+            what a standalone ``bernstein-worker`` invocation wants.
 
     Returns:
         Wrapped command list.
     """
+    resolved_heartbeat_dir = str(heartbeat_dir) if heartbeat_dir is not None else os.environ.get(HEARTBEAT_DIR_ENV, "")
     return [
         sys.executable,
         "-m",
@@ -387,6 +408,7 @@ def build_worker_cmd(
         str(log_path),
         "--model",
         model,
+        *(["--heartbeat-dir", resolved_heartbeat_dir] if resolved_heartbeat_dir else []),
         "--",
         *cmd,
     ]

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -617,6 +617,22 @@ class Orchestrator:
             logger.info("Exported BERNSTEIN_RUN_ID=%s for spawned-agent instrumentation", run_id)
         except Exception as exc:  # intentional-broad-except: defensive, must never block startup
             logger.warning("Failed to export BERNSTEIN_RUN_ID=%s to process env: %s", run_id, exc)
+        # Issue #4330: the same worktree-vs-root split, for liveness. Adapters
+        # derive their runtime paths from the workdir they are spawned into --
+        # the agent's worktree -- while the probes below read heartbeats from
+        # this root. Export the root so ``build_worker_cmd`` can hand every
+        # wrapped adapter's worker the directory that is actually polled;
+        # without it the worker's heartbeat lands in the worktree, nothing
+        # advances the file the orchestrator reads, and a working agent is
+        # recycled on its own uptime.
+        from bernstein.adapters.base import HEARTBEAT_DIR_ENV
+
+        _heartbeat_dir = self._workdir / ".sdd" / "runtime" / "heartbeats"
+        try:
+            os.environ[HEARTBEAT_DIR_ENV] = str(_heartbeat_dir)
+            logger.info("Exported %s=%s for spawned workers", HEARTBEAT_DIR_ENV, _heartbeat_dir)
+        except Exception as exc:  # intentional-broad-except: defensive, must never block startup
+            logger.warning("Failed to export %s to process env: %s", HEARTBEAT_DIR_ENV, exc)
         hard_budget_usd = 0.0
         _raw_hard = os.environ.get("BERNSTEIN_HARD_BUDGET_USD", "").strip()
         if _raw_hard:

--- a/src/bernstein/core/orchestration/worker.py
+++ b/src/bernstein/core/orchestration/worker.py
@@ -234,6 +234,86 @@ def _atomic_write_json(path: Path, info: dict[str, object]) -> None:
     write_atomic_json(path, info, indent=None)
 
 
+#: How often the worker samples the runner log for new output.
+#: Every consumer of heartbeat age works in minutes (170s for the stalled-manager
+#: detector, ~10 min for the idle recycler, 15 min for the escalation ladder), so
+#: sampling far below the tightest of them costs nothing and keeps the reported
+#: age within one interval of the truth.
+_HEARTBEAT_SAMPLE_INTERVAL_S = 15.0
+
+
+def _resolve_heartbeat_path(args: argparse.Namespace) -> Path:
+    """Where this session's heartbeat belongs.
+
+    ``--heartbeat-dir`` is the orchestrator root's heartbeat directory, passed
+    down because ``--workdir`` is the agent's worktree under worktree isolation
+    and the orchestrator reads from the root. Falling back to ``--workdir``
+    keeps a standalone ``bernstein-worker`` invocation self-consistent.
+    """
+    base = (
+        Path(args.heartbeat_dir)
+        if getattr(args, "heartbeat_dir", "")
+        else Path(args.workdir) / ".sdd" / "runtime" / "heartbeats"
+    )
+    return base / f"{args.session}.json"
+
+
+def _write_heartbeat(path: Path, *, now: float) -> None:
+    """Stamp *path* with the current time, preserving any richer body.
+
+    Adapters that parse a structured event stream report a real ``phase`` of
+    their own; this worker sees only bytes on a pipe. So it corrects the one
+    field it can speak to honestly and leaves the rest of the body as it found
+    it, rather than flattening a meaningful phase into a generic one.
+    """
+    body: dict[str, object] = {}
+    with contextlib.suppress(OSError, ValueError):
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(parsed, dict):
+            body = parsed
+    body["timestamp"] = now
+    body.setdefault("status", "running")
+    body.setdefault("phase", "running")
+    _atomic_write_json(path, body)
+
+
+def _heartbeat_refresh_loop(
+    heartbeat_path: Path,
+    log_path: Path | None,
+    is_running: Callable[[], bool],
+    *,
+    interval_s: float = _HEARTBEAT_SAMPLE_INTERVAL_S,
+) -> None:
+    """Advance the heartbeat while the child keeps producing output.
+
+    Deliberately not a timer. A heartbeat bumped on wall-clock alone reports
+    uptime, which is precisely the defect this replaces -- it would keep a
+    hung agent alive forever and leave the recycler and the escalation ladder
+    with nothing to act on. Growth in the runner log is the one progress signal
+    available for an adapter whose output the worker does not parse, so the
+    stamp moves only when new bytes have actually arrived.
+    """
+    if log_path is None:
+        return
+
+    def _size() -> int:
+        try:
+            return log_path.stat().st_size
+        except OSError:
+            return -1
+
+    last_size = _size()
+    while is_running():
+        if interval_s > 0:
+            time.sleep(interval_s)
+        size = _size()
+        # Strictly greater: a truncated or rotated log is not progress.
+        if size > last_size:
+            last_size = size
+            with contextlib.suppress(OSError):
+                _write_heartbeat(heartbeat_path, now=time.time())
+
+
 def _write_pid_file(
     pid_dir: Path,
     session: str,
@@ -404,6 +484,15 @@ def main() -> None:
     parser.add_argument("--pid-dir", required=True, help="Directory for PID metadata files")
     parser.add_argument("--workdir", default=".", help="Project root directory")
     parser.add_argument("--log-path", help="Path to the agent log file")
+    parser.add_argument(
+        "--heartbeat-dir",
+        default="",
+        help=(
+            "Directory the orchestrator polls for heartbeats. Defaults to "
+            "<workdir>/.sdd/runtime/heartbeats, which is wrong whenever "
+            "--workdir is a per-agent worktree."
+        ),
+    )
     parser.add_argument("--model", default="", help="Model name for metadata")
     parser.add_argument(
         "--tool-abort-policy",
@@ -512,13 +601,13 @@ def main() -> None:
         on_resolved=_pid_file_holder.append,
     )
 
-    # 2c. Touch heartbeat file so the agent starts with a fresh timestamp.
+    # 2c. Write the heartbeat so the agent starts with a fresh timestamp.
     # Without this, idle recycling can kill agents before their first
     # stream-json event arrives (e.g. Claude Code thinking for 2+ minutes).
+    heartbeat_path = _resolve_heartbeat_path(args)
     with contextlib.suppress(OSError):
-        hb_dir = Path(args.workdir) / ".sdd" / "runtime" / "heartbeats"
-        hb_dir.mkdir(parents=True, exist_ok=True)
-        (hb_dir / args.session).touch()
+        heartbeat_path.parent.mkdir(parents=True, exist_ok=True)
+        _write_heartbeat(heartbeat_path, now=time.time())
 
     # 3. Spawn child process (inherits our stdout/stderr/stdin).
     #
@@ -547,6 +636,19 @@ def main() -> None:
         # handler forwards to it (and lets main() reap it) instead of
         # unlinking + exiting on its own.
         _child_holder.append(child)
+        # 3b. Keep the heartbeat honest for the child's lifetime. The prompt's
+        # own heartbeat loop only runs if the model chooses to run it, and most
+        # do not, so for every wrapped adapter this thread is the only writer.
+        threading.Thread(
+            target=_heartbeat_refresh_loop,
+            args=(
+                heartbeat_path,
+                Path(args.log_path) if args.log_path else None,
+                lambda: child.poll() is None,
+            ),
+            daemon=True,
+            name="bernstein-worker-heartbeat",
+        ).start()
     except FileNotFoundError as exc:
         # Typed first-run error: the adapter binary is missing from PATH.
         # Callers running this worker as a subprocess can categorise via

--- a/tests/unit/test_worker_heartbeat_refresh.py
+++ b/tests/unit/test_worker_heartbeat_refresh.py
@@ -1,0 +1,279 @@
+"""The worker keeps the heartbeat honest for every adapter it wraps.
+
+``bernstein-worker`` wraps every adapter that is not ``claude`` -- qwen,
+codex, opencode, cursor and the rest. For that whole population nothing
+advanced ``<root>/.sdd/runtime/heartbeats/<session>.json`` past the
+spawner's pre-spawn write: the refresh loop lives in a shell snippet
+pasted into the agent's prompt, and a model that never runs it leaves the
+file frozen. Heartbeat age then measured uptime, so the idle recycler and
+the escalation ladder killed working agents on a fixed clock (issue #4330).
+
+The worker's own attempt to cover that gap missed in three ways at once:
+it aimed at ``<worktree>/.sdd/runtime/heartbeats/`` while the orchestrator
+reads the project root, it dropped the ``.json`` suffix the readers require,
+and ``Path.touch()`` left a zero-byte file with no timestamp to parse.
+
+The tests below pin the fix and, just as importantly, pin its limit: the
+heartbeat advances only when the runner log has grown, so an agent that has
+genuinely stopped emitting still ages out and is still recycled.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from bernstein.adapters.base import HEARTBEAT_DIR_ENV, build_worker_cmd
+from bernstein.core.orchestration.worker import (
+    _heartbeat_refresh_loop,
+    _write_heartbeat,
+)
+
+
+def _flag(argv: list[str], name: str) -> str | None:
+    return argv[argv.index(name) + 1] if name in argv else None
+
+
+# ---------------------------------------------------------------------------
+# Plumbing the orchestrator root down to the worker
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatDirPlumbing:
+    """The worker must be told where the readers actually look.
+
+    Every adapter derives its runtime paths from the ``workdir`` it is
+    spawned into, which under worktree isolation is the agent's worktree --
+    not the project root the orchestrator polls. The root travels through
+    the process environment, the same channel ``BERNSTEIN_RUN_ID`` already
+    uses to reach agent subprocesses, so none of the ~50 adapter call sites
+    have to learn about it.
+    """
+
+    def test_flag_carries_the_exported_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        root_hb = tmp_path / "root" / ".sdd" / "runtime" / "heartbeats"
+        monkeypatch.setenv(HEARTBEAT_DIR_ENV, str(root_hb))
+
+        argv = build_worker_cmd(
+            ["qwen"],
+            role="backend",
+            session_id="backend-abc",
+            pid_dir=tmp_path / "wt" / "pids",
+            workdir=tmp_path / "wt",
+            log_path=tmp_path / "wt" / "backend-abc.log",
+        )
+
+        assert _flag(argv, "--heartbeat-dir") == str(root_hb)
+
+    def test_no_flag_without_an_exported_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A standalone worker keeps working off ``--workdir`` as before."""
+        monkeypatch.delenv(HEARTBEAT_DIR_ENV, raising=False)
+
+        argv = build_worker_cmd(
+            ["qwen"],
+            role="backend",
+            session_id="backend-abc",
+            pid_dir=tmp_path / "pids",
+            workdir=tmp_path,
+            log_path=tmp_path / "backend-abc.log",
+        )
+
+        assert "--heartbeat-dir" not in argv
+
+    def test_explicit_argument_wins_over_the_environment(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(HEARTBEAT_DIR_ENV, str(tmp_path / "from-env"))
+
+        argv = build_worker_cmd(
+            ["qwen"],
+            role="backend",
+            session_id="backend-abc",
+            pid_dir=tmp_path / "pids",
+            workdir=tmp_path,
+            log_path=tmp_path / "backend-abc.log",
+            heartbeat_dir=tmp_path / "explicit",
+        )
+
+        assert _flag(argv, "--heartbeat-dir") == str(tmp_path / "explicit")
+
+
+# ---------------------------------------------------------------------------
+# The heartbeat body
+# ---------------------------------------------------------------------------
+
+
+class TestWriteHeartbeat:
+    def test_creates_a_body_the_readers_can_parse(self, tmp_path: Path) -> None:
+        """``touch()`` left nothing to read; every consumer parses JSON."""
+        path = tmp_path / "backend-abc.json"
+
+        _write_heartbeat(path, now=1234.5)
+
+        assert json.loads(path.read_text()) == {
+            "timestamp": 1234.5,
+            "status": "running",
+            "phase": "running",
+        }
+
+    def test_preserves_a_richer_body_written_by_another_writer(self, tmp_path: Path) -> None:
+        """Adapters that report real phases must not be flattened.
+
+        The claude wrapper writes a phase per parsed stream-json event. The
+        worker only has bytes on a pipe, so it corrects the timestamp and
+        leaves every field it cannot honestly speak to alone.
+        """
+        path = tmp_path / "backend-abc.json"
+        path.write_text(json.dumps({"timestamp": 1.0, "status": "working", "phase": "implementing", "task": "t-9"}))
+
+        _write_heartbeat(path, now=99.0)
+
+        assert json.loads(path.read_text()) == {
+            "timestamp": 99.0,
+            "status": "working",
+            "phase": "implementing",
+            "task": "t-9",
+        }
+
+    def test_survives_a_corrupt_body(self, tmp_path: Path) -> None:
+        path = tmp_path / "backend-abc.json"
+        path.write_text("{not json")
+
+        _write_heartbeat(path, now=7.0)
+
+        assert json.loads(path.read_text())["timestamp"] == 7.0
+
+
+# ---------------------------------------------------------------------------
+# What the refresh is allowed to mean
+# ---------------------------------------------------------------------------
+
+
+def _runs(times: int) -> Callable[[], bool]:
+    state = {"n": 0}
+
+    def _is_running() -> bool:
+        state["n"] += 1
+        return state["n"] <= times
+
+    return _is_running
+
+
+class TestRefreshLoop:
+    def test_growing_log_advances_the_heartbeat(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("")
+        hb = tmp_path / "agent.json"
+        _write_heartbeat(hb, now=0.0)
+
+        def _is_running() -> bool:
+            log.write_text(log.read_text() + "tool call\n")
+            return log.stat().st_size < 40
+
+        _heartbeat_refresh_loop(hb, log, _is_running, interval_s=0.0)
+
+        assert json.loads(hb.read_text())["timestamp"] > 0.0
+
+    def test_silent_agent_still_ages_out(self, tmp_path: Path) -> None:
+        """The point of the fix is a truthful signal, not an immortal agent.
+
+        A worker that bumped the heartbeat on a timer would report uptime --
+        exactly the defect being fixed, only harder to see. With no new bytes
+        in the log the heartbeat must stay where it was so the recycler and
+        the escalation ladder can still do their job.
+        """
+        log = tmp_path / "agent.log"
+        log.write_text("frozen")
+        hb = tmp_path / "agent.json"
+        _write_heartbeat(hb, now=0.0)
+
+        _heartbeat_refresh_loop(hb, log, _runs(25), interval_s=0.0)
+
+        assert json.loads(hb.read_text())["timestamp"] == 0.0
+
+    def test_no_log_path_means_no_refresh(self, tmp_path: Path) -> None:
+        hb = tmp_path / "agent.json"
+        _write_heartbeat(hb, now=0.0)
+
+        _heartbeat_refresh_loop(hb, None, _runs(25), interval_s=0.0)
+
+        assert json.loads(hb.read_text())["timestamp"] == 0.0
+
+    def test_a_truncated_log_is_not_progress(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("aaaaaaaaaa")
+        hb = tmp_path / "agent.json"
+        _write_heartbeat(hb, now=0.0)
+
+        def _is_running() -> bool:
+            log.write_text("a")
+            return True
+
+        _heartbeat_refresh_loop(hb, log, _runs_then(_is_running, 5), interval_s=0.0)
+
+        assert json.loads(hb.read_text())["timestamp"] == 0.0
+
+
+def _runs_then(side_effect: Callable[[], bool], times: int) -> Callable[[], bool]:
+    state = {"n": 0}
+
+    def _is_running() -> bool:
+        state["n"] += 1
+        side_effect()
+        return state["n"] <= times
+
+    return _is_running
+
+
+# ---------------------------------------------------------------------------
+# End to end through a real worker process
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group signals")
+class TestWorkerProcessHeartbeat:
+    def test_worker_writes_the_heartbeat_where_the_orchestrator_reads_it(self, tmp_path: Path) -> None:
+        """The whole defect, end to end: right directory, right name, real body."""
+        root_hb = tmp_path / "root" / ".sdd" / "runtime" / "heartbeats"
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        log_path = worktree / "backend-e2e.log"
+
+        argv = build_worker_cmd(
+            ["sleep", "10"],
+            role="backend",
+            session_id="backend-e2e",
+            pid_dir=tmp_path / "pids",
+            workdir=worktree,
+            log_path=log_path,
+            heartbeat_dir=root_hb,
+        )
+        proc = subprocess.Popen(argv, start_new_session=True)
+        try:
+            hb_file = root_hb / "backend-e2e.json"
+            deadline = time.monotonic() + 15
+            while not hb_file.exists() and time.monotonic() < deadline:
+                time.sleep(0.05)
+
+            assert hb_file.exists(), f"no heartbeat at {hb_file}; wrote {list(root_hb.parent.rglob('*'))}"
+            body = json.loads(hb_file.read_text())
+            assert isinstance(body["timestamp"], (int, float))
+            assert not (worktree / ".sdd" / "runtime" / "heartbeats" / "backend-e2e").exists()
+        finally:
+            os.killpg(os.getpgid(proc.pid), 15)
+            proc.wait(timeout=10)
+
+
+def test_worker_help_documents_the_flag() -> None:
+    out = subprocess.run(
+        [sys.executable, "-m", "bernstein.core.orchestration.worker", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert "--heartbeat-dir" in out.stdout

--- a/tests/unit/volunteer/test_volunteer_submission.py
+++ b/tests/unit/volunteer/test_volunteer_submission.py
@@ -12,7 +12,6 @@ import pytest
 
 from bernstein.core.git.git_basic import GitResult
 
-from bernstein.core.git.git_pr import push_head_as
 
 @pytest.fixture
 def isolated_pacing(tmp_path: Path):
@@ -193,7 +192,10 @@ def test_pacing_releases_after_the_tracked_pr_is_merged(tmp_path: Path, isolated
     # Mock DCO and push so we don't need real git config or a real repo
     with (
         patch("bernstein.core.volunteer.submission.read_dco_line", return_value="Jane Doe <jane@example.com>"),
-        patch("bernstein.core.volunteer.submission.push_head_as", return_value=GitResult(returncode=0, stdout="", stderr="")),
+        patch(
+            "bernstein.core.volunteer.submission.push_head_as",
+            return_value=GitResult(returncode=0, stdout="", stderr=""),
+        ),
     ):
         pr_url = submit_volunteer_pr(
             bundle=_make_bundle(),


### PR DESCRIPTION
Closes #4330.

## What was wrong

For every adapter `build_worker_cmd` wraps — qwen, codex, opencode, cursor and the rest — nothing advanced `<root>/.sdd/runtime/heartbeats/<session>.json` past the spawner's pre-spawn write.

The refresh loop ships as a shell snippet pasted into the agent's prompt (`HeartbeatMonitor.inject_heartbeat_instructions`, under `## Heartbeat (background)`). It runs only if the model chooses to run it. Most do not. Heartbeat age therefore measured **uptime**, not idleness — so the idle recycler and the escalation ladder killed working agents on a fixed clock, mid-edit, on every run.

The worker already tried to cover that gap. It missed three ways at once:

| | |
|---|---|
| wrong directory | wrote under `<worktree>/.sdd/runtime/heartbeats/`; the orchestrator reads the project root |
| wrong name | no `.json` suffix, which every reader requires |
| no body | `Path.touch()` leaves a zero-byte file with no timestamp to parse |

The worktree/root half of this is already documented in `spawner_core._mcp_config_for_adapter`, which fixes exactly this problem for `openai_agents` via `consumes_heartbeat_dir` — including the sentence "workers wrote heartbeats into the worktree, the monitor polled the orchestrator root, and every spawn was killed at the stale threshold with no log line pointing at the cause." That fix was scoped to the one adapter with its own runner. Every other adapter has `bernstein-worker` and was left in the same trap.

## The change

- The orchestrator exports its heartbeat directory onto the process environment, next to and modelled on the existing `BERNSTEIN_RUN_ID` export, which solves the same worktree-vs-root problem for wave-3 instrumentation.
- `build_worker_cmd` turns it into `--heartbeat-dir`. **No adapter call site changes** — there are ~50 of them and they all derive their paths the same way.
- The worker writes a real body through the existing `_atomic_write_json` helper and **preserves any richer body another writer left**, so the claude wrapper's per-event `phase` is not flattened into a generic one.
- A daemon thread keeps the stamp current for the child's lifetime.

## What this is not

The refresh is deliberately **not** a timer.

A worker that bumped the heartbeat every N seconds while the child existed would report uptime — the same defect, only harder to see — and would leave the recycler and the escalation ladder with nothing to act on. That would trade one broken signal for a permanently disabled one.

Instead the stamp advances only when the runner log has grown. An agent that has genuinely stopped emitting still ages out and is still recycled. Growth is strictly-greater, so a truncated or rotated log does not count as progress.

Two tests pin that limit specifically, and both fail against a timer implementation:

- `test_silent_agent_still_ages_out`
- `test_a_truncated_log_is_not_progress`

Verified by mutating `if size > last_size:` to `if True:` — both fail; restored — both pass.

## Tests

`tests/unit/test_worker_heartbeat_refresh.py`, 12 tests: flag plumbing (including that a standalone worker with no exported root keeps its current `--workdir` behaviour), body shape, richer-body preservation, corrupt-body recovery, the four refresh-semantics cases, and one end-to-end pass through a real worker process asserting the file lands at the `--heartbeat-dir` and *not* at the old worktree path.

Regression check: `tests/unit/test_worker*.py` + `tests/property/test_adapter_spawn_bughunt.py` + adapter spawn tests — 217 passed, 7 skipped, 2 xfailed.

## Note

Two lint errors reported by the local pre-push hook (`I001`, `F401` in `tests/unit/volunteer/test_volunteer_submission.py`) are pre-existing on `main` and untouched by this branch; a separate PR clears them.
