### PR TITLE
fix(adapters): slug receipt filenames so spaced adapter names can persist

### DIFF
--- a/docs/adapters/admission-receipts.md
+++ b/docs/adapters/admission-receipts.md
@@ -102,6 +102,14 @@ Sealed receipts live under `.sdd/adapters/admission/` and are
 content-addressed, so a tampered body no longer hashes to its recorded
 identity and is rejected without any key material.
 
+Receipt filenames embed a slug of the adapter name: a display name such as
+`Qwen CLI` is folded to `qwen-cli` for the filename, while the operator-visible
+name stays unmodified in the receipt body. This lets an adapter whose name is
+not already a filesystem-safe slug write a receipt at all. The slug fold also
+changes the stored filename for any adapter whose name was already slug-safe
+but under a different convention; after an upgrade the first run re-derives
+the receipt rather than reuses the previous file.
+
 ## Where the evidence comes from
 
 The verdict is derived from two trees that live under `tests/` in a source

--- a/src/bernstein/adapters/admission.py
+++ b/src/bernstein/adapters/admission.py
@@ -45,7 +45,6 @@ import hashlib
 import json
 import logging
 import os
-import re
 import shutil
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -56,6 +55,7 @@ from bernstein.core.security.path_containment import (
     PathContainmentError,
     PathTooLongError,
     contained_path,
+    slug_identifier,
 )
 
 if TYPE_CHECKING:
@@ -290,8 +290,6 @@ _GOLDEN_DIR_DEFAULT = Path(__file__).parents[3] / "tests" / "golden"
 #: in ``pyproject.toml``) so a pip install can replay the spawn path instead of
 #: refusing every adapter with :data:`REASON_NO_TRANSCRIPT` (issue #3547).
 _GOLDEN_DIR_PACKAGED = Path(__file__).resolve().parents[1] / "_default_templates" / "adapter_golden"
-
-_RECEIPT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 
 
 class AdapterAdmissionRefusal(RuntimeError):
@@ -940,9 +938,7 @@ def write_admission_receipt(base_dir: Path, receipt: dict[str, Any]) -> Path:
             escapes ``base_dir``.
     """
     adapter = str(receipt.get("adapter") or "")
-    adapter_key = adapter.lower()
-    if not _RECEIPT_NAME_RE.match(adapter_key):
-        raise ValueError(f"invalid adapter name for receipt filename: {adapter!r}")
+    adapter_key = slug_identifier(adapter, label="adapter name")
     sha = receipt_sha256(receipt)
     base_dir.mkdir(parents=True, exist_ok=True)
     stem = f"{adapter_key}-{sha[:16]}"
@@ -980,8 +976,11 @@ def load_admission_receipt(base_dir: Path, adapter: str) -> tuple[dict[str, Any]
         :data:`REASON_RECEIPT_TAMPERED` when every candidate failed its
         content-hash check.
     """
-    adapter_key = adapter.lower()
-    if not _RECEIPT_NAME_RE.match(adapter_key) or not base_dir.exists():
+    try:
+        adapter_key = slug_identifier(adapter, label="adapter name")
+    except PathContainmentError:
+        return None, REASON_NO_RECEIPT
+    if not base_dir.exists():
         return None, REASON_NO_RECEIPT
 
     candidates: list[dict[str, Any]] = []
@@ -996,7 +995,9 @@ def load_admission_receipt(base_dir: Path, adapter: str) -> tuple[dict[str, Any]
         body = doc.get("receipt")
         if not isinstance(body, dict) or body.get("kind") != RECEIPT_KIND:
             continue
-        if str(body.get("adapter") or "").lower() != adapter_key:
+        # Match on the unmodified adapter name, not the slug: the slug is a
+        # filename concern only, the body keeps the operator-visible name.
+        if str(body.get("adapter") or "").lower() != adapter.lower():
             continue
         if not verify_admission_receipt(doc):
             tampered = True

--- a/src/bernstein/adapters/canary.py
+++ b/src/bernstein/adapters/canary.py
@@ -45,6 +45,7 @@ from bernstein.core.security.path_containment import (
     PathContainmentError,
     PathTooLongError,
     contained_path,
+    slug_identifier,
 )
 
 from .base import VERSION_TOKEN_RE
@@ -132,7 +133,6 @@ LAST_GREEN_JSON_PATH = Path(__file__).parent / "last_green.json"
 #: Docs page carrying the rendered last-green table (dev checkout path).
 LAST_GREEN_DOC_PATH = Path(__file__).parents[3] / "docs" / "adapters" / "conformance-canary.md"
 
-_ADAPTER_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 
 _VERSION_TIMEOUT_SECONDS = 10
 
@@ -513,11 +513,10 @@ def write_canary_receipt(base_dir: Path, receipt: dict[str, Any]) -> Path:
             path escapes ``base_dir``.
     """
     adapter = str(receipt.get("adapter") or "")
-    if not _ADAPTER_NAME_RE.match(adapter):
-        raise ValueError(f"invalid adapter name for receipt filename: {adapter!r}")
+    adapter_key = slug_identifier(adapter, label="adapter name")
     sha = receipt_sha256(receipt)
     base_dir.mkdir(parents=True, exist_ok=True)
-    stem = f"{adapter}-{sha[:16]}"
+    stem = f"{adapter_key}-{sha[:16]}"
     try:
         candidate = contained_path(base_dir, f"{stem}.json", label="receipt path")
         # The temporary sibling is opened *before* the rename, so it needs the

--- a/src/bernstein/adapters/security_floor.py
+++ b/src/bernstein/adapters/security_floor.py
@@ -30,7 +30,6 @@ import hashlib
 import json
 import logging
 import os
-import re
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -41,6 +40,7 @@ from bernstein.core.security.path_containment import (
     PathContainmentError,
     PathTooLongError,
     contained_path,
+    slug_identifier,
 )
 
 from .base import VERSION_TOKEN_RE
@@ -114,7 +114,6 @@ POLICY_WARN = "warn"
 _POLICY_ENV = "BERNSTEIN_ADAPTER_FLOOR_POLICY"
 _WARN_TOKENS = frozenset({"warn", "warn-only", "warn_only", "advisory"})
 _VERSION_TIMEOUT_SECONDS = 10
-_RECEIPT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 
 
 class AdapterSecurityFloorRefusal(RuntimeError):
@@ -434,11 +433,10 @@ def write_preflight_receipt(base_dir: Path, receipt: dict[str, Any]) -> Path:
     adapter string can never escape the receipts directory.
     """
     adapter = str(receipt.get("adapter") or "")
-    if not _RECEIPT_NAME_RE.match(adapter):
-        raise ValueError(f"invalid adapter name for receipt filename: {adapter!r}")
+    adapter_key = slug_identifier(adapter, label="adapter name")
     sha = receipt_sha256(receipt)
     base_dir.mkdir(parents=True, exist_ok=True)
-    stem = f"{adapter}-{sha[:16]}"
+    stem = f"{adapter_key}-{sha[:16]}"
     try:
         candidate = contained_path(base_dir, f"{stem}.json", label="receipt path")
         # The temporary sibling is opened *before* the rename, so it needs the

--- a/src/bernstein/core/security/path_containment.py
+++ b/src/bernstein/core/security/path_containment.py
@@ -96,6 +96,46 @@ class PathTooLongError(PathContainmentError):
     """
 
 
+def slug_identifier(name: str, *, label: str = "identifier") -> str:
+    """Fold an externally-influenced identifier into a filename-safe slug.
+
+    Some receipts embed a *human-readable* adapter name (``Qwen CLI``,
+    ``Claude Code``) that contains spaces, while the persistence layer wants
+    a single filename component. Rather than reject such names outright, this
+    folds the name to the :data:`SAFE_SEGMENT_RE` alphabet so the caller can
+    keep writing a file.
+
+    The fold is deliberately not a path. Any character that could change
+    where the file lands -- a separator, a NUL byte, or anything that would
+    make the slug start with a dot -- is refused *before* the fold, so a
+    hostile name cannot be silently relocated into something that looks safe.
+
+    Args:
+        name: The identifier to fold. May contain spaces and punctuation,
+            but never a path component operator.
+        label: Noun used in error messages (e.g. ``"adapter name"``).
+
+    Returns:
+        The lowercase slug: every run of non-``[a-z0-9]`` collapsed to a
+        single ``-``, with leading/trailing ``-`` stripped. Safe as a single
+        path segment under :func:`contained_path`.
+
+    Raises:
+        PathContainmentError: If *name* is empty, carries a separator/NUL/``..``
+            traversal shape, or folds to an empty slug.
+        PathTooLongError: If the slug exceeds :data:`MAX_SEGMENT_BYTES` once
+            encoded.
+    """
+    if not name:
+        raise PathContainmentError(f"invalid {label}: {name!r} (empty)")
+    if "\x00" in name or "/" in name or "\\" in name:
+        raise PathContainmentError(f"invalid {label}: {name!r} (traversal is refused)")
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    if not slug:
+        raise PathContainmentError(f"invalid {label}: {name!r} (folds to an empty slug)")
+    return validate_path_segment(slug, label=label)
+
+
 def validate_path_segment(segment: str, *, label: str = "identifier") -> str:
     """Return *segment* unchanged when it is a safe single path segment.
 

--- a/tests/unit/test_adapter_admission.py
+++ b/tests/unit/test_adapter_admission.py
@@ -364,6 +364,25 @@ def test_tampered_receipt_fails_its_content_hash(receipts_dir: Path) -> None:
     assert problem == REASON_RECEIPT_TAMPERED
 
 
+def test_spaced_adapter_name_persists_and_loads_receipt(tmp_path: Path) -> None:
+    """Issue #4363: A spaced display name (e.g. 'Qwen CLI') is slugified to a
+    safe filename but keeps its operator-visible name in the receipt body, and
+    round-trips through load_admission_receipt."""
+    evidence = _bare_evidence(adapter="Qwen CLI", binary="qwen")
+    decision = evaluate_admission(evidence, ttl_seconds=86400)
+
+    receipt = build_admission_receipt(decision, generated_at=_NOW.isoformat(), kind=RECEIPT_KIND)
+    receipt_file = write_admission_receipt(tmp_path, receipt)
+    assert receipt_file.exists()
+    assert receipt_file.name.startswith("qwen-cli-")
+
+    loaded, problem = load_admission_receipt(tmp_path, "Qwen CLI")
+    assert problem == ""
+    assert loaded is not None
+    assert loaded["adapter"] == "Qwen CLI"
+    assert loaded["verdict"] == VERDICT_ADMIT
+
+
 def test_write_admission_receipt_rejects_a_hostile_adapter_name(receipts_dir: Path) -> None:
     decision = evaluate_admission(_bare_evidence(adapter="../../etc/passwd"))
     receipt = build_admission_receipt(decision, generated_at=_NOW.isoformat())

--- a/tests/unit/test_adapter_canary.py
+++ b/tests/unit/test_adapter_canary.py
@@ -329,6 +329,17 @@ class TestCanaryReceipts:
         with pytest.raises(ValueError, match="adapter"):
             write_canary_receipt(tmp_path / "receipts", receipt)
 
+    def test_spaced_adapter_name_writes_a_slugged_receipt(self, tmp_path: Path) -> None:
+        """Issue #4363: A spaced display name is folded to a safe slug filename."""
+        outcome = _outcome(adapter="Qwen CLI")
+        receipt = build_canary_receipt(outcome, generated_at=_GENERATED_AT)
+        path = write_canary_receipt(tmp_path / "receipts", receipt)
+        assert path.exists()
+        assert path.name.startswith("qwen-cli-")
+        doc = json.loads(path.read_text(encoding="utf-8"))
+        assert verify_canary_receipt(doc)
+        assert doc["receipt"]["adapter"] == "Qwen CLI"
+
 
 # ---------------------------------------------------------------------------
 # Failure threshold + issue dedupe

--- a/tests/unit/test_adapter_security_floor.py
+++ b/tests/unit/test_adapter_security_floor.py
@@ -165,6 +165,17 @@ class TestReceipts:
         # A map mutated after the fact yields a hash mismatch at verification.
         assert not receipt_floor_map_matches(doc, current_hash="sha256:" + "0" * 64)
 
+    def test_spaced_adapter_name_writes_a_slugged_receipt(self, tmp_path: Path) -> None:
+        """Issue #4363: A spaced display name is folded to a safe slug filename."""
+        v = evaluate_spawn_floor("Qwen CLI", "qwen", _BELOW)
+        r = build_preflight_receipt(v, generated_at=_GENERATED_AT)
+        path = write_preflight_receipt(tmp_path, r)
+        assert path.exists()
+        assert path.name.startswith("qwen-cli-")
+        doc = json.loads(path.read_text(encoding="utf-8"))
+        assert verify_preflight_receipt(doc)
+        assert doc["receipt"]["adapter"] == "Qwen CLI"
+
 
 # ---------------------------------------------------------------------------
 # Enforcement: the refusal IS the chain-anchored receipt (AC1)


### PR DESCRIPTION
Fixes #4363.

## Problem

An adapter whose display name contains a space (e.g. `Qwen CLI`) hits:

```
WARNING bernstein.adapters.admission: Could not write admission gate receipt for Qwen CLI:
  invalid adapter name for receipt filename: 'Qwen CLI'
```

The write path (`write_admission_receipt`, and the identical pattern in the
security-floor and canary writers) validates the adapter name against a strict
`^[a-z0-9][a-z0-9_-]*$` allow-pattern and *raises* rather than write, so a name
that is merely not a slug discards the decision receipt. Consequently a
`decisions_dir` collects nothing for those adapters and
`load_admission_receipt` can never find stored evidence, re-deriving on every
spawn instead of honouring the TTL.

## Fix

Normalise instead of reject:

- New `slug_identifier()` in `path_containment.py` folds the name to a
  filename-safe slug (lowercase, runs of non-`[a-z0-9]` collapsed to a single
  `-`, leading/trailing `-` stripped).
- The writers use the slug for the storage filename only; the unmodified
  adapter name stays in the receipt body (which is what gets hashed and
  anchored).
- `load_admission_receipt` derives the same slug for its glob, and matches
  candidates against the unmodified body name, so a spaced-name receipt
  round-trips.
- Traversal characters (`/`, `\`, NUL) are refused *before* the fold, so a
  hostile name (`../../etc/passwd`, one that folds to empty, or one long
  enough to blow the filename limit) is still rejected rather than slipped
  through the slug. The existing containment check on the resolved path is
  unchanged.
- Applied to all three writers (admission, security-floor, canary) since the
  same bug shape existed in each.

## Note on storage-name changes

Receipt filenames change for any adapter whose old name happened to be
slug-clean under a *different* convention than this fold (e.g. an underscore).
After an upgrade the first run re-derives rather than reuses the previous file
for those adapters.

## Tests

- Round-trip: `Qwen CLI` writes `qwen-cli-<hash>.json` and loads back with its
  original name intact (admission, security-floor, canary).
- Regression: hostile name `../../etc/passwd` and over-long names still raise
  `ValueError`; previous containment/symlink tests unchanged.

Ran locally: `ruff check` clean, `ruff format` clean, `mypy` clean, dedicated
suites pass (admission 67, security-floor 38, canary 87, receipt containment
15, path containment 177, admission hardening 21).