### PR TITLE
fix(tasks): reject cycle-forming dependency on POST /tasks before persistence (#4298)

### DIFF
--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -20870,6 +20870,18 @@
       },
       "TaskCreate": {
         "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 1000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
           "title": {
             "type": "string",
             "maxLength": 500,
@@ -22605,6 +22617,18 @@
       },
       "WebhookTaskCreate": {
         "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 1000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
           "title": {
             "type": "string",
             "maxLength": 500,

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -1061,6 +1061,37 @@ async def create_task(body: TaskCreate, request: Request) -> TaskResponse:
                 "present but empty" if seed_config is not None else "absent",
             )
 
+        # Validate dependency graph: reject cycle-forming edges before persistence (#4298)
+        if effective_body.depends_on:
+            from bernstein.core.models import Complexity, Scope, Task
+            from bernstein.core.quality.dep_validator import DependencyValidator
+
+            existing_tasks = store.list_tasks(tenant_id=effective_tenant)
+            candidate_id = effective_body.id or "__candidate__"
+            candidate_task = Task(
+                id=candidate_id,
+                title=effective_body.title,
+                description=effective_body.description,
+                role=effective_body.role,
+                priority=effective_body.priority,
+                scope=Scope(effective_body.scope),
+                complexity=Complexity(effective_body.complexity),
+                depends_on=list(effective_body.depends_on),
+                tenant_id=effective_tenant,
+            )
+            tasks_for_validation = [t for t in existing_tasks if t.id != candidate_id] + [candidate_task]
+            val_result = DependencyValidator().validate(tasks_for_validation)
+            if val_result.cycles:
+                cycle_str = "; ".join(" -> ".join(c) for c in val_result.cycles)
+                logger.warning(
+                    "Rejecting task create: dependency cycle detected: %s",
+                    cycle_str,
+                )
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Task dependency cycle detected: {cycle_str}",
+                )
+
         task = await store.create(effective_body)
         append_assessment_log(
             request.app.state.sdd_dir,

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -134,6 +134,7 @@ class TaskCreate(BaseModel):
     """Body for POST /tasks."""
 
     # bounded string lengths prevent trivial memory exhaustion.
+    id: str | None = Field(default=None, max_length=_MAX_SHORT_STR_LEN)
     title: str = Field(max_length=_MAX_TITLE_LEN)
     description: str = Field(max_length=_MAX_DESCRIPTION_LEN)
     role: str = Field(default="auto", max_length=_MAX_SHORT_STR_LEN)

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -1443,7 +1443,7 @@ class TaskStore:
         )
 
         task = Task(
-            id=uuid.uuid4().hex[:12],
+            id=getattr(req, "id", None) or uuid.uuid4().hex[:12],
             title=req.title,
             description=req.description,
             role=req.role,
@@ -1496,7 +1496,7 @@ class TaskStore:
                 cycle = self._detect_cycle(self._tasks, task)
                 if cycle is not None:
                     raise HTTPException(
-                        status_code=422,
+                        status_code=400,
                         detail="Circular dependency detected: " + " -> ".join(cycle),
                     )
             if task.depends_on_repo is not None:

--- a/tests/unit/test_task_crud_dependency_cycle.py
+++ b/tests/unit/test_task_crud_dependency_cycle.py
@@ -1,0 +1,151 @@
+"""Unit tests for POST /tasks dependency cycle validation (#4298)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from starlette.testclient import TestClient
+
+from bernstein.core.server import create_app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_post_tasks_accepts_normal_acyclic_chain(tmp_path: Path) -> None:
+    """Acyclic dependency chain A -> B -> C creates successfully."""
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+
+    with TestClient(app) as client:
+        resp_a = client.post(
+            "/tasks",
+            json={
+                "id": "task-a",
+                "title": "Task A",
+                "description": "First task in chain.",
+                "role": "backend",
+            },
+        )
+        assert resp_a.status_code == 201, resp_a.text
+
+        resp_b = client.post(
+            "/tasks",
+            json={
+                "id": "task-b",
+                "title": "Task B",
+                "description": "Second task in chain.",
+                "role": "backend",
+                "depends_on": ["task-a"],
+            },
+        )
+        assert resp_b.status_code == 201, resp_b.text
+
+        resp_c = client.post(
+            "/tasks",
+            json={
+                "id": "task-c",
+                "title": "Task C",
+                "description": "Third task in chain.",
+                "role": "backend",
+                "depends_on": ["task-b"],
+            },
+        )
+        assert resp_c.status_code == 201, resp_c.text
+
+
+def test_post_tasks_rejects_two_node_dependency_cycle(tmp_path: Path) -> None:
+    """Creating a cycle A -> B -> A is rejected with HTTP 400 naming the cycle."""
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+
+    with TestClient(app) as client:
+        resp_a = client.post(
+            "/tasks",
+            json={
+                "id": "task-a",
+                "title": "Task A",
+                "description": "Task A.",
+                "role": "backend",
+            },
+        )
+        assert resp_a.status_code == 201
+
+        resp_b = client.post(
+            "/tasks",
+            json={
+                "id": "task-b",
+                "title": "Task B",
+                "description": "Task B depends on A.",
+                "role": "backend",
+                "depends_on": ["task-a"],
+            },
+        )
+        assert resp_b.status_code == 201
+
+        # Attempt to create or overwrite Task A with dependency on B -> closing the cycle
+        resp_cycle = client.post(
+            "/tasks",
+            json={
+                "id": "task-a",
+                "title": "Task A replacement",
+                "description": "Task A now depends on B.",
+                "role": "backend",
+                "depends_on": ["task-b"],
+            },
+        )
+        assert resp_cycle.status_code == 400, resp_cycle.text
+        error_detail = resp_cycle.json().get("detail", "")
+        assert "task-a" in error_detail
+        assert "task-b" in error_detail
+        assert "cycle" in error_detail.lower()
+
+
+def test_post_tasks_rejects_three_node_dependency_cycle(tmp_path: Path) -> None:
+    """Creating a 3-node cycle A -> B -> C -> A is rejected with HTTP 400."""
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+
+    with TestClient(app) as client:
+        client.post(
+            "/tasks",
+            json={"id": "task-1", "title": "Task 1", "description": "1", "role": "backend"},
+        )
+        client.post(
+            "/tasks",
+            json={"id": "task-2", "title": "Task 2", "description": "2", "role": "backend", "depends_on": ["task-1"]},
+        )
+        client.post(
+            "/tasks",
+            json={"id": "task-3", "title": "Task 3", "description": "3", "role": "backend", "depends_on": ["task-2"]},
+        )
+
+        resp = client.post(
+            "/tasks",
+            json={
+                "id": "task-1",
+                "title": "Task 1 cycle",
+                "description": "1 depends on 3",
+                "role": "backend",
+                "depends_on": ["task-3"],
+            },
+        )
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "task-1" in detail and "task-2" in detail and "task-3" in detail
+
+
+def test_post_tasks_rejects_self_dependency_cycle(tmp_path: Path) -> None:
+    """A task depending on itself is rejected with HTTP 400."""
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/tasks",
+            json={
+                "id": "task-self",
+                "title": "Self cycle",
+                "description": "Task depending on itself.",
+                "role": "backend",
+                "depends_on": ["task-self"],
+            },
+        )
+        assert resp.status_code == 400
+        assert "task-self" in resp.json()["detail"]


### PR DESCRIPTION
Fixes #4298 (Part of #4287)

### Problem
When creating tasks via \POST /tasks\ (\create_task\ in \src/bernstein/core/routes/task_crud.py\), candidate task dependencies were not validated against existing tasks for cycle creation before persisting the row. Storing a cycle breaks \TaskGraph.topological_order()\, leading to recurring warnings and stalled tasks that the scheduler could never dispatch.

### Solution
1. Integrated \DependencyValidator\ in \create_task\ to evaluate the tenant's current task graph alongside the candidate task before persistence.
2. If a dependency cycle is detected, \POST /tasks\ immediately rejects the request with HTTP 400 and a descriptive error message specifying the cycle path (e.g. \Task dependency cycle detected: task-A -> task-B -> task-A\).
3. Added optional \id\ support to \TaskCreate\ and \TaskStore.create\ and ensured store-level cycle detection raises HTTP 400.
4. Added tests in \	ests/unit/test_task_crud_dependency_cycle.py\ covering acyclic chains, 2-node cycles, 3-node cycles, and self-cycles.