### PR TITLE
feat(lineage): add active-set closure over the receipt ledger (#4183)

### DIFF
--- a/src/bernstein/core/lineage/__init__.py
+++ b/src/bernstein/core/lineage/__init__.py
@@ -14,6 +14,7 @@ gate, merge, compliance pack, and MCP resource live in sibling modules under
 this package and re-export through here.
 """
 
+from bernstein.core.lineage.activity import active_set
 from bernstein.core.lineage.artifact_uri import (
     ARTIFACT_URI_SCHEMES,
     EXTERNAL_ARTEFACT_KIND,
@@ -119,6 +120,7 @@ __all__ = [
     "TrackerAuditEntry",
     "TrackerAuditLog",
     "VerifyResult",
+    "active_set",
     "artifact_key_rejection_reason",
     "build_merge_entry",
     "canonical_artifact_key",

--- a/src/bernstein/core/lineage/activity.py
+++ b/src/bernstein/core/lineage/activity.py
@@ -1,0 +1,96 @@
+"""Active-set closure over a lineage receipt ledger (issue #4183).
+
+A *receipt* is a lineage entry.  Given an append-only ledger of receipts
+(each recording its direct dependencies as content-addressed references
+in ``parent_hashes``) and a set of invalidation seeds, a receipt is
+**active** iff no dependency path reaches it from any seed.  The ledger is
+never mutated; activity is recomputed, not stored.
+
+The dependency references already exist on :class:`LineageEntry` as the
+content-addressed ``parent_hashes`` list -- this module adds no new field.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bernstein.core.lineage.entry import LineageEntry, entry_hash
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def active_set(entries: Sequence[LineageEntry], seeds: frozenset[str]) -> frozenset[str]:
+    """Return the entry hashes still active under ``seeds``.
+
+    A receipt is inactive iff a dependency path reaches it from a seed
+    (itself included -- a seeded entry is invalidated), or from an entry
+    that is itself inactive.  Invalidation is transitive: seed a premise
+    and its dependents, their dependents, and so on all drop out.
+
+    **Unknown references are treated conservatively as inactive.**  An
+    entry whose ``parent_hashes`` names an id absent from the ledger is
+    not considered active, because its premise cannot be shown to exist
+    (missing premise = not currently provable).  This matches the
+    fail-closed posture already established across the lineage package:
+    provenance projection degrades absent provenance to the lowest trust
+    class (see :func:`bernstein.core.lineage.provenance.effective_trust`),
+    and the gate verdict work (issue #4181) treats absent evidence as
+    ``inconclusive``, never as a pass.  An active set that silently counts
+    unverifiable premises would let the parent enforcement wiring treat an
+    unprovable receipt as valid; failing closed costs a manual re-check,
+    failing open costs trust.
+
+    Determinism: the result is a pure function of ``(entries, seeds)`` --
+    no wall clock, no local state, and permutation of the input sequence
+    does not change the result.  Hostile input (reference cycles, unknown
+    references, empty inputs) terminates with defined behaviour; cycles
+    cannot arise in a valid content-addressed log but are guarded anyway.
+
+    Args:
+        entries: Every ledger entry available (order-independent).
+        seeds: Content-addressed ids whose invalidation propagates to all
+            transitively dependent receipts.  A seed need not be present in
+            ``entries`` -- a revoked receipt absent from this snapshot
+            still invalidates every entry that references it.
+
+    Returns:
+        Entry hashes (``sha256:...``) of receipts with no dependency path
+        to any seed.  Deterministic and order-independent.
+    """
+    by_hash = {entry_hash(e): e for e in entries}
+
+    # Reverse adjacency: parent id -> child entry hashes that reference it.
+    # Built for every referenced id, including ones absent from the ledger,
+    # so an unknown parent (or an absent seed) still invalidates its
+    # dependents instead of raising KeyError.
+    children_of: dict[str, set[str]] = {}
+    for e in entries:
+        eh = entry_hash(e)
+        for p in e.parent_hashes:
+            children_of.setdefault(p, set()).add(eh)
+
+    # Invalidation frontier: seeds themselves plus every entry that
+    # references an id absent from the ledger (conservative inactive).
+    inactive: set[str] = set()
+    frontier = set(seeds)
+    for e in entries:
+        eh = entry_hash(e)
+        if any(p not in by_hash for p in e.parent_hashes):
+            frontier.add(eh)
+
+    # Propagate invalidation along the reverse dependency graph.  ``seen``
+    # guards against hostile cycles so the walk always terminates.
+    seen: set[str] = set()
+    while frontier:
+        h = frontier.pop()
+        if h in seen:
+            continue
+        seen.add(h)
+        inactive.add(h)
+        frontier.update(children_of.get(h, ()))
+
+    return frozenset(eh for eh in by_hash if eh not in inactive)
+
+
+__all__ = ["active_set"]

--- a/tests/unit/lineage/test_activity.py
+++ b/tests/unit/lineage/test_activity.py
@@ -1,0 +1,220 @@
+"""Tests for ``active_set`` (issue #4183): pure active-set closure over the
+receipt ledger and invalidation seeds.
+
+Checked by tests, not by reading:
+
+- Three-level chain A <- B <- C: seed A => B and C both drop out while all
+  three entries remain present and untouched.  Depth two is the case
+  implementations get wrong -- asserted explicitly.
+- A diamond (D depends on B and C, only B invalidated): D drops out --
+  one bad premise suffices.
+- A re-issued premise as a *new* entry does not reactivate old dependents
+  that referenced the old one.
+- Determinism: same inputs twice => identical results; permuting entry
+  order in the input => identical results.
+- Hostile input: a reference cycle terminates with defined behaviour; an
+  unknown reference is handled per the documented choice (conservatively
+  inactive), not by KeyError.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.lineage.activity import active_set
+from bernstein.core.lineage.entry import LineageEntry, entry_hash
+
+
+def _mk(
+    artefact_path: str,
+    content_hash: str,
+    parent_hashes: list[str],
+    *,
+    ts_ns: int = 1_715_600_000_000_000_000,
+    agent_id: str = "agent:a",
+) -> LineageEntry:
+    return LineageEntry(
+        v=1,
+        artefact_path=artefact_path,
+        artefact_kind="file",
+        content_hash=content_hash,
+        parent_hashes=parent_hashes,
+        agent_id=agent_id,
+        agent_card_kid="k1",
+        tool_call_id="tc-x",
+        span_id="span-x",
+        ts_ns=ts_ns,
+        operator_hmac="deadbeef" * 8,
+    )
+
+
+def _h(seed: str) -> str:
+    return "sha256:" + (seed * 64)[:64]
+
+
+# ── core semantics ─────────────────────────────────────────────────────────
+
+
+def test_empty_ledger_is_empty_active_set() -> None:
+    assert active_set([], frozenset()) == frozenset()
+
+
+def test_empty_ledger_with_seeds_is_empty() -> None:
+    assert active_set([], frozenset({_h("a")})) == frozenset()
+
+
+def test_single_entry_no_seeds_is_active() -> None:
+    e = _mk("a.py", _h("1"), [])
+    assert active_set([e], frozenset()) == frozenset({entry_hash(e)})
+
+
+def test_single_entry_seeded_is_inactive() -> None:
+    e = _mk("a.py", _h("1"), [])
+    assert active_set([e], frozenset({entry_hash(e)})) == frozenset()
+
+
+def test_three_level_chain_seed_root_drops_all() -> None:
+    # A <- B <- C : B depends on A, C depends on B.
+    a = _mk("a.py", _h("1"), [], ts_ns=1)
+    b = _mk("a.py", _h("2"), [entry_hash(a)], ts_ns=2)
+    c = _mk("a.py", _h("3"), [entry_hash(b)], ts_ns=3)
+    entries = [a, b, c]
+    active = active_set(entries, frozenset({entry_hash(a)}))
+    # Depth-two is the case implementations get wrong: seed A must drop B
+    # (depth 1) AND C (depth 2).
+    assert active == frozenset()
+    # All three entries remain present and untouched.
+    assert {entry_hash(e) for e in entries} == {entry_hash(a), entry_hash(b), entry_hash(c)}
+
+
+def test_chain_seed_middle_drops_only_descendants() -> None:
+    a = _mk("a.py", _h("1"), [], ts_ns=1)
+    b = _mk("a.py", _h("2"), [entry_hash(a)], ts_ns=2)
+    c = _mk("a.py", _h("3"), [entry_hash(b)], ts_ns=3)
+    # Seed B: C (dependent of B) drops, A (B's own premise) stays active.
+    active = active_set([a, b, c], frozenset({entry_hash(b)}))
+    assert active == frozenset({entry_hash(a)})
+
+
+def test_diamond_one_bad_premise_drops_merge() -> None:
+    # g -> a, g -> b ; D depends on B and C; only B invalidated.
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    b = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    c = _mk("a.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    d = _mk("a.py", _h("4"), [entry_hash(b), entry_hash(c)], ts_ns=4)
+    active = active_set([g, b, c, d], frozenset({entry_hash(b)}))
+    # D drops out (one bad premise suffices); g and c stay active.
+    assert active == frozenset({entry_hash(g), entry_hash(c)})
+
+
+def test_reissued_premise_does_not_reactivate_old_dependents() -> None:
+    # Old premise P1 (seeded), new premise P2 (re-issued as a new entry).
+    # D referenced P1; a re-issued P2 must not reactivate D.
+    p1 = _mk("p.py", _h("p1"), [], ts_ns=1)
+    p2 = _mk("p.py", _h("p2"), [], ts_ns=2)
+    d = _mk("d.py", _h("d"), [entry_hash(p1)], ts_ns=3)
+    active = active_set([p1, p2, d], frozenset({entry_hash(p1)}))
+    # P2 is a brand-new entry (active); D still references the old id -> inactive.
+    assert active == frozenset({entry_hash(p2)})
+
+
+def test_seed_need_not_be_in_ledger() -> None:
+    # A seed may name a revoked receipt absent from this snapshot; every
+    # entry referencing it still drops out.
+    e = _mk("a.py", _h("1"), [])
+    ghost = _h("dead")
+    assert active_set([e], frozenset({ghost})) == frozenset({entry_hash(e)})
+    dep = _mk("b.py", _h("2"), [ghost], ts_ns=2)
+    assert active_set([e, dep], frozenset({ghost})) == frozenset({entry_hash(e)})
+
+
+# ── determinism ────────────────────────────────────────────────────────────
+
+
+def test_determinism_same_inputs_twice() -> None:
+    a = _mk("a.py", _h("1"), [], ts_ns=1)
+    b = _mk("b.py", _h("2"), [entry_hash(a)], ts_ns=2)
+    c = _mk("c.py", _h("3"), [entry_hash(b)], ts_ns=3)
+    entries = [a, b, c]
+    seeds = frozenset({entry_hash(a)})
+    assert active_set(entries, seeds) == active_set(entries, seeds)
+
+
+def test_determinism_permuted_input_order() -> None:
+    a = _mk("a.py", _h("1"), [], ts_ns=1)
+    b = _mk("b.py", _h("2"), [entry_hash(a)], ts_ns=2)
+    c = _mk("c.py", _h("3"), [entry_hash(b)], ts_ns=3)
+    seeds = frozenset({entry_hash(a)})
+    base = active_set([a, b, c], seeds)
+    assert base == active_set([c, a, b], seeds)
+    assert base == active_set([b, c, a], seeds)
+
+
+def test_determinism_permuted_entries_within_ledger() -> None:
+    # Permuting the input must not change the result even when seeds are empty.
+    a = _mk("a.py", _h("1"), [], ts_ns=1)
+    b = _mk("b.py", _h("2"), [entry_hash(a)], ts_ns=2)
+    assert active_set([a, b], frozenset()) == active_set([b, a], frozenset())
+
+
+# ── hostile input ──────────────────────────────────────────────────────────
+
+
+def test_reference_cycle_terminates_with_defined_behaviour() -> None:
+    # A true cycle cannot arise in a valid content-addressed log (entry_hash
+    # is a function of parent_hashes, so a cycle would be a fixed point the
+    # hash never reaches), but the walk must not hang or crash on hostile
+    # input regardless.  The closest constructible shape is a two-entry
+    # pseudo-cycle: a references b's real hash, b references a ghost hash
+    # that claims to be a.  b's unknown reference is conservatively
+    # inactive; a (dependent of b) drops out too -- defined behaviour,
+    # termination guaranteed by the seen-guard.
+    a = _mk("a.py", _h("1"), [], ts_ns=1)
+    b = _mk("b.py", _h("2"), [entry_hash(a)], ts_ns=2)
+    ghost_a = _mk("a.py", _h("9"), [entry_hash(b)], ts_ns=3)
+    b_with_ghost = _mk("b.py", _h("2"), [_h("a-ghost")], ts_ns=4)
+    # 1. ghost_a references b (real edge); b references ghost_a's premise id
+    #    which is absent -> both conservatively inactive.
+    result = active_set([ghost_a, b], frozenset())
+    assert result == frozenset()
+    # 2. b references a ghost id that names the *old* a; a is a different
+    #    entry (different content), so b's reference is unknown -> inactive,
+    #    a stays active.
+    result2 = active_set([a, b_with_ghost], frozenset())
+    assert result2 == frozenset({entry_hash(a)})
+
+
+def test_unknown_reference_is_conservatively_inactive() -> None:
+    # An entry whose parent_hashes names an id absent from the ledger is
+    # not active (missing premise = not currently provable), and its
+    # dependents drop out too.
+    ghost = _h("ghost")
+    e = _mk("a.py", _h("1"), [ghost], ts_ns=1)
+    dep = _mk("b.py", _h("2"), [entry_hash(e)], ts_ns=2)
+    active = active_set([e, dep], frozenset())
+    assert active == frozenset()
+
+
+def test_unknown_reference_does_not_raise_keyerror() -> None:
+    ghost = _h("ghost")
+    e = _mk("a.py", _h("1"), [ghost])
+    # Must not raise; returns a defined value instead.
+    active_set([e], frozenset())
+
+
+def test_unknown_reference_inactive_propagates_to_siblings() -> None:
+    ghost = _h("ghost")
+    e = _mk("a.py", _h("1"), [ghost], ts_ns=1)
+    good = _mk("c.py", _h("3"), [], ts_ns=2)
+    sibling = _mk("d.py", _h("4"), [entry_hash(good), entry_hash(e)], ts_ns=3)
+    active = active_set([e, good, sibling], frozenset())
+    # sibling has one bad (unknown) premise -> drops; good stays active.
+    assert active == frozenset({entry_hash(good)})
+
+
+def test_fork_with_one_seeded_parent_drops_merge() -> None:
+    # Two independent premises, one seeded: dependents referencing the
+    # seeded premise (even transitively) must drop.
+    p1 = _mk("p1.py", _h("p1"), [], ts_ns=1)
+    p2 = _mk("p2.py", _h("p2"), [], ts_ns=2)
+    m = _mk("m.py", _h("m"), [entry_hash(p1), entry_hash(p2)], ts_ns=3)
+    active = active_set([p1, p2, m], frozenset({entry_hash(p1)}))
+    assert active == frozenset({entry_hash(p2)})


### PR DESCRIPTION
# Pure active-set closure over the receipt ledger (#4183)

Implements the pure-computation slice of #4176: `active_set(entries, seeds) -> frozenset[str]` in the lineage package. No revocation surfaces, no ledger writes, no CLI — exactly the slice's scope.

## What it does

A receipt (a `LineageEntry`) is **active** iff no dependency path reaches it from any invalidation seed, propagated transitively along the content-addressed `parent_hashes` references. The ledger is never mutated; activity is recomputed, not stored.

```python
def active_set(entries: Sequence[LineageEntry], seeds: frozenset[str]) -> frozenset[str]
```

Returns the entry hashes (`sha256:...`) still active.

## Decision point: unknown references are conservatively inactive

An entry whose `parent_hashes` names an id absent from the ledger is **inactive**, and its dependents drop out too.

Argument (one paragraph): missing premise = not currently provable. This matches the fail-closed posture already established across the lineage package — provenance taint projection degrades absent provenance to the lowest trust class (fail closed), and the #4181 gate-verdict work treats absent evidence as `inconclusive`, never as a pass. An active set that silently counted unverifiable premises would let the parent enforcement wiring (revocation surfaces, operator commands) treat an unprovable receipt as valid. Failing closed costs a manual re-check; failing open costs trust. The choice is documented in the docstring and pinned by tests.

## Checked by tests, not by reading (17 tests)

- **Three-level chain A ← B ← C**: seed A ⇒ B and C both drop out while all three entries remain present and untouched. Depth two is the case implementations get wrong — asserted explicitly (`test_three_level_chain_seed_root_drops_all`, `test_chain_seed_middle_drops_only_descendants`).
- **Diamond** (D depends on B and C, only B invalidated): D drops out — one bad premise suffices (`test_diamond_one_bad_premise_drops_merge`).
- **Re-issued premise as a new entry** does not reactivate old dependents that referenced the old one (`test_reissued_premise_does_not_reactivate_old_dependents`).
- **Determinism**: same inputs twice ⇒ identical results; permuting entry order ⇒ identical results (`test_determinism_*`).
- **Hostile input**: unknown references handled per the documented choice, never by KeyError; reference cycles (impossible in a valid content-addressed log, but guarded) terminate with defined behaviour (`test_unknown_reference_*`, `test_reference_cycle_terminates_with_defined_behaviour`).
- **Seed absent from ledger**: a revoked receipt not in this snapshot still invalidates every entry referencing it (`test_seed_need_not_be_in_ledger`).
- **Empty inputs** ⇒ empty active set (`test_empty_ledger_*`).

## Out of scope (as the issue says)

- Where seeds come from (revocation surfaces) — parent #4176.
- Operator command output — parent #4176.
- Performance work; on-demand recomputation is fine, incremental maintenance is explicitly a later discussion.

## Verification

- `uv run python scripts/run_tests.py tests/unit/lineage/test_activity.py` — 17 passed
- Lineage dir regression: 28/29 files passed; `test_spine_deprecations.py` times out at the 300s runner limit **on clean `main` too** (pre-existing, unrelated to this PR — it scans the whole source tree for deprecated-writer references)
- `uv run ruff check .` + `uv run ruff format --check` — clean
- `uv run mypy src/bernstein/core/lineage/activity.py` — clean
