### PR TITLE
test: wire record_persistent_agent_step tests into both spawn paths

### DIFF
--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -94,7 +94,6 @@ from bernstein.core.agents.spawner_worktree import (
     release_warm_pool_slot,
     worktree_manager_for_repo,
 )
-from bernstein.core.evidence.run_artifacts import record_persistent_agent_step
 from bernstein.core.agents.spawner_worktree import (
     cleanup_worktree as _cleanup_worktree,
 )
@@ -104,6 +103,7 @@ from bernstein.core.agents.spawner_worktree import (
 from bernstein.core.context import TaskContextBuilder
 from bernstein.core.context_recommendations import RecommendationEngine
 from bernstein.core.defaults import SPAWN
+from bernstein.core.evidence.run_artifacts import record_persistent_agent_step
 from bernstein.core.lessons import gather_lessons_for_context
 from bernstein.core.lifecycle import transition_agent
 from bernstein.core.models import (

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -94,6 +94,7 @@ from bernstein.core.agents.spawner_worktree import (
     release_warm_pool_slot,
     worktree_manager_for_repo,
 )
+from bernstein.core.evidence.run_artifacts import record_persistent_agent_step
 from bernstein.core.agents.spawner_worktree import (
     cleanup_worktree as _cleanup_worktree,
 )
@@ -4878,6 +4879,10 @@ class AgentSpawner:
             except Exception as exc:
                 logger.warning("Failed to write initial trace for %s: %s", session_id, exc)
 
+            # Record persistent-agent step for each task if adapter is persistent
+            for _t in tasks:
+                record_persistent_agent_step(self._workdir / ".sdd", _t.id, adapter_name)
+
             get_plugin_manager().fire_agent_spawned(
                 session_id=session.id, role=session.role, model=session.model_config.model
             )
@@ -5239,6 +5244,10 @@ class AgentSpawner:
 
         # Track worktree so reap_completed_agent can merge+clean up
         self._worktree_paths[session_id] = worktree_path
+
+        # Record persistent-agent step for each task if adapter is persistent
+        for _t in tasks:
+            record_persistent_agent_step(self._workdir / ".sdd", _t.id, self._adapter.name())
 
         return session
 

--- a/tests/unit/test_spawner_persistent_agent_wiring.py
+++ b/tests/unit/test_spawner_persistent_agent_wiring.py
@@ -1,0 +1,268 @@
+"""Verify ``record_persistent_agent_step`` is wired into both spawn paths.
+
+Tests confirm that the journal event is emitted through the real spawn
+flow (not just the unit-tested helper), and that the evidence-bundle
+verdict reflects the presence of the persistent-agent event.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock as unittest_mock
+
+from bernstein.adapters._contract import AdapterStrategy, SessionState
+from bernstein.core.defaults import JOURNAL_EVENT_PERSISTENT_AGENT_STEP
+from bernstein.core.evidence.run_artifacts import (
+    ArtifactPayload,
+    post_run_artifact,
+    verify_run_artifacts,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_KEY = b"agent-step-wiring-test-hmac-key-012345"
+
+
+def _sdd(tmp_path: Path) -> Path:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir(exist_ok=True)
+    return sdd
+
+
+# ---------------------------------------------------------------------------
+# Primary spawn path (spawn_for_tasks)
+# ---------------------------------------------------------------------------
+
+
+class TestPrimarySpawnWiring:
+    """Wiring in ``_spawn_for_tasks_internal`` — the main spawn path."""
+
+    def test_persistent_adapter_records_step(
+        self,
+        tmp_path: Path,
+        make_task,
+        mock_adapter_factory,
+    ) -> None:
+        """A persistent-agent adapter creates a ``persistent_agent_step`` journal event."""
+        adapter = mock_adapter_factory(pid=100)
+        adapter.name.return_value = "persistent-test"
+
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+
+        from bernstein.core.spawner import AgentSpawner
+
+        spawner = AgentSpawner(
+            adapter,
+            templates_dir,
+            tmp_path,
+            use_worktrees=False,
+            default_model="mock-model",
+        )
+
+        task = make_task()
+        with unittest_mock.patch(
+            "bernstein.adapters._contract.STRATEGY_MATRIX",
+            {"persistent-test": AdapterStrategy(session_state=SessionState.PERSISTENT_AGENT)},
+        ):
+            session = spawner.spawn_for_tasks([task])
+
+        assert session.task_ids == ["T-001"]
+
+        from bernstein.core.replay.journal import load_events
+
+        journal_path = tmp_path / ".sdd" / "runs" / "task-T-001" / "journal.jsonl"
+        assert journal_path.is_file(), "persistent-agent adapter must create a journal"
+        events = load_events(journal_path).events
+        step_events = [
+            r for r in events if str(r.get("event", "")) == JOURNAL_EVENT_PERSISTENT_AGENT_STEP
+        ]
+        assert len(step_events) == 1
+        assert step_events[0]["task_id"] == "T-001"
+        assert step_events[0]["adapter"] == "persistent-test"
+
+    def test_stateless_adapter_records_no_step(
+        self,
+        tmp_path: Path,
+        make_task,
+        mock_adapter_factory,
+    ) -> None:
+        """A stateless adapter must not create a journal — runs stay byte-identical."""
+        adapter = mock_adapter_factory(pid=100)
+
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+
+        from bernstein.core.spawner import AgentSpawner
+
+        spawner = AgentSpawner(
+            adapter,
+            templates_dir,
+            tmp_path,
+            use_worktrees=False,
+            default_model="mock-model",
+        )
+
+        task = make_task()
+        session = spawner.spawn_for_tasks([task])
+
+        assert session.task_ids == ["T-001"]
+
+        journal_path = tmp_path / ".sdd" / "runs" / "task-T-001" / "journal.jsonl"
+        assert not journal_path.is_file(), "stateless adapter must not create a journal"
+
+    def test_persistent_step_forces_unverifiable_identity(
+        self,
+        tmp_path: Path,
+        make_task,
+        mock_adapter_factory,
+    ) -> None:
+        """After a persistent-agent spawn, ``verify_run_artifacts`` reports unverifiable."""
+        adapter = mock_adapter_factory(pid=100)
+        adapter.name.return_value = "persistent-test"
+
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+
+        from bernstein.core.spawner import AgentSpawner
+
+        spawner = AgentSpawner(
+            adapter,
+            templates_dir,
+            tmp_path,
+            use_worktrees=False,
+            default_model="mock-model",
+        )
+
+        task = make_task()
+        with unittest_mock.patch(
+            "bernstein.adapters._contract.STRATEGY_MATRIX",
+            {"persistent-test": AdapterStrategy(session_state=SessionState.PERSISTENT_AGENT)},
+        ):
+            spawner.spawn_for_tasks([task])
+
+        sdd = _sdd(tmp_path)
+        post_run_artifact(
+            sdd_dir=sdd,
+            task_id="T-001",
+            key="report",
+            payload=ArtifactPayload.report("# Wiring Test"),
+            actor="worker",
+            hmac_key=_KEY,
+        )
+
+        results = verify_run_artifacts(sdd, "T-001", hmac_key=_KEY)
+        assert len(results) == 1
+        assert results[0].ok, results[0].reason
+        assert results[0].journal_identity == "unverifiable"
+
+
+# ---------------------------------------------------------------------------
+# Crash-resume spawn path (spawn_for_resume)
+# ---------------------------------------------------------------------------
+
+
+class TestResumeSpawnWiring:
+    """Wiring in ``spawn_for_resume`` — the crash-recovery path."""
+
+    def test_persistent_adapter_records_step_on_resume(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A persistent-agent adapter records the journal event on resume spawn."""
+        from unittest.mock import MagicMock
+
+        from bernstein.core.models import Task
+        from bernstein.core.spawner import AgentSpawner
+
+        from bernstein.adapters.base import CLIAdapter, SpawnResult
+
+        adapter = MagicMock(spec=CLIAdapter)
+        adapter.spawn.return_value = SpawnResult(pid=200, proc=None, log_path=None)
+        adapter.is_alive.return_value = True
+        adapter.is_rate_limited.return_value = False
+        adapter.name.return_value = "persistent-test"
+
+        spawner = AgentSpawner(
+            adapter,
+            tmp_path / "templates",
+            tmp_path,
+            default_model="mock-model",
+        )
+
+        worktree_path = tmp_path / ".sdd" / "worktrees" / "old-session"
+        worktree_path.mkdir(parents=True)
+
+        task = Task(
+            id="T-R01",
+            title="Resume task",
+            description="Continue.",
+            role="backend",
+        )
+
+        with unittest_mock.patch(
+            "bernstein.adapters._contract.STRATEGY_MATRIX",
+            {"persistent-test": AdapterStrategy(session_state=SessionState.PERSISTENT_AGENT)},
+        ):
+            session = spawner.spawn_for_resume(
+                [task], worktree_path=worktree_path, changed_files=[]
+            )
+
+        assert session.task_ids == ["T-R01"]
+
+        from bernstein.core.replay.journal import load_events
+
+        journal_path = tmp_path / ".sdd" / "runs" / "task-T-R01" / "journal.jsonl"
+        assert journal_path.is_file(), "persistent-agent resume must create a journal"
+        events = load_events(journal_path).events
+        step_events = [
+            r for r in events if str(r.get("event", "")) == JOURNAL_EVENT_PERSISTENT_AGENT_STEP
+        ]
+        assert len(step_events) == 1
+        assert step_events[0]["task_id"] == "T-R01"
+        assert step_events[0]["adapter"] == "persistent-test"
+
+    def test_stateless_adapter_records_no_step_on_resume(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A stateless adapter must not create a journal on resume — byte-identical."""
+        from unittest.mock import MagicMock
+
+        from bernstein.core.models import Task
+        from bernstein.core.spawner import AgentSpawner
+
+        from bernstein.adapters.base import CLIAdapter, SpawnResult
+
+        adapter = MagicMock(spec=CLIAdapter)
+        adapter.spawn.return_value = SpawnResult(pid=200, proc=None, log_path=None)
+        adapter.is_alive.return_value = True
+        adapter.is_rate_limited.return_value = False
+
+        spawner = AgentSpawner(
+            adapter,
+            tmp_path / "templates",
+            tmp_path,
+            default_model="mock-model",
+        )
+
+        worktree_path = tmp_path / ".sdd" / "worktrees" / "old-session"
+        worktree_path.mkdir(parents=True)
+
+        task = Task(
+            id="T-R02",
+            title="Resume task",
+            description="Continue.",
+            role="backend",
+        )
+
+        session = spawner.spawn_for_resume(
+            [task], worktree_path=worktree_path, changed_files=[]
+        )
+
+        assert session.task_ids == ["T-R02"]
+
+        journal_path = tmp_path / ".sdd" / "runs" / "task-T-R02" / "journal.jsonl"
+        assert not journal_path.is_file(), "stateless adapter must not create a journal on resume"


### PR DESCRIPTION
Closes #3670

## Problem
The adapter contract has no axis for agent-side persistent state, so a stateful spawn path could drop `record_persistent_agent_step` without any test noticing.

## Change
- `src/bernstein/core/agents/spawner_core.py`: wire `record_persistent_agent_step` into both spawn paths (+9).
- `tests/unit/test_spawner_persistent_agent_wiring.py`: cover both paths so a future refactor that skips the call fails a test rather than silently losing the step record.

## Verification
- `ruff check` + `pytest tests/unit/test_spawner_persistent_agent_wiring.py` — passed (host gate before publish).


---
_Generated from a Bernstein unattended run; body edited by the operator (session wrap-up id was lost with the workspace reset)._

---
Made by bernstein v3.17.2 - unattended run `run-20260824T091039p3917526Z`, no operator in the loop.
