### PR TITLE
ci(release): fail publish when the docker-mcp catalog pins a stale source.commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -605,6 +605,34 @@ jobs:
             echo "::error::server.json version $MANIFEST_VERSION does not match release $VERSION"
             exit 1
           fi
+      - name: Check docker-mcp catalog source.commit matches the release commit
+        run: |
+          set -euo pipefail
+          # server.yaml is hand-maintained: the commit hash cannot be known
+          # before the release commit exists, so nothing regenerates it. This
+          # step catches a forgotten refresh before the catalog PR ships a
+          # source.commit that does not point at the release being submitted.
+          python3 - <<'PY'
+          import re
+          import subprocess
+          from pathlib import Path
+
+          text = Path("packaging/docker-mcp/server.yaml").read_text(encoding="utf-8")
+          match = re.search(r"^  commit:\s*([0-9a-f]{40})\s*$", text, re.MULTILINE)
+          if not match:
+              print("::error::packaging/docker-mcp/server.yaml has no valid source.commit (40-char lowercase hex SHA)")
+              raise SystemExit(1)
+          pinned = match.group(1)
+          head = subprocess.run(
+              ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+          ).stdout.strip()
+          if pinned != head:
+              print(
+                  f"::error::packaging/docker-mcp/server.yaml source.commit {pinned} does not match "
+                  f"the release commit {head}; refresh it before opening the catalog PR"
+              )
+              raise SystemExit(1)
+          PY
       - name: Install mcp-publisher
         env:
           # Pinned mcp-publisher release. Bumping requires updating the tag and

--- a/tests/unit/test_distribution_manifests.py
+++ b/tests/unit/test_distribution_manifests.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 import tomllib
@@ -369,6 +370,34 @@ def test_dockerfile_has_mcp_registry_server_name_label() -> None:
     server_name = _json.loads((_REPO / "server.json").read_text(encoding="utf-8"))["name"]
     assert "io.modelcontextprotocol.server.name" in dockerfile
     assert server_name in dockerfile
+
+
+def test_docker_mcp_catalog_source_commit_and_project_are_valid() -> None:
+    """The Docker MCP catalog entry must pin a real commit and the right repo.
+
+    ``packaging/docker-mcp/server.yaml`` is hand-maintained: the commit hash
+    cannot be known before the release commit exists, so nothing regenerates
+    it. This pins the two fields the catalog validator enforces - a 40-char
+    lowercase hex SHA and a ``source.project`` that agrees with the
+    ``server.json`` repository URL - so a stale or mis-targeted entry fails at
+    commit time instead of at catalog review.
+    """
+    import yaml
+
+    catalog = yaml.safe_load(
+        (_REPO / "packaging" / "docker-mcp" / "server.yaml").read_text(encoding="utf-8")
+    )
+    commit = catalog["source"]["commit"]
+    assert re.fullmatch(r"[0-9a-f]{40}", commit), (
+        f"server.yaml source.commit {commit!r} is not a 40-char lowercase hex SHA"
+    )
+
+    project = catalog["source"]["project"]
+    server = json.loads((_REPO / "server.json").read_text(encoding="utf-8"))
+    assert project == server["repository"]["url"], (
+        f"server.yaml source.project {project!r} does not match "
+        f"server.json repository.url {server['repository']['url']!r}"
+    )
 
 
 def test_publish_workflow_mcp_registry_is_idempotent() -> None:


### PR DESCRIPTION
Closes #3646

## Problem
#4166 taught the MCP capability card to advertise repo and build provenance, but the Docker MCP catalog entry (`packaging/docker-mcp/server.yaml`) is hand-maintained: its `source.commit` cannot be known before the release commit exists, and nothing regenerated or checked it. A release could ship a catalog PR whose pinned commit points at the previous release.

## Change
- `.github/workflows/publish.yml`: a release-time step fails the publish when `server.yaml`'s `source.commit` is not the release commit (`git rev-parse HEAD`), with an actionable `::error::` message.
- `tests/unit/test_distribution_manifests.py`: unit test pinning the manifest shape — `source.commit` must be a 40-char lowercase SHA and the project URL must name this repo.

## Verification
- `ruff check` + `pytest tests/unit/test_distribution_manifests.py` — passed (host gate before publish).

---
_Generated from Bernstein session `1787557831`, body edited by the operator._

bernstein-session-id: 1787557831
