### PR TITLE
test: stop git background maintenance racing helpers that delete .git

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,6 +190,24 @@ def _memory_guard_teardown(system: str) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _no_git_background_maintenance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop every git the suite starts from running background housekeeping.
+
+    ``git commit`` may hand off to ``git maintenance``, which writes and then
+    unlinks ``.git/objects/maintenance.lock`` on its own schedule. A helper
+    that walks or deletes ``.git`` right after committing races that unlink
+    and dies with ``FileNotFoundError: 'maintenance.lock'``. Pinning the
+    config through the environment reaches every git process the suite
+    starts, including helpers that never call ``git config`` themselves.
+    """
+    start = int(os.environ.get("GIT_CONFIG_COUNT", "0"))
+    for offset, (key, value) in enumerate((("gc.auto", "0"), ("maintenance.auto", "false"))):
+        monkeypatch.setenv(f"GIT_CONFIG_KEY_{start + offset}", key)
+        monkeypatch.setenv(f"GIT_CONFIG_VALUE_{start + offset}", value)
+    monkeypatch.setenv("GIT_CONFIG_COUNT", str(start + 2))
+
+
+@pytest.fixture(autouse=True)
 def _memory_guard():
     """Reclaim as RSS approaches the cap; abort the session once it exceeds it."""
     yield

--- a/tests/unit/test_git_basic.py
+++ b/tests/unit/test_git_basic.py
@@ -138,9 +138,7 @@ class TestTerminalPushError:
     """Tests for _is_terminal_push_error marker matching."""
 
     def test_credential_errors_are_terminal(self) -> None:
-        assert _is_terminal_push_error(
-            "could not read Username for 'https://github.com': No such device or address"
-        )
+        assert _is_terminal_push_error("could not read Username for 'https://github.com': No such device or address")
         assert _is_terminal_push_error("Authentication failed")
         assert _is_terminal_push_error("Permission denied (publickey)")
 

--- a/tests/unit/test_suite_git_isolation.py
+++ b/tests/unit/test_suite_git_isolation.py
@@ -1,0 +1,26 @@
+"""Git processes started by the suite must not run background housekeeping."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_git_background_maintenance_is_disabled_for_the_suite(tmp_path: Path) -> None:
+    """`git init` anywhere in the suite inherits housekeeping-off config.
+
+    `git commit` may hand off to `git maintenance`, which writes and then
+    unlinks `.git/objects/maintenance.lock` on its own schedule. A helper that
+    walks or deletes `.git` right after committing races that unlink and dies
+    with `FileNotFoundError: 'maintenance.lock'`.
+    """
+    subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, check=True, capture_output=True)
+    for key, expected in (("gc.auto", "0"), ("maintenance.auto", "false")):
+        result = subprocess.run(
+            ["git", "config", "--get", key],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout.strip() == expected, f"{key} is not pinned for the suite"


### PR DESCRIPTION
`tests/unit/test_mock_adapter.py::test_mock_without_git_repo_degrades_to_log_evidence` turned main red with `FileNotFoundError: [Errno 2] No such file or directory: 'maintenance.lock'` (main CI run 32583625954, ubuntu shard 1). Nothing was wrong in the product.

## Cause

The helper builds a demo workdir with `git init` + `git commit`, then the test does `shutil.rmtree(project / ".git")`. `git commit` can hand off to `git maintenance`, which writes and then unlinks `.git/objects/maintenance.lock` on its own schedule. `rmtree` lists the directory, then unlinks each entry by bare name — if maintenance removes the lock in between, the unlink raises with the relative name the traceback showed.

`tests/unit/test_grant_bound_checkpoint.py` already hit this and worked around it by running `git config gc.auto 0` inside its own helper, so the pattern was known but only fixed for one file.

## Fix

An autouse fixture in `tests/conftest.py` pins `gc.auto=0` and `maintenance.auto=false` through `GIT_CONFIG_KEY_*` / `GIT_CONFIG_VALUE_*`. The environment form reaches every git process the suite starts, including helpers that never call `git config` themselves, so the writer is removed rather than its output filtered — assertions that watch `.git/` for writes still catch a real one.

The fixture appends to any `GIT_CONFIG_COUNT` already present instead of overwriting it.

## Test

`tests/unit/test_suite_git_isolation.py` runs `git init` in a tmpdir and asserts both keys resolve to the pinned values. Red before the fixture, green after — the race itself is not deterministically reproducible, so the invariant is what gets pinned.

Local: 54 passed across the new file plus both files that build git repos this way.
