### PR TITLE
feat: no probe step turns an installed CLI's own output into evidence bernstein can admit from

### DIFF
--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -149,6 +149,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `mock.py`                   | Mock CLI adapter for zero-API-key demos and testing |
 | `muse.py`                   | Muse Code CLI adapter for Bernstein |
 | `ollama.py`                 | Ollama / OpenAI-compatible local LLM adapter - run coding agents without cloud API keys |
+| `onboarding.py`             | Probe an installed CLI binary and capture its self-description as evidence |
 | `open_interpreter.py`       | Open Interpreter CLI adapter |
 | `openai_agents.py`          | OpenAI Agents SDK v2 adapter |
 | `openai_agents_builtins.py` | Opt-in builtin tools for the OpenAI Agents runner |

--- a/src/bernstein/adapters/onboarding.py
+++ b/src/bernstein/adapters/onboarding.py
@@ -1,0 +1,114 @@
+"""Probe an installed CLI binary and capture its self-description as evidence.
+
+Issue #3762: no probe step turns an installed CLI's own output into evidence
+Bernstein can admit from. This module closes that gap: it runs the binary's
+``--version``, ``--help``, and a set of common shell-completion introspection
+invocations, and writes each captured result to a content-addressed evidence
+file (the SHA-256 of the record's canonical JSON bytes is the filename).
+
+Design invariants:
+
+* **Never raises.** A missing binary, non-zero exit, or timeout is recorded
+  as evidence rather than surfaced as an exception, mirroring
+  :func:`bernstein.adapters._contract._run_capture`'s 127/not-found handling.
+* **Content-addressed.** Two runs that observed the same upstream surface
+  produce byte-identical evidence files; a mutated file no longer hashes to
+  its recorded identity.
+* **Deterministic.** The sandboxed environment strips color and telemetry
+  opt-outs, so the captured output is stable across runs.
+
+Network-level sandboxing is deliberately out of scope: ``_sandbox_env`` only
+sets opt-out environment variables (``CI``, ``NO_COLOR``, ``DO_NOT_TRACK``).
+Denying network egress is left to the caller's environment.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters._contract import _run_capture, _sandbox_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: Per-command timeout for probe invocations.
+_PROBE_TIMEOUT_SECONDS = 30
+
+#: Shell-completion introspection patterns, tried in order. Each is run and
+#: recorded regardless of success; a CLI that supports none of them still
+#: yields evidence naming the failures.
+_COMPLETION_PATTERNS: tuple[tuple[str, ...], ...] = (
+    ("completion", "bash"),
+    ("--generate-completions", "bash"),
+    ("shell-completion", "bash"),
+)
+
+__all__ = ["ProbeEvidence", "probe_cli"]
+
+
+@dataclass(frozen=True)
+class ProbeEvidence:
+    """One content-addressed evidence file for a single probe command."""
+
+    command: str
+    exit_code: int
+    path: Path
+    sha256: str
+
+
+def _canonical_bytes(data: dict[str, Any]) -> bytes:
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _sha256_hex(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _write_evidence(out_dir: Path, record: dict[str, Any]) -> ProbeEvidence:
+    """Write ``record`` under its content-addressed name and return its handle."""
+    payload = _canonical_bytes(record)
+    sha = _sha256_hex(payload)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"{sha}.json"
+    path.write_bytes(payload)
+    return ProbeEvidence(
+        command=record["command"],
+        exit_code=record["exit_code"],
+        path=path,
+        sha256=sha,
+    )
+
+
+def probe_cli(binary: str, out_dir: Path) -> list[ProbeEvidence]:
+    """Probe an installed CLI binary, capturing its self-description as evidence.
+
+    Runs ``<binary> --version``, ``<binary> --help``, and a set of common
+    shell-completion introspection invocations, writing each captured result
+    to a content-addressed evidence file under ``out_dir``. Never raises: a
+    missing binary, non-zero exit, or timeout is recorded as evidence rather
+    than surfaced as an exception.
+
+    Args:
+        binary: The CLI binary name to probe (resolved via ``PATH``).
+        out_dir: Directory to write evidence files into (created if absent).
+
+    Returns:
+        One :class:`ProbeEvidence` per probe command, in probe order.
+    """
+    commands: list[list[str]] = [[binary, "--version"], [binary, "--help"]]
+    commands.extend([binary, *pattern] for pattern in _COMPLETION_PATTERNS)
+
+    evidence: list[ProbeEvidence] = []
+    for cmd in commands:
+        rc, output = _run_capture(cmd, timeout=_PROBE_TIMEOUT_SECONDS, env=_sandbox_env())
+        record = {
+            "binary": binary,
+            "command": " ".join(cmd),
+            "exit_code": rc,
+            "output": output,
+        }
+        evidence.append(_write_evidence(out_dir, record))
+    return evidence

--- a/tests/fixtures/probe/probe_fail_version.py
+++ b/tests/fixtures/probe/probe_fail_version.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Deterministic probe fixture: exits non-zero on ``--version``.
+
+Used to exercise the failed-probe evidence path: the exit code and captured
+stderr are recorded in the evidence file rather than raising.
+"""
+
+import sys
+
+
+def main() -> int:
+    if "--version" in sys.argv:
+        print("probe-fixture: version check failed", file=sys.stderr)
+        return 2
+    if "--help" in sys.argv:
+        print("probe-fixture: deterministic help text")
+        return 0
+    print("probe-fixture: unknown invocation")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/probe/probe_ok.py
+++ b/tests/fixtures/probe/probe_ok.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Deterministic probe fixture: fixed ``--version`` and ``--help`` output.
+
+Output is byte-stable across runs so the content-addressed evidence hash is
+stable. Any other invocation (e.g. shell-completion patterns) prints a fixed
+fallback line and exits 0.
+"""
+
+import sys
+
+
+def main() -> int:
+    if "--version" in sys.argv:
+        print("probe-fixture 1.2.3")
+        return 0
+    if "--help" in sys.argv:
+        print("probe-fixture: deterministic help text")
+        return 0
+    print("probe-fixture: unknown invocation")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/adapters/test_adapter_onboard_probe.py
+++ b/tests/unit/adapters/test_adapter_onboard_probe.py
@@ -1,0 +1,59 @@
+"""Tests for the CLI probe evidence capture (issue #3762).
+
+Covers the three evidence shapes: a deterministic happy-path probe, a probe
+whose ``--version`` exits non-zero, and a binary absent from ``PATH``. All
+three must produce a content-addressed evidence file and never raise.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.adapters.onboarding import probe_cli
+
+FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "probe"
+
+
+def _read_evidence(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_deterministic_hash(tmp_path: Path) -> None:
+    """Probing the same fixture twice yields identical content hashes."""
+    binary = str(FIXTURES / "probe_ok.py")
+
+    first = probe_cli(binary, tmp_path / "a")
+    second = probe_cli(binary, tmp_path / "b")
+
+    assert [e.sha256 for e in first] == [e.sha256 for e in second]
+    # The version evidence is present, non-empty, and self-describing.
+    version_ev = first[0]
+    assert version_ev.path.is_file()
+    doc = _read_evidence(version_ev.path)
+    assert doc["exit_code"] == 0
+    assert "probe-fixture 1.2.3" in doc["output"]
+
+
+def test_failed_probe_evidence(tmp_path: Path) -> None:
+    """A non-zero ``--version`` exit is recorded, not raised."""
+    binary = str(FIXTURES / "probe_fail_version.py")
+
+    evidence = probe_cli(binary, tmp_path)
+
+    version_ev = evidence[0]
+    assert version_ev.path.is_file()
+    doc = _read_evidence(version_ev.path)
+    assert doc["exit_code"] == 2
+    assert "version check failed" in doc["output"]
+
+
+def test_missing_binary_evidence(tmp_path: Path) -> None:
+    """A binary absent from PATH yields evidence naming the failure, no raise."""
+    evidence = probe_cli("definitely-not-a-real-binary-xyz", tmp_path)
+
+    version_ev = evidence[0]
+    assert version_ev.path.is_file()
+    doc = _read_evidence(version_ev.path)
+    assert doc["exit_code"] == 127
+    assert "not found in PATH" in doc["output"]


### PR DESCRIPTION
Closes #3762

## Summary
- Resolve GitHub issue #3762: No probe step turns an installed CLI's own output into evidence bernstein can admit from

Slice 1 of 4 of #3544
- The probe only: turn an installed binary's own output into a content-addressed evidence file
- No profile drafting, no transcript recording, no admission

## Changes
```
docs/sdd/module-map.md                            |   1 +
 src/bernstein/adapters/onboarding.py              | 114 ++++++++++++++++++++++
 tests/fixtures/probe/probe_fail_version.py        |  23 +++++
 tests/fixtures/probe/probe_ok.py                  |  24 +++++
 tests/unit/adapters/test_adapter_onboard_probe.py |  59 +++++++++++
 5 files changed, 221 insertions(+)
```

## Verification
- Host gate before publish: ruff check + pytest tests/fixtures/probe/probe_fail_version.py tests/fixtures/probe/probe_ok.py tests/unit/adapters/test_adapter_onboard_probe.py - passed.

---
_Generated from Bernstein session `1787534162`._

bernstein-session-id: 1787534162

---
Made by bernstein v3.17.1 - unattended run `run-20260824T010835p3337208Z`, no operator in the loop.
