### PR TITLE
Add issue-to-PR and PR-intake-review scenario recipes

### DIFF
--- a/.bernstein/rules.yaml
+++ b/.bernstein/rules.yaml
@@ -52,6 +52,17 @@ rules:
     message: "Replace 'master' with 'main'. This repo uses 'main' as the default branch."
 
   # ---------------------------------------------------------------------------
+  # Release notes
+  # ---------------------------------------------------------------------------
+  - id: release-note-entry-carries-a-number
+    type: forbidden_pattern
+    description: "Every unreleased entry names the issue or PR it ships"
+    pattern: '^- (?!.*#\d+).+$'
+    files: "docs/release-notes/unreleased.md"
+    severity: warning
+    message: "Add the issue or PR number (#NNNN) to the entry. The release rotation attributes each line by that number; an unnumbered entry cannot be carried onto a release page."
+
+  # ---------------------------------------------------------------------------
   # Python code quality
   # ---------------------------------------------------------------------------
   - id: no-print-statements

--- a/.bernstein/scenarios/software/issue-to-pr.yaml
+++ b/.bernstein/scenarios/software/issue-to-pr.yaml
@@ -1,0 +1,48 @@
+id: issue-to-pr
+name: Issue to Pull Request
+version: "1.0"
+description: Resolve one tracked issue end to end and leave a reviewable pull request behind.
+tags:
+  - github
+  - issues
+  - quality
+  - automation
+tasks:
+  - title: Confirm the defect still exists at HEAD
+    role: qa
+    priority: 0
+    scope: small
+    complexity: medium
+    description: |
+      Issue bodies go stale: counts drift, referenced code moves, an unrelated
+      merge fixes the defect first. Re-derive the reproduction from the issue
+      against the current checkout before anyone implements. If the defect is
+      gone, say so with the commit that fixed it and stop the scenario there.
+  - title: Write the failing test first
+    role: qa
+    priority: 1
+    scope: small
+    complexity: medium
+    description: |
+      Encode the issue's acceptance criteria as a test that fails on the
+      unmodified checkout. Quote the failing assertion in the task result --
+      a fix whose test was never seen red proves nothing.
+  - title: Implement the fix
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: high
+    description: |
+      Fix the root cause, not the symptom. Keep the diff scoped to the issue:
+      no drive-by refactors, no unrelated cleanups. Name the new or changed
+      files in the completion signal so the quality gate can verify them on
+      the merged result.
+  - title: Prepare the pull request record
+    role: reviewer
+    priority: 2
+    scope: small
+    complexity: medium
+    description: |
+      The PR body states the root cause, the red-then-green test evidence, and
+      which acceptance criterion each change satisfies. Add a release-notes
+      entry naming the issue number. Link the issue with a closing keyword.

--- a/.bernstein/scenarios/software/pr-intake-review.yaml
+++ b/.bernstein/scenarios/software/pr-intake-review.yaml
@@ -1,0 +1,57 @@
+id: pr-intake-review
+name: PR Intake Review
+version: "1.0"
+description: Review a machine-opened pull request before it enters the merge queue.
+tags:
+  - review
+  - github
+  - quality
+tasks:
+  - title: Scope check against the linked issue
+    role: reviewer
+    priority: 0
+    scope: small
+    complexity: medium
+    description: |
+      Every hunk in the diff traces to the linked issue's acceptance criteria.
+      Flag drive-by edits, generated files, and leftover run scaffolding
+      (pinned configs, local workaround commits) that should not ship.
+  - title: Verify the test evidence
+    role: qa
+    priority: 0
+    scope: small
+    complexity: medium
+    description: |
+      The PR claims its tests failed before the change: check the tests assert
+      the defect, not the implementation, and run the affected set against the
+      merge result with the base branch -- a green PR lane on a stale base is
+      not evidence.
+  - title: Security pass on the diff
+    role: security
+    priority: 1
+    scope: small
+    complexity: medium
+    description: |
+      Review additions for injected commands, credential handling, network
+      calls to new hosts, and permission widening. A machine-authored diff
+      gets the same scrutiny a first-time contributor's would.
+  - title: Release-notes and linkage hygiene
+    role: reviewer
+    priority: 1
+    scope: small
+    complexity: medium
+    description: |
+      The release-notes entry exists, names the issue number, and is appended
+      at the end of its section rather than prepended at the section header --
+      entries that all prepend to one anchor conflict with every other open
+      PR and no two can merge in the same queue group. The closing keyword
+      references an issue that is still open and matches the change.
+  - title: Record the verdict
+    role: manager
+    priority: 2
+    scope: small
+    complexity: medium
+    description: |
+      Leave one review on the PR: approve, or request changes naming each
+      blocking finding with file and line. Silence is not a verdict; a PR
+      nobody reviewed does not enter the queue.


### PR DESCRIPTION
`.bernstein/scenarios/` ships recipes for docs, research, and ops work, but nothing for the path this repo exercises most: take an open issue, produce a pull request. Unattended runs against this repo currently rely on the manager decomposing that from scratch every time, so the shape of the work — and whether a failing test is written before the fix — varies run to run.

This adds two software-domain recipes and one rules entry.

## `software/issue-to-pr.yaml`

Four tasks, in order:

1. **Confirm the defect still exists at HEAD** (qa). Issue bodies go stale; a run that skips this sends an agent after code that an unrelated change already fixed.
2. **Write the failing test first** (qa). The test must fail for the stated reason before any implementation exists.
3. **Implement the fix** (backend), gated on the test from step 2 going green.
4. **Prepare the pull request record** (reviewer) — linkage, scope, and the evidence that the test was red first.

## `software/pr-intake-review.yaml`

Five tasks for reviewing a pull request the project opened itself, where no outside reviewer is in the loop: scope against the linked issue, verify the test evidence rather than trusting the summary, a security pass, release-notes and linkage hygiene, and a recorded verdict.

The release-notes task explicitly warns about the shared prepend anchor: every entry added at the same line of `docs/release-notes/unreleased.md` makes any two pull requests mutually unmergeable inside one merge-queue group. Spreading entries across distinct anchors is what keeps the queue moving.

## `.bernstein/rules.yaml`

One `forbidden_pattern` rule, severity `warning`: an entry in `docs/release-notes/unreleased.md` that names no issue or pull request number. An entry with no number cannot be traced back to the change that produced it once the file rotates at release time.

## Testing

Both scenarios parse under the existing scenario loader and are picked up by the recursive discovery in `.bernstein/scenarios/`. The rules entry was checked against the current `unreleased.md`, which it passes.
