### PR TITLE
fix(docker): run the volunteer rig seeder as a non-root user

### DIFF
--- a/docker/volunteer-rig/Dockerfile
+++ b/docker/volunteer-rig/Dockerfile
@@ -11,4 +11,8 @@ RUN chmod +x /usr/local/bin/volunteer-rig-seed /usr/local/bin/volunteer-rig-asse
 # Fixture project files
 COPY docker/volunteer-rig/fixtures/ /fixtures/
 
+# The rig clones into /tmp and reads /fixtures; nothing here needs root.
+RUN useradd --create-home --uid 1000 rig
+USER rig
+
 ENTRYPOINT ["volunteer-rig-seed"]


### PR DESCRIPTION
`static-analysis (extended)` fails on main since #4283: Trivy's IaC gate flags `docker/volunteer-rig/Dockerfile` with DS-0002 (no `USER` directive, HIGH). The PR lane does not run the extended scan, so it surfaced only after the merge.

The seeder clones into `/tmp` and reads `/fixtures`; nothing in it needs root. Add a non-root user.

Verified locally: the image builds, and under `uid=1000(rig)` the entrypoint's dependencies (`git`, `jq`, `curl`) and `/fixtures` remain readable.

Failing runs: [32579736299](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/32579736299), and the identical failure one merge earlier.
