### PR TITLE
feat: declare letta_code's session_state as persistent-agent

### DIFF
--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -692,7 +692,10 @@ STRATEGY_MATRIX: dict[str, AdapterStrategy] = {
     "charm": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
     "kimi": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
     "rovo": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
-    "letta_code": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
+    "letta_code": AdapterStrategy(
+        dangerous_mode=DangerousModeStrategy.CLI_FLAG,
+        session_state=SessionState.PERSISTENT_AGENT,
+    ),
     # Codex drives unattended via its sandbox/full-auto flag.
     "codex": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
     # Everyone else - no native resume, text-signal channel. Dangerous-mode

--- a/tests/unit/adapters/test_session_state_axis.py
+++ b/tests/unit/adapters/test_session_state_axis.py
@@ -39,11 +39,22 @@ def test_default_is_stateless_so_existing_rows_keep_their_meaning() -> None:
 
 def test_no_shipped_adapter_silently_became_persistent() -> None:
     # Every row was written before this axis existed, so all of them must still
-    # read as stateless. Declaring letta_code is a separate issue under #3670.
-    persistent = [
-        name for name, strategy in STRATEGY_MATRIX.items() if strategy.session_state is not SessionState.STATELESS
-    ]
-    assert persistent == [], f"unexpected non-stateless declarations: {persistent}"
+    # read as stateless — except letta_code, which carries cross-task memory via
+    # Letta Cloud and is now explicitly declared PERSISTENT_AGENT (issue #4289).
+    persistent = {
+        name: strategy.session_state
+        for name, strategy in STRATEGY_MATRIX.items()
+        if strategy.session_state is not SessionState.STATELESS
+    }
+    assert set(persistent) == {"letta_code"}, f"unexpected non-stateless declarations: {persistent}"
+    assert persistent["letta_code"] is SessionState.PERSISTENT_AGENT
+
+
+def test_letta_code_declared_persistent_agent() -> None:
+    # Regression guard: letta_code maintains long-lived state across separate
+    # invocations via Letta Cloud. This row cannot quietly revert to the
+    # stateless default.
+    assert STRATEGY_MATRIX["letta_code"].session_state is SessionState.PERSISTENT_AGENT
 
 
 def test_axis_reaches_the_operator_facing_view() -> None:


### PR DESCRIPTION
Closes #4289

## Summary
- Resolve GitHub issue #4289: Declare letta_code's session_state as persistent-agent

## Defect

`_STRATEGIES["letta_code"]` (`src/bernstein/adapters/_contract.py:670`) only sets `dangerous_mode`
- `resume` defaults to `ResumeStrategy.UNSUPPORTED`, which the rest of the codebase reads as "each spawn starts from nothing." For this adapter that's false — `src/bernstein/adapters/letta_code.py`'s own docstring says Letta's cross-task memory and agent IDs persist in Letta's backend across invocations, opaque to bernstein
- No research is needed to fix this one row: the adapter's own docs already say what its value should be

## Changes
```
bernstein.yaml                                 | 28 +++++++++++++++-----------
 src/bernstein/adapters/_contract.py            |  5 ++++-
 tests/unit/adapters/test_session_state_axis.py | 21 ++++++++++++++-----
 3 files changed, 36 insertions(+), 18 deletions(-)
```

## Verification
- _No quality gates were configured for this session._

## Cost
- **Total:** $3.43
- **Tokens:** 0
- **Effective rate:** n/a

---
_Generated from Bernstein session `1787496090`._

bernstein-session-id: 1787496090

---
Made by bernstein v3.17.1 - unattended run `run-20260823T144109Z`, no operator in the loop.
