### PR TITLE
fix(orchestration): stop orphan handling from crashing the tick

### DIFF
--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -346,6 +346,28 @@ def _save_partial_work(spawner: Any, session: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _handle_orphaned_task_guarded(
+    orch: Any,
+    task_id: str,
+    session: AgentSession,
+    tasks_snapshot: dict[str, list[Task]],
+) -> None:
+    """Orphan handling for one task, isolated from the rest of the cleanup.
+
+    An exception here used to propagate out of the tick, skipping
+    ``_save_partial_work`` and worktree cleanup, so the dying agent's
+    uncommitted work was lost.
+    """
+    try:
+        handle_orphaned_task(orch, task_id, session, tasks_snapshot)
+    except Exception:
+        logger.exception(
+            "handle_orphaned_task failed for task %s (agent %s); continuing death cleanup",
+            task_id,
+            session.id,
+        )
+
+
 def _handle_dead_agent(orch: Any, session: AgentSession, tasks_snapshot: dict[str, list[Task]]) -> None:
     """Process a single agent that has been detected as dead."""
     abort_reason, abort_detail = classify_agent_abort_reason(session)
@@ -378,7 +400,7 @@ def _handle_dead_agent(orch: Any, session: AgentSession, tasks_snapshot: dict[st
     for task_id in session.task_ids:
         orch._crash_counts[task_id] = orch._crash_counts.get(task_id, 0) + 1
         _maybe_preserve_worktree(orch, session, task_id)
-        handle_orphaned_task(orch, task_id, session, tasks_snapshot)
+        _handle_orphaned_task_guarded(orch, task_id, session, tasks_snapshot)
     _save_partial_work(orch._spawner, session)
     _preserved = getattr(orch, "_preserved_worktrees", {})
     _session_preserved = any(
@@ -2212,9 +2234,6 @@ def handle_orphaned_task(
         emit_orphan_metrics(orch._workdir, task_id, session, start_ts, success=False, error_type="escalated")
         return
 
-    # Collect structured completion data from agent log
-    completion_data = collect_completion_data(orch._workdir, session)
-
     # Artifact-mode tasks run the pass even with no declared signals: the
     # signed receipt it records is their completion identity (issue #2608).
     if task.completion_signals or is_artifact_mode(task):
@@ -2223,7 +2242,7 @@ def handle_orphaned_task(
             try:
                 result_payload: dict[str, Any] = {
                     "result_summary": f"Auto-completed after agent {session.id} died; janitor passed",
-                } | completion_data
+                }
                 orch._client.post(
                     f"{base}/tasks/{task_id}/complete",
                     json=result_payload,
@@ -2673,7 +2692,7 @@ def _reap_wall_clock_timeout(
         orch._signal_mgr.clear_signals(session.id)
     _preserve_runner_logs(orch, session)
     for task_id in session.task_ids:
-        handle_orphaned_task(orch, task_id, session, tasks_snapshot)
+        _handle_orphaned_task_guarded(orch, task_id, session, tasks_snapshot)
     _save_partial_work(orch._spawner, session)
     _preserved = getattr(orch, "_preserved_worktrees", {})
     _session_preserved = any(

--- a/tests/unit/test_orphan_completion_payload.py
+++ b/tests/unit/test_orphan_completion_payload.py
@@ -1,0 +1,132 @@
+"""The dead-agent cleanup must survive its own orphan handling.
+
+``handle_orphaned_task`` posted the completion payload merged with
+``collect_completion_data``, whose ``log_summary`` is an ``AgentLogSummary``
+object. ``httpx`` raised ``TypeError`` while encoding the body, the exception
+left ``handle_orphaned_task`` (which only guards ``httpx.HTTPError``) and
+aborted the whole tick, so ``_save_partial_work`` never ran and the dying
+agent's uncommitted work was lost. The server never wanted those keys:
+``TaskCompleteRequest`` accepts ``result_summary`` and ``payload`` only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from bernstein.core.models import AgentSession, ModelConfig, Task, TaskStatus, TaskType
+
+from bernstein.core.agents import agent_lifecycle
+from bernstein.core.agents.agent_lifecycle import _handle_dead_agent, handle_orphaned_task
+from bernstein.core.tasks.task_lifecycle import collect_completion_data
+
+_SESSION_ID = "backend-orphan-1"
+
+
+def _write_agent_log(workdir: Path, session_id: str) -> None:
+    log = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text(
+        "[2026-08-22 14:00:00] starting\n"
+        "[2026-08-22 14:00:01] Edited src/bernstein/cli.py\n"
+        "[2026-08-22 14:00:02] done\n",
+        encoding="utf-8",
+    )
+
+
+def _make_session() -> AgentSession:
+    return AgentSession(
+        id=_SESSION_ID,
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=["T-orphan"],
+        exit_code=137,
+    )
+
+
+def _make_orch(tmp_path: Path) -> SimpleNamespace:
+    orch = SimpleNamespace()
+    orch._config = SimpleNamespace(
+        server_url="http://server",
+        recovery="restart",
+        max_crash_retries=3,
+        max_task_retries=3,
+    )
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    orch._client = MagicMock()
+    orch._client.post.return_value = response
+    orch._workdir = tmp_path
+    orch._rate_limit_tracker = None
+    orch._crash_counts = {}
+    orch._retried_task_ids = set()
+    orch._record_provider_health = MagicMock()
+    orch._evolution = None
+    orch._wal_writer = None
+    orch._spawner = MagicMock()
+    orch._spawner.get_worktree_path.return_value = None
+    return orch
+
+
+def test_agent_log_really_produces_a_log_summary_object(tmp_path: Path) -> None:
+    """Guard against a vacuous regression test below."""
+    _write_agent_log(tmp_path, _SESSION_ID)
+    data = collect_completion_data(tmp_path, _make_session())
+    assert data.get("log_summary") is not None
+
+
+def test_orphan_auto_complete_body_is_json_serializable(tmp_path: Path) -> None:
+    """The janitor-passed completion POST must be encodable by httpx."""
+    _write_agent_log(tmp_path, _SESSION_ID)
+    task = Task(
+        id="T-orphan",
+        title="Implement cli.py hello",
+        description="Add a hello subcommand",
+        role="backend",
+        task_type=TaskType.STANDARD,
+        status=TaskStatus.CLAIMED,
+    )
+    orch = _make_orch(tmp_path)
+
+    with (
+        patch.object(agent_lifecycle, "is_artifact_mode", return_value=True),
+        patch.object(agent_lifecycle, "verify_task_completion", return_value=(True, [])),
+    ):
+        handle_orphaned_task(
+            orch,
+            task.id,
+            _make_session(),
+            {"claimed": [task], "open": [], "in_progress": [], "done": []},
+        )
+
+    body = orch._client.post.call_args.kwargs["json"]
+    json.dumps(body)
+    assert set(body) <= {"result_summary", "payload"}
+
+
+def test_death_cleanup_runs_when_orphan_handling_raises(tmp_path: Path) -> None:
+    """One task's orphan failure must not cost the session its partial work."""
+    orch = MagicMock()
+    orch._workdir = tmp_path
+    orch._crash_counts = {}
+    orch._preserved_worktrees = {}
+    orch._agent_failure_timestamps = {}
+    session = _make_session()
+
+    with (
+        patch.object(agent_lifecycle, "handle_orphaned_task", side_effect=TypeError("not serializable")),
+        patch.object(agent_lifecycle, "_save_partial_work") as save_partial,
+        patch.object(agent_lifecycle, "_capture_agent_crash"),
+        patch.object(agent_lifecycle, "_propagate_abort_to_children"),
+        patch.object(agent_lifecycle, "_preserve_runner_logs"),
+        patch.object(agent_lifecycle, "_maybe_preserve_worktree"),
+        patch.object(agent_lifecycle, "_release_file_ownership"),
+        patch.object(agent_lifecycle, "_release_task_to_session"),
+    ):
+        _handle_dead_agent(orch, session, {"claimed": [], "open": [], "in_progress": [], "done": []})
+
+    save_partial.assert_called_once()
+    orch._spawner.cleanup_worktree.assert_called_once_with(session.id)


### PR DESCRIPTION
Closes #4345.

A dead agent's uncommitted work was lost whenever the orphan handler ran on a session that had written a log.

`handle_orphaned_task` merged `collect_completion_data(...)` into the auto-complete request body. Its `log_summary` is an `AgentLogSummary` object, `httpx` could not encode it, and the resulting `TypeError` escaped the function — which guards only `httpx.HTTPError` — and aborted the tick before `_save_partial_work` and `cleanup_worktree` ran.

Observed on a fleet run at tick 677:

```
INFO  Crash recovery: preserving worktree . for task ad3b8e24d65f
ERROR Tick 677 failed (1 consecutive failures)
TypeError: Object of type AgentLogSummary is not JSON serializable
```

**Drop the merge.** `TaskCompleteRequest` accepts `result_summary` and `payload` only, so `files_modified` and `test_results` were already being dropped server-side and `log_summary` never arrived. It stays an in-process value, read by `quality/effectiveness.py`, `agents/heartbeat.py`, and `tasks/task_lifecycle.py`.

**Isolate the orphan handling.** `_handle_orphaned_task_guarded` logs the task and agent id and returns, so one task's failure no longer skips the session's partial-work commit or worktree cleanup. Both death-cleanup loops use it.

### Tests

`tests/unit/test_orphan_completion_payload.py`:

| Test | Asserts |
|---|---|
| `test_agent_log_really_produces_a_log_summary_object` | the fixture log really yields a `log_summary` — guards the next test against being vacuous |
| `test_orphan_auto_complete_body_is_json_serializable` | the POST body round-trips through `json.dumps` and carries only declared keys |
| `test_death_cleanup_runs_when_orphan_handling_raises` | `_save_partial_work` and `cleanup_worktree` still run when the handler raises |

Both regression tests fail on `main` — the first reproduces the exact production `TypeError` — and the vacuity guard passes on both sides.

96 tests pass across `test_agent_lifecycle`, `test_janitor_alive_exit`, `test_idle_agent_recycling`, `test_max_output_tokens_escalation`, and `test_reactive_compact_413`.
