### PR TITLE
chore(ci): raise diff-coverage floor to 88%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
-  "diff_coverage_floor_percent": 87,
+  "diff_coverage_floor_percent": 88,
   "head_sha": "c1c805d57b23a5def49f3dc8b9672818b9cc431a",
   "line_rate": 0.8408,
   "run_id": "32646126357",
   "total_coverage_percent": 84.08,
-  "updated_at": "2026-08-23T15:16:24+00:00"
+  "updated_at": "2026-08-24T08:07:58+00:00"
 }


### PR DESCRIPTION
Weekly nudge of the LEVEL 1 diff-coverage floor.

The diff-coverage gate in `.github/workflows/ci.yml` reads
`diff_coverage_floor_percent` from `.coverage-baseline.json`.
This PR raises that floor so every subsequent PR must cover a
slightly higher share of its changed lines.

New floor: **88%**.

The gate stays advisory (`continue-on-error`) until an operator
promotes it; see `docs/operations/coverage-ratchet.md` for the
promotion and override procedure. If the increment is too steep
for the current trunk, close this PR - the floor only moves when
the PR merges.

Generated by `.github/workflows/coverage-ratchet-weekly.yml`.