### PR TITLE
feat(cli): add bernstein runs report

### DIFF
--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -239,6 +239,7 @@ test, and a row naming a command the CLI no longer registers fails it too.
 | `bernstein doctor` | Full | 4 | Pre-flight health check |
 | `bernstein recap` | Full | 3 | Post-run summary |
 | `bernstein retro` | Full | 3 | Retrospective report |
+| `bernstein runs report` | Full | 3 | Finished runs projected from the work ledger and classified `pr-opened` / `gate-failed` / `no-changes` / `infra-error` / `wedged`, each with the evidence line it was read from |
 | `bernstein report commits/incident/postmortem` | Brief | 3 | Per-run markdown summaries: `commits` is per-agent commit attribution ([reference](../operations/commit-attribution.md)); `incident` correlates a timeline from logs, metrics, and traces; `postmortem` writes a structured report for a failed run. The group has no reference page of its own; `cli-reference.md` and `bernstein report --help` carry it |
 | `bernstein trace ID` | Full | 3 | Decision trace |
 | `bernstein logs` | Full | 3 | Agent log tail |

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -345,6 +345,7 @@ hand-assembled as a request with a bearer header.
 | `bernstein retro` | Detailed retrospective. | `cli/commands/advanced_cmd.py:299` |
 | `bernstein wrap-up` | End-of-session summary. | `cli/wrap_up_cmd.py` |
 | `bernstein history` | Show run history. | `cli/maintenance_cmd.py:history_cmd` |
+| `bernstein runs report` | Finished runs with a classified outcome. | `cli/commands/runs_cmd.py` |
 | `bernstein report commits` | Per-run git diff stats. | `cli/commands/status_cmd.py:1232` |
 | `bernstein report` | Build a custom report (group). | `cli/report_cmd.py` |
 | `bernstein slo` | SLO dashboard. | `cli/slo_cmd.py:191` |
@@ -415,6 +416,30 @@ it still answers what happened after the run and its server have exited.
 | `--output FILE` / `-o` | `.sdd/runtime/retrospective.md` | Output path. |
 | `--print` | off | Also print to stdout. |
 | `--archive PATH` | `.sdd/archive/tasks.jsonl` | Source archive. |
+
+#### `bernstein runs`
+
+Group over the runs recorded in the work ledger.
+
+| Subcommand | Flags | Purpose |
+|---|---|---|
+| `report` | `--since DURATION`, `--workdir PATH`, `--json` | Finished runs with a classified outcome and one line of evidence. |
+
+##### `bernstein runs report`
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--since DURATION` | all | Only include runs started in the last DURATION (`45m`, `6h`, `2d`). |
+| `--workdir PATH` | `.` | Project root. |
+| `--json` | off | Emit stable machine-readable rows instead of the table. |
+
+The report is projected from `.sdd/` alone, so it still answers what came of a
+batch of runs after the orchestrator and its task server have exited. Each row
+carries the outcome class and the one line of evidence it was classified from:
+`pr-opened` (a branch was published), `gate-failed` (a quality gate blocked the
+run), `no-changes` (zero commits over base), `infra-error` (adapter or transport
+death, or no wrap-up was ever recorded), and `wedged` (the run ended with open
+tasks nothing could spawn).
 
 #### `bernstein watch`
 

--- a/docs/release-notes/fragments/4465-runs-report.md
+++ b/docs/release-notes/fragments/4465-runs-report.md
@@ -1,0 +1,8 @@
+## `bernstein runs report` classifies finished runs from the work ledger
+
+Asking what came of a batch of runs meant reading `.sdd/` by hand once the
+orchestrator and its task server had exited. `bernstein runs report` projects
+the work ledger into one row per finished run -- `pr-opened`, `gate-failed`,
+`no-changes`, `infra-error` or `wedged` -- each carrying the line of evidence
+it was classified from. `--since` narrows the window and `--json` emits stable
+machine-readable rows (#4465).

--- a/src/bernstein/cli/commands/runs_cmd.py
+++ b/src/bernstein/cli/commands/runs_cmd.py
@@ -1,0 +1,98 @@
+"""``bernstein runs`` -- operator surface over finished runs (#4465).
+
+The classification rule lives in
+:mod:`bernstein.core.persistence.runs_report`, next to the ledger it reads.
+This module is the thin renderer on top: it turns CLI flags into a
+:func:`~bernstein.core.persistence.runs_report.list_finished_runs` call and
+prints either a table or the stable ``--json`` rows.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import click
+from rich.table import Table
+
+from bernstein.cli.helpers import console
+from bernstein.core.observability.decision_log import parse_duration
+from bernstein.core.persistence.runs_report import RunOutcome, list_finished_runs
+
+#: Rich style per outcome class, for the table renderer only -- the
+#: ``--json`` rows never carry color.
+_OUTCOME_STYLE: dict[RunOutcome, str] = {
+    RunOutcome.PR_OPENED: "green",
+    RunOutcome.GATE_FAILED: "red",
+    RunOutcome.NO_CHANGES: "dim",
+    RunOutcome.INFRA_ERROR: "red",
+    RunOutcome.WEDGED: "yellow",
+}
+
+
+@click.group("runs")
+def runs_group() -> None:
+    """Operator surface over runs projected from the work ledger."""
+
+
+@runs_group.command("report")
+@click.option(
+    "--since",
+    default=None,
+    help='Only include runs started in the last DURATION, e.g. "6h", "2d".',
+)
+@click.option(
+    "--workdir",
+    default=None,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Project root (defaults to current directory).",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    default=False,
+    help="Emit stable machine-readable rows instead of a table.",
+)
+def runs_report_cmd(since: str | None, workdir: Path | None, output_json: bool) -> None:
+    """List finished runs with a classified outcome and one-line evidence.
+
+    \b
+    Outcome classes:
+      pr-opened     branch published
+      gate-failed   a quality gate blocked the run
+      no-changes    zero commits over base
+      infra-error   adapter/transport death, or no wrap-up was ever recorded
+      wedged        the run ended with unspawnable open tasks
+
+    \b
+      bernstein runs report                 # every run in the ledger
+      bernstein runs report --since 6h      # only runs started in the last 6 hours
+      bernstein runs report --json          # stable machine-readable rows
+    """
+    root = (workdir or Path.cwd()).resolve()
+    cutoff = time.time() - parse_duration(since) if since else None
+    runs = list_finished_runs(root / ".sdd", since=cutoff)
+
+    if output_json:
+        console.print_json(json.dumps({"runs": [run.to_dict() for run in runs]}))
+        return
+
+    if not runs:
+        console.print("[dim]No finished runs in this repository's ledger.[/dim]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Run")
+    table.add_column("Branch")
+    table.add_column("Outcome")
+    table.add_column("Evidence")
+    for run in runs:
+        style = _OUTCOME_STYLE.get(run.outcome, "")
+        outcome_text = f"[{style}]{run.outcome.value}[/{style}]" if style else run.outcome.value
+        table.add_row(run.run_id, run.branch or "-", outcome_text, run.evidence)
+    console.print(table)
+
+
+__all__ = ["runs_group"]

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -1428,6 +1428,12 @@ from bernstein.cli.commands.ledger_cmd import ledger_group  # noqa: E402
 
 cli.add_command(ledger_group, "ledger")
 
+# Finished-run classification projected from the work ledger: which runs
+# opened a PR, which failed the gate, which were killed mid-flight (#4465).
+from bernstein.cli.commands.runs_cmd import runs_group  # noqa: E402
+
+cli.add_command(runs_group, "runs")
+
 # Ledger-projected missions: multi-day goals with phase gates + envelopes (#2509).
 from bernstein.cli.commands.mission_cmd import mission_group  # noqa: E402
 

--- a/src/bernstein/core/persistence/runs_report.py
+++ b/src/bernstein/core/persistence/runs_report.py
@@ -1,0 +1,290 @@
+"""Finished-run classification, projected from the work ledger (#4465).
+
+After a batch of unattended runs the first operator question is always the
+same: which runs opened a PR, which failed the gate, which produced no
+changes, which died on infrastructure. Every fact already lives in the work
+ledger (:mod:`bernstein.core.persistence.work_ledger`) -- this module is the
+read-only classifier over it. ``bernstein runs report`` is a thin renderer
+on top; the classification rule lives here, next to the ledger it reads, so
+there is exactly one place that can answer "why did this run end that way".
+
+The wrap-up contract
+---------------------
+A run's terminal facts -- the branch it published, the gate that blocked it,
+the commit count against base, the infra error that killed it -- travel as
+the payload of its last ``run.closed`` entry (see
+:data:`bernstein.core.persistence.work_ledger.KIND_RUN_CLOSED`). That
+payload is the "wrap-up" this module's docstrings and tests refer to:
+:class:`RunWrapUp` is its typed, round-trippable shape. A run that never
+appended a ``run.closed`` entry -- killed mid-flight, before it could record
+anything -- has no wrap-up at all, and :func:`classify_run` maps that
+absence to :attr:`RunOutcome.INFRA_ERROR` rather than raising.
+
+Outcome classes (stable values -- the ``--json`` contract)
+------------------------------------------------------------
+``pr-opened``    branch published (a PR was opened)
+``gate-failed``  a quality gate blocked the run
+``no-changes``   zero commits over base
+``infra-error``  adapter/transport death, or no wrap-up was ever recorded
+``wedged``       the run ended with unspawnable open tasks
+
+Scope note: this module reports what a run's ledger holds; it does not poll
+process liveness. It is meant to run after a batch, so a run still actually
+in flight when invoked simply shows whatever its ledger holds so far -- the
+same "no run.closed entry yet" shape as a kill, which is the honest answer
+absent a heartbeat check.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.persistence.work_ledger import (
+    KIND_RUN_CLOSED,
+    LedgerError,
+    LedgerReader,
+    LedgerState,
+    default_ledger_root,
+    replay_state,
+    run_ledger_dir,
+)
+from bernstein.core.security.path_containment import PathContainmentError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.persistence.work_ledger import LedgerEntry
+
+#: Error-kind values on a wrap-up that indicate an infrastructure death
+#: rather than a task or gate outcome.
+_INFRA_ERROR_KINDS = frozenset({"adapter", "transport"})
+
+_NO_WRAPUP_EVIDENCE = "no wrap-up recorded before the run ended (likely killed mid-flight)"
+
+
+class RunOutcome(StrEnum):
+    """The five outcome classes ``bernstein runs report`` distinguishes."""
+
+    PR_OPENED = "pr-opened"
+    GATE_FAILED = "gate-failed"
+    NO_CHANGES = "no-changes"
+    INFRA_ERROR = "infra-error"
+    WEDGED = "wedged"
+
+
+@dataclass(frozen=True)
+class RunWrapUp:
+    """Terminal facts a run records on its closing (``run.closed``) entry.
+
+    Every field is optional: different endings populate different subsets,
+    and an all-defaults instance is a valid (if uninformative) wrap-up. The
+    payload is redacted and hashed like any other ledger entry payload, so
+    these fields must stay JSON-primitive (str, int, or None).
+
+    Attributes:
+        branch: Branch name published for this run, if any.
+        pr_number: Pull request number opened for this run, if any.
+        gate_name: Name of the quality gate that blocked the run, if any.
+        failing_check: First failing check under ``gate_name``, if any.
+        commits_over_base: Commit count against the base branch. ``0`` means
+            the run produced no changes; ``None`` means not recorded.
+        error_kind: ``"adapter"`` or ``"transport"`` when the run ended on
+            an infrastructure death the supervisor detected; ``""`` else.
+        error_message: Human-readable detail for ``error_kind``.
+    """
+
+    branch: str = ""
+    pr_number: int | None = None
+    gate_name: str = ""
+    failing_check: str = ""
+    commits_over_base: int | None = None
+    error_kind: str = ""
+    error_message: str = ""
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return the dict this wrap-up would be stored as, unset fields omitted."""
+        payload: dict[str, Any] = {}
+        if self.branch:
+            payload["branch"] = self.branch
+        if self.pr_number is not None:
+            payload["pr_number"] = self.pr_number
+        if self.gate_name:
+            payload["gate_name"] = self.gate_name
+        if self.failing_check:
+            payload["failing_check"] = self.failing_check
+        if self.commits_over_base is not None:
+            payload["commits_over_base"] = self.commits_over_base
+        if self.error_kind:
+            payload["error_kind"] = self.error_kind
+        if self.error_message:
+            payload["error_message"] = self.error_message
+        return payload
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> RunWrapUp:
+        """Build a wrap-up from a ``run.closed`` entry's payload dict.
+
+        Malformed or missing fields fall back to their defaults rather than
+        raising -- a wrap-up is best-effort evidence, not a second ledger
+        that can fail closed.
+        """
+        pr_number = payload.get("pr_number")
+        commits = payload.get("commits_over_base")
+        return cls(
+            branch=str(payload.get("branch", "")),
+            pr_number=pr_number if isinstance(pr_number, int) and not isinstance(pr_number, bool) else None,
+            gate_name=str(payload.get("gate_name", "")),
+            failing_check=str(payload.get("failing_check", "")),
+            commits_over_base=commits if isinstance(commits, int) and not isinstance(commits, bool) else None,
+            error_kind=str(payload.get("error_kind", "")),
+            error_message=str(payload.get("error_message", "")),
+        )
+
+
+@dataclass(frozen=True)
+class FinishedRun:
+    """One row of ``bernstein runs report``: a classified finished run.
+
+    Field names are the stable ``--json`` contract; a scheduler reacting to
+    these rows programmatically should key off them, not off ``evidence``
+    text.
+    """
+
+    run_id: str
+    branch: str
+    outcome: RunOutcome
+    evidence: str
+    started_at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable JSON row shape (``outcome`` as its string value)."""
+        return {
+            "run_id": self.run_id,
+            "branch": self.branch,
+            "outcome": self.outcome.value,
+            "evidence": self.evidence,
+            "started_at": self.started_at,
+        }
+
+
+def classify_run(state: LedgerState, wrapup: RunWrapUp | None) -> tuple[RunOutcome, str]:
+    """Classify one run from its ledger projection and its wrap-up.
+
+    Precedence, first match wins -- this order is the classifier's public
+    contract and each branch is covered by a dedicated fixture test:
+
+    1. ``wrapup.error_kind`` is ``"adapter"`` or ``"transport"`` -- the
+       supervisor itself detected an infrastructure death.
+    2. *wrapup* is ``None`` -- no ``run.closed`` entry exists at all, the
+       run was killed mid-flight and never got to record anything.
+    3. ``wrapup.gate_name`` is set -- a quality gate blocked the run.
+    4. the run closed with tasks still scheduled or in flight -- wedged on
+       unspawnable open tasks.
+    5. ``wrapup.branch`` or ``wrapup.pr_number`` is set -- the success path.
+    6. otherwise -- no changes over base.
+
+    Returns:
+        ``(outcome, evidence)``: the class, and a one-line human string.
+    """
+    if wrapup is not None and wrapup.error_kind in _INFRA_ERROR_KINDS:
+        message = wrapup.error_message or "no further detail recorded"
+        return RunOutcome.INFRA_ERROR, f"{wrapup.error_kind}: {message}"
+
+    if wrapup is None:
+        return RunOutcome.INFRA_ERROR, _NO_WRAPUP_EVIDENCE
+
+    if wrapup.gate_name:
+        check = wrapup.failing_check or "(failing check not recorded)"
+        return RunOutcome.GATE_FAILED, f"{wrapup.gate_name}: {check}"
+
+    open_tasks = state.resume_frontier()
+    if open_tasks:
+        return RunOutcome.WEDGED, f"{len(open_tasks)} unspawnable task(s): {', '.join(open_tasks)}"
+
+    if wrapup.branch or wrapup.pr_number is not None:
+        evidence = wrapup.branch or "(branch not recorded)"
+        if wrapup.pr_number is not None:
+            evidence = f"{evidence} (PR #{wrapup.pr_number})"
+        return RunOutcome.PR_OPENED, evidence
+
+    commits = wrapup.commits_over_base or 0
+    return RunOutcome.NO_CHANGES, f"{commits} commits over base"
+
+
+def _last_wrapup(entries: list[LedgerEntry]) -> RunWrapUp | None:
+    """Return the wrap-up on the last ``run.closed`` entry, or ``None``."""
+    for entry in reversed(entries):
+        if entry.kind == KIND_RUN_CLOSED:
+            return RunWrapUp.from_payload(entry.payload)
+    return None
+
+
+def classify_ledger_dir(ledger_dir: Path, *, run_id: str) -> FinishedRun | None:
+    """Classify one on-disk ledger directory.
+
+    Returns:
+        A :class:`FinishedRun`, or ``None`` when the directory holds no
+        ledger entries at all (nothing to report).
+    """
+    reader = LedgerReader(ledger_dir)
+    if not reader.exists():
+        return None
+    entries = list(reader.entries())
+    if not entries:
+        return None
+    state = replay_state(entries, run_id=run_id)
+    wrapup = _last_wrapup(entries)
+    outcome, evidence = classify_run(state, wrapup)
+    return FinishedRun(
+        run_id=state.run_id or run_id,
+        branch=wrapup.branch if wrapup is not None else "",
+        outcome=outcome,
+        evidence=evidence,
+        started_at=entries[0].ts,
+    )
+
+
+def list_finished_runs(sdd_dir: Path, *, since: float | None = None) -> list[FinishedRun]:
+    """Classify every run under the ledger root, newest-started first.
+
+    Args:
+        sdd_dir: The install's ``.sdd`` directory.
+        since: When given, a unix timestamp; runs that started earlier are
+            omitted.
+
+    Returns:
+        One :class:`FinishedRun` per run directory with ledger entries.
+        A run directory that fails to classify (a malformed id, an
+        unreadable file) is skipped rather than raised -- one bad run
+        cannot take the whole report down, the same contract a run with no
+        wrap-up gets from :func:`classify_run`.
+    """
+    root = default_ledger_root(sdd_dir)
+    runs: list[FinishedRun] = []
+    for child in sorted(root.iterdir()):
+        if not child.is_dir():
+            continue
+        try:
+            ledger_dir = run_ledger_dir(sdd_dir, child.name)
+            run = classify_ledger_dir(ledger_dir, run_id=child.name)
+        except (LedgerError, PathContainmentError, OSError):
+            continue
+        if run is None:
+            continue
+        if since is not None and run.started_at < since:
+            continue
+        runs.append(run)
+    runs.sort(key=lambda run: (-run.started_at, run.run_id))
+    return runs
+
+
+__all__ = [
+    "FinishedRun",
+    "RunOutcome",
+    "RunWrapUp",
+    "classify_ledger_dir",
+    "classify_run",
+    "list_finished_runs",
+]

--- a/tests/unit/test_pr_gen.py
+++ b/tests/unit/test_pr_gen.py
@@ -105,7 +105,9 @@ def test_title_respects_existing_conventional_prefix() -> None:
 
 def test_title_uses_changes_summary_when_provided() -> None:
     changes_summary = "- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect"
-    title = build_pr_title("Add JWT authentication with refresh tokens", role="engineer", changes_summary=changes_summary)
+    title = build_pr_title(
+        "Add JWT authentication with refresh tokens", role="engineer", changes_summary=changes_summary
+    )
     # Outcome derived from changes_summary first line (task title before ": ")
     assert title.startswith("feat: add JWT auth")
     # Conventional type still from goal/role/labels (not changes_summary)
@@ -132,9 +134,7 @@ def test_title_falls_back_to_goal_when_changes_summary_empty() -> None:
 
 
 def test_body_uses_changes_summary_for_change_section() -> None:
-    summary = _fixture_summary(
-        changes_summary="- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect"
-    )
+    summary = _fixture_summary(changes_summary="- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect")
     body = build_pr_body(summary)
     assert "## Change" in body
     assert "Add JWT auth: wired refresh tokens" in body
@@ -149,9 +149,7 @@ def test_body_falls_back_to_diff_stat_when_changes_summary_empty() -> None:
 
 
 def test_body_problem_is_single_line_from_goal() -> None:
-    summary = _fixture_summary(
-        goal="Add JWT authentication with refresh tokens. Also secure cookies and audit logs."
-    )
+    summary = _fixture_summary(goal="Add JWT authentication with refresh tokens. Also secure cookies and audit logs.")
     body = build_pr_body(summary)
     assert "## Problem" in body
     # Only first sentence, no trailing period in the line (since it's the first part)
@@ -160,9 +158,7 @@ def test_body_problem_is_single_line_from_goal() -> None:
 
 
 def test_body_problem_extracts_issue_title_from_goal() -> None:
-    summary = _fixture_summary(
-        goal="Resolve GitHub issue #42: Fix broken login on mobile"
-    )
+    summary = _fixture_summary(goal="Resolve GitHub issue #42: Fix broken login on mobile")
     body = build_pr_body(summary)
     assert "## Problem" in body
     assert "Fix broken login on mobile" in body
@@ -251,9 +247,7 @@ def test_load_session_summary_reads_changes_summary(tmp_path: Path) -> None:
 
     summary = load_session_summary(None, workdir=tmp_path)
 
-    assert summary.changes_summary == (
-        "- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect"
-    )
+    assert summary.changes_summary == ("- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect")
 
 
 def test_load_session_summary_falls_back_to_live_session(tmp_path: Path) -> None:

--- a/tests/unit/test_runs_cmd.py
+++ b/tests/unit/test_runs_cmd.py
@@ -1,0 +1,118 @@
+"""CLI tests for ``bernstein runs report`` (#4465).
+
+The command is a thin renderer over
+:func:`bernstein.core.persistence.runs_report.list_finished_runs`: these
+tests drive it through :class:`click.testing.CliRunner` the way
+``test_ledger_cmd.py`` drives ``ledger_group``, so a mis-wired decorator or
+a broken ``--json`` contract is caught at the layer an operator hits it.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.runs_cmd import runs_group
+from bernstein.core.persistence.runs_report import RunWrapUp
+from bernstein.core.persistence.work_ledger import (
+    KIND_RUN_CLOSED,
+    KIND_RUN_OPEN,
+    KIND_TASK_COMPLETED,
+    KIND_TASK_SCHEDULED,
+    KIND_TASK_STARTED,
+    WorkLedger,
+    run_ledger_dir,
+)
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+def _seed_closed_run(root: Path, run_id: str, *, wrapup: RunWrapUp | None) -> None:
+    ledger = WorkLedger.open(run_ledger_dir(root / ".sdd", run_id))
+    ledger.append(kind=KIND_RUN_OPEN, payload={"run_id": run_id})
+    ledger.append(kind=KIND_TASK_SCHEDULED, task_id="t1")
+    ledger.append(kind=KIND_TASK_STARTED, task_id="t1")
+    ledger.append(kind=KIND_TASK_COMPLETED, task_id="t1")
+    payload: dict[str, object] = {"run_id": run_id}
+    if wrapup is not None:
+        payload.update(wrapup.to_payload())
+    ledger.append(kind=KIND_RUN_CLOSED, payload=payload)
+    ledger.close()
+
+
+def _seed_killed_run(root: Path, run_id: str) -> None:
+    ledger = WorkLedger.open(run_ledger_dir(root / ".sdd", run_id))
+    ledger.append(kind=KIND_RUN_OPEN, payload={"run_id": run_id})
+    ledger.append(kind=KIND_TASK_SCHEDULED, task_id="t1")
+    ledger.close()
+
+
+class TestRunsReportJson:
+    def test_json_rows_carry_the_stable_field_names(self, project: Path) -> None:
+        _seed_closed_run(project, "run-pr", wrapup=RunWrapUp(branch="fix/thing", pr_number=99))
+        result = CliRunner().invoke(runs_group, ["report", "--workdir", str(project), "--json"])
+        assert result.exit_code == 0, result.output
+
+        payload = json.loads(result.output)
+        assert list(payload.keys()) == ["runs"]
+        row = payload["runs"][0]
+        assert set(row.keys()) == {"run_id", "branch", "outcome", "evidence", "started_at"}
+        assert row["run_id"] == "run-pr"
+        assert row["branch"] == "fix/thing"
+        assert row["outcome"] == "pr-opened"
+        assert "99" in row["evidence"]
+
+    def test_empty_ledger_emits_empty_rows_not_an_error(self, project: Path) -> None:
+        result = CliRunner().invoke(runs_group, ["report", "--workdir", str(project), "--json"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {"runs": []}
+
+    def test_missing_wrapup_never_crashes_the_report(self, project: Path) -> None:
+        _seed_killed_run(project, "run-killed")
+        result = CliRunner().invoke(runs_group, ["report", "--workdir", str(project), "--json"])
+        assert result.exit_code == 0, result.output
+        row = json.loads(result.output)["runs"][0]
+        assert row["outcome"] == "infra-error"
+
+
+class TestRunsReportTable:
+    def test_table_lists_run_branch_outcome_and_evidence(self, project: Path) -> None:
+        _seed_closed_run(project, "run-gate", wrapup=RunWrapUp(gate_name="lint", failing_check="ruff check ."))
+        result = CliRunner().invoke(runs_group, ["report", "--workdir", str(project)])
+        assert result.exit_code == 0, result.output
+        assert "run-gate" in result.output
+        assert "gate-failed" in result.output
+        assert "ruff check ." in result.output
+
+    def test_no_runs_prints_a_clear_message(self, project: Path) -> None:
+        result = CliRunner().invoke(runs_group, ["report", "--workdir", str(project)])
+        assert result.exit_code == 0, result.output
+        assert "no finished runs" in result.output.lower()
+
+
+class TestRunsReportSince:
+    def test_since_excludes_runs_started_before_the_window(self, project: Path) -> None:
+        _seed_closed_run(project, "run-old", wrapup=RunWrapUp(commits_over_base=0))
+
+        # Rewrite the seeded run's first entry to look like it started two
+        # days ago, so a 1-hour `--since` window excludes it deterministically.
+        bucket = run_ledger_dir(project / ".sdd", "run-old") / "000000.jsonl"
+        lines = bucket.read_text(encoding="utf-8").splitlines()
+        first = json.loads(lines[0])
+        first["ts"] = time.time() - (2 * 86400)
+        lines[0] = json.dumps(first, sort_keys=True, separators=(",", ":"))
+        bucket.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        result = CliRunner().invoke(runs_group, ["report", "--workdir", str(project), "--since", "1h", "--json"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {"runs": []}
+
+        result_all = CliRunner().invoke(runs_group, ["report", "--workdir", str(project), "--json"])
+        assert len(json.loads(result_all.output)["runs"]) == 1

--- a/tests/unit/test_runs_report.py
+++ b/tests/unit/test_runs_report.py
@@ -1,0 +1,197 @@
+"""Tests for finished-run classification over the work ledger (#4465).
+
+Each outcome class gets a dedicated fixture: a :class:`LedgerState` (or a
+real on-disk :class:`WorkLedger`) paired with a :class:`RunWrapUp` derived
+from the run's terminal ``run.closed`` entry. ``classify_run`` is pure and
+covers the five classes in isolation; ``list_finished_runs`` exercises the
+same classifier against real ledger directories, including a run with no
+``run.closed`` entry at all (killed mid-flight).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from bernstein.core.persistence.runs_report import (
+    RunOutcome,
+    RunWrapUp,
+    classify_run,
+    list_finished_runs,
+)
+from bernstein.core.persistence.work_ledger import (
+    KIND_RUN_CLOSED,
+    KIND_RUN_OPEN,
+    KIND_TASK_COMPLETED,
+    KIND_TASK_SCHEDULED,
+    KIND_TASK_STARTED,
+    LedgerState,
+    TaskState,
+    WorkLedger,
+    run_ledger_dir,
+)
+
+
+def _open_run_state(run_id: str = "run-a") -> LedgerState:
+    """A minimal closed-run state with no open tasks (the common case)."""
+    state = LedgerState(run_id=run_id)
+    state.run_open = True
+    state.run_closed = True
+    return state
+
+
+class TestClassifyRun:
+    """One test per outcome class -- the classifier's public contract."""
+
+    def test_pr_opened(self) -> None:
+        state = _open_run_state()
+        wrapup = RunWrapUp(branch="fix/runs-report", pr_number=4471)
+        outcome, evidence = classify_run(state, wrapup)
+        assert outcome is RunOutcome.PR_OPENED
+        assert "fix/runs-report" in evidence
+        assert "4471" in evidence
+
+    def test_gate_failed(self) -> None:
+        state = _open_run_state()
+        wrapup = RunWrapUp(gate_name="lint", failing_check="ruff check")
+        outcome, evidence = classify_run(state, wrapup)
+        assert outcome is RunOutcome.GATE_FAILED
+        assert "lint" in evidence
+        assert "ruff check" in evidence
+
+    def test_no_changes(self) -> None:
+        state = _open_run_state()
+        wrapup = RunWrapUp(commits_over_base=0)
+        outcome, evidence = classify_run(state, wrapup)
+        assert outcome is RunOutcome.NO_CHANGES
+        assert "0" in evidence
+
+    def test_infra_error_from_adapter_death(self) -> None:
+        state = _open_run_state()
+        wrapup = RunWrapUp(error_kind="adapter", error_message="claude-cli exited 137")
+        outcome, evidence = classify_run(state, wrapup)
+        assert outcome is RunOutcome.INFRA_ERROR
+        assert "claude-cli exited 137" in evidence
+
+    def test_infra_error_from_transport_death(self) -> None:
+        state = _open_run_state()
+        wrapup = RunWrapUp(error_kind="transport", error_message="connection reset")
+        outcome, evidence = classify_run(state, wrapup)
+        assert outcome is RunOutcome.INFRA_ERROR
+        assert "connection reset" in evidence
+
+    def test_infra_error_when_wrapup_missing(self) -> None:
+        state = _open_run_state()
+        outcome, evidence = classify_run(state, None)
+        assert outcome is RunOutcome.INFRA_ERROR
+        assert evidence
+
+    def test_wedged_when_tasks_remain_unspawnable(self) -> None:
+        state = _open_run_state()
+        state.tasks["t1"] = TaskState(task_id="t1", state="scheduled")
+        state.tasks["t2"] = TaskState(task_id="t2", state="started")
+        wrapup = RunWrapUp()
+        outcome, evidence = classify_run(state, wrapup)
+        assert outcome is RunOutcome.WEDGED
+        assert "t1" in evidence
+        assert "t2" in evidence
+
+    def test_priority_infra_error_beats_gate_failed(self) -> None:
+        """An adapter death takes precedence even if a gate name is also set."""
+        state = _open_run_state()
+        wrapup = RunWrapUp(error_kind="adapter", error_message="oom", gate_name="lint")
+        outcome, _ = classify_run(state, wrapup)
+        assert outcome is RunOutcome.INFRA_ERROR
+
+
+class TestRunWrapUpPayloadRoundTrip:
+    def test_round_trip(self) -> None:
+        wrapup = RunWrapUp(
+            branch="feat/x",
+            pr_number=42,
+            gate_name="tests",
+            failing_check="pytest",
+            commits_over_base=3,
+            error_kind="adapter",
+            error_message="boom",
+        )
+        restored = RunWrapUp.from_payload(wrapup.to_payload())
+        assert restored == wrapup
+
+    def test_empty_payload_round_trips_to_defaults(self) -> None:
+        assert RunWrapUp.from_payload({}) == RunWrapUp()
+
+
+def _seed_closed_run(root: Path, run_id: str, *, wrapup: RunWrapUp | None) -> None:
+    ledger = WorkLedger.open(run_ledger_dir(root / ".sdd", run_id))
+    ledger.append(kind=KIND_RUN_OPEN, payload={"run_id": run_id})
+    ledger.append(kind=KIND_TASK_SCHEDULED, task_id="t1")
+    ledger.append(kind=KIND_TASK_STARTED, task_id="t1")
+    ledger.append(kind=KIND_TASK_COMPLETED, task_id="t1")
+    payload: dict[str, object] = {"run_id": run_id}
+    if wrapup is not None:
+        payload.update(wrapup.to_payload())
+    ledger.append(kind=KIND_RUN_CLOSED, payload=payload)
+    ledger.close()
+
+
+def _seed_killed_run(root: Path, run_id: str) -> None:
+    """A run with ledger activity but no ``run.closed`` -- a real crash shape."""
+    ledger = WorkLedger.open(run_ledger_dir(root / ".sdd", run_id))
+    ledger.append(kind=KIND_RUN_OPEN, payload={"run_id": run_id})
+    ledger.append(kind=KIND_TASK_SCHEDULED, task_id="t1")
+    ledger.append(kind=KIND_TASK_STARTED, task_id="t1")
+    ledger.close()
+
+
+class TestListFinishedRuns:
+    """End-to-end over real :class:`WorkLedger` directories on disk."""
+
+    def test_classifies_a_real_pr_opened_run(self, tmp_path: Path) -> None:
+        _seed_closed_run(tmp_path, "run-pr", wrapup=RunWrapUp(branch="fix/thing", pr_number=99))
+        runs = list_finished_runs(tmp_path / ".sdd")
+        assert len(runs) == 1
+        assert runs[0].run_id == "run-pr"
+        assert runs[0].outcome is RunOutcome.PR_OPENED
+        assert runs[0].branch == "fix/thing"
+
+    def test_killed_mid_flight_run_is_infra_error_not_a_crash(self, tmp_path: Path) -> None:
+        _seed_killed_run(tmp_path, "run-killed")
+        runs = list_finished_runs(tmp_path / ".sdd")
+        assert len(runs) == 1
+        assert runs[0].outcome is RunOutcome.INFRA_ERROR
+
+    def test_empty_ledger_root_returns_no_rows(self, tmp_path: Path) -> None:
+        assert list_finished_runs(tmp_path / ".sdd") == []
+
+    def test_mixed_batch_classifies_each_run_independently(self, tmp_path: Path) -> None:
+        _seed_closed_run(tmp_path, "run-pr", wrapup=RunWrapUp(branch="fix/thing", pr_number=1))
+        _seed_closed_run(tmp_path, "run-nochange", wrapup=RunWrapUp(commits_over_base=0))
+        _seed_closed_run(tmp_path, "run-gate", wrapup=RunWrapUp(gate_name="lint", failing_check="ruff check ."))
+        _seed_killed_run(tmp_path, "run-killed")
+        runs = {run.run_id: run.outcome for run in list_finished_runs(tmp_path / ".sdd")}
+        assert runs == {
+            "run-pr": RunOutcome.PR_OPENED,
+            "run-nochange": RunOutcome.NO_CHANGES,
+            "run-gate": RunOutcome.GATE_FAILED,
+            "run-killed": RunOutcome.INFRA_ERROR,
+        }
+
+    def test_since_filters_by_run_start_time(self, tmp_path: Path) -> None:
+        _seed_closed_run(tmp_path, "run-old", wrapup=RunWrapUp(commits_over_base=0))
+        cutoff = time.time() + 3600  # one hour in the future: nothing qualifies
+        runs = list_finished_runs(tmp_path / ".sdd", since=cutoff)
+        assert runs == []
+
+        runs_all = list_finished_runs(tmp_path / ".sdd", since=0.0)
+        assert len(runs_all) == 1
+
+    def test_malformed_run_directory_is_skipped_not_raised(self, tmp_path: Path) -> None:
+        _seed_closed_run(tmp_path, "run-good", wrapup=RunWrapUp(branch="ok", pr_number=1))
+        ledger_root = tmp_path / ".sdd" / "runtime" / "ledger"
+        ledger_root.mkdir(parents=True, exist_ok=True)
+        # A stray file (not a directory) alongside real run directories must
+        # not take the whole report down.
+        (ledger_root / "not-a-run.txt").write_text("noise", encoding="utf-8")
+        runs = list_finished_runs(tmp_path / ".sdd")
+        assert [r.run_id for r in runs] == ["run-good"]


### PR DESCRIPTION
After a batch of unattended runs, operators had no surface answering which runs opened a PR, which failed the gate, which produced no changes, or which died on infrastructure -- only grep over run logs.

`bernstein runs report` classifies every finished run from the work ledger into one of five outcome classes (`pr-opened`, `gate-failed`, `no-changes`, `infra-error`, `wedged`) with a one-line evidence string per row. The classifier reads the wrap-up payload on a run's terminal `run.closed` ledger entry; a run with no such entry (killed mid-flight) classifies as `infra-error` instead of crashing the report. `--since` filters by run start time, `--json` emits stable machine-readable rows.

Tested with a unit fixture per outcome class plus end-to-end coverage against real `WorkLedger` directories on disk (closed runs, a killed-mid-flight run, a mixed batch, `--since` filtering, and a malformed run directory that must not take the report down), at both the classifier and CLI layers.

Closes #4465