### PR TITLE
fix(tests): stop asserting on Rich-wrapped output in ticket validate CLI

### DIFF
--- a/tests/integration/test_ticket_validate_cli.py
+++ b/tests/integration/test_ticket_validate_cli.py
@@ -148,4 +148,11 @@ def test_cli_missing_path_reports_as_failure(runner: CliRunner, tmp_path: Path) 
         catch_exceptions=False,
     )
     assert result.exit_code == 1
-    assert "does-not-exist" in result.output
+    # The report renders through Rich, which hard-wraps at the terminal width
+    # and can split the filename mid-token
+    # (``does-not-ex\nist.md``). Whether the CLI names the offending file is
+    # the behaviour under test; where the renderer broke the line is not, and
+    # asserting on the wrapped form makes the test fail on nothing but a long
+    # tmpdir path or a narrow terminal.
+    unwrapped = result.output.replace("\n", "")
+    assert "does-not-exist" in unwrapped


### PR DESCRIPTION
## Problem

`test_cli_missing_path_reports_as_failure` asserts that the validation report names the missing file:

```python
assert "does-not-exist" in result.output
```

The report renders through Rich, which hard-wraps at the terminal width. When the tmpdir path is long enough, the filename crosses the wrap column and the assertion sees `does-not-ex\nist.md`:

```
E   AssertionError: assert 'does-not-exist' in '[FAIL] \n/tmp/pytest-of-<user>/pytest-783/test_cli_missing_path_reports_0/does-not-ex\nist.md ...'
```

Reproduce on current `main`:

```bash
COLUMNS=40 uv run pytest tests/integration/test_ticket_validate_cli.py::test_cli_missing_path_reports_as_failure
```

Whether the CLI names the offending file is the behaviour under test. Where the renderer chose to break the line is not.

## How

Strip newlines from the captured output before the membership check.

`CliRunner(env={"COLUMNS": ...})` does not fix this — the console width is not resolved from the runner's env at invoke time — so the fix is at the assertion rather than the fixture.

## Verification

`tests/integration/test_ticket_validate_cli.py` — 11 passed at `COLUMNS=40` and at the default width. Test-only change.
