### PR TITLE
feat: reject internal-host destinations in the MCP-catalog fetcher

### DIFF
--- a/src/bernstein/core/protocols/mcp_catalog/fetcher.py
+++ b/src/bernstein/core/protocols/mcp_catalog/fetcher.py
@@ -24,7 +24,7 @@ from bernstein.core.protocols.mcp_catalog.manifest import (
     CatalogValidationError,
     validate_catalog,
 )
-from bernstein.core.security.url_allowlist import ensure_http_url
+from bernstein.core.security.url_allowlist import ensure_public_http_url
 
 logger = logging.getLogger(__name__)
 
@@ -82,9 +82,10 @@ class _UrllibTransport:
 
     def get(self, url: str, *, headers: dict[str, str]) -> HTTPResponse:
         # Operators may override the catalog URL via config; restrict the
-        # scheme so a malicious config cannot turn this transport into a
-        # ``file://`` reader.
-        ensure_http_url(url, allow_http=True, source="mcp_catalog.fetcher")
+        # scheme and destination so a malicious config or third-party catalog
+        # entry cannot turn this transport into a ``file://`` reader or aim it
+        # at an internal/loopback/link-local address (SSRF).
+        ensure_public_http_url(url, allow_http=True, source="mcp_catalog.fetcher")
         request = urllib.request.Request(url, headers=headers)
         try:
             # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected

--- a/tests/unit/protocols/mcp_catalog/test_fetcher.py
+++ b/tests/unit/protocols/mcp_catalog/test_fetcher.py
@@ -12,8 +12,10 @@ import pytest
 from bernstein.core.protocols.mcp_catalog.fetcher import (
     CatalogFetcher,
     HTTPResponse,
+    _UrllibTransport,
 )
 from bernstein.core.protocols.mcp_catalog.manifest import CatalogValidationError
+from bernstein.core.security.url_allowlist import UrlSchemeError
 
 
 def _good_catalog() -> dict[str, Any]:
@@ -154,3 +156,23 @@ def test_fetch_raises_when_no_cache_and_4xx(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="HTTP 404"):
         fetcher.fetch()
     assert not fetcher.cache_path.exists()
+
+
+def test_hostile_url_loopback_https_rejected() -> None:
+    """A loopback destination must be rejected before any network I/O.
+
+    The catalog URL is third-party-derived content, so the transport must
+    refuse to aim at an internal address (SSRF protection).
+    """
+    with pytest.raises(UrlSchemeError):
+        _UrllibTransport().get("https://127.0.0.1/catalog.json", headers={})
+
+
+def test_hostile_url_link_local_http_rejected() -> None:
+    """A link-local (cloud metadata) destination must be rejected.
+
+    ``allow_http=True`` is preserved, so the scheme passes; the host
+    restriction is what rejects the link-local address.
+    """
+    with pytest.raises(UrlSchemeError):
+        _UrllibTransport().get("http://169.254.169.254/latest/meta-data/", headers={})


### PR DESCRIPTION
Closes #4302

## Summary
- Resolve GitHub issue #4302: Reject internal-host destinations in the MCP-catalog fetcher

## Problem

`src/bernstein/core/protocols/mcp_catalog/fetcher.py:87` validates each URL read out of a fetched MCP catalog with:

```python
ensure_http_url(url, allow_http=True, source="mcp_catalog.fetcher")
```

`ensure_http_url` (`src/bernstein/core/security/url_allowlist.py:36-91`) checks scheme only, not the destination host
- Unlike the skills-catalog fetcher, this call site already passes `allow_http=True` (plain HTTP is accepted, not just for loopback hosts), which makes host restriction more important here, not less — a crafted MCP catalog entry can point at an internal HTTP endpoint just as easily as an HTTPS one
- The URLs validated here come from a fetched, third-party-authored catalog, the same threat shape as the skills-catalog fetcher

## Changes
```
bernstein.yaml | 22 +++++++++++-----------
 1 file changed, 11 insertions(+), 11 deletions(-)
```

## Verification
- _No quality gates were configured for this session._

## Cost
- **Total:** $0.00
- **Tokens:** 0
- **Effective rate:** n/a

---
_Generated from Bernstein session `1787482844`._

bernstein-session-id: 1787482844