### PR TITLE
fix(cas): anchor sidecar metadata reads

### DIFF
--- a/docs/architecture/sandbox.md
+++ b/docs/architecture/sandbox.md
@@ -341,13 +341,16 @@ anything that is not a regular file, opening non-blocking and checking the type
 on the descriptor. A FIFO planted at a blob's own name needs no link at all,
 and would otherwise block the read until a writer appeared.
 
-This covers the **blob** read, which is what `receipt verify` consults. The
-`.meta.json` sidecar beside each blob is read without the walk, and deliberately
-so: unlike the blob, it is not content-addressed, so there is no digest to check
-it against. An attacker holding the write access needed to plant a symlink in
-the store can equally write a hostile sidecar in place, which no symlink refusal
-would catch. Nothing in the verification path reads metadata; treat it as
-descriptive, not as evidence.
+The same anchored walk protects direct reads of the `.meta.json` sidecar beside
+each blob, including the reads used by `list_entries`. This prevents a shard or
+sidecar symlink from redirecting the file open, but it does **not** authenticate
+the metadata: unlike the blob, the sidecar is not content-addressed and has no
+digest to verify. Treat its fields as descriptive, not as evidence.
+
+On POSIX, anchoring a metadata read adds descriptor opens for the store root and
+shard plus a regular-file check before reading the sidecar. This small per-read
+cost is accepted so a future metadata consumer cannot silently inherit an
+unanchored path. Windows retains the single-open fallback described above.
 
 `fork-race` requires a microVM-capable host; on an unsupported host it
 fails loudly. The determinism/tamper guarantees are validated

--- a/src/bernstein/core/persistence/cas_store.py
+++ b/src/bernstein/core/persistence/cas_store.py
@@ -175,22 +175,23 @@ class CASStore:
     def _read_meta(self, digest: str) -> CASEntry | None:
         """Load the :class:`CASEntry` sidecar, or ``None`` if missing.
 
-        This read is **not** anchored the way :meth:`get` is, deliberately.
-        Unlike a blob, the sidecar is not content-addressed: there is no digest
-        to check it against, so an attacker holding the write access needed to
-        plant a symlink in the store can write a hostile sidecar in place and a
-        symlink refusal would catch nothing. Nothing in the verification path
-        reads metadata -- see "Symlink refusal, and where it stops" in
-        ``docs/architecture/sandbox.md``.
-
-        **That exemption depends on metadata staying descriptive.** A caller
-        that starts making a trust decision from these fields invalidates the
-        reasoning above, and this read needs anchoring before it does.
+        The sidecar is descriptive rather than content-addressed, so anchoring
+        does not authenticate its fields. It does ensure the read cannot be
+        redirected through a symlinked shard or sidecar, matching the path
+        guarantees of :meth:`get` without claiming an integrity guarantee.
         """
-        meta = self._meta_path(digest)
-        if not meta.exists():
+        try:
+            fd = open_anchored(
+                self._root,
+                digest[:2],
+                f"{digest}.meta.json",
+                flags=os.O_RDONLY,
+                require_regular_file=True,
+            )
+        except FileNotFoundError:
             return None
-        data: dict[str, Any] = json.loads(meta.read_text())
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            data: dict[str, Any] = json.load(handle)
         return CASEntry(**data)
 
     # -- public API ----------------------------------------------------------
@@ -380,8 +381,10 @@ class CASStore:
                 continue
             for meta_file in sorted(shard.glob("*.meta.json")):
                 try:
-                    data: dict[str, Any] = json.loads(meta_file.read_text())
-                    entries.append(CASEntry(**data))
+                    digest = meta_file.name.removesuffix(".meta.json")
+                    entry = self._read_meta(digest)
+                    if entry is not None:
+                        entries.append(entry)
                 except (json.JSONDecodeError, TypeError, KeyError):
                     logger.warning("Corrupt CAS metadata: %s", meta_file)
 

--- a/tests/unit/test_cas_store.py
+++ b/tests/unit/test_cas_store.py
@@ -416,6 +416,39 @@ class TestCASStoreInit:
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX symlink semantics")
 class TestCASStoreSymlinkSafety:
+    def test_get_entry_refuses_to_follow_a_symlinked_sidecar(self, cas: CASStore, tmp_path: Path) -> None:
+        """Metadata lookup must not follow a sidecar replaced by a link."""
+        digest = cas.put(b"authentic blob")
+        sidecar = cas.root / digest[:2] / f"{digest}.meta.json"
+        target = tmp_path / "attacker-meta.json"
+        target.write_text(sidecar.read_text())
+        sidecar.unlink()
+        sidecar.symlink_to(target)
+
+        with pytest.raises(OSError) as excinfo:
+            cas.get_entry(digest)
+        assert not isinstance(excinfo.value, FileNotFoundError)
+
+    def test_get_entry_refuses_to_follow_a_symlinked_shard_directory(
+        self,
+        cas: CASStore,
+        tmp_path: Path,
+    ) -> None:
+        """Metadata lookup must anchor every component below the CAS root."""
+        digest = cas.put(b"authentic blob")
+        shard = cas.root / digest[:2]
+        sidecar = shard / f"{digest}.meta.json"
+        decoy = tmp_path / "attacker-shard"
+        decoy.mkdir()
+        (decoy / sidecar.name).write_text(sidecar.read_text())
+        shutil.rmtree(shard)
+        shard.symlink_to(decoy, target_is_directory=True)
+
+        with pytest.raises(OSError) as excinfo:
+            cas.get_entry(digest)
+        assert not isinstance(excinfo.value, FileNotFoundError)
+        assert excinfo.value.errno in {errno.ELOOP, errno.ENOTDIR}
+
     def test_get_refuses_to_follow_a_symlinked_blob(self, cas: CASStore, tmp_path: Path) -> None:
         """A blob path replaced by a symlink must be rejected by the read itself
         (O_NOFOLLOW), atomically - never followed to its target. This is the


### PR DESCRIPTION
## What

- Route direct CAS `.meta.json` reads through `open_anchored`, refusing a symlinked shard or sidecar and requiring the final object to be a regular file.
- Make `list_entries()` reuse the anchored metadata reader instead of retaining a second direct `Path.read_text()` path.
- Document the security boundary and the extra POSIX descriptor-walk cost.

## Why

The sidecar exemption was justified only while metadata remained descriptive, but nothing executable enforced that assumption. Anchoring the read removes that latent dependency without claiming the sidecar is authenticated or content-addressed.

Closes #3582.

## How

`_read_meta()` now walks `root -> shard -> sidecar` with `O_NOFOLLOW` where supported and `require_regular_file=True`. It catches only `FileNotFoundError`, preserving the existing `None` result for a genuinely missing sidecar while allowing symlink and irregular-file refusals to propagate.

The commits preserve the requested TDD order: the sidecar and shard symlink tests were added first and both failed on `main`, then the implementation made them pass. The existing ordinary `get_entry()` test remains the positive control.

On POSIX this replaces the direct metadata path read with opens for the store root, shard, and sidecar plus a final `fstat`; that small per-read cost is the tradeoff for making the invariant independent of future consumers. Windows keeps `open_anchored`'s documented single-open fallback.

## Verification

- `python scripts/run_tests.py tests/unit/test_cas_store.py` — 55 passed
- `python scripts/run_tests.py tests/property/test_cas_store_properties.py` — 7 passed, 1 skipped
- `python scripts/run_tests.py tests/unit/storage/ tests/unit/security/` — 41 files passed (869 tests passed, 4 skipped)
- `ruff check src/` — passed
- `ruff format --check src/bernstein/core/persistence/cas_store.py tests/unit/test_cas_store.py` — passed
- `lint-imports` — 3 contracts kept, 0 broken
- repository `pre-push` blocking phases — lint and import contracts passed
- `mypy src/bernstein/core/persistence/cas_store.py` — no issues
- `pyright src/bernstein/core/persistence/cas_store.py` — 0 errors, 0 warnings

Environment note: full `uv sync --frozen` on this macOS arm64 host built `z3-solver==4.16.0.0`, but uv rejected the resulting `macosx_14_8_arm64` wheel as incompatible with the local platform tag. That dependency is introduced only by the development-only CrossHair chain. `uv sync --frozen --no-dev` succeeded, after which the test/lint/type tools needed above were installed separately. The issue-requested whole-core mypy command was also executed; current `main` reports 205 existing errors across 134 files, while the modified file is clean as reported above.

## Checklist

- [x] `ruff check src/` passes
- [x] Modified module passes both mypy and pyright
- [x] New code retains type hints
- [x] Architecture documentation updated
- [x] Tests cover ordinary reads and both final-component and parent-component symlink refusal
- [x] README / operations docs: N/A (internal CAS read hardening; architecture documentation updated instead)
- [x] API schema regeneration: N/A (no public schema change)
- [x] `bernstein agents-md sync`: N/A (no module or architecture-map change)

## AI assistance

This contribution was prepared with assistance from OpenAI Codex for issue triage, test and implementation drafting, documentation, and local verification. The test-first commit split and all validation results are included above for review.
