### PR TITLE
fix(orchestration): stand down the watchdog after a clean quiescence self-stop

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -14,3 +14,7 @@ rather than as its own attribution is exempted by hand there, with the reason.
 ## Nightly dependency audit is green again
 
 The nightly full-closure audit runs `pip-audit --strict` over the dev closure and had failed since 2026-08-22 on `pip` 26.1.2 (PYSEC-2026-3721). A permanently red nightly hides the next real advisory behind it. `pip` is bumped to 26.2.1 in the lockfile.
+
+## Watchdog no longer restarts a run that already finished
+
+A clean quiescence self-stop journals `run_completed` and exits, but the recovery watchdog's stand-down check only recognised teardown in progress, so it restarted the orchestrator anyway — five times, until it gave up and logged a spurious error. The check now reads the run's own completion record before restarting it (#4445).

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -1015,7 +1015,7 @@ def _supervisor_should_stand_down(workdir: Path) -> str | None:
 
     Only POSITIVE evidence counts, because the default has to be to recover: a
     supervisor that withholds a restart on a merely ambiguous reading leaves the
-    run with no orchestrator and nothing to notice, permanently. Two signals
+    run with no orchestrator and nothing to notice, permanently. Three signals
     qualify:
 
     * ``.sdd/runtime/draining`` -- written by ``DrainCoordinator._phase_freeze``
@@ -1024,6 +1024,17 @@ def _supervisor_should_stand_down(workdir: Path) -> str | None:
     * ``watchdog.pid`` no longer naming this process -- we have been superseded
       or killed (teardown SIGTERMs it first), so we are not the supervisor of
       record any more and must not act as one.
+    * the run this supervisor's owner record names already journaled
+      ``run_completed`` -- written only by ``Orchestrator.run()``'s own
+      shutdown sequence, right before the process exits on a clean quiescence
+      self-stop (issue #4445). A crash never reaches that code: the process
+      dies before it can journal anything, so the row is absent and the
+      ordinary restart default is untouched. Reading the journal directly
+      (rather than the audit-chain closure marker ``_restart_spawner``
+      reconciles as bookkeeping) keeps this cheap enough to call every poll --
+      the marker it looks for is written once, at the very end of one run's
+      own small journal, not re-derived by re-verifying the whole project's
+      audit history.
 
     A missing pidfile for a SUPERVISED process is deliberately not on this list.
     It is the ordinary aftermath of a crash plus ``bernstein doctor --fix``, and
@@ -1040,6 +1051,17 @@ def _supervisor_should_stand_down(workdir: Path) -> str | None:
             return None
         if recorded != os.getpid():
             return f"watchdog.pid names pid {recorded}, not this supervisor ({os.getpid()})"
+
+    from bernstein.core.orchestration.run_closure_owner import read_spawner_run_owner
+    from bernstein.core.replay.journal import contained_run_journal, load_events
+
+    sdd_dir = workdir / ".sdd"
+    owner = read_spawner_run_owner(sdd_dir)
+    if owner is not None:
+        journal_path = contained_run_journal(sdd_dir / "runs", owner.run_id)
+        events = load_events(journal_path).events if journal_path is not None else []
+        if events and events[-1].get("event") == "run_completed":
+            return f"run {owner.run_id} already self-stopped cleanly (run_completed journaled)"
     return None
 
 

--- a/tests/integration/test_capability_matrix_spawn_refusal.py
+++ b/tests/integration/test_capability_matrix_spawn_refusal.py
@@ -983,8 +983,7 @@ class TestScalarFrontmatterTrifectaEnforcement:
         # Each listed tool is a full name, never a single character.
         for tool in manifest["tools"]:
             assert len(tool) > 1, (
-                f"Manifest tool {tool!r} is a single character — "
-                "scalar frontmatter was not split on comma"
+                f"Manifest tool {tool!r} is a single character — scalar frontmatter was not split on comma"
             )
         # The scalar-parsed tools must appear in full form in the manifest.
         # The spawner prepends the adapter tool, so the manifest has 4 entries.

--- a/tests/unit/test_distribution_manifests.py
+++ b/tests/unit/test_distribution_manifests.py
@@ -384,9 +384,7 @@ def test_docker_mcp_catalog_source_commit_and_project_are_valid() -> None:
     """
     import yaml
 
-    catalog = yaml.safe_load(
-        (_REPO / "packaging" / "docker-mcp" / "server.yaml").read_text(encoding="utf-8")
-    )
+    catalog = yaml.safe_load((_REPO / "packaging" / "docker-mcp" / "server.yaml").read_text(encoding="utf-8"))
     commit = catalog["source"]["commit"]
     assert re.fullmatch(r"[0-9a-f]{40}", commit), (
         f"server.yaml source.commit {commit!r} is not a 40-char lowercase hex SHA"

--- a/tests/unit/test_orchestrator_liveness_false_positives.py
+++ b/tests/unit/test_orchestrator_liveness_false_positives.py
@@ -523,3 +523,80 @@ def test_an_error_body_is_not_a_task_histogram(tmp_path: Path, monkeypatch: pyte
         n_incomplete, full_counts = rb._incomplete_declared_counts(STATUS_OPEN)
     assert full_counts == FULL_OPEN
     assert n_incomplete == 1
+
+
+# ---------------------------------------------------------------------------
+# Defect 6 (issue #4445): a cleanly completed run was restarted like a crash,
+# five times, until the restart budget was exhausted.
+# ---------------------------------------------------------------------------
+
+
+def _owned_run_journal(tmp_path: Path, *, run_id: str = "run-1", pid: int = DEAD_PID) -> Any:
+    """Write an owner record naming *pid* and return its open journal."""
+    from bernstein.core.orchestration.run_closure_owner import write_spawner_run_owner
+    from bernstein.core.replay.journal import EventJournal
+
+    journal = EventJournal(run_id, tmp_path / ".sdd")
+    journal.record("run_started", run_id=run_id)
+    write_spawner_run_owner(
+        sdd_dir=tmp_path / ".sdd",
+        run_id=run_id,
+        journal_head=journal.fingerprint(),
+        journal_event_count=journal.event_count(),
+        pid=pid,
+    )
+    return journal
+
+
+def test_supervisor_stands_down_after_a_clean_quiescence_self_stop(tmp_path: Path) -> None:
+    """The exact regression: a completed run was restarted like a crash.
+
+    ``Orchestrator.run()`` journals ``run_completed`` as the last thing it does
+    before a clean quiescence self-stop lets the process exit (the
+    ``tick-quiescence-self-stop`` / ``tick-loop-drain`` paths in
+    orchestrator.py). That marker is positive evidence the run is over, and
+    the supervisor must read it before deciding to restart -- not only after,
+    as bookkeeping inside the restart itself.
+    """
+    from bernstein.core.orchestration.bootstrap import _supervisor_should_stand_down
+
+    journal = _owned_run_journal(tmp_path)
+    journal.record("run_completed", run_id="run-1", outcome="completed")
+
+    assert _supervisor_should_stand_down(tmp_path) is not None
+
+
+def test_supervisor_still_restarts_a_crash_with_open_tasks(tmp_path: Path) -> None:
+    """The regression's twin: recovery must not weaken for a genuine crash.
+
+    A ``kill -9`` mid-run never reaches ``Orchestrator.run()``'s shutdown
+    sequence, so its journal has no ``run_completed`` row -- only the ordinary
+    in-flight events a live run produces. The supervisor must keep supervising.
+    """
+    from bernstein.core.orchestration.bootstrap import _supervisor_should_stand_down
+
+    journal = _owned_run_journal(tmp_path)
+    journal.record("task_claimed", run_id="run-1", task_id="t1")
+
+    assert _supervisor_should_stand_down(tmp_path) is None
+
+
+def test_supervisor_ignores_an_owner_record_with_no_journal(tmp_path: Path) -> None:
+    """An owner record naming a run whose journal doesn't exist must fail open.
+
+    Not the crash case (that one has SOME journal); this is what a corrupted
+    or hand-edited owner file leaves behind. Absence must read the same as
+    "not yet closed", never as "closed".
+    """
+    from bernstein.core.orchestration.bootstrap import _supervisor_should_stand_down
+    from bernstein.core.orchestration.run_closure_owner import write_spawner_run_owner
+
+    write_spawner_run_owner(
+        sdd_dir=tmp_path / ".sdd",
+        run_id="ghost-run",
+        journal_head="a" * 64,
+        journal_event_count=1,
+        pid=DEAD_PID,
+    )
+
+    assert _supervisor_should_stand_down(tmp_path) is None

--- a/tests/unit/test_spawner_persistent_agent_wiring.py
+++ b/tests/unit/test_spawner_persistent_agent_wiring.py
@@ -76,9 +76,7 @@ class TestPrimarySpawnWiring:
         journal_path = tmp_path / ".sdd" / "runs" / "task-T-001" / "journal.jsonl"
         assert journal_path.is_file(), "persistent-agent adapter must create a journal"
         events = load_events(journal_path).events
-        step_events = [
-            r for r in events if str(r.get("event", "")) == JOURNAL_EVENT_PERSISTENT_AGENT_STEP
-        ]
+        step_events = [r for r in events if str(r.get("event", "")) == JOURNAL_EVENT_PERSISTENT_AGENT_STEP]
         assert len(step_events) == 1
         assert step_events[0]["task_id"] == "T-001"
         assert step_events[0]["adapter"] == "persistent-test"
@@ -206,9 +204,7 @@ class TestResumeSpawnWiring:
             "bernstein.adapters._contract.STRATEGY_MATRIX",
             {"persistent-test": AdapterStrategy(session_state=SessionState.PERSISTENT_AGENT)},
         ):
-            session = spawner.spawn_for_resume(
-                [task], worktree_path=worktree_path, changed_files=[]
-            )
+            session = spawner.spawn_for_resume([task], worktree_path=worktree_path, changed_files=[])
 
         assert session.task_ids == ["T-R01"]
 
@@ -217,9 +213,7 @@ class TestResumeSpawnWiring:
         journal_path = tmp_path / ".sdd" / "runs" / "task-T-R01" / "journal.jsonl"
         assert journal_path.is_file(), "persistent-agent resume must create a journal"
         events = load_events(journal_path).events
-        step_events = [
-            r for r in events if str(r.get("event", "")) == JOURNAL_EVENT_PERSISTENT_AGENT_STEP
-        ]
+        step_events = [r for r in events if str(r.get("event", "")) == JOURNAL_EVENT_PERSISTENT_AGENT_STEP]
         assert len(step_events) == 1
         assert step_events[0]["task_id"] == "T-R01"
         assert step_events[0]["adapter"] == "persistent-test"
@@ -258,9 +252,7 @@ class TestResumeSpawnWiring:
             role="backend",
         )
 
-        session = spawner.spawn_for_resume(
-            [task], worktree_path=worktree_path, changed_files=[]
-        )
+        session = spawner.spawn_for_resume([task], worktree_path=worktree_path, changed_files=[])
 
         assert session.task_ids == ["T-R02"]
 


### PR DESCRIPTION
A run that self-stops on quiescence journals `run_completed` and exits cleanly, but the recovery watchdog's stand-down check only recognised the draining marker and a superseded `watchdog.pid` as terminal. Every completed run got restarted anyway, found no work, went quiescent again in seconds, and repeated until the restart budget ran out and an error got logged for a run that had already succeeded.

`_supervisor_should_stand_down` now also reads the owned run's own journal: a `run_completed` row is written only by the orchestrator's own shutdown path, never by a crash, so its presence is reliable evidence the run is over without re-deriving the whole audit chain on every poll. A crash still leaves no such row, so the existing restart default is unchanged for it.

Tested at the `_watchdog_check_process` / `_supervisor_should_stand_down` seam: a clean self-stop now stands the supervisor down, a crash with open tasks still restarts, and a corrupted owner record fails open instead of raising.

Closes #4445