### PR TITLE
fix(adapters): forward OPENAI_BASE_URL through the Cline adapter env

### DIFF
--- a/docs/operations/env-isolation.md
+++ b/docs/operations/env-isolation.md
@@ -76,6 +76,7 @@ Each adapter passes its own allowlist of API-key-style variables to
 | Adapter      | Extra keys |
 |--------------|------------|
 | Claude Code  | `ANTHROPIC_API_KEY` |
+| Cline        | `CLINE_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_BASE_URL` |
 | Codex        | `OPENAI_API_KEY`, `OPENAI_ORG_ID`, `OPENAI_BASE_URL` |
 | Gemini       | `GOOGLE_API_KEY`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_APPLICATION_CREDENTIALS` |
 | Qwen         | `OPENAI_API_KEY`, `OPENAI_BASE_URL` |

--- a/src/bernstein/adapters/cline.py
+++ b/src/bernstein/adapters/cline.py
@@ -76,7 +76,7 @@ class ClineAdapter(CLIAdapter):
         )
 
         env = build_filtered_env(
-            ["CLINE_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"],
+            ["CLINE_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY", "OPENAI_BASE_URL"],
         )
         with log_path.open("w") as log_file:
             try:

--- a/tests/unit/test_adapter_cline.py
+++ b/tests/unit/test_adapter_cline.py
@@ -54,6 +54,51 @@ class TestClineSpawnMissingBinary:
             )
 
 
+class TestClineEnvIsolation:
+    """spawn() forwards a custom OpenAI-compatible base URL to the CLI."""
+
+    def test_env_forwards_openai_base_url(self, tmp_path: Path) -> None:
+        adapter = ClineAdapter()
+        proc_mock = make_popen_mock(pid=801)
+        with (
+            patch("bernstein.adapters.cline.subprocess.Popen", return_value=proc_mock) as popen,
+            patch.dict(
+                "os.environ",
+                {
+                    "OPENAI_BASE_URL": "https://inference.internal/v1",
+                    "CLINE_API_KEY": "test-cline-key-123",
+                    "PATH": "/usr/bin",
+                },
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="cline-env",
+            )
+        env = popen.call_args.kwargs.get("env", {})
+        assert env["OPENAI_BASE_URL"] == "https://inference.internal/v1"
+        assert env["CLINE_API_KEY"] == "test-cline-key-123"
+
+    def test_env_omits_base_url_when_unset(self, tmp_path: Path) -> None:
+        adapter = ClineAdapter()
+        proc_mock = make_popen_mock(pid=802)
+        with (
+            patch("bernstein.adapters.cline.subprocess.Popen", return_value=proc_mock) as popen,
+            patch.dict("os.environ", {"PATH": "/usr/bin", "CLINE_API_KEY": "plain-cline-key"}, clear=True),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="cline-env2",
+            )
+        env = popen.call_args.kwargs.get("env", {})
+        assert "OPENAI_BASE_URL" not in env
+
+
 class TestClineAdapterName:
     def test_name(self) -> None:
         assert ClineAdapter().name() == "Cline"


### PR DESCRIPTION
Closes #4270.

## What

`ClineAdapter.spawn` now forwards `OPENAI_BASE_URL` to the spawned `cline`
process environment, mirroring the `codex` and `qwen` adapters.

## Why

The Cline adapter's env allowlist omitted the base-URL variables, so a
spawned `cline` process always fell back to whatever endpoint its own stored
credentials point at, regardless of how the run was configured. Operators
running self-hosted OpenAI-compatible endpoints (air-gapped deployments,
internal inference services, shared team gateways) could use `--cli codex` or
`--cli qwen` but not `--cli cline` — the run would start, produce no error, and
silently talk to the wrong endpoint.

## The one decision in the slice

I chose **environment variable only** — no `cline auth -b` invocation at spawn
time. Cline's CLI reads `OPENAI_BASE_URL` for its openai-compatible provider,
and the `codex`/`qwen` adapters set the same precedent of relying on the env
var rather than re-running an auth command on every spawn. A spawn-time auth
subcommand would add a blocking step and a credential side-effect that the
other adapters deliberately avoid.

## Out of scope (respected)

- No changes to `build_filtered_env` itself.
- No changes to any other adapter.

## Tests

- `tests/unit/test_adapter_cline.py`: spawned env carries the base URL when
  configured; omits it when unset.
- Gates: `ruff check`, `ruff format --check`, `lint-imports`, and the Cline
  adapter tests all pass locally.

## Docs

Updated the per-adapter env table in `docs/operations/env-isolation.md` to
list Cline's extra keys with `OPENAI_BASE_URL`.