### PR TITLE
fix(tests): make plan-loader flag assertion path-independent

### DIFF
--- a/tests/unit/test_plan_loader.py
+++ b/tests/unit/test_plan_loader.py
@@ -104,7 +104,11 @@ def test_load_plan_seed_shaped_file_gives_actionable_error(tmp_path: Path) -> No
     run_option_flags = {opt for param in run_bootstrap.run.params for opt in getattr(param, "opts", [])}
     assert "--seed" in run_option_flags
     assert "--seed" in message
-    assert "-f" not in message
+    # The path is embedded in the message and may legitimately contain "-f"
+    # (a checkout under e.g. ~/my-feature/, a CI tmpdir named after the user).
+    # Strip it so the assertion judges only the advice text.
+    message_without_path = message.replace(str(plan_file), "")
+    assert "-f" not in message_without_path
 
 
 def test_load_plan_seed_shaped_file_goal_only(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Makes the `-f`-flag assertion in `test_load_plan_seed_shaped_file_gives_actionable_error` path-independent.

## Problem

The test guards that the seed-shaped-plan error message never suggests a nonexistent `-f` flag. But the message embeds the plan file path twice, and the assertion scans the whole string. Any environment whose tmp path contains the substring `-f` fails the test on text that is not advice at all — e.g. a pytest tmpdir derived from a username (`/tmp/pytest-of-fleet/...`) or a checkout under a directory like `my-feature/`.

Reproduce on current `main`:

```bash
sudo -u fleet uv run pytest tests/unit/test_plan_loader.py::test_load_plan_seed_shaped_file_gives_actionable_error
# FAILED — assert "-f" not in '/tmp/pytest-of-fleet/.../plan.yaml looks like a seed config...'
```

## How

Strip `str(plan_file)` from the message before the `-f` check. The guard still catches a suggested `-f` flag in the advice wording, which is what it was written for.

Test-only change; `tests/unit/test_plan_loader.py` passes under both a plain username and one that trips the old assertion (78 passed).
