### PR TITLE
docs: regenerate adapter last-green table from canary receipts

### DIFF
--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -191,16 +191,16 @@ covered under *Chronic-skip handling*.
 <!-- last-green:begin -->
 | Adapter | Binary | Last-green version | Verified | Receipt |
 |---|---|---|---|---|
-| agy | `agy` | 1.0.0 | 2026-07-11T05:57:23Z (stale) | `006fb946868d` |
-| aider | `aider` | 0.86.2 | 2026-08-23T05:17:42Z | `4a08b6df53b9` |
-| claude | `claude` | 2.1.241 | 2026-08-23T05:17:42Z | `4ab0959af8db` |
-| codex | `codex` | 0.149.0 | 2026-08-23T05:17:42Z | `08518cd19b11` |
-| copilot | `copilot` | 1.0.80 | 2026-08-23T05:17:42Z | `cac0d528426f` |
-| gemini | `gemini` | 0.56.0 | 2026-08-23T05:17:42Z | `a47f2c650f4c` |
-| kimi | `kimi` | 1.49.0 | 2026-08-23T05:17:42Z | `a8c9b7068255` |
-| opencode | `opencode` | 1.18.21 | 2026-08-23T05:17:42Z | `b1521b4371b7` |
-| pydantic_ai | `clai` | 2.33.0 | 2026-08-23T05:17:42Z | `5ca0e4ab4a4a` |
-| qwen | `qwen` | 0.22.0 | 2026-08-23T05:17:42Z | `f46d787b5906` |
+| agy | `agy` | 1.0.0 | 2026-07-11T05:57:23Z (not probed) | `006fb946868d` |
+| aider | `aider` | 0.86.2 | 2026-08-24T05:26:59Z | `440df6b99b1c` |
+| claude | `claude` | 2.1.241 | 2026-08-24T05:26:59Z | `a99a61e2d0d8` |
+| codex | `codex` | 0.149.1 | 2026-08-24T05:26:59Z | `25bae9a5a2ca` |
+| copilot | `copilot` | 1.0.80 | 2026-08-24T05:26:59Z | `7f6fe7d34f52` |
+| gemini | `gemini` | 0.56.0 | 2026-08-24T05:26:59Z | `ab89cab289ec` |
+| kimi | `kimi` | 1.49.0 | 2026-08-24T05:26:59Z | `62d980416d74` |
+| opencode | `opencode` | 1.18.21 | 2026-08-24T05:26:59Z | `9ce9575ba003` |
+| pydantic_ai | `clai` | 2.33.0 | 2026-08-24T05:26:59Z | `8814865fc47b` |
+| qwen | `qwen` | 0.22.0 | 2026-08-24T05:26:59Z | `cc64a4222a1f` |
 <!-- last-green:end -->
 
 ## Operator knobs

--- a/src/bernstein/adapters/last_green.json
+++ b/src/bernstein/adapters/last_green.json
@@ -8,56 +8,56 @@
     },
     "aider": {
       "binary": "aider",
-      "receipt_sha256": "4a08b6df53b9b14721648ea2d7e7a21ab2ba5869ef53c9abb23cf31c6a39ae43",
-      "recorded_at": "2026-08-23T05:17:42Z",
+      "receipt_sha256": "440df6b99b1c8b2df51d493bacd3a4bb22563b1eaed309e36a3d97f3d3b114a9",
+      "recorded_at": "2026-08-24T05:26:59Z",
       "version": "0.86.2"
     },
     "claude": {
       "binary": "claude",
-      "receipt_sha256": "4ab0959af8db3d7e561dd295fe0fd89f6e78958136a0f319072e70b312550120",
-      "recorded_at": "2026-08-23T05:17:42Z",
+      "receipt_sha256": "a99a61e2d0d88f913392a899e1b9ddab012f5343ca19a3de726478f79571bfbe",
+      "recorded_at": "2026-08-24T05:26:59Z",
       "version": "2.1.241"
     },
     "codex": {
       "binary": "codex",
-      "receipt_sha256": "08518cd19b11474afe4f3ba49b9280ff21b0ddcdf712716ac78b6115673c9e87",
-      "recorded_at": "2026-08-23T05:17:42Z",
-      "version": "0.149.0"
+      "receipt_sha256": "25bae9a5a2ca93d8a5f23990df0d240362e9e630be6a5283ed9e247a75f0c4d7",
+      "recorded_at": "2026-08-24T05:26:59Z",
+      "version": "0.149.1"
     },
     "copilot": {
       "binary": "copilot",
-      "receipt_sha256": "cac0d528426fe023c0259d9647745217d576612ed2915aa76b4e69be61455bbc",
-      "recorded_at": "2026-08-23T05:17:42Z",
+      "receipt_sha256": "7f6fe7d34f529df7958e3d19deb2d690e7dc509dd94411e95d85b8437b56c5ec",
+      "recorded_at": "2026-08-24T05:26:59Z",
       "version": "1.0.80"
     },
     "gemini": {
       "binary": "gemini",
-      "receipt_sha256": "a47f2c650f4c268fd62cc41778778a6b86ebb868dc946c55bd19a953bcdc37bd",
-      "recorded_at": "2026-08-23T05:17:42Z",
+      "receipt_sha256": "ab89cab289ec91ff6a5d2c738c9e9244f81306d994d2f8dfe1e3ccc11de071ad",
+      "recorded_at": "2026-08-24T05:26:59Z",
       "version": "0.56.0"
     },
     "kimi": {
       "binary": "kimi",
-      "receipt_sha256": "a8c9b706825569e6d62b3d67bb431c82d1f5ce5ee873633d67710e44dc5d65ae",
-      "recorded_at": "2026-08-23T05:17:42Z",
+      "receipt_sha256": "62d980416d74405ad7dc490d8bd87bb9c1e6e2291c3bd8a11d49160cd959b0f8",
+      "recorded_at": "2026-08-24T05:26:59Z",
       "version": "1.49.0"
     },
     "opencode": {
       "binary": "opencode",
-      "receipt_sha256": "b1521b4371b770e62f116087e1ae79de53d490435498e96d0d2bcb37b5d4f341",
-      "recorded_at": "2026-08-23T05:17:42Z",
+      "receipt_sha256": "9ce9575ba003c9b514d6c1df9d75a202423261147c51a590e005850a1adbc3e4",
+      "recorded_at": "2026-08-24T05:26:59Z",
       "version": "1.18.21"
     },
     "pydantic_ai": {
       "binary": "clai",
-      "receipt_sha256": "5ca0e4ab4a4a94bac7d4e4239e0810ba74e28cf6e8321cd3b23525773ef7138c",
-      "recorded_at": "2026-08-23T05:17:42Z",
+      "receipt_sha256": "8814865fc47b27ac3bd9b261a9ee8655e6f041da6c99b29fc24241f2fa292743",
+      "recorded_at": "2026-08-24T05:26:59Z",
       "version": "2.33.0"
     },
     "qwen": {
       "binary": "qwen",
-      "receipt_sha256": "f46d787b5906fe955eae88e4580c2b4a1db70af4cee78978c3d66e1cd3de4f36",
-      "recorded_at": "2026-08-23T05:17:42Z",
+      "receipt_sha256": "cc64a4222a1f36404e20328ed0576e72142298f20abf8708b2f88c24cff1f1cf",
+      "recorded_at": "2026-08-24T05:26:59Z",
       "version": "0.22.0"
     }
   },


### PR DESCRIPTION
Nightly adapter conformance canary regeneration of the per-adapter last-green projection (packaged last_green.json + the docs table). Every row is anchored to the receipt that attested it; receipts for this run are attached to the workflow run as artifacts.

Workflow run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/32693509209