### PR TITLE
docs(contributing): document the route for contributors who cannot open a PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,18 @@ All three must pass before committing. No exceptions, no "fix later."
 
 All non-trivial changes land via PR with at least one approving review. Security-touching changes need two approvals or operator-only push. Full process and reviewer expectations: [docs/CODE_REVIEW.md](docs/CODE_REVIEW.md).
 
+### If you cannot open a pull request
+
+Some contributors cannot reach GitHub from where they work. Post the diff as a
+comment on the issue it addresses -- inline in a fenced block, not as a link to
+a file elsewhere. Maintainers do not fetch patches from external hosts, so a
+download link is a dead end; a diff in the thread is reviewable where it lands,
+and if the issue is already assigned, the assignee can take it or decline it
+without anyone having to fetch anything.
+
+Include what a PR would carry: what changed, the tests that prove it, and the
+commit the diff applies to.
+
 ### Docs alongside code
 
 Every PR that adds or changes a feature MUST update docs in the same PR:


### PR DESCRIPTION
`CONTRIBUTING.md` documents exactly one route: fork, branch, PR. Contributors who cannot reach GitHub from where they work have nothing to follow, and what they improvise does not work.

A recent case: a contributor sent a line-accurate audit of an open issue plus a patch, by email, with the patch hosted on an external bucket. The audit was correct and checked out against the tree. The patch was unusable anyway — maintainers do not fetch patches from external hosts, so there was nowhere for it to go, and the issue was already assigned to someone else who never saw it.

Name the route that works: post the diff inline in the issue thread. It is reviewable where it lands, nothing has to be fetched, and an assigned issue stays with its assignee, who can take the diff or decline it.

Docs-only; no code paths touched.
