### PR TITLE
fix(git): do not retry missing push credentials

### DIFF
--- a/src/bernstein/core/git/git_basic.py
+++ b/src/bernstein/core/git/git_basic.py
@@ -411,7 +411,7 @@ def _rebase_or_merge(cwd: Path, remote: str, branch: str) -> GitResult | None:
 
 _TRANSIENT_MARKERS = (
     "unable to access",
-    "could not read",
+    "could not read from remote",
     "connection",
     "timed out",
     "timeout",

--- a/tests/unit/test_git_basic.py
+++ b/tests/unit/test_git_basic.py
@@ -11,12 +11,28 @@ from unittest.mock import patch
 import pytest
 from bernstein.core.git_basic import (
     GitResult,
+    _is_transient_push_error,
     run_git,
     safe_push,
     stage_all_except,
     stage_files,
     stage_task_files,
 )
+
+
+@pytest.mark.parametrize(
+    ("stderr", "expected"),
+    [
+        ("fatal: unable to access 'https://github.com/org/repo.git': Could not resolve host", True),
+        ("fatal: could not read from remote repository", True),
+        ("fatal: could not read Username for 'https://github.com': No such device or address", False),
+        ("fatal: Could not read Password for 'https://github.com': terminal prompts disabled", False),
+        ("error: failed to push some refs", False),
+    ],
+)
+def test_is_transient_push_error_distinguishes_credential_prompts(stderr: str, expected: bool) -> None:
+    """Credential prompts are terminal; transport failures remain retryable."""
+    assert _is_transient_push_error(stderr) is expected
 
 
 def test_run_git_raises_called_process_error_when_check_is_true(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #4340 by narrowing the push retry marker for `could not read` errors.

Git's non-interactive credential prompt (`could not read Username` / `Could not read Password`) is a terminal configuration failure, not a transient transport failure. The marker now requires `could not read from remote`, preserving retries for the transport error while avoiding retry backoff for missing credentials.

## Validation

- `python -m pytest tests/unit/test_git_basic.py -q` — 10 passed
- `python -m ruff check src/bernstein/core/git/git_basic.py tests/unit/test_git_basic.py` — passed
- `python -m ruff format --check src/bernstein/core/git/git_basic.py tests/unit/test_git_basic.py` — passed
- `git diff --check` — passed

The repository's initial `uv run --frozen` setup was blocked while downloading large dependencies; focused tests and lint/format checks were run with the available Python environment.