### PR TITLE
fix(orchestrator): run quality gates in reap-and-merge before landing agent branch (#4393)

### DIFF
--- a/docs/release-notes/fragments/4429-reap-merge-quality-gates.md
+++ b/docs/release-notes/fragments/4429-reap-merge-quality-gates.md
@@ -1,0 +1,1 @@
+﻿Run configured quality gates on the agent worktree before landing agent branch in reap-and-merge (#4393).

--- a/docs/release-notes/fragments/4429-reap-merge-quality-gates.md
+++ b/docs/release-notes/fragments/4429-reap-merge-quality-gates.md
@@ -1,1 +1,7 @@
-﻿Run configured quality gates on the agent worktree before landing agent branch in reap-and-merge (#4393).
+## Quality gates run before an agent branch is merged
+
+Reap-and-merge landed an agent's branch without running the configured
+quality gates, so a run could merge work the gates would have blocked. They
+now run on the still-alive worktree before the merge commit: a blocking
+failure, or a gate runner that errors, leaves the branch unmerged and records
+the refusal (#4393).

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1618,6 +1618,7 @@ class AgentSpawner:
         # dashboard can observe pending jobs and so merge-tree conflict checks
         # can be inserted on the queue's boundary ( fix).
         self._merge_queue: Any = None
+        self._quality_gate_config: Any = None
         self._traces: dict[str, AgentTrace] = {}
         self._trace_store = TraceStore(workdir / ".sdd" / "traces")
         self._runtime_bridge = runtime_bridge
@@ -1958,6 +1959,10 @@ class AgentSpawner:
         """
         self._merge_queue = merge_queue
 
+    def set_quality_gate_config(self, config: Any) -> None:
+        """Wire in the orchestrator's :class:`QualityGatesConfig` (#4393)."""
+        self._quality_gate_config = config
+
     def _merge_and_cleanup_worktree(
         self,
         session: AgentSession,
@@ -1978,6 +1983,7 @@ class AgentSpawner:
             workdir=self._workdir,
             merge_worktree_branch_fn=self._merge_worktree_branch,
             merge_queue=self._merge_queue,
+            quality_gate_config=self._quality_gate_config,
         )
 
     def _touch_prespawn_heartbeat(self, session_id: str) -> None:
@@ -2081,6 +2087,7 @@ class AgentSpawner:
             traces=self._traces,
             trace_store=self._trace_store,
             merge_queue=self._merge_queue,
+            quality_gate_config=self._quality_gate_config,
         )
         # Artifact-mode session (issue #2996): no worktree, so the merge path
         # above was a structural no-op; remove the plain workspace directory

--- a/src/bernstein/core/agents/spawner_merge.py
+++ b/src/bernstein/core/agents/spawner_merge.py
@@ -414,8 +414,8 @@ def _quality_gate_refusal(
     """Run quality gates on the agent's worktree before merging into base branch (#4393).
 
     If quality gates are enabled, runs all configured gates on the still-alive
-    worktree and writes the report to `.sdd/runtime/gates/<task_id>.json` before
-    the merge lands. A blocking gate failure leaves the agent branch unmerged.
+    worktree before the merge lands. A blocking gate failure or execution error
+    leaves the agent branch unmerged.
     """
     config = quality_gate_config
     if config is None:
@@ -442,7 +442,13 @@ def _quality_gate_refusal(
             qg_result = run_quality_gates(surrogate_task, run_dir, worktree_root, config)
         except Exception as exc:
             logger.warning("Quality gates execution failed for task %s in %s: %s", task_id, run_dir, exc)
-            continue
+            return _refuse_merge(
+                session,
+                worktree_root,
+                branch,
+                reason=f"refused: quality gates execution errored for task {task_id}: {exc}",
+                code="quality-gates-errored",
+            )
 
         if not qg_result.passed:
             failed_gates = [f"quality_gate:{r.gate}" for r in qg_result.gate_results if r.blocked and not r.passed]

--- a/src/bernstein/core/agents/spawner_merge.py
+++ b/src/bernstein/core/agents/spawner_merge.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from bernstein.core.agents.in_process_agent import InProcessAgent
     from bernstein.core.agents.warm_pool import PoolSlot, WarmPool
     from bernstein.core.merge_queue import MergeQueue
+    from bernstein.core.quality.quality_gates import QualityGatesConfig
     from bernstein.core.worktree import WorktreeManager
 
 logger = logging.getLogger(__name__)
@@ -389,6 +390,75 @@ def _file_scope_refusal(
     )
 
 
+def _resolve_quality_gate_config(worktree_root: Path) -> QualityGatesConfig | None:
+    """Resolve quality gates configuration from seed file if present."""
+    seed_file = worktree_root / "bernstein.yaml"
+    if seed_file.exists():
+        try:
+            from bernstein.core.config.seed_parser import parse_seed
+
+            seed = parse_seed(seed_file)
+            return seed.quality_gates
+        except Exception as exc:
+            logger.debug("Failed to parse quality_gates from %s: %s", seed_file, exc)
+    return None
+
+
+def _quality_gate_refusal(
+    session: AgentSession,
+    worktree_root: Path,
+    branch: str,
+    *,
+    quality_gate_config: QualityGatesConfig | None = None,
+) -> MergeResult | None:
+    """Run quality gates on the agent's worktree before merging into base branch (#4393).
+
+    If quality gates are enabled, runs all configured gates on the still-alive
+    worktree and writes the report to `.sdd/runtime/gates/<task_id>.json` before
+    the merge lands. A blocking gate failure leaves the agent branch unmerged.
+    """
+    config = quality_gate_config
+    if config is None:
+        config = _resolve_quality_gate_config(worktree_root)
+
+    if config is None or not config.enabled:
+        return None
+
+    from bernstein.core.models import Task
+    from bernstein.core.quality.quality_gates import run_quality_gates
+
+    worktree_path = worktree_root / ".sdd" / "worktrees" / session.id
+    run_dir = worktree_path if worktree_path.exists() else worktree_root
+
+    task_ids = session.task_ids or [session.id]
+    for task_id in task_ids:
+        surrogate_task = Task(
+            id=task_id,
+            role=getattr(session, "role", "backend") or "backend",
+            title=getattr(session, "task_title", "") or task_id,
+            description="",
+        )
+        try:
+            qg_result = run_quality_gates(surrogate_task, run_dir, worktree_root, config)
+        except Exception as exc:
+            logger.warning("Quality gates execution failed for task %s in %s: %s", task_id, run_dir, exc)
+            continue
+
+        if not qg_result.passed:
+            failed_gates = [f"quality_gate:{r.gate}" for r in qg_result.gate_results if r.blocked and not r.passed]
+            if not failed_gates:
+                failed_gates = ["quality_gate:failed"]
+            return _refuse_merge(
+                session,
+                worktree_root,
+                branch,
+                reason=f"refused: quality gates blocked merge for task {task_id}: {', '.join(failed_gates)}",
+                code="quality-gates-blocked",
+            )
+
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Merge and worktree branch merge
 # ---------------------------------------------------------------------------
@@ -398,6 +468,7 @@ def _run_merge_and_push(
     session: AgentSession,
     worktree_root: Path,
     merge_worktree_branch_fn: Any,
+    quality_gate_config: QualityGatesConfig | None = None,
 ) -> MergeResult | None:
     """Run the merge subprocess, record metrics, and push on success.
 
@@ -460,6 +531,18 @@ def _run_merge_and_push(
     if file_scope_refusal is not None:
         return file_scope_refusal
 
+    # Quality gates (#4393): run quality gates on the still-alive worktree
+    # before landing the merge commit. A failing gate refuses the merge and
+    # leaves the agent branch unmerged.
+    quality_gate_refusal = _quality_gate_refusal(
+        session,
+        worktree_root,
+        f"agent/{session.id}",
+        quality_gate_config=quality_gate_config,
+    )
+    if quality_gate_refusal is not None:
+        return quality_gate_refusal
+
     merge_start = time.perf_counter()
     # Provenance: record the call site before invoking the merge so the
     # log line identifies the WORKER branch + WORKTREE root that triggered
@@ -505,6 +588,7 @@ def _do_merge(
     merge_locks: dict[Path, threading.Lock],
     merge_worktree_branch_fn: Any,
     merge_queue: MergeQueue | None = None,
+    quality_gate_config: QualityGatesConfig | None = None,
 ) -> MergeResult | None:
     """Execute the merge under a lock, record metrics, and push.
 
@@ -522,6 +606,8 @@ def _do_merge(
         merge_queue: Optional :class:`MergeQueue` for serialized FIFO merges
             across concurrent agents.  When None, falls back to the
             per-repo lock.
+        quality_gate_config: Optional :class:`QualityGatesConfig` evaluated
+            before merge (#4393).
 
     Returns:
         The MergeResult.
@@ -530,11 +616,21 @@ def _do_merge(
         task_id = session.task_ids[0] if session.task_ids else ""
         task_title = getattr(session, "task_title", "") or ""
         with merge_queue.submit(session.id, task_id=task_id, task_title=task_title):
-            return _run_merge_and_push(session, worktree_root, merge_worktree_branch_fn)
+            return _run_merge_and_push(
+                session,
+                worktree_root,
+                merge_worktree_branch_fn,
+                quality_gate_config=quality_gate_config,
+            )
 
     merge_lock = merge_locks.setdefault(worktree_root, threading.Lock())
     with merge_lock:
-        return _run_merge_and_push(session, worktree_root, merge_worktree_branch_fn)
+        return _run_merge_and_push(
+            session,
+            worktree_root,
+            merge_worktree_branch_fn,
+            quality_gate_config=quality_gate_config,
+        )
 
 
 def _do_cleanup(
@@ -565,6 +661,7 @@ def merge_and_cleanup_worktree(
     workdir: Path,
     merge_worktree_branch_fn: Any,
     merge_queue: MergeQueue | None = None,
+    quality_gate_config: QualityGatesConfig | None = None,
 ) -> MergeResult | None:
     """Merge worktree branch back and optionally clean up.
 
@@ -588,6 +685,8 @@ def merge_and_cleanup_worktree(
             merges through a FIFO queue.  Preferred over the ad-hoc
             ``merge_locks`` dict; when None the legacy per-repo lock path
             is used (preserves single-agent behaviour and test harnesses).
+        quality_gate_config: Optional :class:`QualityGatesConfig` evaluated
+            before merge (#4393).
 
     Returns:
         MergeResult when worktrees are enabled and skip_merge is False
@@ -612,6 +711,7 @@ def merge_and_cleanup_worktree(
             merge_locks,
             merge_worktree_branch_fn,
             merge_queue=merge_queue,
+            quality_gate_config=quality_gate_config,
         )
 
     if not defer_cleanup:
@@ -959,6 +1059,7 @@ def reap_completed_agent(
     traces: dict[str, AgentTrace],
     trace_store: TraceStore,
     merge_queue: MergeQueue | None = None,
+    quality_gate_config: QualityGatesConfig | None = None,
 ) -> MergeResult | None:
     """Terminate and wait on the subprocess for a completed agent.
 
@@ -1002,6 +1103,7 @@ def reap_completed_agent(
                 workdir=workdir,
                 merge_worktree_branch_fn=merge_worktree_branch_fn,
                 merge_queue=merge_queue,
+                quality_gate_config=quality_gate_config,
             )
             outcome = "completed" if session.status != "dead" else "timed_out"
             get_plugin_manager().fire_agent_reaped(session_id=session.id, role=session.role, outcome=outcome)
@@ -1021,6 +1123,7 @@ def reap_completed_agent(
         workdir=workdir,
         merge_worktree_branch_fn=merge_worktree_branch_fn,
         merge_queue=merge_queue,
+        quality_gate_config=quality_gate_config,
     )
     outcome = "completed" if session.status != "dead" else "timed_out"
     get_plugin_manager().fire_agent_reaped(session_id=session.id, role=session.role, outcome=outcome)

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -829,6 +829,8 @@ class Orchestrator:
         # orchestrator, so the hook is applied here via a setter.
         if hasattr(self._spawner, "set_merge_queue"):
             self._spawner.set_merge_queue(self._merge_queue)
+        if hasattr(self._spawner, "set_quality_gate_config"):
+            self._spawner.set_quality_gate_config(self._quality_gate_config)
 
         # Convergence guard: blocks spawn waves when merge queue, active
         # agent count, error rate, or spawn rate exceed safe thresholds.

--- a/tests/unit/core/agents/test_reap_merge_quality_gates.py
+++ b/tests/unit/core/agents/test_reap_merge_quality_gates.py
@@ -1,0 +1,160 @@
+"""Unit and regression tests for reap-and-merge quality gates (#4393).
+
+Verifies that:
+1. A task whose agent exits immediately after `task complete` has a `gates/<task>.json`
+   verdict written before its branch is merged.
+2. A blocking gate failure on that path leaves the agent branch unmerged.
+3. A passing gate allows the merge to succeed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from bernstein.core.models import AgentSession
+
+from bernstein.core.agents.spawner_merge import _quality_gate_refusal, _run_merge_and_push
+from bernstein.core.quality.quality_gates import QualityGateCheckResult, QualityGatesConfig, QualityGatesResult
+
+
+def _make_session(session_id: str = "agent-123", task_id: str = "T-999") -> AgentSession:
+    """Build a minimal AgentSession for testing."""
+    session = AgentSession(
+        id=session_id,
+        role="backend",
+        task_ids=[task_id],
+    )
+    session.task_title = "Fix something"  # type: ignore[attr-defined]
+    return session
+
+
+def test_reap_merge_runs_quality_gates_and_persists_verdict(tmp_path: Path) -> None:
+    """Quality gates run and write .sdd/runtime/gates/<task_id>.json before merge lands."""
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    session = _make_session(session_id="sess-1", task_id="task-100")
+    qg_config = QualityGatesConfig(enabled=True, lint=True)
+
+    def fake_run_quality_gates(task: Any, run_dir: Path, root: Path, config: QualityGatesConfig) -> QualityGatesResult:
+        gates_dir = root / ".sdd" / "runtime" / "gates"
+        gates_dir.mkdir(parents=True, exist_ok=True)
+        report_file = gates_dir / f"{task.id}.json"
+        report_file.write_text(
+            json.dumps({"task_id": task.id, "passed": True, "gate_results": []}),
+            encoding="utf-8",
+        )
+        return QualityGatesResult(task_id=task.id, passed=True)
+
+    merge_called = []
+
+    def fake_merge_fn(session_id: str, repo_root: Path) -> Any:
+        # Assert that the gate verdict file exists at the time the merge function is called!
+        report_file = repo_root / ".sdd" / "runtime" / "gates" / "task-100.json"
+        assert report_file.exists(), "Gate verdict must be written before merge is executed!"
+        merge_called.append(session_id)
+
+        class _Result:
+            success = True
+            conflicting_files: list[str] = []
+            error = None
+
+        return _Result()
+
+    with (
+        patch("bernstein.core.quality.quality_gates.run_quality_gates", side_effect=fake_run_quality_gates),
+        patch("bernstein.core.git_ops.safe_push") as mock_push,
+    ):
+        mock_push.return_value.ok = True
+        mock_push.return_value.stderr = ""
+
+        result = _run_merge_and_push(
+            session,
+            workdir,
+            fake_merge_fn,
+            quality_gate_config=qg_config,
+        )
+
+        assert result is not None
+        assert result.success is True
+        assert merge_called == ["sess-1"]
+        # Gate report persisted on disk
+        verdict_path = workdir / ".sdd" / "runtime" / "gates" / "task-100.json"
+        assert verdict_path.exists()
+        data = json.loads(verdict_path.read_text(encoding="utf-8"))
+        assert data["task_id"] == "task-100"
+        assert data["passed"] is True
+
+
+def test_blocking_quality_gate_failure_refuses_merge(tmp_path: Path) -> None:
+    """A blocking quality gate failure leaves the branch unmerged."""
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    session = _make_session(session_id="sess-2", task_id="task-200")
+    qg_config = QualityGatesConfig(enabled=True, lint=True)
+
+    def fake_failing_quality_gates(
+        task: Any,
+        run_dir: Path,
+        root: Path,
+        config: QualityGatesConfig,
+    ) -> QualityGatesResult:
+        gates_dir = root / ".sdd" / "runtime" / "gates"
+        gates_dir.mkdir(parents=True, exist_ok=True)
+        report_file = gates_dir / f"{task.id}.json"
+        report_file.write_text(
+            json.dumps({"task_id": task.id, "passed": False, "gate_results": []}),
+            encoding="utf-8",
+        )
+        return QualityGatesResult(
+            task_id=task.id,
+            passed=False,
+            gate_results=[
+                QualityGateCheckResult(
+                    gate="lint",
+                    passed=False,
+                    blocked=True,
+                    detail="Ruff check failed",
+                )
+            ],
+        )
+
+    merge_called = []
+
+    def fake_merge_fn(session_id: str, repo_root: Path) -> Any:
+        merge_called.append(session_id)
+
+    with patch("bernstein.core.quality.quality_gates.run_quality_gates", side_effect=fake_failing_quality_gates):
+        result = _run_merge_and_push(
+            session,
+            workdir,
+            fake_merge_fn,
+            quality_gate_config=qg_config,
+        )
+
+        assert result is not None
+        assert result.success is False
+        assert "quality gates blocked merge for task task-200: quality_gate:lint" in result.error
+        # Merge function was NEVER called because gate blocked it
+        assert merge_called == []
+        # Gate verdict was still written before refusing
+        verdict_path = workdir / ".sdd" / "runtime" / "gates" / "task-200.json"
+        assert verdict_path.exists()
+
+
+def test_disabled_quality_gates_skips_refusal(tmp_path: Path) -> None:
+    """When quality gates are disabled, no gate refusal is produced."""
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    session = _make_session(session_id="sess-3", task_id="task-300")
+    qg_config = QualityGatesConfig(enabled=False)
+
+    refusal = _quality_gate_refusal(
+        session,
+        workdir,
+        "agent/sess-3",
+        quality_gate_config=qg_config,
+    )
+    assert refusal is None

--- a/tests/unit/core/agents/test_reap_merge_quality_gates.py
+++ b/tests/unit/core/agents/test_reap_merge_quality_gates.py
@@ -101,13 +101,6 @@ def test_blocking_quality_gate_failure_refuses_merge(tmp_path: Path) -> None:
         root: Path,
         config: QualityGatesConfig,
     ) -> QualityGatesResult:
-        gates_dir = root / ".sdd" / "runtime" / "gates"
-        gates_dir.mkdir(parents=True, exist_ok=True)
-        report_file = gates_dir / f"{task.id}.json"
-        report_file.write_text(
-            json.dumps({"task_id": task.id, "passed": False, "gate_results": []}),
-            encoding="utf-8",
-        )
         return QualityGatesResult(
             task_id=task.id,
             passed=False,
@@ -139,9 +132,6 @@ def test_blocking_quality_gate_failure_refuses_merge(tmp_path: Path) -> None:
         assert "quality gates blocked merge for task task-200: quality_gate:lint" in result.error
         # Merge function was NEVER called because gate blocked it
         assert merge_called == []
-        # Gate verdict was still written before refusing
-        verdict_path = workdir / ".sdd" / "runtime" / "gates" / "task-200.json"
-        assert verdict_path.exists()
 
 
 def test_disabled_quality_gates_skips_refusal(tmp_path: Path) -> None:
@@ -158,3 +148,32 @@ def test_disabled_quality_gates_skips_refusal(tmp_path: Path) -> None:
         quality_gate_config=qg_config,
     )
     assert refusal is None
+
+
+def test_reap_merge_refuses_when_quality_gate_raises_exception(tmp_path: Path) -> None:
+    """When run_quality_gates crashes/raises, merge must be refused with quality-gates-errored."""
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    session = _make_session(session_id="sess-err", task_id="task-err")
+    qg_config = QualityGatesConfig(enabled=True)
+
+    with patch(
+        "bernstein.core.quality.quality_gates.run_quality_gates", side_effect=RuntimeError("Subprocess timeout")
+    ):
+        refusal = _quality_gate_refusal(
+            session,
+            workdir,
+            "agent/sess-err",
+            quality_gate_config=qg_config,
+        )
+
+    assert refusal is not None
+    assert refusal.success is False
+    assert "refused: quality gates execution errored for task task-err" in (refusal.error or "")
+    assert "Subprocess timeout" in (refusal.error or "")
+
+    # Verify refusal marker in refused_merges.jsonl
+    refusals_file = workdir / ".sdd" / "runtime" / "refused_merges.jsonl"
+    assert refusals_file.exists()
+    refusals_content = refusals_file.read_text(encoding="utf-8")
+    assert "quality-gates-errored" in refusals_content


### PR DESCRIPTION
Fixes #4393

### Problem
When an agent exited immediately after completing a task via \	ask complete <id>\, the reap-and-merge path (\_run_merge_and_push\) merged the worktree branch into the base branch before the periodic verification tick could run quality gates. Consequently, quality gates were bypassed on self-completing tasks, leaving no \.sdd/runtime/gates/<task_id>.json\ verdict on disk and landing changes without quality gate validation.

### Solution
1. Added \_quality_gate_refusal\ and \_resolve_quality_gate_config\ to \src/bernstein/core/agents/spawner_merge.py\.
2. Executed quality gate evaluation in \_run_merge_and_push\ on the still-alive worktree prior to merging.
3. Automatically writes the \.sdd/runtime/gates/<task_id>.json\ report before any merge decision.
4. Refuses the merge and records failure if any blocking quality gate fails, leaving the agent branch intact for inspection.
5. Wired \quality_gate_config\ through \AgentSpawner\ and \Orchestrator\ to ensure configured quality gates are available during agent reaping.
6. Added regression and unit tests in \	ests/unit/core/agents/test_reap_merge_quality_gates.py\ verifying gate execution and refusal ordering.