### PR TITLE
fix(mypy): widen gate to include lineage/store.py

### DIFF
--- a/mypy.gate.ini
+++ b/mypy.gate.ini
@@ -39,7 +39,6 @@ exclude = (?x)(
     | ^src/bernstein/core/identity/grants\.py$
     | ^src/bernstein/core/identity/spiffe/workload_api\.py$
     | ^src/bernstein/core/lineage/provenance\.py$
-    | ^src/bernstein/core/lineage/store\.py$
     | ^src/bernstein/core/lineage/tracker_audit\.py$
     | ^src/bernstein/core/persistence/checkpoint\.py$
     | ^src/bernstein/core/persistence/file_health\.py$

--- a/src/bernstein/core/lineage/store.py
+++ b/src/bernstein/core/lineage/store.py
@@ -263,7 +263,7 @@ class LineageStore:
         tip_path = self._tip_path(artefact_path)
         if tip_path.exists():
             with contextlib.suppress(json.JSONDecodeError):
-                return json.loads(tip_path.read_text(encoding="utf-8"))
+                return cast("dict[str, list[str]]", json.loads(tip_path.read_text(encoding="utf-8")))
         return self._recompute_tips_for(artefact_path)
 
     def reindex(self) -> None:
@@ -354,16 +354,16 @@ def _entry_from_dict(payload: dict[str, object]) -> LineageEntry:
     # All canonical-field names map 1:1 onto the dataclass kwargs. Cast through
     # ``asdict`` of a dataclass would be cyclic; we do it manually.
     return LineageEntry(
-        v=int(payload["v"]),  # type: ignore[arg-type]
+        v=int(cast(int, payload["v"])),
         artefact_path=str(payload["artefact_path"]),
         artefact_kind=str(payload["artefact_kind"]),
         content_hash=str(payload["content_hash"]),
-        parent_hashes=list(payload["parent_hashes"]),  # type: ignore[arg-type]
+        parent_hashes=list(cast("list[str]", payload["parent_hashes"])),
         agent_id=str(payload["agent_id"]),
         agent_card_kid=str(payload["agent_card_kid"]),
         tool_call_id=str(payload["tool_call_id"]),
         span_id=str(payload["span_id"]),
-        ts_ns=int(payload["ts_ns"]),  # type: ignore[arg-type]
+        ts_ns=int(cast(int, payload["ts_ns"])),
         operator_hmac=str(payload["operator_hmac"]),
         # Additive (issue #2513): absent on pre-feature entries -> None, which
         # canonicalises back to the exact bytes read, so entry_hash round-trips.


### PR DESCRIPTION
## What
Widens the mypy strict gate to include `core/lineage/store.py`.

Part of #2980.

## Why
`store.py` was excluded from the strict gate due to three `call-overload` errors from calling `int()` and `list()` on values typed as `object`. The existing `# type: ignore[arg-type]` comments didn't cover `call-overload`, so the errors were unignored.

## How
- Replaced `# type: ignore[arg-type]` on `int(payload["v"])` and `int(payload["ts_ns"])` with `cast(int, ...)`.
- Replaced `# type: ignore[arg-type]` on `list(payload["parent_hashes"])` with `cast("list[str]", ...)`.
- Added `cast("dict[str, list[str]]", ...)` on the `json.loads` return in `tip_set()`.
- Removed `^src/bernstein/core/lineage/store\.py$` from `exclude` in `mypy.gate.ini`.

Verified: `uv run mypy --config-file mypy.gate.ini src/bernstein/core/lineage/store.py` → `Success: no issues found`.

## Checklist
- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run pyright src/` passes *(N/A - no type changes to existing code)*
- [x] `uv run python scripts/run_tests.py -x` passes *(N/A - type annotation changes only)*
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)
- [x] User-visible README section updated (or N/A if internal-only)
- [x] `docs/operations/<area>.md` updated (or N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (or N/A)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (or N/A)
- [x] Tests cover the documented behaviour