### PR TITLE
feat(cli): add `pr --issue` to title and link the PR from its issue

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1418,9 +1418,10 @@ See [`reference/mcp-catalog.md`](mcp-catalog.md) for the full reference.
 |---|---|---|
 | `--session-id ID` | most recent completed session | Session to publish. |
 | `--base BRANCH` | main | Base branch for the pull request. |
+| `--issue N\|URL` | none | Title the PR from a GitHub issue and open its body with `Closes #N`. Reads the issue, so `--dry-run` makes that one request. |
 | `--title TEXT` | auto-generated | Override the PR title. |
 | `--draft` | off | Open as a draft PR. |
-| `--dry-run` | off | Print the would-be title and body without calling `gh`. |
+| `--dry-run` | off | Print the would-be title and body without calling `gh`. Reads the issue when `--issue` is given. |
 | `--no-push` | off | Skip `git push`; assume the branch is already on origin. |
 
 (`cli/commands/pr_cmd.py:183-220`.)

--- a/src/bernstein/cli/commands/pr_cmd.py
+++ b/src/bernstein/cli/commands/pr_cmd.py
@@ -28,6 +28,12 @@ from bernstein.core.integrations.pr_gen import (
     build_pr_title,
     load_session_summary,
 )
+from bernstein.core.integrations.tickets import (
+    TicketAuthError,
+    TicketParseError,
+    TicketPayload,
+    fetch_ticket,
+)
 
 _GH_MISSING_HINT = (
     "Could not find the `gh` CLI on PATH. Install it with `brew install gh` "
@@ -180,6 +186,45 @@ def _gh_pr_create(
     return True, result.stdout.strip()
 
 
+def _resolve_issue(ref: str, workdir: Path) -> tuple[int, TicketPayload]:
+    """Resolve ``--issue`` (a number or a GitHub issue URL) to its ticket.
+
+    A bare number is resolved against the repository ``gh`` sees in
+    ``workdir``, then goes down the same path as a URL so the provider's
+    ``gh``-then-REST fallback is shared.
+    """
+    ref = ref.strip().lstrip("#")
+    url = ref
+    if ref.isdigit():
+        if shutil.which("gh") is None:
+            raise click.ClickException(_GH_MISSING_HINT)
+        slug = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+            capture_output=True,
+            text=True,
+            cwd=str(workdir),
+            timeout=30,
+            check=False,
+        ).stdout.strip()
+        if not slug:
+            raise click.ClickException(
+                f"Could not tell which repository #{ref} belongs to. Pass the full issue URL instead."
+            )
+        url = f"https://github.com/{slug}/issues/{ref}"
+
+    try:
+        ticket = fetch_ticket(url)
+    except TicketAuthError as exc:
+        raise click.ClickException(f"Authentication error reading the issue: {exc}") from exc
+    except TicketParseError as exc:
+        raise click.ClickException(f"Could not read the issue: {exc}") from exc
+
+    number = ticket.id.rsplit("#", 1)[-1]
+    if not number.isdigit():
+        raise click.ClickException(f"{url} is not a GitHub issue; --issue needs one to link.")
+    return int(number), ticket
+
+
 @click.command("pr")
 @click.option(
     "--session-id",
@@ -193,6 +238,17 @@ def _gh_pr_create(
     default="main",
     show_default=True,
     help="Base branch for the pull request.",
+)
+@click.option(
+    "--issue",
+    "issue_ref",
+    default=None,
+    metavar="N|URL",
+    help=(
+        "Link the PR to a GitHub issue: title it from the issue and open the "
+        "body with `Closes #N`. Reads the issue, so --dry-run makes that one "
+        "request."
+    ),
 )
 @click.option(
     "--title",
@@ -223,6 +279,7 @@ def _gh_pr_create(
 def pr_cmd(
     session_id: str | None,
     base: str,
+    issue_ref: str | None,
     title_override: str | None,
     draft: bool,
     dry_run: bool,
@@ -230,17 +287,29 @@ def pr_cmd(
 ) -> None:
     """Open a GitHub pull request from a completed Bernstein session.
 
-    The command is safe to re-run: on ``--dry-run`` it never touches the
-    network, and when ``gh`` is missing it exits with a helpful message
-    instead of a traceback.
+    The command is safe to re-run: on ``--dry-run`` it touches the network
+    only to read the issue named by ``--issue`` (nothing at all without it),
+    and when ``gh`` is missing it exits with a helpful message instead of a
+    traceback.
     """
     workdir = Path.cwd()
 
     summary = load_session_summary(session_id, workdir=workdir, base_branch=base)
     summary = _enrich_summary_with_git(summary, workdir)
 
-    title = title_override or build_pr_title(summary.goal or summary.session_id, summary.primary_role)
+    issue_number: int | None = None
+    issue_title = ""
+    if issue_ref is not None:
+        issue_number, ticket = _resolve_issue(issue_ref, workdir)
+        issue_title = ticket.title
+
+    # The issue title is a cleaner source than the goal, which carries the
+    # instructions handed to the run.
+    title = title_override or build_pr_title(issue_title or summary.goal or summary.session_id, summary.primary_role)
     body = build_pr_body(summary)
+    if issue_number is not None:
+        # GitHub links an issue from the body or a commit message only.
+        body = f"Closes #{issue_number}\n\n{body}"
 
     if dry_run:
         click.echo(f"Title: {title}")

--- a/tests/unit/test_pr_cmd_issue_link.py
+++ b/tests/unit/test_pr_cmd_issue_link.py
@@ -1,0 +1,119 @@
+"""``bernstein pr --issue`` titles the PR from the issue and links it.
+
+Without it the title comes from the run's goal, and the goal a fleet hands
+an agent starts with the instructions it was given -- so an issue-driven run
+opened PRs titled ``fix: resolve GitHub issue #4345: ...`` truncated
+mid-word. The link was worse: nothing put a closing keyword anywhere GitHub
+reads, so merging the PR left the issue open.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+from bernstein.core.integrations.pr_gen import CostBreakdown, SessionSummary
+from bernstein.core.integrations.tickets import TicketParseError, TicketPayload
+
+ISSUE = TicketPayload(
+    id="sipyourdrink-ltd/bernstein#4345",
+    title="Dead-agent orphan handling crashes the tick",
+    description="body text",
+    labels=("bug",),
+    url="https://github.com/sipyourdrink-ltd/bernstein/issues/4345",
+    source="github",
+)
+
+GOAL = (
+    "Resolve GitHub issue #4345: Dead-agent orphan handling crashes the tick\n\n"
+    "Work only inside this repository. Follow existing code style."
+)
+
+
+def _summary() -> SessionSummary:
+    return SessionSummary(
+        session_id="backend-1",
+        goal=GOAL,
+        branch="run-1",
+        base_branch="main",
+        primary_role="backend",
+        diff_stat=" src/x.py | 2 +-",
+        gates=(),
+        cost=CostBreakdown(total_usd=0.0, total_tokens=0, by_role={}),
+        evidence=None,
+    )
+
+
+def _run(args: list[str], *, ticket: Any = ISSUE) -> Any:
+    """Invoke `bernstein pr --dry-run` with the session and issue stubbed."""
+    fetch = MagicMock(side_effect=ticket) if isinstance(ticket, Exception) else MagicMock(return_value=ticket)
+    slug = MagicMock(stdout="sipyourdrink-ltd/bernstein\n")
+    with (
+        patch("bernstein.cli.commands.pr_cmd.load_session_summary", return_value=_summary()),
+        patch("bernstein.cli.commands.pr_cmd._enrich_summary_with_git", side_effect=lambda s, _w: s),
+        patch("bernstein.cli.commands.pr_cmd.fetch_ticket", fetch),
+        patch("bernstein.cli.commands.pr_cmd.shutil.which", return_value="/usr/bin/gh"),
+        patch("bernstein.cli.commands.pr_cmd.subprocess.run", return_value=slug),
+    ):
+        result = CliRunner().invoke(cli, ["pr", "--dry-run", *args])
+    result.fetch = fetch  # type: ignore[attr-defined]
+    return result
+
+
+def test_issue_is_a_registered_pr_option() -> None:
+    from bernstein.cli.commands.pr_cmd import pr_cmd
+
+    assert "--issue" in {p.opts[0] for p in pr_cmd.params}
+
+
+def test_body_opens_with_the_closing_keyword() -> None:
+    """A comment does not close an issue; only the body or a commit does."""
+    out = _run(["--issue", "4345"]).output
+
+    assert out.splitlines()[2].strip() == "Closes #4345"
+
+
+def test_title_comes_from_the_issue_not_the_goal_preamble() -> None:
+    """The regression this flag exists for."""
+    out = _run(["--issue", "4345"]).output
+    title = next(line for line in out.splitlines() if line.startswith("Title:"))
+
+    assert "dead-agent orphan handling crashes the tick" in title.lower()
+    assert "resolve github issue" not in title.lower()
+    assert "…" not in title
+
+
+@pytest.mark.parametrize("ref", ["4345", "#4345", "https://github.com/sipyourdrink-ltd/bernstein/issues/4345"])
+def test_a_number_a_hash_and_a_url_all_resolve(ref: str) -> None:
+    result = _run(["--issue", ref])
+
+    assert result.exit_code == 0
+    assert "Closes #4345" in result.output
+    # A bare number still reaches the shared provider path, not a second one.
+    assert result.fetch.call_args.args[0].endswith("/issues/4345")
+
+
+def test_explicit_title_still_wins() -> None:
+    out = _run(["--issue", "4345", "--title", "fix: something else"]).output
+
+    assert "Title: fix: something else" in out
+    assert "Closes #4345" in out
+
+
+def test_without_the_flag_nothing_changes() -> None:
+    """No link, and the title still comes from the goal."""
+    out = _run([]).output
+
+    assert "Closes #" not in out
+    assert "resolve github issue" in out.lower()
+
+
+def test_an_unreadable_issue_fails_loudly() -> None:
+    result = _run(["--issue", "4345"], ticket=TicketParseError("not an issue"))
+
+    assert result.exit_code != 0
+    assert "Could not read the issue" in result.output


### PR DESCRIPTION
Closes #4353.

`bernstein pr` had no way to know which issue a run was for, so an issue-driven run opened a PR that neither read like the issue nor closed it.

**Title.** It came from `summary.goal`, and a goal composed from an issue carries the instructions handed to the run, so a realistic one produced `fix: resolve GitHub issue #4345: Dead-agent orphan handling crashes t…` — preamble as noise, real subject truncated mid-word. `build_pr_title` already picks the conventional prefix; it only needed a cleaner input, so there is no new title logic here.

**Link.** GitHub closes an issue from a keyword in the PR body or a commit message; a comment does not count. The body now opens with `Closes #N`.

`--issue` accepts `4345`, `#4345`, or the full URL. A bare number resolves its repository via `gh repo view --json nameWithOwner` and then takes the same path as a URL, so `core/integrations/tickets.fetch_ticket` stays the single provider path and its `gh`-then-REST fallback is shared rather than reimplemented.

One honest consequence: the docstring promised `--dry-run` "never touches the network". Reading the issue is one request, so the docstring now says that instead of quietly breaking the promise.

### Tests

`tests/unit/test_pr_cmd_issue_link.py`:

| Test | Asserts |
|---|---|
| `test_issue_is_a_registered_pr_option` | the flag exists on the command |
| `test_body_opens_with_the_closing_keyword` | `Closes #N` lands where GitHub reads it |
| `test_title_comes_from_the_issue_not_the_goal_preamble` | no preamble, no mid-word truncation — the regression the flag exists for |
| `test_a_number_a_hash_and_a_url_all_resolve` | all three forms reach one provider path |
| `test_explicit_title_still_wins` | `--title` overrides but the link stays |
| `test_without_the_flag_nothing_changes` | no link, title still from the goal |
| `test_an_unreadable_issue_fails_loudly` | a clear message, not a traceback |

22 tests pass across `test_pr_cmd_issue_link`, `test_pr_gen`, and `test_issue_to_pr_cmd`.
