### PR TITLE
feat: refuse a resume whose grant moved, before the first side effect

### DIFF
--- a/src/bernstein/cli/commands/resume_cmd.py
+++ b/src/bernstein/cli/commands/resume_cmd.py
@@ -107,7 +107,7 @@ def prepare_resume(
     _runtime_dir = workdir / ".sdd" / "runtime"
     _agent_checkpoint = find_checkpoint_for_task(task_id, _runtime_dir)
     if _agent_checkpoint is not None:
-        _ok, _reason = is_checkpoint_recoverable(_agent_checkpoint)
+        _ok, _reason = is_checkpoint_recoverable(_agent_checkpoint, current_task_id=task_id)
         if not _ok:
             raise GrantRefusedError(_reason)
 

--- a/src/bernstein/core/persistence/agent_checkpoint.py
+++ b/src/bernstein/core/persistence/agent_checkpoint.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import subprocess
 import sys
 import time
@@ -38,6 +39,7 @@ from bernstein.core.persistence.atomic_write import write_atomic_json
 from bernstein.core.security.permissions import AgentPermissions, get_permissions_for_role
 
 _CHECKPOINT_FILENAME = "checkpoint.json"
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -292,6 +294,10 @@ def is_checkpoint_recoverable(
     checkpoint: AgentCheckpoint,
     *,
     role_overrides: dict[str, AgentPermissions] | None = None,
+    current_role: str | None = None,
+    current_task_id: str | None = None,
+    current_parent_run_id: str | None = None,
+    current_chain_head: str | None = None,
 ) -> tuple[bool, str]:
     """Check if a checkpoint can be recovered.
 
@@ -308,32 +314,51 @@ def is_checkpoint_recoverable(
         checkpoint: The checkpoint to inspect.
         role_overrides: Optional per-project permission overrides forwarded
             to :func:`get_permissions_for_role`.
+        current_role: The role currently assigned to the agent.
+        current_task_id: The task id currently assigned.
+        current_parent_run_id: The parent run id currently assigned.
+        current_chain_head: The current journal chain head.
 
     Returns:
         ``(recoverable, reason)``. Recoverable if the grant still holds and
         the worktree has uncommitted changes that can be resumed.
     """
     # --- Authority check (must happen before any side effect) ---
-    if checkpoint.grant_hash:
+    if not checkpoint.grant_hash:
+        logger.warning(
+            "checkpoint for task %s has no grant_hash -- authority check skipped; "
+            "resume proceeds with liveness checks only",
+            checkpoint.task_id,
+        )
+    else:
         current_perms = get_permissions_for_role(checkpoint.role, role_overrides)
         expected_hash = compute_grant_hash(
-            role=checkpoint.role,
+            role=current_role if current_role is not None else checkpoint.role,
             permissions=current_perms,
-            task_id=checkpoint.task_id,
-            parent_run_id=checkpoint.parent_run_id,
-            chain_head=checkpoint.chain_head_at_suspend,
+            task_id=current_task_id if current_task_id is not None else checkpoint.task_id,
+            parent_run_id=current_parent_run_id if current_parent_run_id is not None else checkpoint.parent_run_id,
+            chain_head=current_chain_head if current_chain_head is not None else checkpoint.chain_head_at_suspend,
         )
         if expected_hash != checkpoint.grant_hash:
-            # Only the hash of the suspend-time grant is stored, so the
-            # refusal cannot prove which single input moved; it names the
-            # bindings the hash covers so the operator knows where to look.
-            reason = (
-                "grant mismatch — resume refused before first side effect; "
-                f"role '{checkpoint.role}' permissions narrowed or changed, "
-                f"or a grant-bound field no longer matches (task "
-                f"'{checkpoint.task_id}', parent run '{checkpoint.parent_run_id}', "
-                "chain head at suspend)"
-            )
+            changes = []
+            if current_role is not None and current_role != checkpoint.role:
+                changes.append("role changed")
+            if current_task_id is not None and current_task_id != checkpoint.task_id:
+                changes.append("task_id changed")
+            if current_parent_run_id is not None and current_parent_run_id != checkpoint.parent_run_id:
+                changes.append("parent_run_id changed")
+            if current_chain_head is not None and current_chain_head != checkpoint.chain_head_at_suspend:
+                changes.append("chain_head_at_suspend changed")
+
+            if changes:
+                reason = f"grant mismatch — {', '.join(changes)}"
+            elif all(v is None for v in (current_role, current_task_id, current_parent_run_id, current_chain_head)):
+                reason = (
+                    "grant mismatch — cannot determine which field changed (no current values "
+                    "provided); role permissions (allowed_paths/denied_paths) changed"
+                )
+            else:
+                reason = "grant mismatch — role permissions (allowed_paths/denied_paths) changed"
             return False, reason
 
     # --- Liveness checks (only reached when grant is valid or absent) ---

--- a/tests/unit/test_grant_bound_checkpoint.py
+++ b/tests/unit/test_grant_bound_checkpoint.py
@@ -228,7 +228,7 @@ class TestRoleNarrowed:
         ok, reason = is_checkpoint_recoverable(cp, role_overrides={"backend": narrow})
         assert ok is False
         assert "grant mismatch" in reason
-        assert "narrowed" in reason
+        assert "permissions" in reason
 
     def test_refusal_before_worktree_access(self, tmp_path: Path) -> None:
         """Grant check fires even when worktree does not exist."""
@@ -270,11 +270,11 @@ class TestRoleNarrowed:
 class TestTaskReassigned:
     def test_different_task_id_refuses(self, tmp_path: Path) -> None:
         cp = _make_checkpoint(tmp_path, task_id="task-original")
-        # Simulate a checkpoint whose task_id was changed in storage
-        cp.task_id = "task-reassigned"
-        ok, reason = is_checkpoint_recoverable(cp)
+        # Call with a different current_task_id to simulate reassignment
+        ok, reason = is_checkpoint_recoverable(cp, current_task_id="task-reassigned")
         assert ok is False
         assert "grant mismatch" in reason
+        assert "task_id changed" in reason
 
     def test_same_task_id_passes(self, tmp_path: Path) -> None:
         cp = _make_checkpoint(tmp_path, task_id="task-same")
@@ -290,10 +290,11 @@ class TestTaskReassigned:
 class TestParentCancelled:
     def test_different_parent_run_id_refuses(self, tmp_path: Path) -> None:
         cp = _make_checkpoint(tmp_path, parent_run_id="run-original")
-        cp.parent_run_id = "run-replacement"  # simulates re-parenting
-        ok, reason = is_checkpoint_recoverable(cp)
+        # Call with a different current_parent_run_id to simulate re-parenting
+        ok, reason = is_checkpoint_recoverable(cp, current_parent_run_id="run-replacement")
         assert ok is False
         assert "grant mismatch" in reason
+        assert "parent_run_id changed" in reason
 
     def test_same_parent_run_id_passes(self, tmp_path: Path) -> None:
         cp = _make_checkpoint(tmp_path, parent_run_id="run-stable")
@@ -307,6 +308,14 @@ class TestParentCancelled:
 
 
 class TestResumeAfterCrash:
+    def test_different_chain_head_refuses(self, tmp_path: Path) -> None:
+        """Changing the chain head causes refusal."""
+        cp = _make_checkpoint(tmp_path, chain_head="old-head")
+        ok, reason = is_checkpoint_recoverable(cp, current_chain_head="new-head")
+        assert ok is False
+        assert "grant mismatch" in reason
+        assert "chain_head_at_suspend changed" in reason
+
     def test_missing_continuation_entry_is_new_run(self, tmp_path: Path) -> None:
         """Absence of ContinuationEntry means the resume never completed.
 
@@ -395,7 +404,7 @@ class TestAbsenceNotContinuity:
 
 
 class TestLegacyCheckpointNoGrantFields:
-    def test_no_grant_hash_skips_authority_check(self, tmp_path: Path) -> None:
+    def test_no_grant_hash_skips_authority_check(self, tmp_path: Path, caplog) -> None:
         """Checkpoints written before #3649 have empty grant_hash.
 
         They should fall through to the liveness checks unchanged so
@@ -416,6 +425,18 @@ class TestLegacyCheckpointNoGrantFields:
         ok, reason = is_checkpoint_recoverable(cp)
         assert ok is True
         assert "uncommitted" in reason
+        assert "no grant_hash" in caplog.text or "authority check skipped" in caplog.text
+
+    def test_hash_mismatch_without_current_values(self, tmp_path: Path) -> None:
+        """If hash mismatches but no current values are provided, return generic message."""
+        cp = _make_checkpoint(tmp_path)
+        # Narrow permissions via override
+        narrow = AgentPermissions(allowed_paths=("src/*",), denied_paths=())
+        ok, reason = is_checkpoint_recoverable(cp, role_overrides={"backend": narrow})
+        assert ok is False
+        assert "grant mismatch" in reason
+        assert "cannot determine which field changed (no current values provided)" in reason
+        assert "narrowed" not in reason
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3834

## Summary
- Resolve GitHub issue #3834: Refuse a resume whose grant moved, before the first side effect

Slice 2 of 4 of #3649
- **Narrowed 2026-08-16.** The core of this slice — re-derive the grant, compare, refuse before the first side effect — landed in #3723 (merged, combined with slice 1)
- What remains is two specific gaps the merged PR left open

## Changes
```
src/bernstein/cli/commands/resume_cmd.py           |  2 +-
 src/bernstein/core/persistence/agent_checkpoint.py | 55 ++++++++++++++++------
 tests/unit/test_grant_bound_checkpoint.py          | 35 +++++++++++---
 3 files changed, 69 insertions(+), 23 deletions(-)
```

## Verification
- Host gate before publish: ruff check + pytest tests/unit/test_grant_bound_checkpoint.py - passed.

---
_Generated from Bernstein session `1787507373`._

bernstein-session-id: 1787507373

---
Made by bernstein v3.17.1 - unattended run `run-20260823T174912Z`, no operator in the loop.
