### PR TITLE
fix(mypy): fix call-overload and no-any-return in core/cost

### DIFF
--- a/src/bernstein/core/cost/cost_tracker.py
+++ b/src/bernstein/core/cost/cost_tracker.py
@@ -148,10 +148,10 @@ def _usage_tenant_scope(raw: object) -> str:
         ValueError: The row carries a ``tenant_id`` that is not a string.
     """
     if raw is None:
-        return DEFAULT_TENANT_ID
+        return cast(str, DEFAULT_TENANT_ID)
     if not isinstance(raw, str):
         raise ValueError(f"usage tenant_id must be a string, got {type(raw).__name__}")
-    return normalize_tenant_id(raw)
+    return cast(str, normalize_tenant_id(raw))
 
 
 def _resolve_usage_buffer_size() -> int:
@@ -1598,7 +1598,7 @@ class CostTracker:
             pricing: dict[str, float] | None = None
             for key, costs in MODEL_COSTS_PER_1M_TOKENS.items():
                 if key in model_lower:
-                    pricing = costs
+                    pricing = cast("dict[str, float]", costs)
                     break
             if pricing is not None:
                 input_price = pricing.get("input", 0.0)

--- a/src/bernstein/core/cost/free_tier.py
+++ b/src/bernstein/core/cost/free_tier.py
@@ -10,7 +10,7 @@ import logging
 import operator
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -100,10 +100,10 @@ class FreeTierMaximizer:
             for provider, limits in FREE_TIER_LIMITS.items():
                 self._statuses[provider] = FreeTierStatus(
                     provider=provider,
-                    remaining_today=int(limits["requests_per_day"]),
-                    limit_today=int(limits["requests_per_day"]),
-                    remaining_minute=int(limits["requests_per_minute"]),
-                    limit_minute=int(limits["requests_per_minute"]),
+                    remaining_today=int(cast(int, limits["requests_per_day"])),
+                    limit_today=int(cast(int, limits["requests_per_day"])),
+                    remaining_minute=int(cast(int, limits["requests_per_minute"])),
+                    limit_minute=int(cast(int, limits["requests_per_minute"])),
                 )
             return
 
@@ -112,10 +112,10 @@ class FreeTierMaximizer:
             for provider, status_data in data.get("providers", {}).items():
                 self._statuses[provider] = FreeTierStatus(
                     provider=provider,
-                    remaining_today=int(status_data.get("remaining_today", 0)),
-                    limit_today=int(status_data.get("limit_today", 0)),
-                    remaining_minute=int(status_data.get("remaining_minute", 0)),
-                    limit_minute=int(status_data.get("limit_minute", 0)),
+                    remaining_today=int(cast(int, status_data.get("remaining_today", 0))),
+                    limit_today=int(cast(int, status_data.get("limit_today", 0))),
+                    remaining_minute=int(cast(int, status_data.get("remaining_minute", 0))),
+                    limit_minute=int(cast(int, status_data.get("limit_minute", 0))),
                     reset_time=status_data.get("reset_time"),
                     last_updated=float(status_data.get("last_updated", time.time())),
                 )


### PR DESCRIPTION
## What
Fixes mypy errors in `core/cost/free_tier.py` and `core/cost/cost_tracker.py`.

Part of #2980.

## Why
`int()` calls on `object` from JSON dicts caused `call-overload` errors, and `normalize_tenant_id()` returning `Any` caused `no-any-return` errors.

## How
- `free_tier.py`: Added `cast(int, ...)` on `int(limits[...])` and `int(status_data.get(...))` calls. Added `from typing import cast`.
- `cost_tracker.py`: Added `cast(str, ...)` on `DEFAULT_TENANT_ID` and `normalize_tenant_id(raw)` returns. Added `cast("dict[str, float]", costs)` for `ModelUsdPer1MTokens` assignment.

Verified: `uv run mypy --config-file mypy.gate.ini src/bernstein/core/cost/free_tier.py src/bernstein/core/cost/cost_tracker.py` → `Success`.

## Checklist
- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run pyright src/` passes *(N/A - no type changes to existing code)*
- [x] `uv run python scripts/run_tests.py -x` passes *(N/A - type annotation changes only)*
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)
- [x] User-visible README section updated (or N/A if internal-only)
- [x] `docs/operations/<area>.md` updated (or N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (or N/A)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (or N/A)
- [x] Tests cover the documented behaviour