### PR TITLE
feat(checkpoint): bind the adapter and model a checkpoint resumes under

### DIFF
--- a/src/bernstein/cli/commands/resume_cmd.py
+++ b/src/bernstein/cli/commands/resume_cmd.py
@@ -77,6 +77,7 @@ def prepare_resume(
     task_id: str,
     *,
     hooks: HookRegistry | None = None,
+    override_interpreter: bool = False,
 ) -> ResumePlan:
     """Load + validate the checkpoint, bump ``resume_count``, fire the hook.
 
@@ -84,6 +85,9 @@ def prepare_resume(
         workdir: Project root containing ``.sdd/runtime/checkpoints``.
         task_id: Task to resume.
         hooks: Optional registry; ``task.resume`` fires on it when given.
+        override_interpreter: When ``True``, bypass the interpreter mismatch
+            check (``--override-interpreter``) so a resume proceeds even
+            though the adapter or resolved model moved.
 
     Returns:
         A :class:`ResumePlan` ready for the orchestrator.
@@ -95,19 +99,27 @@ def prepare_resume(
     """
     # Reading once before the bump gives us a clear error path: if the
     # file is corrupt we exit before incrementing the counter.
-    load_checkpoint(workdir, task_id)
+    checkpoint = load_checkpoint(workdir, task_id)
 
-    # --- Grant authority check (issue #3649) ---
+    # --- Grant + interpreter authority checks (issues #3649, #3852) ---
     # Look up the AgentCheckpoint for this task (written by the orchestrator
     # at suspend time).  Checkpoints are stored per agent, so the lookup
     # scans for the task rather than treating the task id as an agent id.
     # If the checkpoint carries a grant_hash we verify the current
     # configuration still matches before taking any side effect (bump,
-    # hook, signal); a stale grant refuses with the bindings named.
+    # hook, signal); a stale grant refuses with the bindings named.  The
+    # same pre-side-effect gate verifies the interpreter (adapter + resolved
+    # model) still matches, unless the operator overrides it.
     _runtime_dir = workdir / ".sdd" / "runtime"
     _agent_checkpoint = find_checkpoint_for_task(task_id, _runtime_dir)
     if _agent_checkpoint is not None:
-        _ok, _reason = is_checkpoint_recoverable(_agent_checkpoint, current_task_id=task_id)
+        _ok, _reason = is_checkpoint_recoverable(
+            _agent_checkpoint,
+            current_task_id=task_id,
+            current_adapter=checkpoint.adapter or None,
+            current_model=checkpoint.meta.get("model") or None,
+            override_interpreter=override_interpreter,
+        )
         if not _ok:
             raise GrantRefusedError(_reason)
 
@@ -205,7 +217,19 @@ def _render_plan(workdir: Path, plan: ResumePlan, *, output_json: bool) -> None:
     default=False,
     help="Validate + bump resume_count + print plan; do not re-spawn.",
 )
-def resume_cmd(task_id: str, workdir: Path | None, output_json: bool, dry_run: bool) -> None:
+@click.option(
+    "--override-interpreter",
+    is_flag=True,
+    default=False,
+    help="Resume even though the adapter or resolved model moved since suspend.",
+)
+def resume_cmd(
+    task_id: str,
+    workdir: Path | None,
+    output_json: bool,
+    dry_run: bool,
+    override_interpreter: bool,
+) -> None:
     """Pick up a paused/killed/crashed task from its last checkpoint.
 
     \b
@@ -218,7 +242,7 @@ def resume_cmd(task_id: str, workdir: Path | None, output_json: bool, dry_run: b
     """
     project_root = workdir or Path.cwd()
     try:
-        plan = prepare_resume(project_root, task_id)
+        plan = prepare_resume(project_root, task_id, override_interpreter=override_interpreter)
     except CheckpointMissingError as exc:
         console.print(f"[red]No checkpoint:[/red] {exc}")
         _hint_work_ledger(project_root, task_id)

--- a/src/bernstein/core/persistence/agent_checkpoint.py
+++ b/src/bernstein/core/persistence/agent_checkpoint.py
@@ -85,6 +85,29 @@ def compute_grant_hash(
     return hashlib.sha256(payload).hexdigest()
 
 
+def compute_interpreter_hash(adapter: str, model: str) -> str:
+    """Stable SHA-256 of the interpreter (adapter + resolved model).
+
+    Binds the adapter registry name and the *resolved* model identity -- not
+    the requested string -- so ``model: auto`` is captured as whatever it
+    resolved to, or the field proves nothing.  Stable across processes and
+    Python runs: the same inputs always produce the same hash.
+
+    Args:
+        adapter: Adapter registry name (e.g. ``"claude_code"``).
+        model: Resolved model identity the adapter ran under.
+
+    Returns:
+        Lowercase hex SHA-256 string.
+    """
+    payload = json.dumps(
+        {"adapter": adapter, "model": model},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
 def checkpoint_hash(checkpoint: AgentCheckpoint) -> str:
     """Stable SHA-256 fingerprint of an :class:`AgentCheckpoint`.
 
@@ -119,6 +142,13 @@ class ContinuationEntry:
         grant_hash: SHA-256 of the grant that was live at suspend time.
         chain_head_at_suspend: Journal Merkle-head at the moment of suspension.
         chain_head_at_resume: Journal Merkle-head at the moment of resumption.
+        interpreter_hash: SHA-256 of the interpreter (adapter + resolved
+            model) the suspended run ran under, so a verifier with no
+            filesystem access can tell the resumed run ran under the same
+            interpreter.
+        interpreter_overridden: Whether the operator forced the resume past an
+            interpreter mismatch (``--override-interpreter``). A later reader
+            can distinguish an overridden resume from a clean one.
         resumed_at: Unix timestamp of resumption.
     """
 
@@ -126,6 +156,8 @@ class ContinuationEntry:
     grant_hash: str
     chain_head_at_suspend: str
     chain_head_at_resume: str
+    interpreter_hash: str = ""
+    interpreter_overridden: bool = False
     resumed_at: float = field(default_factory=time.time)
 
 
@@ -168,6 +200,10 @@ class AgentCheckpoint:
     grant_hash: str = ""
     parent_run_id: str = ""
     chain_head_at_suspend: str = ""
+    # --- interpreter fields (issue #3852) ---
+    adapter: str = ""
+    model: str = ""
+    interpreter_hash: str = ""
 
 
 def save_checkpoint(checkpoint: AgentCheckpoint, runtime_dir: Path) -> Path:
@@ -298,6 +334,9 @@ def is_checkpoint_recoverable(
     current_task_id: str | None = None,
     current_parent_run_id: str | None = None,
     current_chain_head: str | None = None,
+    current_adapter: str | None = None,
+    current_model: str | None = None,
+    override_interpreter: bool = False,
 ) -> tuple[bool, str]:
     """Check if a checkpoint can be recovered.
 
@@ -318,10 +357,16 @@ def is_checkpoint_recoverable(
         current_task_id: The task id currently assigned.
         current_parent_run_id: The parent run id currently assigned.
         current_chain_head: The current journal chain head.
+        current_adapter: The adapter the task would resume under.
+        current_model: The resolved model the task would resume under.
+        override_interpreter: When ``True``, bypass the interpreter mismatch
+            check (``--override-interpreter``) so the resume proceeds even
+            though the adapter or resolved model moved.
 
     Returns:
-        ``(recoverable, reason)``. Recoverable if the grant still holds and
-        the worktree has uncommitted changes that can be resumed.
+        ``(recoverable, reason)``. Recoverable if the grant still holds, the
+        interpreter (when recorded) still matches, and the worktree has
+        uncommitted changes that can be resumed.
     """
     # --- Authority check (must happen before any side effect) ---
     if not checkpoint.grant_hash:
@@ -359,6 +404,34 @@ def is_checkpoint_recoverable(
                 )
             else:
                 reason = "grant mismatch — role permissions (allowed_paths/denied_paths) changed"
+            return False, reason
+
+    # --- Interpreter check (issue #3852) ---
+    # A checkpoint written before this field existed carries no interpreter
+    # identity. It loads without error and the check is skipped (with a
+    # warning) rather than silently treated as a clean match; the resume
+    # proceeds with liveness checks only.
+    if not checkpoint.interpreter_hash:
+        logger.warning(
+            "checkpoint for task %s has no interpreter_hash -- interpreter check skipped; "
+            "resume proceeds with liveness checks only",
+            checkpoint.task_id,
+        )
+    elif not override_interpreter:
+        current_hash = compute_interpreter_hash(
+            adapter=current_adapter if current_adapter is not None else checkpoint.adapter,
+            model=current_model if current_model is not None else checkpoint.model,
+        )
+        if current_hash != checkpoint.interpreter_hash:
+            changes = []
+            if current_adapter is not None and current_adapter != checkpoint.adapter:
+                changes.append("adapter changed")
+            if current_model is not None and current_model != checkpoint.model:
+                changes.append("model changed")
+            if changes:
+                reason = f"interpreter mismatch — {', '.join(changes)}"
+            else:
+                reason = "interpreter mismatch — resolved interpreter changed"
             return False, reason
 
     # --- Liveness checks (only reached when grant is valid or absent) ---
@@ -412,6 +485,7 @@ def build_continuation_entry(
     checkpoint: AgentCheckpoint,
     *,
     chain_head_at_resume: str = "",
+    interpreter_overridden: bool = False,
 ) -> ContinuationEntry:
     """Build the authenticated journal entry for a successful resume.
 
@@ -426,6 +500,9 @@ def build_continuation_entry(
     Args:
         checkpoint: The checkpoint that was verified and is now resuming.
         chain_head_at_resume: The journal Merkle-head at resumption time.
+        interpreter_overridden: Whether the operator forced the resume past an
+            interpreter mismatch (``--override-interpreter``). Recorded so a
+            later reader can tell an overridden resume from a clean one.
 
     Returns:
         A :class:`ContinuationEntry` ready to append to the journal.
@@ -435,6 +512,8 @@ def build_continuation_entry(
         grant_hash=checkpoint.grant_hash,
         chain_head_at_suspend=checkpoint.chain_head_at_suspend,
         chain_head_at_resume=chain_head_at_resume,
+        interpreter_hash=checkpoint.interpreter_hash,
+        interpreter_overridden=interpreter_overridden,
     )
 
 

--- a/src/bernstein/core/tasks/suspension.py
+++ b/src/bernstein/core/tasks/suspension.py
@@ -975,6 +975,7 @@ def park_task(
     role: str = "",
     permissions: AgentPermissions | None = None,
     parent_run_id: str = "",
+    model: str = "",
 ) -> ParkResult:
     """Durably park ``task_id``: row, receipt, releases, then ledger.
 
@@ -1006,6 +1007,8 @@ def park_task(
         role: Agent role name at suspend time.
         permissions: Live :class:`AgentPermissions` at suspend time.
         parent_run_id: Run that owns the task.
+        model: The *resolved* model string the adapter ran under at suspend
+            time (``auto`` captured as whatever it resolved to).
 
     Returns:
         A :class:`ParkResult` with the row, receipt hash, release outcome, and
@@ -1017,7 +1020,12 @@ def park_task(
             path would later refuse.
     """
     from bernstein.core.cost.budget_actions import compute_released_headroom
-    from bernstein.core.persistence.agent_checkpoint import AgentCheckpoint, compute_grant_hash, save_checkpoint
+    from bernstein.core.persistence.agent_checkpoint import (
+        AgentCheckpoint,
+        compute_grant_hash,
+        compute_interpreter_hash,
+        save_checkpoint,
+    )
     from bernstein.core.persistence.work_ledger import KIND_TASK_SUSPENDED
     from bernstein.core.security.audit_chain import record_task_suspension
 
@@ -1078,6 +1086,9 @@ def park_task(
         grant_hash=grant_hash,
         parent_run_id=parent_run_id,
         chain_head_at_suspend=suspend_row.event_hash,
+        adapter=adapter,
+        model=model,
+        interpreter_hash=compute_interpreter_hash(adapter, model) if adapter else "",
     )
     save_checkpoint(checkpoint, sdd_dir / "runtime")
 
@@ -1184,6 +1195,7 @@ def resume_task(
     requested_mode: RetryMode | str = RetryMode.WARM,
     ledger: WorkLedger | None = None,
     approval_ref: str = "",
+    override_interpreter: bool = False,
 ) -> ResumeResult:
     """Durably resume a parked task from its suspend row.
 
@@ -1201,6 +1213,10 @@ def resume_task(
         requested_mode: Operator-requested continuation mode (default warm).
         ledger: Optional work ledger to persist the RESUMED transition.
         approval_ref: Approval decision digest for an ``--until approval`` park.
+        override_interpreter: Whether the operator forced the resume past an
+            interpreter mismatch (``--override-interpreter``); recorded in the
+            continuation row so a later reader can tell an overridden resume
+            from a clean one.
 
     Returns:
         A :class:`ResumeResult` with the decision and both continuity anchors.
@@ -1300,7 +1316,11 @@ def resume_task(
             build_continuation_entry as _bce,
         )
 
-        _entry = _bce(_cp_for_cont, chain_head_at_resume=resume_event_hash)
+        _entry = _bce(
+            _cp_for_cont,
+            chain_head_at_resume=resume_event_hash,
+            interpreter_overridden=override_interpreter,
+        )
         journal.record(
             JOURNAL_EVENT_GRANT_CONTINUATION,
             task_id=suspend_row.task_id,
@@ -1308,6 +1328,8 @@ def resume_task(
             grant_hash=_entry.grant_hash,
             chain_head_at_suspend=_entry.chain_head_at_suspend,
             chain_head_at_resume=_entry.chain_head_at_resume,
+            interpreter_hash=_entry.interpreter_hash,
+            interpreter_overridden=_entry.interpreter_overridden,
         )
 
     receipt = record_task_resume(

--- a/tests/unit/test_agent_checkpoint.py
+++ b/tests/unit/test_agent_checkpoint.py
@@ -11,7 +11,10 @@ import pytest
 
 from bernstein.core.persistence.agent_checkpoint import (
     AgentCheckpoint,
+    ContinuationEntry,
+    build_continuation_entry,
     build_resume_prompt,
+    compute_interpreter_hash,
     is_checkpoint_recoverable,
     load_checkpoint,
     save_checkpoint,
@@ -286,3 +289,132 @@ def test_build_resume_prompt_contains_instructions() -> None:
     # Must tell the agent NOT to restart from scratch
     assert "Do NOT restart" in prompt
     assert "Resuming from checkpoint" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Interpreter identity (issue #3852)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_interpreter_hash_is_stable() -> None:
+    h1 = compute_interpreter_hash("claude_code", "claude-sonnet-4-5")
+    h2 = compute_interpreter_hash("claude_code", "claude-sonnet-4-5")
+    assert h1 == h2
+    assert len(h1) == 64  # SHA-256 hex
+
+
+def test_compute_interpreter_hash_sensitive_to_adapter_and_model() -> None:
+    base = compute_interpreter_hash("claude_code", "claude-sonnet-4-5")
+    assert compute_interpreter_hash("codex", "claude-sonnet-4-5") != base
+    assert compute_interpreter_hash("claude_code", "claude-opus-4-5") != base
+
+
+def test_compute_interpreter_hash_stable_across_processes() -> None:
+    import subprocess
+    import sys
+
+    code = (
+        "from bernstein.core.persistence.agent_checkpoint import compute_interpreter_hash; "
+        "print(compute_interpreter_hash('claude_code', 'claude-sonnet-4-5'))"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert out.stdout.strip() == compute_interpreter_hash("claude_code", "claude-sonnet-4-5")
+
+
+def test_resume_refuses_when_adapter_changed_before_side_effects(tmp_path: Path) -> None:
+    # Suspended under adapter A; resume would run under adapter B. The refusal
+    # must happen before any filesystem side effect, so the worktree path is
+    # deliberately missing: an interpreter-first check reports the mismatch,
+    # not "worktree missing".
+    checkpoint = AgentCheckpoint(
+        agent_id="agent-1",
+        task_id="task-1",
+        worktree_path=str(tmp_path / "does-not-exist"),
+        adapter="adapter_a",
+        model="model-x",
+        interpreter_hash=compute_interpreter_hash("adapter_a", "model-x"),
+    )
+    recoverable, reason = is_checkpoint_recoverable(
+        checkpoint,
+        current_adapter="adapter_b",
+        current_model="model-x",
+    )
+    assert recoverable is False
+    assert "interpreter mismatch" in reason
+    assert "adapter changed" in reason
+    assert "worktree missing" not in reason  # refused before liveness checks
+
+
+def test_resume_refuses_when_resolved_model_changed_alias(tmp_path: Path) -> None:
+    # Same adapter, same *requested* model string, but the resolved model
+    # moved. This is the case that separates recording the request from
+    # recording what actually ran.
+    checkpoint = AgentCheckpoint(
+        agent_id="agent-1",
+        task_id="task-1",
+        worktree_path=str(tmp_path / "does-not-exist"),
+        adapter="adapter_a",
+        model="resolved-model-1",
+        interpreter_hash=compute_interpreter_hash("adapter_a", "resolved-model-1"),
+    )
+    recoverable, reason = is_checkpoint_recoverable(
+        checkpoint,
+        current_adapter="adapter_a",
+        current_model="resolved-model-2",
+    )
+    assert recoverable is False
+    assert "interpreter mismatch" in reason
+    assert "model changed" in reason
+
+
+def test_older_checkpoint_without_interpreter_hash_loads_and_passes(tmp_path: Path) -> None:
+    # A checkpoint written before the interpreter field existed has an empty
+    # interpreter_hash. It must load without error and pass the recoverability
+    # check (the interpreter check is skipped, not silently treated as a
+    # clean match).
+    checkpoint = _make_checkpoint(worktree_path=str(tmp_path))
+    save_checkpoint(checkpoint, tmp_path)
+    loaded = load_checkpoint("agent-1", tmp_path)
+    assert loaded is not None
+    assert loaded.interpreter_hash == ""
+
+    _init_git_repo(tmp_path)
+    (tmp_path / "new_file.py").write_text("print('hi')\n")
+    recoverable, reason = is_checkpoint_recoverable(loaded)
+    assert recoverable is True
+    assert "uncommitted" in reason
+
+
+def test_override_interpreter_allows_resume_and_records_in_chain(tmp_path: Path) -> None:
+    # Suspended under adapter A, resume would run under adapter B, but the
+    # operator passes --override-interpreter. The resume is allowed and the
+    # continuation entry records the override so a later reader can tell an
+    # overridden resume from a clean one.
+    checkpoint = AgentCheckpoint(
+        agent_id="agent-1",
+        task_id="task-1",
+        worktree_path=str(tmp_path),
+        adapter="adapter_a",
+        model="model-x",
+        interpreter_hash=compute_interpreter_hash("adapter_a", "model-x"),
+    )
+    _init_git_repo(tmp_path)
+    (tmp_path / "new_file.py").write_text("print('hi')\n")
+
+    recoverable, _reason = is_checkpoint_recoverable(
+        checkpoint,
+        current_adapter="adapter_b",
+        current_model="model-x",
+        override_interpreter=True,
+    )
+    assert recoverable is True
+
+    entry = build_continuation_entry(checkpoint, interpreter_overridden=True)
+    assert isinstance(entry, ContinuationEntry)
+    assert entry.interpreter_hash == checkpoint.interpreter_hash
+    assert entry.interpreter_overridden is True


### PR DESCRIPTION
Closes #3852

## Summary
- Resolve GitHub issue #3852: Bind the adapter and model a checkpoint will resume under

Follow-on to #3649
- Slices 1-4 bind what a checkpoint was *permitted* to do
- None binds *who* will do it on resume

## Changes
```
src/bernstein/cli/commands/resume_cmd.py           |  36 +++++-
 src/bernstein/core/persistence/agent_checkpoint.py |  83 ++++++++++++-
 src/bernstein/core/tasks/suspension.py             |  26 +++-
 tests/unit/test_agent_checkpoint.py                | 132 +++++++++++++++++++++
 4 files changed, 267 insertions(+), 10 deletions(-)
```

## Verification
- Host gate before publish: ruff check + pytest tests/unit/test_agent_checkpoint.py - passed.

---
_Generated from Bernstein session `1787557991`._

bernstein-session-id: 1787557991

---
Made by bernstein v3.17.1 - unattended run `run-20260824T075249p3757278Z`, no operator in the loop.
