### PR TITLE
fix(cli): harden run attestation projection

### DIFF
--- a/docs/security/audit-receipt.md
+++ b/docs/security/audit-receipt.md
@@ -138,16 +138,34 @@ bernstein identity attest show --run <run-id> --signing-key-path key.pem
 
 # Rebuild, verify the projection, and emit the receipt.
 bernstein identity attest verify --run <run-id> --signing-key-path key.pem
+
+# Reproduce a historical projection at an authenticated chain boundary.
+bernstein identity attest verify --run <run-id> \
+  --through-hmac <authenticated-hmac> \
+  --signing-key-path key.pem
 ```
 
 `verify` exits non-zero and names each failing check when the recomputed range
 no longer supports the projection. It stages the receipt privately and moves
 it into the evidence directory only after semantic verification passes, so a
-failed projection is never left behind as normal evidence. `show` creates
-neither a receipt nor audit key material. Both verdicts are recomputed from the
-retained range on every invocation; neither is read from a field in the receipt,
-so a serialized claim cannot promote itself through this surface any more than
-it can through the library.
+failed projection is never left behind as normal evidence. Before reporting
+success it re-hashes the promoted file and requires those durable bytes to
+match the verified in-memory projection. `show` creates neither a receipt nor
+audit key material. Both verdicts are recomputed from the retained range on
+every invocation; neither is read from a field in the receipt, so a serialized
+claim cannot promote itself through this surface any more than it can through
+the library.
+
+Without `--through-hmac`, both verbs use the verified source snapshot head.
+Supplying an authenticated HMAC pins the retained range so an unchanged
+historical provisional projection remains reproducible after unrelated audit
+events are appended. Whole-run-complete projections still require the verified
+source snapshot head: a historical boundary cannot prove that the suffix
+contains no later same-run evidence.
+
+`identity attest verify` intentionally does not append an
+`audit.receipt_export` event. Verification must not mutate the chain it checks:
+an appended event would move the default boundary and change the next receipt.
 
 These verbs sit under `identity attest` rather than extending `identity
 verify`, which checks an install-rev fingerprint token. The two answer

--- a/src/bernstein/cli/commands/identity_attest_cmd.py
+++ b/src/bernstein/cli/commands/identity_attest_cmd.py
@@ -171,7 +171,7 @@ def attest_group() -> None:
     \b
       bernstein identity attest show --run r-1234 --signing-key-path key.pem
       bernstein identity attest verify --run r-1234 --signing-key-path key.pem
-      bernstein identity attest verify --run r-1234 --through-hmac <hmac> \
+      bernstein identity attest verify --run r-1234 --through-hmac <hmac> \\
           --signing-key-path key.pem
     """
 
@@ -186,7 +186,7 @@ def show_cmd(
     signing_key_id: str | None,
     workdir: str,
 ) -> None:
-    """Project without writing; exit 1 on key or projection failure."""
+    """Project without writing; exit non-zero on key or projection failure."""
     kms_adapter = _resolve_kms(signing_key_path, signing_env_var, signing_key_id)
     receipt = _build(run_id, workdir, kms_adapter, through_hmac=through_hmac, write=False)
 

--- a/src/bernstein/cli/commands/identity_attest_cmd.py
+++ b/src/bernstein/cli/commands/identity_attest_cmd.py
@@ -24,6 +24,7 @@ a run's attestation evidence. They share a noun and nothing else.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Callable
 from pathlib import Path
 
@@ -36,7 +37,17 @@ EXIT_USAGE = 2
 
 _SIGNING_OPTIONS = (
     click.option("--run", "run_id", required=True, help="Run id to project."),
-    click.option("--signing-key-path", default=None, help="Path to an Ed25519 receipt signing key."),
+    click.option(
+        "--through-hmac",
+        default=None,
+        help="Authenticated audit-chain boundary to project through; defaults to the verified snapshot head.",
+    ),
+    click.option(
+        "--signing-key-path",
+        default=None,
+        type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+        help="Path to an Ed25519 receipt signing key.",
+    ),
     click.option(
         "--signing-env-var",
         default=None,
@@ -73,6 +84,23 @@ def _prepare_output_dir(workdir: str, output: str | None) -> Path:
     return output_dir
 
 
+def _sha256_file(path: Path) -> str:
+    """Return the SHA-256 of the bytes at the final promoted path."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _discard_untrusted_receipt(path: Path) -> None:
+    """Best-effort removal after promoted-byte verification fails."""
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as exc:
+        console.print(f"[red]Failed to remove untrusted promoted receipt:[/red] {exc}")
+
+
 def _resolve_kms(signing_key_path: str | None, signing_env_var: str | None, signing_key_id: str | None):  # type: ignore[no-untyped-def]
     from bernstein.core.persistence.lineage_signer import LineageSignerError
     from bernstein.core.security.lineage_kms import EnvBasedKMSAdapter, FileBasedKMSAdapter, KMSAdapter
@@ -96,7 +124,15 @@ def _resolve_kms(signing_key_path: str | None, signing_env_var: str | None, sign
     return kms_adapter
 
 
-def _build(run_id: str, workdir: str, kms_adapter: object, *, write: bool, output_dir: Path | None = None):  # type: ignore[no-untyped-def]
+def _build(  # type: ignore[no-untyped-def]
+    run_id: str,
+    workdir: str,
+    kms_adapter: object,
+    *,
+    through_hmac: str | None,
+    write: bool,
+    output_dir: Path | None = None,
+):
     from bernstein.core.security.audit import AuditKeyMissingError, AuditKeyPermissionError, load_audit_key
     from bernstein.core.security.run_attestation_receipt import (
         RunAttestationReceiptError,
@@ -116,6 +152,7 @@ def _build(run_id: str, workdir: str, kms_adapter: object, *, write: bool, outpu
             run_id=run_id,
             key=audit_key,
             kms_adapter=kms_adapter,  # type: ignore[arg-type]
+            through_hmac=through_hmac,
             output_dir=output_dir,
             write=write,
         )
@@ -134,6 +171,8 @@ def attest_group() -> None:
     \b
       bernstein identity attest show --run r-1234 --signing-key-path key.pem
       bernstein identity attest verify --run r-1234 --signing-key-path key.pem
+      bernstein identity attest verify --run r-1234 --through-hmac <hmac> \
+          --signing-key-path key.pem
     """
 
 
@@ -141,6 +180,7 @@ def attest_group() -> None:
 @_signing_options
 def show_cmd(
     run_id: str,
+    through_hmac: str | None,
     signing_key_path: str | None,
     signing_env_var: str | None,
     signing_key_id: str | None,
@@ -148,7 +188,7 @@ def show_cmd(
 ) -> None:
     """Project without writing; exit 1 on key or projection failure."""
     kms_adapter = _resolve_kms(signing_key_path, signing_env_var, signing_key_id)
-    receipt = _build(run_id, workdir, kms_adapter, write=False)
+    receipt = _build(run_id, workdir, kms_adapter, through_hmac=through_hmac, write=False)
 
     console.print(f"[bold]run[/bold]                {receipt.run_id}", soft_wrap=True)
     console.print(f"[bold]identity anchor[/bold]    {receipt.identity_anchor_hmac}", soft_wrap=True)
@@ -167,6 +207,7 @@ def show_cmd(
 @click.option("--output", default=None, help="Directory to write the emitted receipt into.")
 def verify_cmd(
     run_id: str,
+    through_hmac: str | None,
     signing_key_path: str | None,
     signing_env_var: str | None,
     signing_key_id: str | None,
@@ -184,9 +225,20 @@ def verify_cmd(
     from bernstein.core.security.run_attestation_receipt import verify_run_attestation_projection
 
     kms_adapter = _resolve_kms(signing_key_path, signing_env_var, signing_key_id)
+    # Resolve the source before creating the default output directory. A
+    # missing project audit chain is a read failure and must leave no
+    # receipt-shaped filesystem residue behind.
+    _resolve_audit_dir(workdir)
     output_dir = _prepare_output_dir(workdir, output)
     with TemporaryDirectory(prefix=".attest-", dir=output_dir) as staging_dir:
-        receipt = _build(run_id, workdir, kms_adapter, write=True, output_dir=Path(staging_dir))
+        receipt = _build(
+            run_id,
+            workdir,
+            kms_adapter,
+            through_hmac=through_hmac,
+            write=True,
+            output_dir=Path(staging_dir),
+        )
 
         verification = verify_run_attestation_projection(receipt.receipt)
         if not verification.ok:
@@ -205,6 +257,21 @@ def verify_cmd(
             console.print(f"[red]Failed to promote verified receipt:[/red] {exc}")
             raise SystemExit(EXIT_FAILURE) from None
 
+        try:
+            promoted_sha256 = _sha256_file(receipt_path)
+        except OSError as exc:
+            _discard_untrusted_receipt(receipt_path)
+            console.print(f"[red]Failed to re-hash promoted receipt:[/red] {exc}")
+            raise SystemExit(EXIT_FAILURE) from None
+        if promoted_sha256 != receipt.sha256:
+            _discard_untrusted_receipt(receipt_path)
+            console.print("[red]Promoted receipt bytes differ from the verified projection.[/red]")
+            raise SystemExit(EXIT_FAILURE)
+
+    # Deliberately do not append ``audit.receipt_export`` here. Verification
+    # must not advance the source chain: doing so would move the next default
+    # boundary and make a repeated projection differ because it was checked.
+
     console.print(
         f"[green]OK[/green] run attestation projection verified for {verification.run_id}",
         soft_wrap=True,
@@ -212,4 +279,4 @@ def verify_cmd(
     console.print(f"  dispatch evidence  {verification.dispatch_evidence_verdict.value}")
     console.print(f"  whole run          {verification.whole_run_verdict.value}")
     console.print(f"  receipt            {receipt_path}", soft_wrap=True)
-    console.print(f"  sha256             {receipt.sha256}", soft_wrap=True)
+    console.print(f"  sha256             {promoted_sha256}", soft_wrap=True)

--- a/src/bernstein/cli/commands/identity_cmd.py
+++ b/src/bernstein/cli/commands/identity_cmd.py
@@ -13,9 +13,12 @@ Subcommands:
   full HMAC-strength verification.
 * ``bernstein identity disable`` - print the env-var line the user can
   paste into their shell to suppress all emit sites.
+* ``bernstein identity attest show|verify --run <id>`` - project or verify a
+  run-attestation receipt without overloading install-rev verification.
 
-The CLI is read-only and never opens a network connection.  This is the
-project's hard rule: no telemetry, ever.
+The install-rev verbs are read-only and never open a network connection.  This
+is the project's hard rule: no telemetry, ever.  The nested ``attest verify``
+verb may write a verified receipt into the operator-selected evidence directory.
 
 See ``docs/operations/install-fingerprint.md`` for the full operator
 playbook (seed generation, storage, rotation, decode).
@@ -56,6 +59,8 @@ def identity_group() -> None:
       bernstein identity verify c4j2k7n8p3q5r9s7 \\
           --nonce 0123456789abcdef0123 --version-major 1
       bernstein identity disable
+      bernstein identity attest show --run r-1234 \
+          --signing-key-path key.pem
     """
 
 

--- a/src/bernstein/cli/commands/identity_cmd.py
+++ b/src/bernstein/cli/commands/identity_cmd.py
@@ -59,7 +59,7 @@ def identity_group() -> None:
       bernstein identity verify c4j2k7n8p3q5r9s7 \\
           --nonce 0123456789abcdef0123 --version-major 1
       bernstein identity disable
-      bernstein identity attest show --run r-1234 \
+      bernstein identity attest show --run r-1234 \\
           --signing-key-path key.pem
     """
 

--- a/tests/unit/cli/test_identity_attest_cmd.py
+++ b/tests/unit/cli/test_identity_attest_cmd.py
@@ -9,6 +9,7 @@ and are deliberately not re-asserted here.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -19,6 +20,7 @@ from click.testing import CliRunner
 from bernstein.cli.commands import identity_attest_cmd
 from bernstein.cli.commands.identity_cmd import identity_group
 from bernstein.core.security import run_attestation_receipt
+from bernstein.core.security.audit_chain import AuditChainStore
 from tests.support.run_attestation import HMAC_KEY, anchored_provider, intent, kms
 
 
@@ -65,6 +67,8 @@ def test_attest_verify_is_not_the_install_rev_verify() -> None:
 
 
 def test_signing_sources_are_mutually_exclusive(tmp_path: Path) -> None:
+    signing_key = tmp_path / "key.pem"
+    signing_key.write_text("unused because the options are mutually exclusive")
     result = CliRunner().invoke(
         identity_group,
         [
@@ -73,7 +77,7 @@ def test_signing_sources_are_mutually_exclusive(tmp_path: Path) -> None:
             "--run",
             "run-1",
             "--signing-key-path",
-            str(tmp_path / "key.pem"),
+            str(signing_key),
             "--signing-env-var",
             "SOME_KEY",
             "--workdir",
@@ -82,6 +86,25 @@ def test_signing_sources_are_mutually_exclusive(tmp_path: Path) -> None:
     )
     assert result.exit_code == 2
     assert "mutually exclusive" in result.output
+
+
+def test_missing_signing_key_path_uses_click_usage_contract(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        identity_group,
+        [
+            "attest",
+            "verify",
+            "--run",
+            "run-1",
+            "--signing-key-path",
+            str(tmp_path / "missing.pem"),
+            "--workdir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == identity_attest_cmd.EXIT_USAGE
+    assert "does not exist" in result.output
 
 
 def test_missing_signing_source_is_refused(tmp_path: Path) -> None:
@@ -110,6 +133,29 @@ def test_missing_audit_directory_names_the_path(tmp_path: Path) -> None:
     )
     assert result.exit_code == 1
     assert "Audit directory not found" in result.output or "signing key" in result.output
+
+
+def test_verify_missing_audit_directory_leaves_no_default_output(tmp_path: Path) -> None:
+    kms(tmp_path / "signing")
+    signing_key = tmp_path / "signing" / "receipt-signing.pem"
+
+    result = CliRunner().invoke(
+        identity_group,
+        [
+            "attest",
+            "verify",
+            "--run",
+            "run-1",
+            "--signing-key-path",
+            str(signing_key),
+            "--workdir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == identity_attest_cmd.EXIT_FAILURE
+    assert "Audit directory not found" in result.output
+    assert not (tmp_path / ".sdd" / "evidence").exists()
 
 
 def test_run_id_is_required(tmp_path: Path) -> None:
@@ -147,6 +193,7 @@ def test_real_chain_show_and_verify_emit(attest_cli_env: tuple[Path, list[str], 
     assert "whole run" in show.output
 
     output_dir = root / "receipts"
+    audit_before = {path.name: path.read_bytes() for path in (root / ".sdd" / "audit").glob("*") if path.is_file()}
     verify = runner.invoke(
         identity_group,
         ["attest", "verify", *common, "--output", str(output_dir)],
@@ -156,7 +203,115 @@ def test_real_chain_show_and_verify_emit(attest_cli_env: tuple[Path, list[str], 
     assert "projection verified" in verify.output
     receipts = list(output_dir.glob("run-attestation-*.json"))
     assert len(receipts) == 1
+    promoted_sha256 = hashlib.sha256(receipts[0].read_bytes()).hexdigest()
+    assert promoted_sha256 in verify.output
     assert not list(output_dir.glob(".attest-*"))
+    audit_after = {path.name: path.read_bytes() for path in (root / ".sdd" / "audit").glob("*") if path.is_file()}
+    assert audit_after == audit_before
+
+
+def test_through_hmac_reproduces_projection_after_chain_advances(
+    attest_cli_env: tuple[Path, list[str], dict[str, str]],
+) -> None:
+    root, common, env = attest_cli_env
+    chain = AuditChainStore(root / ".sdd" / "audit", key=HMAC_KEY)
+    boundary = chain.query(include_archived=True)[-1].hmac
+    runner = CliRunner()
+
+    before = runner.invoke(
+        identity_group,
+        ["attest", "show", *common, "--through-hmac", boundary],
+        env=env,
+    )
+    assert before.exit_code == 0, before.output
+
+    chain.log(
+        event_type="unrelated.audit.event",
+        actor="operator",
+        resource_type="system",
+        resource_id="unrelated",
+    )
+
+    pinned = runner.invoke(
+        identity_group,
+        ["attest", "show", *common, "--through-hmac", boundary],
+        env=env,
+    )
+    current = runner.invoke(identity_group, ["attest", "show", *common], env=env)
+    output_dir = root / "pinned-receipts"
+    verified = runner.invoke(
+        identity_group,
+        [
+            "attest",
+            "verify",
+            *common,
+            "--through-hmac",
+            boundary,
+            "--output",
+            str(output_dir),
+        ],
+        env=env,
+    )
+
+    assert pinned.exit_code == 0, pinned.output
+    assert pinned.output == before.output
+    assert current.exit_code == 0, current.output
+    assert current.output != pinned.output
+    assert verified.exit_code == 0, verified.output
+    receipt_path = next(output_dir.glob("run-attestation-*.json"))
+    receipt = json.loads(receipt_path.read_text())
+    assert receipt["run_attestation"]["through_hmac"] == boundary
+
+
+def test_promoted_digest_mismatch_fails_and_removes_receipt(
+    attest_cli_env: tuple[Path, list[str], dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, common, env = attest_cli_env
+    output_dir = root / "receipts"
+    monkeypatch.setattr(identity_attest_cmd, "_sha256_file", lambda _path: "0" * 64)
+
+    result = CliRunner().invoke(
+        identity_group,
+        ["attest", "verify", *common, "--output", str(output_dir)],
+        env=env,
+    )
+
+    assert result.exit_code == identity_attest_cmd.EXIT_FAILURE
+    assert "Promoted receipt bytes differ" in result.output
+    assert not list(output_dir.glob("*.json"))
+    assert not list(output_dir.glob(".attest-*"))
+
+
+def test_promoted_receipt_read_failure_removes_receipt(
+    attest_cli_env: tuple[Path, list[str], dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, common, env = attest_cli_env
+    output_dir = root / "receipts"
+
+    def _fail_read(_path: Path) -> str:
+        raise OSError("forced durable read failure")
+
+    monkeypatch.setattr(identity_attest_cmd, "_sha256_file", _fail_read)
+
+    result = CliRunner().invoke(
+        identity_group,
+        ["attest", "verify", *common, "--output", str(output_dir)],
+        env=env,
+    )
+
+    assert result.exit_code == identity_attest_cmd.EXIT_FAILURE
+    assert "Failed to re-hash promoted receipt" in result.output
+    assert not list(output_dir.glob("*.json"))
+    assert not list(output_dir.glob(".attest-*"))
+
+
+def test_identity_help_names_attest_operator_surface() -> None:
+    result = CliRunner().invoke(identity_group, ["--help"])
+
+    assert result.exit_code == 0
+    assert "identity attest show" in result.output
 
 
 def test_real_chain_tamper_exits_nonzero_and_names_entry(


### PR DESCRIPTION
## Context

Follow-up to the non-blocking hardening notes in #4139. The run-attestation CLI had the correct projection and fail-closed core, but it did not expose the library's authenticated boundary selector and still had five operator-surface hardening/polish gaps.

## What changed

- expose `--through-hmac` on both `identity attest show` and `verify`;
- keep the library's safety boundary: historical provisional projections can be pinned, while whole-run completion still requires the verified snapshot head;
- resolve a missing audit directory before creating the default evidence directory;
- re-hash the final promoted receipt and compare it with the verified in-memory bytes before printing `OK`;
- remove a promoted receipt when durable readback fails or its digest differs;
- make `--signing-key-path` use the same Click path contract as `audit receipt export`;
- add `attest` to the identity command overview/help;
- document why verification deliberately does not append `audit.receipt_export`.

## Regression boundary

The CLI tests now cover:

- pinned `show` and `verify` remaining reproducible after an unrelated authenticated append;
- default-head output changing when the source head advances;
- the promoted file's actual SHA-256 being reported;
- durable read failure and digest mismatch failing closed with no promoted receipt left behind;
- missing audit input leaving no default evidence directory;
- missing signing paths using exit 2;
- CLI verification leaving the source audit chain byte-identical;
- the identity help surface naming `attest`.

The existing library regression that rejects a historical completion boundary hiding a later same-run event remains unchanged.

## Validation

- 16 identity-attest CLI tests passed
- 21 run-attestation security tests passed
- 3 audit-receipt command tests passed
- 13 verification exit-code tests passed
- 38 documentation/context tests passed
- Ruff format and lint passed on all touched Python files
- mypy and Pyright passed on both touched command modules
- import-linter kept all 3 architecture contracts
- `git diff --check` passed

The only warnings were the existing Starlette `httpx` deprecation warnings.
