### PR TITLE
feat: record a per-part content-hash receipt for spawn-context assembly

### DIFF
--- a/src/bernstein/core/agents/agent_session_token_breakdown.py
+++ b/src/bernstein/core/agents/agent_session_token_breakdown.py
@@ -38,6 +38,21 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
+class ContextPartTokens:
+    """Token estimate for a single named context section from the receipt.
+
+    Attributes:
+        label: Section name, e.g. ``"lessons"``, ``"rag_context"``.
+        token_estimate: Estimated token count from the receipt entry.
+        content_sha256: SHA-256 content hash from the receipt entry.
+    """
+
+    label: str
+    token_estimate: int
+    content_sha256: str
+
+
+@dataclass
 class AgentSessionTokenBreakdown:
     """Token consumption breakdown for a single agent session.
 
@@ -73,6 +88,10 @@ class AgentSessionTokenBreakdown:
     cost_usd: float = 0.0
     task_id: str = ""
     optimization_notes: list[str] = field(default_factory=list)
+    # Per-part context breakdown from the context receipt (issue #4405). Each
+    # entry names a context section actually included in the prompt with its
+    # token estimate and content hash. Empty when no receipt was captured.
+    context_parts: list[ContextPartTokens] = field(default_factory=list)
 
     @property
     def total_tokens(self) -> int:

--- a/src/bernstein/core/agents/context_receipt.py
+++ b/src/bernstein/core/agents/context_receipt.py
@@ -1,0 +1,123 @@
+"""Per-part content-hash receipt for the agent context prompt.
+
+A :class:`ContextReceipt` records, for each named section actually included
+in an agent's context prompt, a SHA-256 content hash plus token/character
+estimates.  This gives a deterministic, auditable fingerprint of what was
+sent to the model so downstream tooling can detect drift or reproduce a
+prompt exactly.
+
+Usage::
+
+    from bernstein.core.agents.context_receipt import build_context_receipt
+
+    receipt = build_context_receipt([("role", role_text), ("tasks", tasks_text)])
+    print(receipt.total_token_estimate)
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from bernstein.core.tokens.token_estimation import estimate_tokens_for_text
+
+
+@dataclass
+class ContextReceiptEntry:
+    """Content-hash receipt for a single named context section.
+
+    Attributes:
+        label: Section name, e.g. ``"role"``, ``"tasks"``, ``"lessons"``.
+        content_sha256: SHA-256 hex digest of the section content (UTF-8 bytes).
+        token_estimate: Estimated token count via :func:`estimate_tokens_for_text`.
+        char_count: Raw character count of the section content.
+    """
+
+    label: str
+    content_sha256: str
+    token_estimate: int
+    char_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-safe dict."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ContextReceiptEntry:
+        """Reconstruct an entry from a dict produced by :meth:`to_dict`."""
+        return cls(
+            label=d["label"],
+            content_sha256=d["content_sha256"],
+            token_estimate=d["token_estimate"],
+            char_count=d["char_count"],
+        )
+
+
+@dataclass
+class ContextReceipt:
+    """Ordered receipt of all context sections actually included.
+
+    Attributes:
+        entries: One :class:`ContextReceiptEntry` per included section, in order.
+        total_token_estimate: Sum of all ``entry.token_estimate``.
+        total_chars: Sum of all ``entry.char_count``.
+        section_count: Number of entries.
+    """
+
+    entries: list[ContextReceiptEntry]
+    total_token_estimate: int
+    total_chars: int
+    section_count: int
+
+    @property
+    def total_tokens(self) -> int:
+        """Convenience alias for :attr:`total_token_estimate`."""
+        return self.total_token_estimate
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-safe dict."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ContextReceipt:
+        """Reconstruct a receipt from a dict produced by :meth:`to_dict`."""
+        entries = [ContextReceiptEntry.from_dict(e) for e in d["entries"]]
+        return cls(
+            entries=entries,
+            total_token_estimate=d["total_token_estimate"],
+            total_chars=d["total_chars"],
+            section_count=d["section_count"],
+        )
+
+
+def build_context_receipt(named_sections: list[tuple[str, str]]) -> ContextReceipt:
+    """Build a receipt from ``(label, content)`` pairs.
+
+    For each pair, computes the SHA-256 content hash, token estimate, and
+    character count, then sums the token and character totals across all
+    entries.
+
+    Args:
+        named_sections: Ordered ``(label, content)`` pairs, one per section
+            actually included in the context prompt.
+
+    Returns:
+        A :class:`ContextReceipt` with one entry per section.
+    """
+    entries: list[ContextReceiptEntry] = []
+    for label, content in named_sections:
+        entries.append(
+            ContextReceiptEntry(
+                label=label,
+                content_sha256=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+                token_estimate=estimate_tokens_for_text(content, assumed_type="text"),
+                char_count=len(content),
+            )
+        )
+    return ContextReceipt(
+        entries=entries,
+        total_token_estimate=sum(e.token_estimate for e in entries),
+        total_chars=sum(e.char_count for e in entries),
+        section_count=len(entries),
+    )

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1437,6 +1437,7 @@ def _render_prompt(*args: Any, **kwargs: Any) -> str:
     """
     return _render_prompt_with_receipt(*args, **kwargs)[0]
 
+
 def _render_fallback(
     role: str,
     templates_dir: Path,

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -137,6 +137,7 @@ if TYPE_CHECKING:
     from bernstein.adapters.base import CLIAdapter
     from bernstein.agents.catalog import CatalogAgent, CatalogRegistry
     from bernstein.core.agency_loader import AgencyAgent
+    from bernstein.core.agents.context_receipt import ContextReceipt
     from bernstein.core.agents.warm_pool import PoolSlot, WarmPool
     from bernstein.core.bulletin import BulletinBoard
     from bernstein.core.config.platform_compat import ProcessReapReceipt
@@ -1103,7 +1104,7 @@ def _render_prompt(
     meta_messages: list[str] | None = None,
     max_turns: int | None = None,
     mailbox_section: str = "",
-) -> str:
+) -> tuple[str, ContextReceipt]:
     """Build the full agent prompt from role template + tasks + context.
 
     Uses the Jinja2-style template renderer for proper variable substitution.
@@ -1140,9 +1141,11 @@ def _render_prompt(
             skipped in that case, not rendered with a placeholder.
 
     Returns:
-        Complete prompt string ready for the CLI adapter.
-        Cache block annotation is available via mark_cacheable_prefix()
-        vs dynamic, so adapters can apply provider-specific caching.
+        Tuple of ``(prompt, receipt)`` where *prompt* is the complete prompt
+        string ready for the CLI adapter (cache block annotation is available
+        via mark_cacheable_prefix() vs dynamic, so adapters can apply
+        provider-specific caching) and *receipt* is the per-section content
+        receipt for the context actually included.
     """
     role = tasks[0].role
 
@@ -1248,59 +1251,65 @@ def _render_prompt(
     # Assemble final prompt
     from bernstein.core.section_dedup import deduplicate_section
 
-    sections = [role_prompt]
+    named_sections: list[tuple[str, str]] = [("role", role_prompt)]
     if specialist_block:
-        sections.append(specialist_block)
-    sections.append(f"\n## Assigned tasks\n{task_block}")
+        named_sections.append(("specialists", specialist_block))
+    named_sections.append(("tasks", f"\n## Assigned tasks\n{task_block}"))
     if lesson_context:
-        sections.append(f"\n{lesson_context}\n")
+        named_sections.append(("lessons", f"\n{lesson_context}\n"))
     if persistent_memory_context:
-        sections.append(deduplicate_section(f"\n{persistent_memory_context}\n"))
+        named_sections.append(("persistent_memory", deduplicate_section(f"\n{persistent_memory_context}\n")))
     if smart_context:
-        sections.append(f"\n{smart_context}\n")
+        named_sections.append(("rag_context", f"\n{smart_context}\n"))
     if rich_context:
-        sections.append(f"\n{rich_context}\n")
+        named_sections.append(("rich_context", f"\n{rich_context}\n"))
     if file_scope_context:
-        sections.append(deduplicate_section(f"\n## File-scope context\n{file_scope_context}\n"))
+        named_sections.append(("file_scope", deduplicate_section(f"\n## File-scope context\n{file_scope_context}\n")))
     # Parent context inheritance: inject parent's context summary
     # when a task was created from decomposing a larger parent task.
     parent_ctx_parts = [t.parent_context for t in tasks if t.parent_context]
     if parent_ctx_parts:
-        sections.append(
-            "\n## Parent context (inherited)\n"
-            "This task was decomposed from a parent task. The parent agent gathered "
-            "the following context:\n" + "\n".join(parent_ctx_parts) + "\n"
+        named_sections.append(
+            (
+                "parent_context",
+                "\n## Parent context (inherited)\n"
+                "This task was decomposed from a parent task. The parent agent gathered "
+                "the following context:\n" + "\n".join(parent_ctx_parts) + "\n",
+            )
         )
     predecessor_ctx = _render_predecessor_context(tasks, task_graph)
     if predecessor_ctx:
-        sections.append(predecessor_ctx)
+        named_sections.append(("predecessor", predecessor_ctx))
     if bulletin_summary:
-        sections.append(
-            deduplicate_section(
-                f"\n## Team awareness\n"
-                f"Other agents are working in parallel. Recent activity:\n{bulletin_summary}\n\n"
-                f"If you need to create a shared utility, check if it already exists first.\n"
-                f"If you define an API endpoint, use consistent naming with existing endpoints.\n"
+        named_sections.append(
+            (
+                "team_awareness",
+                deduplicate_section(
+                    f"\n## Team awareness\n"
+                    f"Other agents are working in parallel. Recent activity:\n{bulletin_summary}\n\n"
+                    f"If you need to create a shared utility, check if it already exists first.\n"
+                    f"If you define an API endpoint, use consistent naming with existing endpoints.\n"
+                ),
             )
         )
     # Coordination mailbox (#2357): typed messages other workers addressed to
     # these tasks, rendered deterministically from the mailbox journal so
     # every adapter type receives byte-identical context.
     if mailbox_section and mailbox_section.strip():
-        sections.append(deduplicate_section(mailbox_section))
+        named_sections.append(("mailbox", deduplicate_section(mailbox_section)))
     try:
         rec_engine = RecommendationEngine(workdir)
         rec_engine.build()
         rec_section = rec_engine.render_for_prompt(role, max_chars=2000)
         if rec_section:
-            sections.append(f"\n{rec_section}\n")
+            named_sections.append(("recommendations", f"\n{rec_section}\n"))
     except Exception as exc:
         logger.debug("Recommendation rendering failed: %s", exc)
     if project_context:
-        sections.append(deduplicate_section(f"\n## Project context\n{project_context}\n"))
+        named_sections.append(("project_context", deduplicate_section(f"\n## Project context\n{project_context}\n")))
     output_style_prompt = _render_output_style(workdir)
     if output_style_prompt:
-        sections.append(deduplicate_section(f"\n## Output style\n{output_style_prompt}\n"))
+        named_sections.append(("output_style", deduplicate_section(f"\n## Output style\n{output_style_prompt}\n")))
     if token_budget > 0:
         if token_budget >= 1_000_000:
             budget_hint = f"~{token_budget // 1_000_000}M"
@@ -1308,32 +1317,38 @@ def _render_prompt(
             budget_hint = f"~{token_budget // 1_000}K"
         else:
             budget_hint = str(token_budget)
-        sections.append(
-            deduplicate_section(
-                f"\n## Token budget\n"
-                f"You have {budget_hint} tokens for this task. Plan your work accordingly - "
-                f"focus on the task, avoid unnecessary exploration, and wrap up promptly.\n"
+        named_sections.append(
+            (
+                "token_budget",
+                deduplicate_section(
+                    f"\n## Token budget\n"
+                    f"You have {budget_hint} tokens for this task. Plan your work accordingly - "
+                    f"focus on the task, avoid unnecessary exploration, and wrap up promptly.\n"
+                ),
             )
         )
-    sections.append(deduplicate_section(f"\n## Instructions\n{instructions}\n"))
+    named_sections.append(("instructions", deduplicate_section(f"\n## Instructions\n{instructions}\n")))
     if session_id:
         try:
             heartbeat_instructions = HeartbeatMonitor(workdir).inject_heartbeat_instructions(session_id)
-            sections.append(
-                deduplicate_section(
-                    "\n## Heartbeat (background)\n"
-                    "Run this in the background to report progress:\n"
-                    f"```bash\n{heartbeat_instructions}\n```\n"
+            named_sections.append(
+                (
+                    "heartbeat",
+                    deduplicate_section(
+                        "\n## Heartbeat (background)\n"
+                        "Run this in the background to report progress:\n"
+                        f"```bash\n{heartbeat_instructions}\n```\n"
+                    ),
                 )
             )
         except Exception as exc:
             logger.debug("Heartbeat instructions unavailable: %s", exc)
     if session_id:
-        sections.append(deduplicate_section(_render_signal_check(session_id)))
+        named_sections.append(("signal_check", deduplicate_section(_render_signal_check(session_id))))
 
     if meta_messages:
         nudges_block = "\n## Operational nudges\n" + "\n".join(f"- {m}" for m in meta_messages) + "\n"
-        sections.append(nudges_block)
+        named_sections.append(("meta_nudges", nudges_block))
 
     # Turn-budget nudge (work/bernstein/m27-nudge-plan.md, Approach C
     # MINIMAL): models spawned in tool-use loops (observed worst on MiniMax
@@ -1375,7 +1390,7 @@ def _render_prompt(
             "- You are re-reading files you already read with no new information to "
             "gain\n"
         )
-        sections.append(turn_budget_block)
+        named_sections.append(("turn_budget", turn_budget_block))
         logger.info(
             "Turn budget nudge injected for session=%s: max_turns=%d halfway=%d near_end=%d",
             session_id,
@@ -1392,6 +1407,14 @@ def _render_prompt(
             max_turns,
         )
 
+    # Build the per-section content receipt and extract the content strings
+    # for cache marking. The joined prompt must be byte-identical to the
+    # pre-receipt output, so the receipt is purely additive instrumentation.
+    from bernstein.core.agents.context_receipt import build_context_receipt
+
+    receipt = build_context_receipt(named_sections)
+    sections = [content for _, content in named_sections]
+
     # Annotate prompt sections with cache hints so adapters can apply
     # provider-specific caching (e.g. Anthropic's cache_control).
     cache_blocks = mark_cacheable_prefix(sections)
@@ -1400,7 +1423,7 @@ def _render_prompt(
     # for backward compatibility.  Callers that need cache hints can call
     # mark_cacheable_prefix(sections) separately.
     _ = cache_blocks  # computed for future use
-    return "".join(sections)
+    return "".join(sections), receipt
 
 
 def _render_fallback(
@@ -4000,12 +4023,13 @@ class AgentSpawner:
             # Multi-task batches with mode=batch are unusual but we handle them by
             # using the first task's goal as the primary directive.
             prompt = _render_batch_prompt(tasks[0])
+            receipt = None
             logger.info(
                 "Batch execution mode: spawning single agent with /batch prompt for task %s",
                 tasks[0].id,
             )
         else:
-            prompt = _render_prompt(
+            prompt, receipt = _render_prompt(
                 tasks,
                 self._templates_dir,
                 self._workdir,
@@ -4097,6 +4121,7 @@ class AgentSpawner:
             meta_messages=meta_messages,
             response_profile=style_resolution.style,
             profile_content_sha256=profile_content_sha,
+            context_receipt=receipt.to_dict()["entries"] if receipt else [],
         )
 
         # Zero-trust: issue a short-lived, task-scoped JWT for this agent.
@@ -4831,6 +4856,9 @@ class AgentSpawner:
                 log_path=session.log_path,
                 task_snapshots=task_snapshots,
             )
+            # Stamp the per-section context receipt on the trace so the
+            # persisted record carries the same fingerprint as the session.
+            trace.context_receipt = session.context_receipt
             self._traces[session_id] = trace
             try:
                 self._trace_store.write(trace)
@@ -5088,7 +5116,7 @@ class AgentSpawner:
             _resume_max_turns,
         )
 
-        prompt = _render_prompt(
+        prompt, receipt = _render_prompt(
             tasks,
             self._templates_dir,
             self._workdir,
@@ -5109,6 +5137,7 @@ class AgentSpawner:
             task_ids=[t.id for t in tasks],
             model_config=model_config,
             status="starting",
+            context_receipt=receipt.to_dict()["entries"],
         )
 
         # Record declared context on resume exactly like a fresh spawn

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1089,7 +1089,7 @@ def _render_output_style(workdir: Path) -> str:
         return ""
 
 
-def _render_prompt(
+def _render_prompt_with_receipt(
     tasks: list[Task],
     templates_dir: Path,
     workdir: Path,
@@ -1425,6 +1425,17 @@ def _render_prompt(
     _ = cache_blocks  # computed for future use
     return "".join(sections), receipt
 
+
+def _render_prompt(*args: Any, **kwargs: Any) -> str:
+    """Build the agent prompt, discarding the context receipt.
+
+    The receipt was added for the spawner, which records it alongside the
+    run. Every other caller — the batch renderer, other modules, and the
+    prompt-shape tests — wants the prompt text, so the receipt is an
+    addition to the spawner's path rather than a change to this signature.
+    See :func:`_render_prompt_with_receipt` when the receipt is needed.
+    """
+    return _render_prompt_with_receipt(*args, **kwargs)[0]
 
 def _render_fallback(
     role: str,
@@ -4029,7 +4040,7 @@ class AgentSpawner:
                 tasks[0].id,
             )
         else:
-            prompt, receipt = _render_prompt(
+            prompt, receipt = _render_prompt_with_receipt(
                 tasks,
                 self._templates_dir,
                 self._workdir,
@@ -5116,7 +5127,7 @@ class AgentSpawner:
             _resume_max_turns,
         )
 
-        prompt, receipt = _render_prompt(
+        prompt, receipt = _render_prompt_with_receipt(
             tasks,
             self._templates_dir,
             self._workdir,

--- a/src/bernstein/core/observability/traces.py
+++ b/src/bernstein/core/observability/traces.py
@@ -127,6 +127,10 @@ class AgentTrace:
     turn_count: int = 0
     # Settings snapshot captured at spawn time (T557)
     settings_snapshot: dict[str, Any] = field(default_factory=dict[str, Any])
+    # Per-section context receipt captured at spawn time (issue #4405). Each
+    # entry is ``{"label", "content_sha256", "token_estimate", "char_count"}``
+    # in prompt order. Empty when no receipt was captured.
+    context_receipt: list[dict[str, Any]] = field(default_factory=list)
 
     @property
     def duration_s(self) -> float | None:
@@ -155,6 +159,7 @@ class AgentTrace:
             log_path=d.get("log_path", ""),
             task_snapshots=cast("list[dict[str, Any]]", d.get("task_snapshots", [])),
             settings_snapshot=cast("dict[str, Any]", d.get("settings_snapshot", {})),
+            context_receipt=cast("list[dict[str, Any]]", d.get("context_receipt", [])),
         )
 
 

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1219,6 +1219,11 @@ class AgentSession:
     # event, so the session record names exactly the digests the chain
     # attests. Empty when the session's tasks declare no attachments.
     multimodal_attachments: list[dict[str, str]] = field(default_factory=list)
+    # Per-section context receipt captured at spawn time (issue #4405). Each
+    # entry is ``{"label", "content_sha256", "token_estimate", "char_count"}``
+    # in prompt order - a deterministic fingerprint of the context actually
+    # sent to the model. Empty when no receipt was captured.
+    context_receipt: list[dict[str, object]] = field(default_factory=list[dict[str, object]])
 
 
 class IsolationMode(StrEnum):

--- a/tests/unit/agents/test_context_receipt.py
+++ b/tests/unit/agents/test_context_receipt.py
@@ -1,0 +1,108 @@
+"""Tests for :mod:`bernstein.core.agents.context_receipt`."""
+
+from __future__ import annotations
+
+import hashlib
+
+from bernstein.core.agents.context_receipt import (
+    ContextReceipt,
+    ContextReceiptEntry,
+    build_context_receipt,
+)
+
+
+def test_entry_fields_match_spec() -> None:
+    entry = ContextReceiptEntry(
+        label="role",
+        content_sha256="abc",
+        token_estimate=10,
+        char_count=100,
+    )
+    assert entry.label == "role"
+    assert entry.content_sha256 == "abc"
+    assert entry.token_estimate == 10
+    assert entry.char_count == 100
+
+
+def test_build_computes_correct_sha256() -> None:
+    content = "You are a backend engineer."
+    expected = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    receipt = build_context_receipt([("role", content)])
+    assert receipt.entries[0].content_sha256 == expected
+
+
+def test_build_computes_char_count() -> None:
+    content = "hello world"
+    receipt = build_context_receipt([("tasks", content)])
+    assert receipt.entries[0].char_count == len(content)
+
+
+def test_total_token_estimate_is_sum() -> None:
+    receipt = build_context_receipt([("role", "aaa"), ("tasks", "bbbb"), ("lessons", "ccccc")])
+    assert receipt.total_token_estimate == sum(e.token_estimate for e in receipt.entries)
+
+
+def test_total_chars_is_sum() -> None:
+    receipt = build_context_receipt([("role", "aaa"), ("tasks", "bbbb"), ("lessons", "ccccc")])
+    assert receipt.total_chars == sum(e.char_count for e in receipt.entries)
+
+
+def test_section_count_matches_entries() -> None:
+    receipt = build_context_receipt([("a", "x"), ("b", "y")])
+    assert receipt.section_count == 2
+    assert len(receipt.entries) == 2
+
+
+def test_empty_sections() -> None:
+    receipt = build_context_receipt([])
+    assert receipt.entries == []
+    assert receipt.total_token_estimate == 0
+    assert receipt.total_chars == 0
+    assert receipt.section_count == 0
+
+
+def test_deterministic_hashes() -> None:
+    sections = [("role", "same content"), ("tasks", "also same")]
+    r1 = build_context_receipt(sections)
+    r2 = build_context_receipt(sections)
+    assert r1 == r2
+
+
+def test_different_content_different_hash() -> None:
+    r1 = build_context_receipt([("role", "content A")])
+    r2 = build_context_receipt([("role", "content B")])
+    assert r1.entries[0].content_sha256 != r2.entries[0].content_sha256
+
+
+def test_entry_to_dict_from_dict_round_trip() -> None:
+    entry = ContextReceiptEntry(
+        label="role",
+        content_sha256="deadbeef",
+        token_estimate=42,
+        char_count=500,
+    )
+    d = entry.to_dict()
+    assert d == {
+        "label": "role",
+        "content_sha256": "deadbeef",
+        "token_estimate": 42,
+        "char_count": 500,
+    }
+    assert ContextReceiptEntry.from_dict(d) == entry
+
+
+def test_receipt_to_dict_from_dict_round_trip() -> None:
+    receipt = build_context_receipt([("role", "You are helpful."), ("tasks", "Do the thing.")])
+    d = receipt.to_dict()
+    restored = ContextReceipt.from_dict(d)
+    assert restored == receipt
+
+
+def test_total_tokens_property_alias() -> None:
+    receipt = build_context_receipt([("role", "some text")])
+    assert receipt.total_tokens == receipt.total_token_estimate
+
+
+def test_entry_order_preserved() -> None:
+    receipt = build_context_receipt([("zeta", "zzz"), ("alpha", "aaa"), ("mid", "mmm")])
+    assert [e.label for e in receipt.entries] == ["zeta", "alpha", "mid"]


### PR DESCRIPTION
Closes #4303

## Summary
- Resolve GitHub issue #4303: Record a per-part content-hash receipt for spawn-context assembly

## Problem

`_render_prompt` (`src/bernstein/core/agents/spawner_core.py:1091-1394`) assembles every worker's prompt by appending to a local `sections: list[str]` — role prompt, task block, lesson context, RAG context, file-scope context, mailbox section, project context, output style, turn budget, and more (each conditionally appended between lines ~1244 and ~1394) — then returns `"".join(sections)` (line 1394)
- The list of parts, their order, and their sizes exist only as a local variable for the duration of one function call
- nothing records which parts a given worker actually received

## Changes
```
.../core/agents/agent_session_token_breakdown.py   |  19 ++++
 src/bernstein/core/agents/context_receipt.py       | 123 +++++++++++++++++++++
 src/bernstein/core/agents/spawner_core.py          | 117 ++++++++++++--------
 src/bernstein/core/observability/traces.py         |   5 +
 src/bernstein/core/tasks/models.py                 |   5 +
 tests/unit/agents/test_context_receipt.py          | 108 ++++++++++++++++++
 6 files changed, 333 insertions(+), 44 deletions(-)
```

## Verification
- Host gate before publish: ruff check + pytest tests/unit/agents/test_context_receipt.py - passed.

---
_Generated from Bernstein session `1787502917`._

bernstein-session-id: 1787502917

---
Made by bernstein v3.17.1 - unattended run `run-20260823T163457Z`, no operator in the loop.
