### PR TITLE
fix: every 429 is backed off as a rate limit, including caps a retry cannot clear

### DIFF
--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -136,6 +136,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `gptme.py`                  | gptme CLI adapter |
 | `hermes.py`                 | Hermes Agent (Nous Research) CLI adapter |
 | `hook_gate_render.py`       | Render in-process verification-gate hooks for capable adapters (issue #2360) |
+| `http_429_classifier.py`    | Data-driven classifier for HTTP 429 responses |
 | `iac.py`                    | Infrastructure-as-Code (Terraform/Pulumi) adapter for Bernstein |
 | `junie.py`                  | JetBrains Junie CLI adapter |
 | `kilo.py`                   | Kilo CLI adapter (Stackblitz) |

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -17,6 +17,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
+from bernstein.adapters.http_429_classifier import HTTP429Classification, classify_429
 from bernstein.core.lineage.artifact_events import emit_production_event
 from bernstein.core.lineage.spine import LineageSpine
 from bernstein.core.platform_compat import (
@@ -71,6 +72,14 @@ class SpawnError(RuntimeError):
 
 class RateLimitError(SpawnError):
     """Raised when an adapter detects provider-side rate limiting on startup."""
+
+
+class StandingCapError(SpawnError):
+    """Raised when an adapter detects a standing account/key/session/spend cap.
+
+    Unlike :class:`RateLimitError`, a standing cap will not clear within
+    the run, so it must not consume the retry budget or trigger backoff.
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -907,6 +916,7 @@ class CLIAdapter(ABC):
 
         Raises:
             RateLimitError: Provider immediately exited due to rate limiting.
+            StandingCapError: Provider immediately exited due to a standing cap.
             SpawnError: Provider immediately exited for another reason.
         """
         try:
@@ -927,6 +937,10 @@ class CLIAdapter(ABC):
         tail_lines = self._read_last_lines(log_path, n=10)
         tail_text = tail_lines[-1] if tail_lines else "(no log output)"
         if self._is_rate_limit_error(tail_lines):
+            # Distinguish a standing cap (won't clear this run) from a
+            # transient request-rate limit before touching the meter.
+            if classify_429(tail_text) is HTTP429Classification.STANDING:
+                raise StandingCapError(f"{provider_name} hit a standing cap during startup: {tail_text}")
             # Tap the meter once before raising so the panel and the
             # ``rate_limit.hit`` event both see the spawn-time 429.
             try:

--- a/src/bernstein/adapters/http_429_classifier.py
+++ b/src/bernstein/adapters/http_429_classifier.py
@@ -1,0 +1,94 @@
+"""Data-driven classifier for HTTP 429 responses.
+
+A 429 status alone does not tell the caller whether the limit is a
+transient request-rate cap (clears with time) or a standing account /
+key / session / spend cap (will not clear within the run). This module
+classifies a 429 response body into one of the two kinds so the backoff
+decision can branch before :class:`~bernstein.adapters.base.RateLimitMeter`
+advises a retry.
+
+The pattern table is data-driven: each entry is a ``(needle,
+classification, reason_label)`` tuple and the classifier is a single
+loop over it. Adding a new endpoint's wording is a one-line append; no
+control flow changes.
+
+An unrecognised body falls back to :data:`HTTP429Classification.RETRYABLE`
+— misclassifying an unknown limit as permanent would be worse than the
+current state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final
+
+
+class HTTP429Classification(Enum):
+    """Two-way split of a 429 response before the backoff decision.
+
+    Attributes:
+        RETRYABLE: Request-rate limit; clears with time.
+        STANDING: Account, key, session, or spend cap; will not clear
+            within the run.
+    """
+
+    RETRYABLE = "retryable"
+    STANDING = "standing"
+
+
+@dataclass(frozen=True, slots=True)
+class _PatternRule:
+    """One data-driven classification rule.
+
+    Attributes:
+        needle: Case-insensitive substring to match against the body.
+        classification: Result when the needle matches.
+        reason_label: Short machine-readable reason (e.g. ``session_cap``).
+    """
+
+    needle: str
+    classification: HTTP429Classification
+    reason_label: str
+
+
+#: Data-driven pattern table. Append a new endpoint's wording here; the
+#: classifier loop needs no changes.
+_PATTERN_RULES: Final[tuple[_PatternRule, ...]] = (
+    _PatternRule(
+        "maximum number of active sessions",
+        HTTP429Classification.STANDING,
+        "session_cap",
+    ),
+    _PatternRule(
+        "close unused sessions",
+        HTTP429Classification.STANDING,
+        "session_cap",
+    ),
+    _PatternRule("spending limit", HTTP429Classification.STANDING, "spend_cap"),
+    _PatternRule("daily limit", HTTP429Classification.STANDING, "spend_cap"),
+    _PatternRule("budget exceeded", HTTP429Classification.STANDING, "spend_cap"),
+)
+
+
+def classify_429(body: str, retry_after: str | None = None) -> HTTP429Classification:
+    """Classify a 429 response body into RETRYABLE or STANDING.
+
+    Args:
+        body: The response body text. Matched case-insensitively against
+            :data:`_PATTERN_RULES`.
+        retry_after: Optional ``Retry-After`` header value. Reserved for
+            future standing-cap heuristics; classification is currently
+            body-driven.
+
+    Returns:
+        :data:`HTTP429Classification.RETRYABLE` for unknown or
+        rate-limit-shaped bodies, :data:`HTTP429Classification.STANDING`
+        for session-cap and spend-cap bodies.
+    """
+
+    lowered = body.lower()
+    for rule in _PATTERN_RULES:
+        if rule.needle in lowered:
+            return rule.classification
+    return HTTP429Classification.RETRYABLE

--- a/src/bernstein/core/orchestration/failure_taxonomy.py
+++ b/src/bernstein/core/orchestration/failure_taxonomy.py
@@ -182,6 +182,7 @@ _EXCEPTION_TYPE_RULES: Final[dict[str, tuple[str, FailureCategory, float]]] = {
     "ConnectionResetError": ("network_error", FailureCategory.TIMEOUT, 0.8),
     "ConnectionRefusedError": ("network_error", FailureCategory.TIMEOUT, 0.8),
     "RateLimited": ("rate_limit", FailureCategory.TIMEOUT, 0.95),
+    "StandingCapError": ("standing_cap", FailureCategory.CONTEXT_MISS, 0.9),
     "PermissionError": ("sandbox_violation", FailureCategory.SCOPE_CREEP, 0.7),
     "ModuleNotFoundError": ("missing_dependency", FailureCategory.HALLUCINATION, 0.9),
     "ImportError": ("missing_dependency", FailureCategory.HALLUCINATION, 0.75),

--- a/src/bernstein/core/orchestration/failure_taxonomy.py
+++ b/src/bernstein/core/orchestration/failure_taxonomy.py
@@ -74,6 +74,7 @@ FAILURE_REASON_CODES: Final[frozenset[str]] = frozenset(
         "merge_conflict",
         "compile_error",
         "context_miss",
+        "standing_cap",
         "unknown",
     }
 )
@@ -212,6 +213,12 @@ _MESSAGE_SUBSTRING_RULES: Final[tuple[tuple[str, str, FailureCategory, float], .
     ("no module named", "missing_dependency", FailureCategory.HALLUCINATION, 0.9),
     ("syntaxerror", "syntax_error", FailureCategory.HALLUCINATION, 0.85),
     ("compile error", "compile_error", FailureCategory.HALLUCINATION, 0.8),
+    ("active sessions", "standing_cap", FailureCategory.CONTEXT_MISS, 0.8),
+    ("session cap", "standing_cap", FailureCategory.CONTEXT_MISS, 0.8),
+    ("spending limit", "standing_cap", FailureCategory.CONTEXT_MISS, 0.8),
+    ("daily limit", "standing_cap", FailureCategory.CONTEXT_MISS, 0.8),
+    ("budget exceeded", "standing_cap", FailureCategory.CONTEXT_MISS, 0.8),
+    ("concurrency limit", "standing_cap", FailureCategory.CONTEXT_MISS, 0.8),
 )
 
 
@@ -403,6 +410,7 @@ def _category_for_reason_code(reason_code: str) -> FailureCategory:
         "sandbox_violation": FailureCategory.SCOPE_CREEP,
         "merge_conflict": FailureCategory.CONFLICT,
         "context_miss": FailureCategory.CONTEXT_MISS,
+        "standing_cap": FailureCategory.CONTEXT_MISS,
         "unknown": FailureCategory.CONTEXT_MISS,
     }
     return fallback_map.get(reason_code, FailureCategory.CONTEXT_MISS)

--- a/tests/unit/adapters/test_429_classification_integration.py
+++ b/tests/unit/adapters/test_429_classification_integration.py
@@ -1,0 +1,235 @@
+"""End-to-end integration tests for 429 classification (issue #4378).
+
+These tests prove the three acceptance scenarios work through the full
+adapter spawn-probe path:
+
+1. A retryable 429 body still backs off exponentially: the meter records
+   a hit and ``RateLimitError`` is raised.
+2. A standing-cap 429 body short-circuits: ``StandingCapError`` is raised
+   instead of ``RateLimitError``, no meter hit is recorded, and the
+   exception classifies to ``reason_code=standing_cap`` with
+   ``transient=False``.
+3. An unrecognised 429 body falls back to retryable behaviour: meter hit
+   recorded, ``RateLimitError`` raised, exponential backoff.
+
+The adapter spawn path is simulated with a fake subprocess and a log file
+so ``_read_last_lines`` picks up the 429 body text exactly as it would in
+production.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.adapters.base import (
+    CLIAdapter,
+    RateLimitError,
+    SpawnResult,
+    StandingCapError,
+    reset_rate_limit_meters,
+    set_rate_limit_emit_callback,
+)
+from bernstein.adapters.http_429_classifier import (
+    HTTP429Classification,
+    classify_429,
+)
+from bernstein.core.orchestration.failure_taxonomy import classify_failure
+
+#: The issue #4378 example body: a standing session cap.
+STANDING_CAP_BODY = (
+    "HTTP 429: You have reached the maximum number of active sessions (48). "
+    "Please close unused sessions or wait for them to expire."
+)
+
+#: A retryable rate-limit body.
+RETRYABLE_BODY = "HTTP 429: too many requests, rate limit exceeded"
+
+#: An unrecognised 429 body with no recognisable message.
+UNKNOWN_BODY = "HTTP 429"
+
+
+@pytest.fixture(autouse=True)
+def _clean_meters() -> Any:
+    """Reset the process-local meter registry around every test."""
+    reset_rate_limit_meters()
+    set_rate_limit_emit_callback(None)
+    yield
+    reset_rate_limit_meters()
+    set_rate_limit_emit_callback(None)
+
+
+class _ProbeAdapter(CLIAdapter):
+    """Minimal adapter exposing the base fast-exit probe for testing."""
+
+    def name(self) -> str:
+        return "probe"
+
+    def spawn(self, **kwargs: Any) -> SpawnResult:  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+class _FakeProc:
+    """WaitableProcess stand-in that exits with a fixed code."""
+
+    def __init__(self, exit_code: int) -> None:
+        self._exit_code = exit_code
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self._exit_code
+
+
+def _write_log(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def _probe_once(adapter: _ProbeAdapter, log_path: Path, body: str) -> None:
+    """Run the fast-exit probe once against a log file containing ``body``."""
+    _write_log(log_path, body)
+    adapter._probe_fast_exit(_FakeProc(1), log_path, provider_name="probe")
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: retryable 429 still backs off exponentially
+# ---------------------------------------------------------------------------
+
+
+def test_classify_429_retryable_body_is_retryable() -> None:
+    """The retryable body maps to RETRYABLE at the classifier level."""
+
+    assert classify_429(RETRYABLE_BODY) is HTTP429Classification.RETRYABLE
+
+
+def test_retryable_429_records_hit_and_raises_rate_limit(tmp_path: Path) -> None:
+    """A retryable 429 records a meter hit and raises ``RateLimitError``."""
+
+    adapter = _ProbeAdapter()
+    log_path = tmp_path / "agent.log"
+
+    with pytest.raises(RateLimitError):
+        _probe_once(adapter, log_path, RETRYABLE_BODY)
+
+    meter = adapter.rate_limit_meter
+    assert meter.consecutive_429_count == 1
+    assert meter.hits_in_window() == 1
+    assert meter.backoff_seconds_current == pytest.approx(1.0)
+
+
+def test_retryable_429_backoff_grows_exponentially(tmp_path: Path) -> None:
+    """Consecutive retryable 429s grow the meter backoff 1s, 2s, 4s."""
+
+    adapter = _ProbeAdapter()
+    log_path = tmp_path / "agent.log"
+
+    for _ in range(3):
+        with pytest.raises(RateLimitError):
+            _probe_once(adapter, log_path, RETRYABLE_BODY)
+
+    meter = adapter.rate_limit_meter
+    assert meter.consecutive_429_count == 3
+    assert meter.hits_in_window() == 3
+    # Exponential backoff: 1s, 2s, 4s.
+    assert meter.backoff_seconds_current == pytest.approx(4.0)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: standing-cap 429 short-circuits with the new reason
+# ---------------------------------------------------------------------------
+
+
+def test_classify_429_standing_cap_body_is_standing() -> None:
+    """The issue example body maps to STANDING at the classifier level."""
+
+    assert classify_429(STANDING_CAP_BODY) is HTTP429Classification.STANDING
+
+
+def test_standing_cap_429_raises_without_meter_hit(tmp_path: Path) -> None:
+    """A standing-cap 429 raises ``StandingCapError`` and skips the meter."""
+
+    adapter = _ProbeAdapter()
+    log_path = tmp_path / "agent.log"
+
+    with pytest.raises(StandingCapError):
+        _probe_once(adapter, log_path, STANDING_CAP_BODY)
+
+    # Standing caps must not consume the retry budget or touch the meter.
+    meter = adapter.rate_limit_meter
+    assert meter.consecutive_429_count == 0
+    assert meter.hits_in_window() == 0
+    assert meter.backoff_seconds_current == 0.0
+
+
+def test_standing_cap_propagates_through_classify_failure(tmp_path: Path) -> None:
+    """``StandingCapError`` classifies to ``standing_cap``, non-transient."""
+
+    adapter = _ProbeAdapter()
+    log_path = tmp_path / "agent.log"
+
+    with pytest.raises(StandingCapError) as excinfo:
+        _probe_once(adapter, log_path, STANDING_CAP_BODY)
+
+    result = classify_failure(excinfo.value)
+    assert result.reason_code == "standing_cap"
+    assert result.transient is False
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: unrecognised 429 body falls back to retryable
+# ---------------------------------------------------------------------------
+
+
+def test_classify_429_unknown_body_is_retryable() -> None:
+    """An unrecognised body falls back to RETRYABLE at the classifier level."""
+
+    assert classify_429(UNKNOWN_BODY) is HTTP429Classification.RETRYABLE
+
+
+def test_unknown_429_falls_back_to_retryable(tmp_path: Path) -> None:
+    """An unrecognised 429 records a hit and raises ``RateLimitError``."""
+
+    adapter = _ProbeAdapter()
+    log_path = tmp_path / "agent.log"
+
+    with pytest.raises(RateLimitError):
+        _probe_once(adapter, log_path, UNKNOWN_BODY)
+
+    meter = adapter.rate_limit_meter
+    assert meter.consecutive_429_count == 1
+    assert meter.hits_in_window() == 1
+    assert meter.backoff_seconds_current == pytest.approx(1.0)
+
+
+def test_unknown_429_backoff_grows_exponentially(tmp_path: Path) -> None:
+    """Consecutive unknown 429s grow the meter backoff like retryable ones."""
+
+    adapter = _ProbeAdapter()
+    log_path = tmp_path / "agent.log"
+
+    for _ in range(3):
+        with pytest.raises(RateLimitError):
+            _probe_once(adapter, log_path, UNKNOWN_BODY)
+
+    meter = adapter.rate_limit_meter
+    assert meter.consecutive_429_count == 3
+    assert meter.backoff_seconds_current == pytest.approx(4.0)
+
+
+# ---------------------------------------------------------------------------
+# Full-path taxonomy mapping
+# ---------------------------------------------------------------------------
+
+
+def test_retryable_429_classifies_as_rate_limit(tmp_path: Path) -> None:
+    """A retryable 429 raised through the probe classifies as ``rate_limit``."""
+
+    adapter = _ProbeAdapter()
+    log_path = tmp_path / "agent.log"
+
+    with pytest.raises(RateLimitError) as excinfo:
+        _probe_once(adapter, log_path, RETRYABLE_BODY)
+
+    result = classify_failure(excinfo.value)
+    assert result.reason_code == "rate_limit"
+    assert result.transient is True

--- a/tests/unit/adapters/test_http_429_classifier.py
+++ b/tests/unit/adapters/test_http_429_classifier.py
@@ -1,0 +1,68 @@
+"""Unit tests for :mod:`bernstein.adapters.http_429_classifier`.
+
+Covers the three classification cases: rate-limit-shaped bodies,
+cap-shaped bodies, and unknown bodies.
+"""
+
+from __future__ import annotations
+
+from bernstein.adapters.http_429_classifier import (
+    HTTP429Classification,
+    classify_429,
+)
+
+
+def test_rate_limit_body_classified_as_retryable() -> None:
+    """A rate-limit-shaped body maps to RETRYABLE."""
+
+    result = classify_429("too many requests, slow down")
+    assert result is HTTP429Classification.RETRYABLE
+
+
+def test_rate_limit_phrase_classified_as_retryable() -> None:
+    """The literal ``rate limit`` phrase maps to RETRYABLE."""
+
+    result = classify_429("rate limit exceeded")
+    assert result is HTTP429Classification.RETRYABLE
+
+
+def test_session_cap_body_classified_as_standing() -> None:
+    """``maximum number of active sessions`` maps to STANDING."""
+
+    result = classify_429("maximum number of active sessions reached")
+    assert result is HTTP429Classification.STANDING
+
+
+def test_close_unused_sessions_classified_as_standing() -> None:
+    """``close unused sessions`` maps to STANDING."""
+
+    result = classify_429("please close unused sessions and retry")
+    assert result is HTTP429Classification.STANDING
+
+
+def test_spend_cap_body_classified_as_standing() -> None:
+    """Spend-cap wording maps to STANDING."""
+
+    for body in ("spending limit exceeded", "daily limit reached", "budget exceeded"):
+        assert classify_429(body) is HTTP429Classification.STANDING
+
+
+def test_unknown_body_classified_as_retryable() -> None:
+    """An unrecognised body falls back to RETRYABLE."""
+
+    result = classify_429("some opaque provider error")
+    assert result is HTTP429Classification.RETRYABLE
+
+
+def test_matching_is_case_insensitive() -> None:
+    """Body matching is case-insensitive."""
+
+    result = classify_429("MAXIMUM NUMBER OF ACTIVE SESSIONS")
+    assert result is HTTP429Classification.STANDING
+
+
+def test_retry_after_parameter_is_accepted() -> None:
+    """The ``retry_after`` parameter is accepted without changing the result."""
+
+    result = classify_429("rate limit exceeded", retry_after="30")
+    assert result is HTTP429Classification.RETRYABLE

--- a/tests/unit/adapters/test_rate_limit_meter.py
+++ b/tests/unit/adapters/test_rate_limit_meter.py
@@ -15,6 +15,7 @@ cover three guarantees:
 from __future__ import annotations
 
 from io import StringIO
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -22,7 +23,11 @@ from rich.console import Console
 
 from bernstein.adapters.base import (
     RATE_LIMIT_WINDOW_SECONDS,
+    CLIAdapter,
+    RateLimitError,
     RateLimitMeter,
+    SpawnResult,
+    StandingCapError,
     fold_rate_limit_events,
     get_rate_limit_meters,
     record_rate_limit_hit,
@@ -35,6 +40,7 @@ from bernstein.cli.status import (
     collect_rate_limit_snapshots,
     render_status,
 )
+from bernstein.core.orchestration.failure_taxonomy import classify_failure
 
 
 @pytest.fixture(autouse=True)
@@ -245,3 +251,65 @@ def test_render_status_shows_panel_when_meter_active() -> None:
     assert "Rate limits" in output
     assert "claude" in output
     assert "anthropic" in output
+
+
+# ---------------------------------------------------------------------------
+# 429 classifier integration in _probe_fast_exit
+# ---------------------------------------------------------------------------
+
+
+class _ProbeAdapter(CLIAdapter):
+    """Minimal adapter exposing the base fast-exit probe for testing."""
+
+    def name(self) -> str:
+        return "probe"
+
+    def spawn(self, **kwargs: Any) -> SpawnResult:  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+class _FakeProc:
+    """WaitableProcess stand-in that exits with a fixed code."""
+
+    def __init__(self, exit_code: int) -> None:
+        self._exit_code = exit_code
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self._exit_code
+
+
+def _write_log(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def test_probe_fast_exit_retryable_429_records_hit_and_raises_rate_limit(tmp_path: Path) -> None:
+    adapter = _ProbeAdapter()
+    log_path = tmp_path / "agent.log"
+    _write_log(log_path, "HTTP 429: too many requests, slow down")
+
+    with pytest.raises(RateLimitError):
+        adapter._probe_fast_exit(_FakeProc(1), log_path, provider_name="probe")
+
+    meter = adapter.rate_limit_meter
+    assert meter.consecutive_429_count == 1
+    assert meter.hits_in_window() == 1
+
+
+def test_probe_fast_exit_standing_cap_raises_without_meter_hit(tmp_path: Path) -> None:
+    adapter = _ProbeAdapter()
+    log_path = tmp_path / "agent.log"
+    _write_log(log_path, "HTTP 429: maximum number of active sessions reached")
+
+    with pytest.raises(StandingCapError):
+        adapter._probe_fast_exit(_FakeProc(1), log_path, provider_name="probe")
+
+    # Standing caps must not consume the retry budget or touch the meter.
+    meter = adapter.rate_limit_meter
+    assert meter.consecutive_429_count == 0
+    assert meter.hits_in_window() == 0
+
+
+def test_standing_cap_error_classifies_as_standing_cap() -> None:
+    result = classify_failure(StandingCapError("probe hit a standing cap during startup"))
+    assert result.reason_code == "standing_cap"
+    assert result.transient is False

--- a/tests/unit/orchestration/test_failure_taxonomy.py
+++ b/tests/unit/orchestration/test_failure_taxonomy.py
@@ -117,6 +117,23 @@ def test_compile_error_string_classified_as_compile_error() -> None:
     assert result.reason_code == "compile_error"
 
 
+def test_standing_cap_string_classified_as_standing_cap() -> None:
+    """A standing-cap message maps to ``standing_cap`` and is not transient."""
+
+    result = classify_failure("maximum number of active sessions reached")
+    assert result.reason_code == "standing_cap"
+    assert result.category is FailureCategory.CONTEXT_MISS
+    assert result.transient is False
+
+
+def test_standing_cap_not_in_transient_codes() -> None:
+    """``standing_cap`` must never be retried."""
+
+    result = classify_failure("spending limit exceeded")
+    assert result.reason_code == "standing_cap"
+    assert result.transient is False
+
+
 # ---------------------------------------------------------------------------
 # Classifier - hint flags and explicit overrides
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4378

## Summary
- Resolve GitHub issue #4378: Every 429 is backed off as a rate limit, including caps a retry cannot clear

The adapter base treats every HTTP 429 as a rolling rate limit and answers it with exponential backoff
- Some 429s are not rate limits: they are account- or key-level caps that no amount of waiting inside a run will clear
- When one of those is hit, the run spends its entire supervision timeout backing off against a wall instead of stopping with a reason an operator can act on

## Changes
```
 docs/sdd/module-map.md | 1 changed
 src/bernstein/adapters/base.py | 14 changed
 src/bernstein/adapters/http_429_classifier.py | 94 changed
 src/bernstein/core/orchestration/failure_taxonomy.py | 9 changed
 tests/unit/adapters/test_429_classification_integration.py | 235 changed
 tests/unit/adapters/test_http_429_classifier.py | 68 changed
 tests/unit/adapters/test_rate_limit_meter.py | 68 changed
 tests/unit/orchestration/test_failure_taxonomy.py | 17 changed
```

## Verification
- Host gate before publish: ruff check + pytest tests/unit/adapters/test_429_classification_integration.py tests/unit/adapters/test_http_429_classifier.py tests/unit/adapters/test_rate_limit_meter.py tests/unit/orchestration/test_failure_taxonomy.py - passed.

---
_Generated from Bernstein session `1787500908`._

bernstein-session-id: 1787500908

---
Made by bernstein v3.17.1 - unattended run `run-20260823T153158Z`, no operator in the loop.
