### PR TITLE
fix(deps): bump pip to 26.2.1 so the nightly dependency audit passes

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -10,4 +10,7 @@ holds the page to that — an entry naming an issue or PR a tagged release page
 already documents fails the build. An entry that cites released work as context
 rather than as its own attribution is exempted by hand there, with the reason.
 
-Nothing yet: v3.17.2 was cut from this page.
+
+## Nightly dependency audit is green again
+
+The nightly full-closure audit runs `pip-audit --strict` over the dev closure and had failed since 2026-08-22 on `pip` 26.1.2 (PYSEC-2026-3721). A permanently red nightly hides the next real advisory behind it. `pip` is bumped to 26.2.1 in the lockfile.

--- a/uv.lock
+++ b/uv.lock
@@ -3644,11 +3644,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The `pip-audit (full closure)` job in `.github/workflows/nightly-deep-tests.yml` runs `pip-audit --strict` over the dev closure. It has failed every night since 2026-08-22 on `pip` 26.1.2 (PYSEC-2026-3721, fixed in 26.2). The equivalent job in `ci.yml` marks the dev audit `continue-on-error`, so the PR lane never saw it.

A nightly that is red for a known reason stops being a signal — the next genuine advisory lands behind an already-failing job and nobody looks.

`uv lock --upgrade-package pip` takes it to 26.2.1; the lockfile is the only change besides the release note.

Checked by a run, not by reading:

```
uv export --no-emit-project --format requirements-txt -o /tmp/req-dev.txt
uv run pip-audit -r /tmp/req-dev.txt --strict --disable-pip --no-deps --ignore-vuln PYSEC-2025-183
# No known vulnerabilities found
```