### PR TITLE
fix(orchestrator): convergence guard stops blocking at zero active agents

### DIFF
--- a/src/bernstein/core/orchestration/convergence_guard.py
+++ b/src/bernstein/core/orchestration/convergence_guard.py
@@ -14,6 +14,7 @@ Usage inside ``claim_and_spawn_batches``::
 
 from __future__ import annotations
 
+import logging
 import time
 from collections import deque
 from dataclasses import dataclass, field
@@ -21,6 +22,8 @@ from dataclasses import dataclass, field
 from bernstein.core.models import ConvergenceGuardConfig
 
 __all__ = ["ConvergenceGuard", "ConvergenceStatus"]
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Status
@@ -136,17 +139,25 @@ class ConvergenceGuard:
             if active_agents >= self._cfg.max_active_agents:
                 reasons.append(f"Too many active agents ({active_agents}/{self._cfg.max_active_agents})")
 
+        # Gates 3 and 4 are backpressure. At zero active agents there is no
+        # pressure to relieve, and blocking the wave removes the only thing
+        # that could clear the condition -- the run cannot recover (#4336).
+        idle = active_agents == 0
+
         # Gate 3: error rate
         if error_rate is not None:
             computed_error_rate = error_rate
-            if error_rate > self._cfg.max_error_rate:
+            if error_rate > self._cfg.max_error_rate and not idle:
                 reasons.append(f"High error rate ({error_rate:.0%} > {self._cfg.max_error_rate:.0%})")
 
         # Gate 4: spawn rate
         if spawn_rate is not None:
             computed_spawn_rate = spawn_rate
-            if spawn_rate > self._cfg.max_spawn_rate:
+            if spawn_rate > self._cfg.max_spawn_rate and not idle:
                 reasons.append(f"Spawn rate too high ({spawn_rate:.1f}/min > {self._cfg.max_spawn_rate:.1f}/min)")
+
+        if idle and (error_rate is not None or spawn_rate is not None):
+            logger.info("convergence_guard: idle floor -- rate gates skipped at 0 active agents")
 
         ready = len(reasons) == 0
         return ConvergenceStatus(

--- a/tests/unit/test_convergence_guard_idle_floor.py
+++ b/tests/unit/test_convergence_guard_idle_floor.py
@@ -1,0 +1,44 @@
+"""A guard that blocks at zero agents can never unblock itself (#4336).
+
+Gates 3 and 4 are backpressure: they exist to slow a system down while it
+is under load. With no agent running there is no load, and the spawn they
+block is the only thing that could bring the error rate back down, so the
+run stalls until its timeout instead of recovering.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.orchestration.convergence_guard import ConvergenceGuard
+
+
+def _guard() -> ConvergenceGuard:
+    return ConvergenceGuard()
+
+
+def test_high_error_rate_does_not_block_when_nothing_is_running() -> None:
+    status = _guard().is_converged(active_agents=0, error_rate=1.0)
+    assert status.ready, status.reasons
+
+
+def test_high_spawn_rate_does_not_block_when_nothing_is_running() -> None:
+    status = _guard().is_converged(active_agents=0, spawn_rate=10_000.0)
+    assert status.ready, status.reasons
+
+
+def test_high_error_rate_still_blocks_while_agents_are_running() -> None:
+    status = _guard().is_converged(active_agents=1, error_rate=1.0)
+    assert not status.ready
+    assert any("error rate" in r.lower() for r in status.reasons)
+
+
+def test_agent_cap_still_blocks_at_its_own_limit() -> None:
+    """The idle floor covers the rate gates only; the cap is not backpressure."""
+    guard = _guard()
+    status = guard.is_converged(active_agents=guard._cfg.max_active_agents, error_rate=1.0)
+    assert not status.ready
+
+
+def test_unknown_agent_count_keeps_the_rate_gates_armed() -> None:
+    """``active_agents=None`` means unmeasured, not zero."""
+    status = _guard().is_converged(error_rate=1.0)
+    assert not status.ready

--- a/tests/unit/test_task_lifecycle.py
+++ b/tests/unit/test_task_lifecycle.py
@@ -442,7 +442,13 @@ def test_claim_and_spawn_batches_sets_xl_timeout_bucket_for_high_risk_batch(tmp_
 
 
 def test_claim_and_spawn_batches_blocked_by_high_error_rate(tmp_path: Path, make_task: Any) -> None:
-    """claim_and_spawn_batches skips the entire spawn wave when convergence guard detects high error rate."""
+    """claim_and_spawn_batches skips the spawn wave when the error rate is high.
+
+    ``alive_count`` is 1, not 0: the rate gates are backpressure, and at zero
+    active agents the guard deliberately stops gating (see
+    ``test_convergence_guard_idle_floor``). One is also below ``max_agents``,
+    so the guard is the only gate that can block this wave.
+    """
     orch = _claim_orch(tmp_path)
     # Wire a convergence guard with a low error-rate threshold
     cg = ConvergenceGuard(ConvergenceGuardConfig(max_error_rate=0.3))
@@ -460,7 +466,7 @@ def test_claim_and_spawn_batches_blocked_by_high_error_rate(tmp_path: Path, make
     task = make_task(id="T-blocked", role="backend")
     result = TickResult()
 
-    claim_and_spawn_batches(orch, [[task]], alive_count=0, assigned_task_ids=set(), done_ids=set(), result=result)
+    claim_and_spawn_batches(orch, [[task]], alive_count=1, assigned_task_ids=set(), done_ids=set(), result=result)
 
     # Spawn must not happen - convergence guard blocked it
     orch._client.post.assert_not_called()


### PR DESCRIPTION
Closes #4336.

Gates 3 and 4 are backpressure: they slow the system while it is under load. At zero active agents there is no load, and the spawn wave they block is the only mechanism that could bring the error rate back down — so a run that trips the gate cannot recover on its own and sits until its timeout.

Both gates now skip when `active_agents == 0`.

Deliberately narrow:
- The agent cap (gate 2) is untouched — it is a cap, not backpressure, and cannot fire at zero anyway.
- `active_agents=None` still means *unmeasured*, not zero, so a caller that passes no count keeps today's behaviour. Pinned by `test_unknown_agent_count_keeps_the_rate_gates_armed`.
- While any agent is running, a high error rate blocks exactly as before.

5 tests in `tests/unit/test_convergence_guard_idle_floor.py`. Verified RED by removing `and not idle`: the two idle-floor tests fail, the three guard-still-armed tests keep passing. 32 convergence tests green after.