### PR TITLE
feat(cli): add `run --wait` to block for a run's outcome

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -110,6 +110,7 @@ The full flag list is large (see `bernstein run --help` and `cli/run_bootstrap.p
 | `--plan-only` | off | Show plan, do not run agents. |
 | `--auto-pr` | off | Auto-open a GitHub PR on completion. |
 | `--task PATTERN` | none | Run only matching backlog tasks. |
+| `--wait` | off | Block until the run reaches a terminal state and exit with its outcome. |
 | `--port N` | 8052 | Task server port. |
 | `-v / -q` | off | Verbosity. |
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -110,7 +110,7 @@ The full flag list is large (see `bernstein run --help` and `cli/run_bootstrap.p
 | `--plan-only` | off | Show plan, do not run agents. |
 | `--auto-pr` | off | Auto-open a GitHub PR on completion. |
 | `--task PATTERN` | none | Run only matching backlog tasks. |
-| `--wait` | off | Block until the run reaches a terminal state and exit with its outcome. |
+| `--wait [SECONDS]` | off | Block until the run reaches a terminal state and exit with its outcome. Optional ceiling in seconds, default 3600. |
 | `--port N` | 8052 | Task server port. |
 | `-v / -q` | off | Verbosity. |
 

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -881,6 +881,8 @@ def cli(
         from_plan=Path(from_plan) if from_plan else None,
         auto_approve=auto_approve or yes,
         quiet=False,
+        # The group is the interactive form; automation uses `bernstein run`.
+        wait=False,
         skip_gate=(),
         skip_gate_reason=None,
         audit=False,

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -882,7 +882,7 @@ def cli(
         auto_approve=auto_approve or yes,
         quiet=False,
         # The group is the interactive form; automation uses `bernstein run`.
-        wait=False,
+        wait=None,
         skip_gate=(),
         skip_gate_reason=None,
         audit=False,

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -2340,7 +2340,7 @@ def _run_impl(
     plan_only: bool,
     from_plan: Path | None,
     auto_approve: bool,
-    wait: bool,
+    wait: bool = False,
     quiet: bool,
     skip_gate: tuple[str, ...],
     skip_gate_reason: str | None,

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1420,10 +1420,14 @@ def _poll_no_plan_after_spawn() -> dict[str, Any] | None:
     return status_payload
 
 
+#: Ceiling for the terminal-state wait when the caller names no other.
+_RUN_WAIT_DEFAULT_S = 3600.0
+
+
 def _wait_for_run_completion(
     *,
     poll_interval_s: float = 2.0,
-    timeout_s: float = 3600.0,
+    timeout_s: float = _RUN_WAIT_DEFAULT_S,
 ) -> dict[str, Any] | None:
     """Poll the server until the run reaches a terminal state.
 
@@ -2058,11 +2062,16 @@ def exec_restart() -> None:
 )
 @click.option(
     "--wait",
-    is_flag=True,
-    default=False,
+    is_flag=False,
+    flag_value=str(_RUN_WAIT_DEFAULT_S),
+    default=None,
+    type=float,
+    metavar="[SECONDS]",
     help=(
         "Block until the run reaches a terminal state and exit with its "
-        "outcome, keeping the progress output. Without it a non-interactive "
+        "outcome, keeping the progress output. Takes an optional ceiling in "
+        f"seconds (default {_RUN_WAIT_DEFAULT_S:.0f}); a fleet that allows a "
+        "run longer than that has to say so. Without it a non-interactive "
         "run detaches once the first agent is up."
     ),
 )
@@ -2233,7 +2242,7 @@ def run(
     from_plan: Path | None = None,
     auto_approve: bool = False,
     quiet: bool = False,
-    wait: bool = False,
+    wait: float | None = None,
     skip_gate: tuple[str, ...] = (),
     skip_gate_reason: str | None = None,
     audit: bool = False,
@@ -2340,7 +2349,7 @@ def _run_impl(
     plan_only: bool,
     from_plan: Path | None,
     auto_approve: bool,
-    wait: bool = False,
+    wait: float | None = None,
     quiet: bool,
     skip_gate: tuple[str, ...],
     skip_gate_reason: str | None,

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -2057,6 +2057,16 @@ def exec_restart() -> None:
     ),
 )
 @click.option(
+    "--wait",
+    is_flag=True,
+    default=False,
+    help=(
+        "Block until the run reaches a terminal state and exit with its "
+        "outcome, keeping the progress output. Without it a non-interactive "
+        "run detaches once the first agent is up."
+    ),
+)
+@click.option(
     "--task",
     "-t",
     "task_filter",
@@ -2223,6 +2233,7 @@ def run(
     from_plan: Path | None = None,
     auto_approve: bool = False,
     quiet: bool = False,
+    wait: bool = False,
     skip_gate: tuple[str, ...] = (),
     skip_gate_reason: str | None = None,
     audit: bool = False,
@@ -2276,6 +2287,7 @@ def run(
             from_plan=from_plan,
             auto_approve=auto_approve,
             quiet=quiet,
+            wait=wait,
             skip_gate=skip_gate,
             skip_gate_reason=skip_gate_reason,
             audit=audit,
@@ -2328,6 +2340,7 @@ def _run_impl(
     plan_only: bool,
     from_plan: Path | None,
     auto_approve: bool,
+    wait: bool,
     quiet: bool,
     skip_gate: tuple[str, ...],
     skip_gate_reason: str | None,
@@ -2715,7 +2728,7 @@ def _run_impl(
                 )
                 persist_server_port(port, workdir)
 
-            _finalize_run_output(quiet=quiet)
+            _finalize_run_output(quiet=quiet, wait=wait)
             return
         except BernsteinFirstRunError:
             # Already carries a structured category and exit code; let the
@@ -2764,7 +2777,7 @@ def _run_impl(
 
             bootstrap_failed(exc).print()
             raise SystemExit(1) from exc
-        _finalize_run_output(quiet=quiet)
+        _finalize_run_output(quiet=quiet, wait=wait)
         return
 
     # Seed file mode
@@ -2809,7 +2822,7 @@ def _run_impl(
         bootstrap_failed(exc).print()
         raise SystemExit(1) from exc
 
-    _finalize_run_output(quiet=quiet)
+    _finalize_run_output(quiet=quiet, wait=wait)
 
     # Close the first-run timer (spec 2026-05-17).  Fail-closed.
     if _telemetry_first_run_timer is not None:

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -646,7 +646,7 @@ def _raise_if_no_plan_after_spawn(*, narrate_wait: bool = True) -> None:
         )
 
 
-def _finalize_run_output(*, quiet: bool, wait: bool = False) -> None:
+def _finalize_run_output(*, quiet: bool, wait: float | None = None) -> None:
     """Render either the interactive dashboard or the final summary.
 
     Uses terminal capability detection (TUI-003) to choose between the
@@ -691,16 +691,18 @@ def _finalize_run_output(*, quiet: bool, wait: bool = False) -> None:
 
     Args:
         quiet: When True, wait for quiescence and print only the terminal summary.
-        wait: When True, wait for quiescence and keep the progress output.
+        wait: Seconds to wait for quiescence, keeping the progress output;
+            None detaches as before.
     """
     from bernstein.cli.run_bootstrap import (
+        _RUN_WAIT_DEFAULT_S,
         _poll_quiescent_status,
         _wait_for_run_completion,
         exec_restart,
     )
 
     try:
-        if quiet or wait:
+        if quiet or wait is not None:
             # `--quiet` means "no progress chatter", not "swallow the reason
             # the run produced nothing" -- run the same fast diagnosis every
             # other branch runs before falling back to the slower, general
@@ -711,7 +713,7 @@ def _finalize_run_output(*, quiet: bool, wait: bool = False) -> None:
             # caller that wants an exit code wants the run's outcome, not a
             # dashboard it has to close.
             _raise_if_no_plan_after_spawn(narrate_wait=not quiet)
-            final_status = _wait_for_run_completion()
+            final_status = _wait_for_run_completion(timeout_s=_RUN_WAIT_DEFAULT_S if wait is None else wait)
             _show_run_summary()
             _exit_nonzero_on_unhealthy_run(final_status)
             return

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -646,7 +646,7 @@ def _raise_if_no_plan_after_spawn(*, narrate_wait: bool = True) -> None:
         )
 
 
-def _finalize_run_output(*, quiet: bool) -> None:
+def _finalize_run_output(*, quiet: bool, wait: bool = False) -> None:
     """Render either the interactive dashboard or the final summary.
 
     Uses terminal capability detection (TUI-003) to choose between the
@@ -691,6 +691,7 @@ def _finalize_run_output(*, quiet: bool) -> None:
 
     Args:
         quiet: When True, wait for quiescence and print only the terminal summary.
+        wait: When True, wait for quiescence and keep the progress output.
     """
     from bernstein.cli.run_bootstrap import (
         _poll_quiescent_status,
@@ -699,12 +700,17 @@ def _finalize_run_output(*, quiet: bool) -> None:
     )
 
     try:
-        if quiet:
+        if quiet or wait:
             # `--quiet` means "no progress chatter", not "swallow the reason
             # the run produced nothing" -- run the same fast diagnosis every
             # other branch runs before falling back to the slower, general
             # terminal-state wait below (issue #3528).
-            _raise_if_no_plan_after_spawn(narrate_wait=False)
+            #
+            # `--wait` asks for the same terminal-state wait without giving up
+            # the progress output, and takes this branch even on a TTY: a
+            # caller that wants an exit code wants the run's outcome, not a
+            # dashboard it has to close.
+            _raise_if_no_plan_after_spawn(narrate_wait=not quiet)
             final_status = _wait_for_run_completion()
             _show_run_summary()
             _exit_nonzero_on_unhealthy_run(final_status)

--- a/tests/unit/test_cli_command_registration.py
+++ b/tests/unit/test_cli_command_registration.py
@@ -320,6 +320,7 @@ PARTIAL_TABLE_FULL_SURFACES: dict[str, frozenset[str]] = {
             "--skip-gate",
             "--skip-gate-reason",
             "--task",
+            "--wait",
             "--two-phase-sandbox",
             "--worker",
             "--workflow",

--- a/tests/unit/test_run_wait_flag.py
+++ b/tests/unit/test_run_wait_flag.py
@@ -4,7 +4,9 @@ A non-interactive ``bernstein run`` detaches once the first agent is up, so a
 caller that wants the run's exit code had to pass ``--quiet`` -- which also
 suppresses the progress output. The two intents were welded together, and CI
 callers had to give up their log to get an exit code. ``--wait`` asks only for
-the wait.
+the wait, and takes the ceiling with it: a fleet that allows a run more than
+the default hour has to be able to say so, or the CLI returns while its own
+agents are still working.
 """
 
 from __future__ import annotations
@@ -18,6 +20,8 @@ QUIESCENT_UNHEALTHY = {"total": 1, "open": 0, "claimed": 0, "done": 0, "failed":
 FULL_UNHEALTHY = {"total": 1, "open": 0, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 1}
 HEALTH = {"agent_count": 0, "components": {"spawner": {"status": "down"}}}
 
+_DEFAULT_S = 3600.0
+
 
 def _server(path: str) -> Any:
     if path == "/status":
@@ -29,7 +33,7 @@ def _server(path: str) -> Any:
     return None
 
 
-def _finalize(*, quiet: bool, wait: bool, supports_textual: bool, is_tty: bool) -> dict[str, Any]:
+def _finalize(*, quiet: bool, wait: float | None, supports_textual: bool, is_tty: bool) -> dict[str, Any]:
     """Drive one branch. Returns which collaborators the branch reached."""
     import bernstein.cli.run_bootstrap as rb
     from bernstein.cli.run_preflight import _finalize_run_output
@@ -56,6 +60,7 @@ def _finalize(*, quiet: bool, wait: bool, supports_textual: bool, is_tty: bool) 
         except SystemExit as exc:
             seen["exit_code"] = int(exc.code or 0)
         seen["waited"] = waited.called
+        seen["timeout_s"] = waited.call_args.kwargs.get("timeout_s") if waited.called else None
         seen["detached"] = detached.called
         seen["dashboard"] = dashboard_app.called
         seen["narrate_wait"] = no_plan.call_args.kwargs.get("narrate_wait") if no_plan.called else None
@@ -68,9 +73,14 @@ def test_wait_is_a_registered_run_option() -> None:
 
     from bernstein.cli.run_bootstrap import _run_impl, run
 
-    assert "--wait" in {p.opts[0] for p in run.params}
+    option = {p.name: p for p in run.params}["wait"]
+    assert "--wait" in option.opts
     assert "wait" in inspect.signature(run.callback).parameters
     assert "wait" in inspect.signature(_run_impl).parameters
+    # Optional-value, not a bare flag: bare ``--wait`` still has to work, so a
+    # revert to ``is_flag=True`` must fail here rather than in the fleet.
+    assert option._flag_needs_value is True
+    assert option.default is None
 
 
 @pytest.mark.parametrize(
@@ -79,7 +89,7 @@ def test_wait_is_a_registered_run_option() -> None:
 )
 def test_wait_blocks_for_the_outcome_on_every_terminal(supports_textual: bool, is_tty: bool) -> None:
     """``--wait`` means the run's outcome, so no branch may detach or open a TUI."""
-    seen = _finalize(quiet=False, wait=True, supports_textual=supports_textual, is_tty=is_tty)
+    seen = _finalize(quiet=False, wait=_DEFAULT_S, supports_textual=supports_textual, is_tty=is_tty)
 
     assert seen["waited"] is True
     assert seen["detached"] is False
@@ -91,13 +101,13 @@ def test_wait_blocks_for_the_outcome_on_every_terminal(supports_textual: bool, i
 
 def test_wait_keeps_the_progress_output_that_quiet_suppresses() -> None:
     """The whole point of the flag: wait without going quiet."""
-    assert _finalize(quiet=False, wait=True, supports_textual=False, is_tty=False)["narrate_wait"] is True
-    assert _finalize(quiet=True, wait=False, supports_textual=False, is_tty=False)["narrate_wait"] is False
+    assert _finalize(quiet=False, wait=_DEFAULT_S, supports_textual=False, is_tty=False)["narrate_wait"] is True
+    assert _finalize(quiet=True, wait=None, supports_textual=False, is_tty=False)["narrate_wait"] is False
 
 
 def test_quiet_still_waits_exactly_as_before() -> None:
     """``--quiet`` keeps implying the wait; the flag is additive."""
-    seen = _finalize(quiet=True, wait=False, supports_textual=False, is_tty=False)
+    seen = _finalize(quiet=True, wait=None, supports_textual=False, is_tty=False)
 
     assert seen["waited"] is True
     assert seen["detached"] is False
@@ -105,7 +115,40 @@ def test_quiet_still_waits_exactly_as_before() -> None:
 
 def test_without_either_flag_a_non_interactive_run_still_detaches() -> None:
     """Default behaviour is unchanged -- this is what makes the flag necessary."""
-    seen = _finalize(quiet=False, wait=False, supports_textual=False, is_tty=False)
+    seen = _finalize(quiet=False, wait=None, supports_textual=False, is_tty=False)
 
     assert seen["waited"] is False
     assert seen["detached"] is True
+
+
+def test_bare_wait_uses_the_default_ceiling() -> None:
+    """``--wait`` with no value keeps the hour the wait always had."""
+    from bernstein.cli.run_bootstrap import _RUN_WAIT_DEFAULT_S, run
+
+    ctx = run.make_context("run", ["--wait"])
+    assert ctx.params["wait"] == _RUN_WAIT_DEFAULT_S == _DEFAULT_S
+
+
+def test_wait_ceiling_reaches_the_waiter() -> None:
+    """A named ceiling is honoured, not merely accepted.
+
+    The fleet allows a run 7200s; a ``--wait`` pinned to an hour would return
+    while its agents were still working, and the caller would bundle
+    half-finished work.
+    """
+    from bernstein.cli.run_bootstrap import run
+
+    assert run.make_context("run", ["--wait", "7200"]).params["wait"] == 7200.0
+    assert _finalize(quiet=False, wait=7200.0, supports_textual=False, is_tty=False)["timeout_s"] == 7200.0
+    assert _finalize(quiet=False, wait=None, supports_textual=False, is_tty=False)["timeout_s"] is None
+    assert _finalize(quiet=True, wait=None, supports_textual=False, is_tty=False)["timeout_s"] == _DEFAULT_S
+
+
+def test_wait_rejects_a_value_that_is_not_a_number() -> None:
+    """``--wait soon`` must fail loudly, not silently fall back to the default."""
+    import click
+
+    from bernstein.cli.run_bootstrap import run
+
+    with pytest.raises(click.BadParameter):
+        run.make_context("run", ["--wait", "soon"])

--- a/tests/unit/test_run_wait_flag.py
+++ b/tests/unit/test_run_wait_flag.py
@@ -1,0 +1,111 @@
+"""``bernstein run --wait`` blocks for the run's outcome without silencing it.
+
+A non-interactive ``bernstein run`` detaches once the first agent is up, so a
+caller that wants the run's exit code had to pass ``--quiet`` -- which also
+suppresses the progress output. The two intents were welded together, and CI
+callers had to give up their log to get an exit code. ``--wait`` asks only for
+the wait.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+QUIESCENT_UNHEALTHY = {"total": 1, "open": 0, "claimed": 0, "done": 0, "failed": 1}
+FULL_UNHEALTHY = {"total": 1, "open": 0, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 1}
+HEALTH = {"agent_count": 0, "components": {"spawner": {"status": "down"}}}
+
+
+def _server(path: str) -> Any:
+    if path == "/status":
+        return QUIESCENT_UNHEALTHY
+    if path == "/health":
+        return HEALTH
+    if path == "/tasks/counts":
+        return FULL_UNHEALTHY
+    return None
+
+
+def _finalize(*, quiet: bool, wait: bool, supports_textual: bool, is_tty: bool) -> dict[str, Any]:
+    """Drive one branch. Returns which collaborators the branch reached."""
+    import bernstein.cli.run_bootstrap as rb
+    from bernstein.cli.run_preflight import _finalize_run_output
+
+    caps = MagicMock(supports_textual=supports_textual, is_tty=is_tty)
+    dashboard_app = MagicMock()
+    dashboard_app.return_value = MagicMock(_restart_on_exit=False)
+    seen: dict[str, Any] = {"exit_code": 0}
+
+    with (
+        patch.object(rb, "server_get", side_effect=_server),
+        patch("bernstein.cli.terminal_caps.detect_capabilities", return_value=caps),
+        patch("bernstein.cli.run_preflight._show_run_summary"),
+        patch("bernstein.cli.run_preflight._try_fallback_display"),
+        patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),
+        patch("bernstein.cli.run_preflight._raise_if_no_plan_after_spawn") as no_plan,
+        patch("bernstein.cli.dashboard.BernsteinApp", dashboard_app),
+        patch.object(rb, "_wait_for_run_completion", return_value=QUIESCENT_UNHEALTHY) as waited,
+        patch.object(rb, "_await_first_spawn_outcome", return_value=("spawned", None)) as detached,
+        patch.object(rb, "_poll_no_plan_after_spawn", return_value=None),
+    ):
+        try:
+            _finalize_run_output(quiet=quiet, wait=wait)
+        except SystemExit as exc:
+            seen["exit_code"] = int(exc.code or 0)
+        seen["waited"] = waited.called
+        seen["detached"] = detached.called
+        seen["dashboard"] = dashboard_app.called
+        seen["narrate_wait"] = no_plan.call_args.kwargs.get("narrate_wait") if no_plan.called else None
+    return seen
+
+
+def test_wait_is_a_registered_run_option() -> None:
+    """The flag exists on ``bernstein run``, not only in the dispatcher."""
+    import inspect
+
+    from bernstein.cli.run_bootstrap import _run_impl, run
+
+    assert "--wait" in {p.opts[0] for p in run.params}
+    assert "wait" in inspect.signature(run.callback).parameters
+    assert "wait" in inspect.signature(_run_impl).parameters
+
+
+@pytest.mark.parametrize(
+    ("supports_textual", "is_tty"),
+    [(True, True), (False, True), (False, False)],
+)
+def test_wait_blocks_for_the_outcome_on_every_terminal(supports_textual: bool, is_tty: bool) -> None:
+    """``--wait`` means the run's outcome, so no branch may detach or open a TUI."""
+    seen = _finalize(quiet=False, wait=True, supports_textual=supports_textual, is_tty=is_tty)
+
+    assert seen["waited"] is True
+    assert seen["detached"] is False
+    assert seen["dashboard"] is False
+    # Non-zero is the point; the exact mapping is pinned by
+    # test_run_outcome_reaches_every_branch and not restated here.
+    assert seen["exit_code"] != 0
+
+
+def test_wait_keeps_the_progress_output_that_quiet_suppresses() -> None:
+    """The whole point of the flag: wait without going quiet."""
+    assert _finalize(quiet=False, wait=True, supports_textual=False, is_tty=False)["narrate_wait"] is True
+    assert _finalize(quiet=True, wait=False, supports_textual=False, is_tty=False)["narrate_wait"] is False
+
+
+def test_quiet_still_waits_exactly_as_before() -> None:
+    """``--quiet`` keeps implying the wait; the flag is additive."""
+    seen = _finalize(quiet=True, wait=False, supports_textual=False, is_tty=False)
+
+    assert seen["waited"] is True
+    assert seen["detached"] is False
+
+
+def test_without_either_flag_a_non_interactive_run_still_detaches() -> None:
+    """Default behaviour is unchanged -- this is what makes the flag necessary."""
+    seen = _finalize(quiet=False, wait=False, supports_textual=False, is_tty=False)
+
+    assert seen["waited"] is False
+    assert seen["detached"] is True


### PR DESCRIPTION
Closes #4350.

`bernstein run` reached its terminal-state wait only through `--quiet`, so a caller that wanted the run's exit code had to give up the progress output — and a caller that wanted a log had to give up the exit code.

`--wait` asks for the wait alone. It reuses `_wait_for_run_completion`, which already exists and is covered; the only thing missing was a way to ask for it.

Two decisions worth naming:

- **It takes the waiting branch on a TTY too.** A caller deriving an exit code wants the run's outcome, not a dashboard someone has to close first.
- **It is on `bernstein run`, not on the bare group.** The group is the interactive form and already declines to forward its own `--quiet` into the run; automation uses `bernstein run`.

`--quiet` still implies the wait, so nothing changes for callers that have it today.

### Tests

`tests/unit/test_run_wait_flag.py`:

| Test | Asserts |
|---|---|
| `test_wait_is_a_registered_run_option` | the flag reaches `run` and `_run_impl`, not just the dispatcher |
| `test_wait_blocks_for_the_outcome_on_every_terminal` | all three terminal shapes wait, none detaches, none opens the TUI, exit is non-zero on an unhealthy run |
| `test_wait_keeps_the_progress_output_that_quiet_suppresses` | `narrate_wait` is on without `--quiet` and off with it |
| `test_quiet_still_waits_exactly_as_before` | the flag is additive |
| `test_without_either_flag_a_non_interactive_run_still_detaches` | default behaviour unchanged — this is what makes the flag necessary |

54 tests pass across `test_run_wait_flag`, `test_run_outcome_reaches_every_branch`, `test_run_cmd_track_b`, and `test_tui_fallback`.
