### PR TITLE
fix(git): narrow transient push marker to avoid matching credential errors

### DIFF
--- a/src/bernstein/core/git/git_basic.py
+++ b/src/bernstein/core/git/git_basic.py
@@ -411,7 +411,7 @@ def _rebase_or_merge(cwd: Path, remote: str, branch: str) -> GitResult | None:
 
 _TRANSIENT_MARKERS = (
     "unable to access",
-    "could not read",
+    "could not read from remote",
     "connection",
     "timed out",
     "timeout",
@@ -419,6 +419,13 @@ _TRANSIENT_MARKERS = (
     "non-fast-forward",
     "fetch first",
     "cannot lock ref",
+)
+
+_TERMINAL_MARKERS = (
+    "could not read username",
+    "authentication failed",
+    "permission denied",
+    "fatal: could not read",
 )
 
 
@@ -433,6 +440,22 @@ def _is_transient_push_error(stderr: str) -> bool:
     """
     lower = stderr.lower()
     return any(marker in lower for marker in _TRANSIENT_MARKERS)
+
+
+def _is_terminal_push_error(stderr: str) -> bool:
+    """Check if a push failure is terminal and should not be retried.
+
+    Terminal errors indicate configuration problems (missing credentials,
+    auth failures) that will not resolve with retries.
+
+    Args:
+        stderr: Stderr output from the failed push.
+
+    Returns:
+        True if the error matches a known terminal pattern.
+    """
+    lower = stderr.lower()
+    return any(marker in lower for marker in _TERMINAL_MARKERS)
 
 
 def remote_exists(cwd: Path, remote: str = "origin") -> bool:
@@ -654,6 +677,15 @@ def _push_with_retry(
             _rebase_or_merge(cwd, remote, branch)
         push_result = run_git(["push", remote, branch], cwd, timeout=60)
         if push_result.ok:
+            return push_result
+        # Terminal errors (missing credentials, auth failures) will not
+        # resolve with retries — fail immediately with a clear message.
+        if _is_terminal_push_error(push_result.stderr):
+            logger.error(
+                "git push to %s failed (configuration error, not retried): %s",
+                remote,
+                push_result.stderr.strip(),
+            )
             return push_result
         if not _is_transient_push_error(push_result.stderr) or attempt >= max_retries:
             if attempt > 0:

--- a/tests/unit/test_git_basic.py
+++ b/tests/unit/test_git_basic.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 import pytest
 from bernstein.core.git_basic import (
     GitResult,
+    _is_terminal_push_error,
+    _is_transient_push_error,
     run_git,
     safe_push,
     stage_all_except,
@@ -105,3 +107,44 @@ def test_safe_push_corrects_master_and_rebases_when_remote_is_ahead(tmp_path: Pa
     assert mock_run_git.call_args_list[1].args[0] == ["rev-list", "--count", "HEAD..origin/main"]
     assert mock_run_git.call_args_list[2].args[0] == ["rebase", "origin/main"]
     assert mock_run_git.call_args_list[3].args[0] == ["push", "origin", "main"]
+
+
+# --- Transient vs terminal push error classification ---
+
+
+class TestTransientPushError:
+    """Tests for _is_transient_push_error marker matching."""
+
+    def test_network_errors_are_transient(self) -> None:
+        assert _is_transient_push_error("could not read from remote repository")
+        assert _is_transient_push_error("unable to access 'https://github.com/repo.git'")
+        assert _is_transient_push_error("Connection refused")
+        assert _is_transient_push_error("timed out")
+        assert _is_transient_push_error("timeout")
+        assert _is_transient_push_error("reset by peer")
+
+    def test_credential_errors_are_not_transient(self) -> None:
+        # The old marker "could not read" matched both — now it shouldn't
+        assert not _is_transient_push_error(
+            "could not read Username for 'https://github.com': No such device or address"
+        )
+
+    def test_non_fast_forward_is_transient(self) -> None:
+        assert _is_transient_push_error("rejected (non-fast-forward)")
+        assert _is_transient_push_error("fetch first")
+
+
+class TestTerminalPushError:
+    """Tests for _is_terminal_push_error marker matching."""
+
+    def test_credential_errors_are_terminal(self) -> None:
+        assert _is_terminal_push_error(
+            "could not read Username for 'https://github.com': No such device or address"
+        )
+        assert _is_terminal_push_error("Authentication failed")
+        assert _is_terminal_push_error("Permission denied (publickey)")
+
+    def test_network_errors_are_not_terminal(self) -> None:
+        assert not _is_terminal_push_error("could not read from remote repository")
+        assert not _is_terminal_push_error("Connection refused")
+        assert not _is_terminal_push_error("timed out")


### PR DESCRIPTION
## Problem

A push blocked by a missing credential is retried four times with backoff, and logged as transient. The bare substring `"could not read"` in `_TRANSIENT_MARKERS` matches both the transport error `could not read from remote repository` (worth retrying) and the credential prompt `could not read Username for '<url>'` (configuration state, not transient).

This causes every missing-credential push to pay the full retry ladder, with misleading "transient" log messages.

## Fix

- Narrow the transient marker from `"could not read"` to `"could not read from remote"` — matches the transport failure without matching the credential prompt
- Add `_TERMINAL_MARKERS` for credential/auth errors (`could not read username`, `authentication failed`, `permission denied`)
- Add `_is_terminal_push_error()` helper function
- Check terminal errors before transient in `_push_with_retry` — fail immediately on configuration errors with a clear message instead of retrying

## Test Plan

- [x] All existing tests pass (`pytest tests/unit/test_git_basic.py`)
- [x] New tests verify transient marker correctly matches network errors but not credential errors
- [x] New tests verify terminal marker correctly matches credential errors but not network errors
- [x] `uv run --python 3.12 python -m pytest tests/unit/test_git_basic.py -v` — 10/10 passed

Closes #4340
