### PR TITLE
chore(tests): drop an unused import that fails the pre-push lint

### DIFF
--- a/tests/unit/volunteer/test_volunteer_submission.py
+++ b/tests/unit/volunteer/test_volunteer_submission.py
@@ -192,7 +192,10 @@ def test_pacing_releases_after_the_tracked_pr_is_merged(tmp_path: Path, isolated
     # Mock DCO and push so we don't need real git config or a real repo
     with (
         patch("bernstein.core.volunteer.submission.read_dco_line", return_value="Jane Doe <jane@example.com>"),
-        patch("bernstein.core.volunteer.submission.push_head_as", return_value=GitResult(returncode=0, stdout="", stderr="")),
+        patch(
+            "bernstein.core.volunteer.submission.push_head_as",
+            return_value=GitResult(returncode=0, stdout="", stderr=""),
+        ),
     ):
         pr_url = submit_volunteer_pr(
             bundle=_make_bundle(),

--- a/tests/unit/volunteer/test_volunteer_submission.py
+++ b/tests/unit/volunteer/test_volunteer_submission.py
@@ -12,7 +12,6 @@ import pytest
 
 from bernstein.core.git.git_basic import GitResult
 
-from bernstein.core.git.git_pr import push_head_as
 
 @pytest.fixture
 def isolated_pacing(tmp_path: Path):


### PR DESCRIPTION
`ruff check src/ tests/ scripts/` currently reports two errors on `main`, so the repo's own pre-push hook rejects every branch that touches anything.

Both come from `tests/unit/volunteer/test_volunteer_submission.py`: `push_head_as` is imported but never referenced (the one test that exercises it patches by dotted string, `"bernstein.core.volunteer.submission.push_head_as"`, not through the symbol), and dropping it lets the import block sort.

`ruff check src/ tests/ scripts/` is clean after this. The file's 6 tests still pass.