### PR TITLE
refactor: drop the unpopulated context_parts breakdown surface

### DIFF
--- a/src/bernstein/core/agents/agent_session_token_breakdown.py
+++ b/src/bernstein/core/agents/agent_session_token_breakdown.py
@@ -38,21 +38,6 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class ContextPartTokens:
-    """Token estimate for a single named context section from the receipt.
-
-    Attributes:
-        label: Section name, e.g. ``"lessons"``, ``"rag_context"``.
-        token_estimate: Estimated token count from the receipt entry.
-        content_sha256: SHA-256 content hash from the receipt entry.
-    """
-
-    label: str
-    token_estimate: int
-    content_sha256: str
-
-
-@dataclass
 class AgentSessionTokenBreakdown:
     """Token consumption breakdown for a single agent session.
 
@@ -88,10 +73,6 @@ class AgentSessionTokenBreakdown:
     cost_usd: float = 0.0
     task_id: str = ""
     optimization_notes: list[str] = field(default_factory=list)
-    # Per-part context breakdown from the context receipt (issue #4405). Each
-    # entry names a context section actually included in the prompt with its
-    # token estimate and content hash. Empty when no receipt was captured.
-    context_parts: list[ContextPartTokens] = field(default_factory=list)
 
     @property
     def total_tokens(self) -> int:


### PR DESCRIPTION
Follow-up to #4409.

`ContextPartTokens` and `AgentSessionTokenBreakdown.context_parts` were added
alongside the context receipt, but a tree-wide search finds no producer and no
consumer for either — they shipped as dead public API on a dataclass other code
constructs.

The receipt entries the field was meant to hold are already persisted on
`AgentSession.context_receipt`, so nothing is lost by removing the empty
container: the breakdown surface can land together with the code that reads it,
and be shaped by what that code actually needs.

## Verification

- `ruff check` on the touched file — passed.
- `tests/unit/test_agent_session_token_breakdown.py` + `tests/unit/agents/test_small_module_gaps.py` — 31 passed.
- `git grep ContextPartTokens|context_parts` over `src/` and `tests/` — no remaining references (`seed.py` has an unrelated local of the same name).
