### PR TITLE
fix: codeQL has no model for sanitize_log, so sanitized log calls keep raising log-injection alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,5 +1,8 @@
 name: "Bernstein CodeQL config"
 
+packs:
+  - bernstein/codeql-sanitizers
+
 paths-ignore:
   - "templates/adapter_plugin"
   - "templates/quality_gate_plugin"

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,7 +1,10 @@
 name: "Bernstein CodeQL config"
 
 packs:
-  - bernstein/codeql-sanitizers
+  # A path, not a pack name: the pack lives in this repository and is never
+  # published, so resolving it by name sends CodeQL to the ghcr.io registry
+  # and the database init fails with 'not found in the registry'.
+  - ./.github/codeql/models
 
 paths-ignore:
   - "templates/adapter_plugin"

--- a/.github/codeql/models/bernstein-sanitizers.model.yml
+++ b/.github/codeql/models/bernstein-sanitizers.model.yml
@@ -1,0 +1,6 @@
+extensions:
+  - addsTo:
+      pack: codeql/python-all
+      extensible: barrierModel
+    data:
+      - ["bernstein.core.security.sanitize", "Member[sanitize_log].ReturnValue", "log-injection"]

--- a/.github/codeql/models/qlpack.yml
+++ b/.github/codeql/models/qlpack.yml
@@ -1,0 +1,7 @@
+name: bernstein/codeql-sanitizers
+version: 0.1.0
+library: true
+extensionTargets:
+  codeql/python-all: "*"
+dataExtensions:
+  - "*.model.yml"


### PR DESCRIPTION
Closes #4424

## Summary
- Resolve GitHub issue #4424: CodeQL has no model for sanitize_log, so sanitized log calls keep raising log-injection alerts

## Problem

`sanitize_log` (`src/bernstein/core/security/sanitize.py`) is the project's log-injection barrier
- It escapes every C0 control, DEL, every C1 control, U+2028 and U+2029 — the exact character set that lets caller-controlled input forge a second log record
- Around 40 call sites across `core/` route untrusted values through it before a `logger.*` call

## Changes
```
.github/codeql/codeql-config.yml                     | 3 +++
 .github/codeql/models/bernstein-sanitizers.model.yml | 6 ++++++
 .github/codeql/models/qlpack.yml                     | 7 +++++++
 3 files changed, 16 insertions(+)
```

## Verification
- Host gate before publish: ruff check (no test files in the diff) - passed.

---
_Generated from Bernstein session `1787533737`._

bernstein-session-id: 1787533737

---
Made by bernstein v3.17.1 - unattended run `run-20260824T010836p3337420Z`, no operator in the loop.
