### PR TITLE
feat(skills): recognize Agent Plugins directory layout in skills install (#3772)

### DIFF
--- a/docs/operations/skills-catalog.md
+++ b/docs/operations/skills-catalog.md
@@ -174,3 +174,19 @@ for every installed catalog skill and reports rows that do not match the
 lockfile. Drift indicates either a manual edit under
 `.bernstein/skills/<name>/` or an upstream rewrite; either is
 operator-actionable, never silently re-installed.
+
+## Agent Plugins directory installs (#3772)
+
+A separate, local-only path: `bernstein skills install <dir>` detects an
+Agent Plugins v1.0.0 directory layout (root `plugin.json` with `name`
+and `skills` fields - strict check, so an unrelated directory that
+happens to contain a `skills/` folder is not mistaken for a plugin) and
+installs every conformant `skills/<name>/SKILL.md` in one invocation.
+
+Installs go through the same lifecycle as a single local skill
+(`install_local`) and land in the same `skills.lock` with `source =
+"plugin"` and the content digest, so `bernstein skills sync` and the
+drift checks treat them like any other local install. A malformed skill
+inside the pack is skipped with a diagnostic naming it rather than
+aborting the whole install. No MCP server registration happens here -
+that is the sibling slice (#3540, out of scope for #3772).

--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -31,6 +31,8 @@ from bernstein.core.skills.lifecycle import (
     SkillsTomlError,
     init_skill,
     install_local,
+    install_plugin_local,
+    is_agent_plugins_layout,
     remove_skill,
     sync_skills,
 )
@@ -314,8 +316,28 @@ def skills_install(source: Path, scope: str, override_name: str | None, strict: 
     """
     install_scope = _parse_scope(scope)
     try:
+        resolved = source.resolve()
+        if is_agent_plugins_layout(resolved):
+            plugin_result = install_plugin_local(
+                resolved,
+                scope=install_scope,
+                workdir=Path.cwd(),
+                strict_lint=strict,
+                accept_risk=accept_risk,
+            )
+            for result in plugin_result.installed:
+                console.print(
+                    f"[green]installed[/green] {result.name} -> {result.install_dir} "
+                    f"(digest {result.digest.digest[:12]}...)",
+                )
+            for skipped in plugin_result.skipped:
+                console.print(f"[yellow]skipped[/yellow] {skipped.name}: {skipped.reason}")
+            if not plugin_result.installed:
+                console.print("[red]plugin install failed:[/red] no skills could be installed")
+                raise SystemExit(1)
+            return
         result = install_local(
-            source.resolve(),
+            resolved,
             scope=install_scope,
             workdir=Path.cwd(),
             override_name=override_name,

--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -318,6 +318,13 @@ def skills_install(source: Path, scope: str, override_name: str | None, strict: 
     try:
         resolved = source.resolve()
         if is_agent_plugins_layout(resolved):
+            if override_name is not None:
+                console.print(
+                    "[red]install failed:[/red] --name does not apply to a plugin "
+                    "directory (a pack installs every skill under skills/ under "
+                    "its own name)"
+                )
+                raise SystemExit(1)
             plugin_result = install_plugin_local(
                 resolved,
                 scope=install_scope,

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -717,6 +717,31 @@ class PluginInstallResult:
     skipped: list[SkippedSkill]
 
 
+def _resolve_plugin_skills_dir(source: Path, data: dict[str, object]) -> Path | None:
+    """Resolve the ``skills`` field of a plugin manifest, containment-checked.
+
+    ``plugin.json`` is untrusted input: it arrives with whatever tree the
+    user was handed. An absolute value, a ``../`` component, or an
+    ordinary-looking component that is a symlink out of the tree would
+    otherwise make ``skills_dir.iterdir()`` walk a directory outside the
+    plugin root, and every ``SKILL.md`` found there would be copied into
+    the install scope. ``contained_subpath`` pairs a string-shape check
+    (rejects absolute and ``..`` shapes before any filesystem call) with a
+    realpath comparison (catches the symlink case), so a manifest that
+    escapes the root is treated as not-a-plugin.
+
+    Returns ``None`` on any refusal so layout detection and install share
+    one resolution path and cannot drift apart.
+    """
+    skills_field = data.get("skills")
+    if not isinstance(skills_field, str) or not skills_field:
+        return None
+    try:
+        return contained_subpath(source, skills_field, label="plugin skills directory")
+    except (PathContainmentError, OSError):
+        return None
+
+
 def is_agent_plugins_layout(source: Path) -> bool:
     """Strict Agent Plugins v1.0.0 layout detection.
 
@@ -724,7 +749,8 @@ def is_agent_plugins_layout(source: Path) -> bool:
     ``plugin.json`` parses with a non-empty ``name`` field and a ``skills``
     field that resolves to a ``skills/`` subdirectory. Strict by design
     (#3772 decision): avoids misfiring on unrelated directories that merely
-    happen to contain a ``skills/`` folder.
+    happen to contain a ``skills/`` folder. The ``skills`` field must stay
+    inside the plugin root (see :func:`_resolve_plugin_skills_dir`).
     """
     if not source.is_dir():
         return False
@@ -741,10 +767,8 @@ def is_agent_plugins_layout(source: Path) -> bool:
     name = data.get("name")
     if not isinstance(name, str) or not name:
         return False
-    skills_field = data.get("skills")
-    if not isinstance(skills_field, str) or not skills_field:
-        return False
-    return (source / skills_field).is_dir()
+    skills_dir = _resolve_plugin_skills_dir(source, data)
+    return skills_dir is not None and skills_dir.is_dir()
 
 
 def install_plugin_local(
@@ -765,14 +789,40 @@ def install_plugin_local(
     invalid individual skill is skipped with a diagnostic naming it rather
     than aborting the whole plugin install.
     """
-    if not is_agent_plugins_layout(source):
+    if not source.is_dir():
         raise SkillLifecycleError(
             f"{source}: not an Agent Plugins directory layout "
             f"(root {PLUGIN_MANIFEST_FILENAME} with name + skills/ required)"
         )
-    manifest_raw = json.loads((source / PLUGIN_MANIFEST_FILENAME).read_text(encoding="utf-8"))
-    manifest: dict[str, Any] = manifest_raw
-    skills_dir = source / str(manifest["skills"])
+    manifest_path = source / PLUGIN_MANIFEST_FILENAME
+    try:
+        manifest_raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise SkillLifecycleError(
+            f"{source}: not an Agent Plugins directory layout "
+            f"(root {PLUGIN_MANIFEST_FILENAME} with name + skills/ required)"
+        ) from exc
+    if not isinstance(manifest_raw, dict):
+        raise SkillLifecycleError(
+            f"{source}: not an Agent Plugins directory layout "
+            f"(root {PLUGIN_MANIFEST_FILENAME} with name + skills/ required)"
+        )
+    manifest = cast("dict[str, object]", manifest_raw)
+    name_field = manifest.get("name")
+    if not isinstance(name_field, str) or not name_field:
+        raise SkillLifecycleError(
+            f"{source}: not an Agent Plugins directory layout "
+            f"(root {PLUGIN_MANIFEST_FILENAME} with name + skills/ required)"
+        )
+    # Resolved once, containment-checked: the same value is used for the
+    # walk below and for the lockfile paths, never re-joined from the raw
+    # manifest string.
+    skills_dir = _resolve_plugin_skills_dir(source, manifest)
+    if skills_dir is None or not skills_dir.is_dir():
+        raise SkillLifecycleError(
+            f"{source}: plugin manifest 'skills' must resolve to a directory "
+            "inside the plugin root"
+        )
 
     installed: list[InstallResult] = []
     skipped: list[SkippedSkill] = []
@@ -800,24 +850,29 @@ def install_plugin_local(
             skipped.append(SkippedSkill(name=name, reason=str(exc)))
 
     if installed:
-        _record_plugin_lock(installed, source, workdir=workdir)
+        _record_plugin_lock(installed, skills_dir, workdir=workdir)
     return PluginInstallResult(installed=installed, skipped=skipped)
 
 
 def _record_plugin_lock(
     installed: list[InstallResult],
-    source: Path,
+    skills_dir: Path,
     *,
     workdir: Path,
 ) -> None:
-    """Merge plugin-installed skills into ``skills.lock`` ([[skills]] rows)."""
+    """Merge plugin-installed skills into ``skills.lock`` ([[skills]] rows).
+
+    Each row's ``path`` names the ``skills/<name>/`` directory the skill
+    came from (not the plugin root), so a later ``sync``/drift reader can
+    locate the individual skill tree.
+    """
     lock_path = workdir / SKILLS_LOCK_FILENAME
     entries = _read_lock(lock_path)
     for result in installed:
         entries[result.name] = LockEntry(
             name=result.name,
             source=_PLUGIN_LOCK_SOURCE,
-            path=str(source),
+            path=str(skills_dir / result.name),
             digest=result.digest.digest,
         )
     _write_lock(lock_path, list(entries.values()))

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -820,8 +820,7 @@ def install_plugin_local(
     skills_dir = _resolve_plugin_skills_dir(source, manifest)
     if skills_dir is None or not skills_dir.is_dir():
         raise SkillLifecycleError(
-            f"{source}: plugin manifest 'skills' must resolve to a directory "
-            "inside the plugin root"
+            f"{source}: plugin manifest 'skills' must resolve to a directory inside the plugin root"
         )
 
     installed: list[InstallResult] = []

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -38,6 +38,7 @@ Out of scope for this module (deferred to follow-up tracks):
 from __future__ import annotations
 
 import hashlib
+import json
 import shutil
 import tomllib
 from dataclasses import dataclass
@@ -53,7 +54,7 @@ from bernstein.core.security.path_containment import (
     contained_subpath,
 )
 from bernstein.core.skills.lint import LintSeverity, lint_skill
-from bernstein.core.skills.manifest import SkillManifest
+from bernstein.core.skills.manifest import SkillManifest, parse_skill_md
 from bernstein.core.skills.sanitizer import strip_invisible_tags
 
 # ---------------------------------------------------------------------------
@@ -687,6 +688,139 @@ def install_local(
         shutil.rmtree(install_dir)
     staging_dir.replace(install_dir)
     return InstallResult(name=name, install_dir=install_dir, digest=digest, changed=True)
+
+
+# ---------------------------------------------------------------------------
+# Agent Plugins directory layout (#3772, slice 1 of #3540)
+# ---------------------------------------------------------------------------
+
+#: Filename of the Agent Plugins v1.0.0 root manifest.
+PLUGIN_MANIFEST_FILENAME: str = "plugin.json"
+
+#: Lockfile ``source`` tag for skills installed from a plugin directory.
+_PLUGIN_LOCK_SOURCE: str = "plugin"
+
+
+@dataclass(frozen=True)
+class SkippedSkill:
+    """A skill inside a plugin tree that was not installed."""
+
+    name: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class PluginInstallResult:
+    """Outcome of installing every skill under an Agent Plugins directory."""
+
+    installed: list[InstallResult]
+    skipped: list[SkippedSkill]
+
+
+def is_agent_plugins_layout(source: Path) -> bool:
+    """Strict Agent Plugins v1.0.0 layout detection.
+
+    A directory counts as an Agent Plugins layout only when a root
+    ``plugin.json`` parses with a non-empty ``name`` field and a ``skills``
+    field that resolves to a ``skills/`` subdirectory. Strict by design
+    (#3772 decision): avoids misfiring on unrelated directories that merely
+    happen to contain a ``skills/`` folder.
+    """
+    if not source.is_dir():
+        return False
+    manifest_path = source / PLUGIN_MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        return False
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    if not isinstance(raw, dict):
+        return False
+    data = cast("dict[str, object]", raw)
+    name = data.get("name")
+    if not isinstance(name, str) or not name:
+        return False
+    skills_field = data.get("skills")
+    if not isinstance(skills_field, str) or not skills_field:
+        return False
+    return (source / skills_field).is_dir()
+
+
+def install_plugin_local(
+    source: Path,
+    *,
+    scope: InstallScope,
+    workdir: Path,
+    home: Path | None = None,
+    strict_lint: bool = False,
+    accept_risk: bool = False,
+) -> PluginInstallResult:
+    """Install every skill under an Agent Plugins directory layout.
+
+    A non-plugin directory raises :class:`SkillLifecycleError`. Each
+    conformant ``skills/<name>/SKILL.md`` is installed through
+    :func:`install_local` and recorded in ``skills.lock`` with its content
+    digest (``source="plugin"``) so a later ``sync`` can detect drift. An
+    invalid individual skill is skipped with a diagnostic naming it rather
+    than aborting the whole plugin install.
+    """
+    if not is_agent_plugins_layout(source):
+        raise SkillLifecycleError(
+            f"{source}: not an Agent Plugins directory layout "
+            f"(root {PLUGIN_MANIFEST_FILENAME} with name + skills/ required)"
+        )
+    manifest_raw = json.loads((source / PLUGIN_MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    manifest: dict[str, Any] = manifest_raw
+    skills_dir = source / str(manifest["skills"])
+
+    installed: list[InstallResult] = []
+    skipped: list[SkippedSkill] = []
+    for skill_dir in sorted(skills_dir.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.is_file():
+            continue
+        name = skill_dir.name
+        # Per-skill isolation: one bad SKILL.md must not abort the pack.
+        try:
+            parse_skill_md(skill_md)
+            installed.append(
+                install_local(
+                    skill_dir,
+                    scope=scope,
+                    workdir=workdir,
+                    home=home,
+                    strict_lint=strict_lint,
+                    accept_risk=accept_risk,
+                )
+            )
+        except Exception as exc:  # per-skill skip contract: one bad SKILL.md must not abort the pack
+            skipped.append(SkippedSkill(name=name, reason=str(exc)))
+
+    if installed:
+        _record_plugin_lock(installed, source, workdir=workdir)
+    return PluginInstallResult(installed=installed, skipped=skipped)
+
+
+def _record_plugin_lock(
+    installed: list[InstallResult],
+    source: Path,
+    *,
+    workdir: Path,
+) -> None:
+    """Merge plugin-installed skills into ``skills.lock`` ([[skills]] rows)."""
+    lock_path = workdir / SKILLS_LOCK_FILENAME
+    entries = _read_lock(lock_path)
+    for result in installed:
+        entries[result.name] = LockEntry(
+            name=result.name,
+            source=_PLUGIN_LOCK_SOURCE,
+            path=str(source),
+            digest=result.digest.digest,
+        )
+    _write_lock(lock_path, list(entries.values()))
 
 
 def _copy_skill_tree(source: Path, dest: Path) -> None:

--- a/tests/unit/skills/test_agent_plugins_install.py
+++ b/tests/unit/skills/test_agent_plugins_install.py
@@ -187,5 +187,69 @@ def test_install_plugin_writes_lockfile_entries(
     lock_path = workdir / "skills.lock"
     assert lock_path.is_file()
     content = lock_path.read_text(encoding="utf-8")
+    resolved_root = plugin_dir.resolve()
     for name in ("alpha", "beta", "gamma"):
         assert f"name = \"{name}\"" in content
+        # path names the skills/<name>/ directory the skill came from, not
+        # the plugin root, so sync/drift can locate the individual tree.
+        assert f"path = \"{resolved_root}/skills/{name}\"" in content
+
+
+# ---------------------------------------------------------------------------
+# Manifest containment (#4448 review): an untrusted plugin.json must not be
+# able to make detection or install walk outside the plugin root.
+# ---------------------------------------------------------------------------
+
+
+def test_layout_detection_rejects_manifest_with_escaping_skills(tmp_path: Path) -> None:
+    """A manifest whose skills field escapes the plugin root is NOT a plugin layout."""
+    root = tmp_path / "escaping"
+    (root / "skills" / "alpha").mkdir(parents=True)
+    _write_skill(root / "skills" / "alpha" / "SKILL.md", "alpha")
+    _write_manifest(root / "plugin.json", name="escaping", skills="../../outside")
+    assert is_agent_plugins_layout(root) is False
+
+
+def test_layout_detection_rejects_manifest_with_absolute_skills(tmp_path: Path) -> None:
+    """An absolute skills value short-circuits the join and is refused."""
+    root = tmp_path / "absolute"
+    (root / "skills" / "alpha").mkdir(parents=True)
+    _write_skill(root / "skills" / "alpha" / "SKILL.md", "alpha")
+    _write_manifest(root / "plugin.json", name="absolute", skills=str(tmp_path))
+    assert is_agent_plugins_layout(root) is False
+
+
+def test_layout_detection_rejects_symlinked_skills_escape(tmp_path: Path) -> None:
+    """A skills directory that is a symlink out of the tree is refused."""
+    root = tmp_path / "symlink-escape"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    (outside / "alpha").mkdir(parents=True)
+    _write_skill(outside / "alpha" / "SKILL.md", "alpha")
+    (root / "skills").symlink_to(outside, target_is_directory=True)
+    _write_manifest(root / "plugin.json", name="symlink-escape")
+    assert is_agent_plugins_layout(root) is False
+
+
+def test_install_plugin_raises_on_escaping_manifest(tmp_path: Path) -> None:
+    """install_plugin_local refuses an escaping skills field outright.
+
+    Nothing may be installed into scope from outside the plugin root, and
+    the failure is a hard error rather than a silent empty install.
+    """
+    root = tmp_path / "escaping"
+    (root / "skills" / "alpha").mkdir(parents=True)
+    _write_skill(root / "skills" / "alpha" / "SKILL.md", "alpha")
+    _write_manifest(root / "plugin.json", name="escaping", skills="../../outside")
+
+    workdir = tmp_path / "project"
+    with pytest.raises(SkillLifecycleError):
+        install_plugin_local(
+            root,
+            scope=InstallScope.PROJECT,
+            workdir=workdir,
+        )
+
+    # Nothing outside the root was walked or copied into scope.
+    dest = scope_root(InstallScope.PROJECT, workdir=workdir)
+    assert not dest.exists()

--- a/tests/unit/skills/test_agent_plugins_install.py
+++ b/tests/unit/skills/test_agent_plugins_install.py
@@ -1,0 +1,191 @@
+"""Tests for Agent Plugins directory layout recognition in skills install (#3772).
+
+Slice 1 of #3540: ``bernstein skills install <path>`` must detect an Agent
+Plugins v1.0.0 directory layout (root ``plugin.json`` + ``skills/<name>/SKILL.md``
+tree) and install every conformant skill in a single invocation.
+
+Design decision (strict layout detection): a directory counts as an Agent
+Plugins layout only when a root ``plugin.json`` parses with a ``name`` field
+and a ``skills`` field that resolves to a ``skills/`` subdirectory. Rationale:
+the strict check avoids misfiring on unrelated directories that merely happen
+to contain a ``skills/`` folder (e.g. a developer's checkout), which a looser
+"any ``skills/*/SKILL.md`` tree" heuristic would install by surprise.
+
+Red-green note: this file references ``install_plugin_local`` and
+``is_agent_plugins_layout`` which do not exist yet — that is the point.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.skills.lifecycle import (
+    InstallScope,
+    SkillLifecycleError,
+    install_plugin_local,
+    is_agent_plugins_layout,
+    scope_root,
+)
+
+
+def _write_skill(path: Path, name: str, description: str = "Plugin skill for tests.") -> None:
+    """Write a minimal valid SKILL.md with frontmatter."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        textwrap.dedent(
+            f"""\
+            ---
+            name: {name}
+            description: {description}
+            ---
+
+            # {name}
+
+            Body content for {name}.
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_manifest(path: Path, *, name: str, skills: str = "./skills/") -> None:
+    """Write a minimal Agent Plugins v1.0.0-style plugin.json."""
+    path.write_text(
+        json.dumps({"name": name, "version": "1.0.0", "skills": skills}),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def plugin_dir(tmp_path: Path) -> Path:
+    """A conformant Agent Plugins directory with three valid skills."""
+    root = tmp_path / "my-pack"
+    skills = root / "skills"
+    skills.mkdir(parents=True)
+    _write_manifest(root / "plugin.json", name="my-pack")
+    for name in ("alpha", "beta", "gamma"):
+        _write_skill(skills / name / "SKILL.md", name)
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Layout detection (strict mode)
+# ---------------------------------------------------------------------------
+
+
+def test_layout_detection_accepts_conformant_plugin_dir(plugin_dir: Path) -> None:
+    assert is_agent_plugins_layout(plugin_dir) is True
+
+
+def test_layout_detection_rejects_directory_without_manifest(tmp_path: Path) -> None:
+    """A directory with skills/ but no plugin.json is NOT a plugin layout."""
+    root = tmp_path / "no-manifest"
+    (root / "skills" / "alpha").mkdir(parents=True)
+    _write_skill(root / "skills" / "alpha" / "SKILL.md", "alpha")
+    assert is_agent_plugins_layout(root) is False
+
+
+def test_layout_detection_rejects_manifest_without_name_field(tmp_path: Path) -> None:
+    root = tmp_path / "no-name"
+    (root / "skills" / "alpha").mkdir(parents=True)
+    _write_skill(root / "skills" / "alpha" / "SKILL.md", "alpha")
+    (root / "plugin.json").write_text(
+        json.dumps({"version": "1.0.0", "skills": "./skills/"}),
+        encoding="utf-8",
+    )
+    assert is_agent_plugins_layout(root) is False
+
+
+def test_layout_detection_rejects_invalid_manifest_json(tmp_path: Path) -> None:
+    root = tmp_path / "bad-json"
+    (root / "skills" / "alpha").mkdir(parents=True)
+    _write_skill(root / "skills" / "alpha" / "SKILL.md", "alpha")
+    (root / "plugin.json").write_text("not json {", encoding="utf-8")
+    assert is_agent_plugins_layout(root) is False
+
+
+# ---------------------------------------------------------------------------
+# Installation behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_install_plugin_installs_all_three_skills(
+    plugin_dir: Path,
+    tmp_path: Path,
+) -> None:
+    workdir = tmp_path / "project"
+    result = install_plugin_local(
+        plugin_dir,
+        scope=InstallScope.PROJECT,
+        workdir=workdir,
+    )
+
+    assert {r.name for r in result.installed} == {"alpha", "beta", "gamma"}
+    assert result.skipped == []
+    dest = scope_root(InstallScope.PROJECT, workdir=workdir)
+    for name in ("alpha", "beta", "gamma"):
+        assert (dest / name / "SKILL.md").is_file()
+    # Every installed skill carries a content digest (lockfile material).
+    assert all(r.digest.digest for r in result.installed)
+
+
+def test_install_plugin_skips_malformed_skill_and_reports_name(
+    plugin_dir: Path,
+    tmp_path: Path,
+) -> None:
+    # Corrupt one skill: missing frontmatter entirely.
+    (plugin_dir / "skills" / "beta" / "SKILL.md").write_text(
+        "# beta\n\nno frontmatter here\n",
+        encoding="utf-8",
+    )
+
+    workdir = tmp_path / "project"
+    result = install_plugin_local(
+        plugin_dir,
+        scope=InstallScope.PROJECT,
+        workdir=workdir,
+    )
+
+    assert {r.name for r in result.installed} == {"alpha", "gamma"}
+    assert len(result.skipped) == 1
+    assert result.skipped[0].name == "beta"
+
+
+def test_install_plugin_rejects_non_plugin_directory(
+    tmp_path: Path,
+) -> None:
+    """A plain skill directory (no plugin.json) is not a plugin install target."""
+    plain = tmp_path / "plain-skill"
+    plain.mkdir()
+    _write_skill(plain / "SKILL.md", "plain-skill")
+
+    with pytest.raises(SkillLifecycleError):
+        install_plugin_local(
+            plain,
+            scope=InstallScope.PROJECT,
+            workdir=tmp_path / "project",
+        )
+
+
+def test_install_plugin_writes_lockfile_entries(
+    plugin_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """Every installed skill lands in skills.lock with a content digest."""
+    workdir = tmp_path / "project"
+    install_plugin_local(
+        plugin_dir,
+        scope=InstallScope.PROJECT,
+        workdir=workdir,
+    )
+
+    lock_path = workdir / "skills.lock"
+    assert lock_path.is_file()
+    content = lock_path.read_text(encoding="utf-8")
+    for name in ("alpha", "beta", "gamma"):
+        assert f"name = \"{name}\"" in content


### PR DESCRIPTION
Closes #3772 (slice 1 of #3540).

## What

`bernstein skills install <path>` now detects an Agent Plugins v1.0.0 directory layout and installs every conformant skill in one invocation.

- Root `plugin.json` with `name` + `skills` fields marks the layout (**strict detection** — an unrelated directory that merely contains a `skills/` folder is not treated as a plugin; chosen over the looser heuristic to avoid surprise installs, per the decision left open in the issue).
- Each `skills/<name>/SKILL.md` installs through the existing `install_local` lifecycle and lands in `skills.lock` (`source = "plugin"`) with its content digest, so sync/drift checks treat it like any local install.
- A malformed skill is skipped with a diagnostic naming it; the rest of the pack still installs.
- No MCP server registration (out of scope, sibling slice).

## Proof (tests)

`tests/unit/skills/test_agent_plugins_install.py` — 8 cases:
- layout detection: conformant dir accepted; no manifest / no name field / invalid JSON all rejected
- install: 3-skill pack all installed with digests; malformed skill skipped and reported by name; non-plugin dir raises; lockfile rows written for every installed skill

Verify commands all green:
```
uv run pytest tests/unit/skills/test_agent_plugins_install.py -q      # 8 passed
uv run pytest tests/unit/skills/test_lifecycle_install.py tests/unit/skills/test_plugin_source.py -q  # 25 passed (regression)
uv run ruff check src/bernstein/cli/commands/skills_cmd.py src/bernstein/core/skills/lifecycle.py tests/unit/skills/test_agent_plugins_install.py  # clean
uv run mypy src/bernstein/core/skills/lifecycle.py src/bernstein/cli/commands/skills_cmd.py  # clean
```

Docs: Agent Plugins section added to `docs/operations/skills-catalog.md`.