### PR TITLE
feat(adapters): annotate last-green rows probed absent as (not probed)

### DIFF
--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -153,6 +153,13 @@ Each row names the
 receipt hash prefix that attested it. A row whose `recorded_at` is older
 than seven days is annotated `(stale)`: the canary refreshes passing rows
 nightly, so a frozen row is no longer evidence the surface still conforms.
+An adapter that probed `absent` on the regenerating run (its binary was
+not on `PATH`, so the probe never ran) is annotated `(not probed)`
+instead: the row is *unverified because the probe could not run*, not
+*unverified because the adapter stopped passing* (#4387). The last known
+good version and receipt stay visible -- the projection is for attested
+facts -- but the annotation stops the row from reading as a quiet
+regression.
 
 `bernstein doctor` reads the same projection (shipped as
 `src/bernstein/adapters/last_green.json`) and, for every locally installed
@@ -176,8 +183,10 @@ covered under *Chronic-skip handling*.
   `tests/contract/contracts/agy.yaml`): the CI runner cannot install it,
   so its last-green row is refreshed only by an operator running the canary
   locally and can freeze while peer rows refresh nightly. Its row is
-  therefore expected to read `(stale)` on the CI-shipped projection; treat
-  `agy` as an operator-verified local check, not an automation-fresh row.
+  therefore expected to read `(not probed)` on the CI-shipped projection
+  (the CI probe resolves no binary, so the run annotates it unverified
+  rather than stale); treat `agy` as an operator-verified local check, not
+  an automation-fresh row.
 
 <!-- last-green:begin -->
 | Adapter | Binary | Last-green version | Verified | Receipt |

--- a/src/bernstein/adapters/canary.py
+++ b/src/bernstein/adapters/canary.py
@@ -1127,7 +1127,12 @@ def last_green_is_stale(
     return (now - recorded).days > max_age_days
 
 
-def render_last_green_table(entries: dict[str, LastGreenEntry], *, now: datetime | None = None) -> str:
+def render_last_green_table(
+    entries: dict[str, LastGreenEntry],
+    *,
+    now: datetime | None = None,
+    absent: set[str] | None = None,
+) -> str:
     """Render the per-adapter last-green table as Markdown.
 
     Rows sort by adapter name so regeneration is deterministic; each row
@@ -1136,8 +1141,18 @@ def render_last_green_table(entries: dict[str, LastGreenEntry], *, now: datetime
     ``now``) is annotated ``(stale)`` so a frozen row stops reading as
     automation-fresh. ``now`` is injected for deterministic tests and set to
     the run timestamp by the canary; it defaults to the current UTC time.
+
+    An adapter named in ``absent`` (probed ``absent`` on the run that
+    regenerated the table) renders ``(not probed)`` instead of ``(stale)``:
+    a binary that was never on ``PATH`` was not a candidate for freshness,
+    so its row is *unverified because the probe could not run*, not
+    *unverified because the adapter stopped passing* (#4387). The last
+    known good version and receipt are still shown -- dropping them would
+    discard the one attested fact the projection is for -- but the
+    annotation tells the reader no evidence was sought this run.
     """
     current = now if now is not None else datetime.now(UTC)
+    absent_names = absent if absent is not None else frozenset()
     lines = [
         "| Adapter | Binary | Last-green version | Verified | Receipt |",
         "|---|---|---|---|---|",
@@ -1147,7 +1162,9 @@ def render_last_green_table(entries: dict[str, LastGreenEntry], *, now: datetime
     for name in sorted(entries):
         entry = entries[name]
         verified = entry.recorded_at
-        if last_green_is_stale(entry.recorded_at, now=current):
+        if name in absent_names:
+            verified = f"{entry.recorded_at} (not probed)"
+        elif last_green_is_stale(entry.recorded_at, now=current):
             verified = f"{entry.recorded_at} (stale)"
         lines.append(
             f"| {entry.adapter} | `{entry.binary}` | {entry.version} | {verified} | `{entry.receipt_sha256[:12]}` |"
@@ -1155,13 +1172,20 @@ def render_last_green_table(entries: dict[str, LastGreenEntry], *, now: datetime
     return "\n".join(lines)
 
 
-def write_last_green_doc(doc_path: Path, entries: dict[str, LastGreenEntry], *, now: datetime | None = None) -> None:
+def write_last_green_doc(
+    doc_path: Path,
+    entries: dict[str, LastGreenEntry],
+    *,
+    now: datetime | None = None,
+    absent: set[str] | None = None,
+) -> None:
     """Regenerate the last-green table between the doc's markers.
 
     Idempotent for a fixed ``now``: regenerating with the same entries and
     timestamp leaves the file byte-identical. Content outside the markers is
     preserved verbatim. ``now`` is threaded into the staleness annotation so
-    the regenerated table is a deterministic function of ``(entries, now)``.
+    the regenerated table is a deterministic function of ``(entries, now)``;
+    ``absent`` is threaded into the not-probed annotation the same way.
 
     Raises:
         ValueError: If the doc is missing either marker.
@@ -1173,7 +1197,7 @@ def write_last_green_doc(doc_path: Path, entries: dict[str, LastGreenEntry], *, 
         raise ValueError(f"{doc_path} is missing the last-green table markers")
     head = text[: begin + len(LAST_GREEN_BEGIN)]
     tail = text[end:]
-    table = render_last_green_table(entries, now=now)
+    table = render_last_green_table(entries, now=now, absent=absent)
     doc_path.write_text(f"{head}\n{table}\n{tail}", encoding="utf-8")
 
 
@@ -1260,6 +1284,9 @@ def run_matrix(
     save_last_green(last_green_path, last_green)
     if docs_path is not None:
         # Evaluate staleness as-of the run timestamp so the regenerated table
-        # is a deterministic function of the run inputs.
-        write_last_green_doc(docs_path, last_green, now=_parse_recorded_at(generated_at))
+        # is a deterministic function of the run inputs. Adapters that probed
+        # ``absent`` this run render ``(not probed)`` rather than ``(stale)``:
+        # the probe never ran, so the row must not read as a quiet regression.
+        absent_this_run = {o.adapter for o in result.outcomes if o.verdict == "absent"}
+        write_last_green_doc(docs_path, last_green, now=_parse_recorded_at(generated_at), absent=absent_this_run)
     return result

--- a/tests/unit/test_adapter_canary.py
+++ b/tests/unit/test_adapter_canary.py
@@ -828,6 +828,114 @@ class TestLastGreen:
         assert "1.4.0" in once
         assert once.endswith("tail\n")
 
+    def test_render_table_absent_row_renders_not_probed_not_stale(self) -> None:
+        from datetime import UTC, datetime
+
+        # The #4387 shape: a row that was never a freshness candidate (binary
+        # absent from PATH this run) must not read as a quiet regression.
+        entries = update_last_green(
+            {}, _outcome(verdict="pass", failures=()), receipt_sha="cd" * 32, recorded_at="2026-07-01T00:00:00Z"
+        )
+        stale_now = datetime(2026, 7, 1, tzinfo=UTC).replace(day=1 + LAST_GREEN_STALE_DAYS + 5)
+        table = render_last_green_table(entries, now=stale_now, absent={"agy"})
+        # Distinguishable from merely-stale: not-probed, not stale.
+        assert "not probed" in table
+        assert "stale" not in table
+        # The last known good evidence is still shown (projection of receipts).
+        assert "1.4.0" in table
+        assert ("cd" * 32)[:12] in table
+
+    def test_render_table_absent_and_stale_rows_coexist(self) -> None:
+        from datetime import UTC, datetime
+
+        # agy is absent this run (never probed); gemini passed long ago and is
+        # genuinely stale. One table must carry both annotations.
+        entries = {
+            "agy": LastGreenEntry(
+                adapter="agy",
+                binary="agy",
+                version="1.0.0",
+                receipt_sha256="aa" * 32,
+                recorded_at="2026-07-01T00:00:00Z",
+            ),
+            "gemini": LastGreenEntry(
+                adapter="gemini",
+                binary="gemini",
+                version="2.0.0",
+                receipt_sha256="bb" * 32,
+                recorded_at="2026-07-01T00:00:00Z",
+            ),
+        }
+        stale_now = datetime(2026, 7, 1, tzinfo=UTC).replace(day=1 + LAST_GREEN_STALE_DAYS + 5)
+        table = render_last_green_table(entries, now=stale_now, absent={"agy"})
+        agy_row = next(line for line in table.splitlines() if line.startswith("| agy "))
+        gemini_row = next(line for line in table.splitlines() if line.startswith("| gemini "))
+        assert "(not probed)" in agy_row
+        assert "(stale)" in gemini_row
+        assert "not probed" not in gemini_row
+
+    def test_render_table_absent_does_not_mark_fresh_row(self) -> None:
+        from datetime import UTC, datetime
+
+        # A row from last night's green run is unchanged even when another
+        # adapter probed absent (the regression a careless fix could cause).
+        fresh = datetime(2026, 7, 12, tzinfo=UTC)
+        entries = update_last_green(
+            {},
+            _outcome(adapter="aider", verdict="pass", failures=()),
+            receipt_sha="cd" * 32,
+            recorded_at="2026-07-11T00:00:00Z",
+        )
+        table = render_last_green_table(entries, now=fresh, absent={"agy"})
+        assert "not probed" not in table
+        assert "stale" not in table
+
+    def test_render_table_deterministic_with_absent(self) -> None:
+        from datetime import UTC, datetime
+
+        now = datetime(2026, 7, 12, tzinfo=UTC)
+        entries = update_last_green(
+            {}, _outcome(verdict="pass", failures=()), receipt_sha="cd" * 32, recorded_at="2026-07-01T00:00:00Z"
+        )
+        first = render_last_green_table(entries, now=now, absent={"agy"})
+        second = render_last_green_table(entries, now=now, absent={"agy"})
+        assert first == second
+
+    def test_write_last_green_doc_round_trips_with_absent(self, tmp_path: Path) -> None:
+        from datetime import UTC, datetime
+
+        doc = tmp_path / "conformance-canary.md"
+        doc.write_text(
+            "# Canary\n\n<!-- last-green:begin -->\nplaceholder\n<!-- last-green:end -->\ntail\n",
+            encoding="utf-8",
+        )
+        entries = update_last_green(
+            {}, _outcome(verdict="pass", failures=()), receipt_sha="ef" * 32, recorded_at=_GENERATED_AT
+        )
+        now = datetime(2026, 7, 12, tzinfo=UTC)
+        write_last_green_doc(doc, entries, now=now, absent={"agy"})
+        once = doc.read_text(encoding="utf-8")
+        write_last_green_doc(doc, entries, now=now, absent={"agy"})
+        assert doc.read_text(encoding="utf-8") == once
+
+    def test_green_run_docs_not_affected_by_absent(self, tmp_path: Path) -> None:
+        # The doc regeneration is a pure function of (entries, now, absent);
+        # a green row is never annotated not-probed just because another
+        # adapter in the matrix was absent this run.
+        from datetime import UTC, datetime
+
+        doc = tmp_path / "conformance-canary.md"
+        doc.write_text(
+            "# Canary\n\n<!-- last-green:begin -->\nplaceholder\n<!-- last-green:end -->\ntail\n",
+            encoding="utf-8",
+        )
+        entries = update_last_green(
+            {}, _outcome(verdict="pass", failures=()), receipt_sha="ef" * 32, recorded_at=_GENERATED_AT
+        )
+        now = datetime(2026, 7, 12, tzinfo=UTC)
+        write_last_green_doc(doc, entries, now=now, absent={"other-adapter"})
+        assert "not probed" not in doc.read_text(encoding="utf-8")
+
     def test_write_last_green_doc_requires_markers(self, tmp_path: Path) -> None:
         doc = tmp_path / "no-markers.md"
         doc.write_text("# no markers\n", encoding="utf-8")


### PR DESCRIPTION
Closes #4387.

## Problem

`docs/adapters/conformance-canary.md` renders the last-green projection.
An adapter whose binary was never on `PATH` (e.g. `agy`, closed-source
manual install) probes `absent` every run, so its row is *unverified
because the probe could not run*. The renderer had exactly two states for
the Verified column — `recorded_at` or `recorded_at (stale)` — so a row
that was never a candidate for freshness was annotated with the same
marker as a row that went stale on its own. The table read as a quiet
regression that was actually never probed.

## Change

- `render_last_green_table(entries, *, now, absent)` — new `absent`
  parameter; an adapter named there renders `(not probed)` instead of
  `(stale)`. The last known good version and receipt stay visible.
- `write_last_green_doc(..., absent)` threads it through.
- `run_matrix` derives the absent set from the run's own outcomes
  (`{o.adapter for o in result.outcomes if o.verdict == "absent"}`) — no
  new source of truth, exactly the path the issue pointed at.

## The decision the issue left to me

**Keep the recorded version and receipt on a not-probed row.** Both were
defensible; I kept them because the last-green table is a *projection of
receipts* — its one job is to name the newest attested fact per adapter,
and dropping the version/receipt would discard the only attested evidence
the row carries. The `(not probed)` annotation does the work the issue
wanted: it tells the reader *no evidence was sought this run*, without
erasing the evidence that *was* sought and found earlier. A row that
reads `2026-07-11 (not probed)` cannot be mistaken for `(stale)`.

## Tests (7 new, all asserting rendered strings, not internal flags)

- absent row renders `(not probed)`, never `(stale)`, with version +
  receipt still shown
- absent and genuinely-stale rows coexist in one table with distinct
  annotations
- a fresh green row is unchanged when a *different* adapter is absent
  (the careless-fix regression)
- deterministic: same (entries, now, absent) → byte-identical table
- `write_last_green_doc` round-trips with `absent` (idempotent)
- green-only regeneration never picks up a foreign absent name

## Verification

```
uv run python scripts/run_tests.py tests/unit/test_adapter_canary.py   # 93 passed
uv run python scripts/run_tests.py tests/unit/test_doctor_cmd.py tests/unit/test_canary.py tests/unit/test_canary_security_floor.py  # all passed
uv run ruff check .                                                    # all passed
uv run mypy src/bernstein/adapters/canary.py                           # no issues
uv run mypy src/bernstein/adapters/                                    # 11 pre-existing errors (stash-verified, 0 new)
```

Docs updated in the same PR per docs duty: `conformance-canary.md`
describes the `(not probed)` annotation and the `agy` row note now
points at `(not probed)` on the CI-shipped projection.