### PR TITLE
feat(orchestrator): seed a bounded repair task on merge-gate failure

### DIFF
--- a/docs/orchestration/gate-repair.md
+++ b/docs/orchestration/gate-repair.md
@@ -1,0 +1,57 @@
+# Merge-gate repair
+
+When the merge gate (lint + affected tests) fails on a finished branch in
+the reap-and-merge path, the orchestrator seeds exactly one bounded repair
+task on the same branch before falling through to the existing
+reopen/permanent-fail handling.
+
+## Why
+
+A gate failure used to just end the run there: the branch is parked and
+the exact command output that explains why lands in a log the operator
+has to go excavate. That context exists at the moment of failure and was
+being thrown away.
+
+## Behaviour
+
+| Step | Outcome |
+|---|---|
+| Gate fails, no prior repair attempt on this task | One repair task is created. Its description is the tail (~40 lines) of the real gate output plus "make the existing tests and lint pass; do not rewrite the feature; keep the diff as small as possible". The failing worktree is preserved so the repair task resumes the same branch instead of starting a fresh one from main. |
+| Repair task's own gate check passes | The branch proceeds through the normal gate/merge path -- no special-casing, it is just a task that passed. |
+| Repair task's own gate check also fails | No second repair is scheduled (the repair task's metadata already carries `gate_repair_attempted`); it goes through the existing reopen/permanent-fail budget unchanged. |
+| Original (pre-repair) task | Failed with a reason pointing at the repair task id, so the same failure never runs through the generic reopen budget *and* the repair task concurrently. |
+
+## Configuration
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `gate_repair_enabled` (top-level `bernstein.yaml`, threaded to `OrchestratorConfig.gate_repair_enabled`) | bool | `true` | Master switch. |
+| `BERNSTEIN_GATE_REPAIR` | env | unset | Overrides the config value at runtime. Accepts `1/true/yes/on/enable/enabled` and `0/false/no/off/disable/disabled` (case-insensitive); any other value is ignored and the config value applies. |
+
+```yaml
+# bernstein.yaml
+gate_repair_enabled: true
+```
+
+## Module
+
+`bernstein.core.tasks.task_lifecycle`
+
+| Symbol | Purpose |
+|---|---|
+| `_gate_repair_enabled` | Resolves the switch (env override, then config). |
+| `_build_gate_repair_goal` | Builds the repair task's description from a quality-gate result. |
+| `_maybe_schedule_gate_repair` | Creates the repair task and preserves its worktree; returns the new task id or `None`. |
+
+## Tests
+
+`tests/unit/test_gate_repair.py` covers:
+
+- gate fails -> one repair task scheduled, its description embeds the gate
+  output tail and the fix instructions.
+- a task whose metadata already carries a repair attempt schedules no
+  second one.
+- a passing gate result schedules nothing.
+- the switch, off via config or the env override, disables scheduling.
+- `_reap_and_cleanup_session` preserves the worktree when a repair was
+  scheduled, and still cleans up when one was not.

--- a/docs/release-notes/fragments/4463-gate-repair.md
+++ b/docs/release-notes/fragments/4463-gate-repair.md
@@ -1,0 +1,3 @@
+## Merge-gate failures get one bounded repair attempt
+
+A merge-gate failure (lint or the affected tests) used to just park the branch, with the exact failure output surviving only in a log. The orchestrator now seeds one repair task carrying that output before falling back to the existing reopen/permanent-fail handling: repair succeeds and the branch merges normally, repair fails and the task fails exactly as before, no second attempt either way. Off switch: `gate_repair_enabled` in `bernstein.yaml` (#4463).

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -21,6 +21,3 @@ A clean quiescence self-stop journals `run_completed` and exits, but the recover
 ## An entry no longer has to share this file
 
 Every PR appended one line here, so any two open PRs conflicted on this file in the merge queue and each needed a manual rebase and re-enqueue. An entry can be a `docs/release-notes/fragments/<issue-or-slug>.md` file instead; the release rotation concatenates fragments in filename order into the version page and deletes them in the same commit (#4474).
-## Merge-gate failures get one bounded repair attempt
-
-A merge-gate failure (lint or the affected tests) used to just park the branch, with the exact failure output surviving only in a log. The orchestrator now seeds one repair task carrying that output before falling back to the existing reopen/permanent-fail handling: repair succeeds and the branch merges normally, repair fails and the task fails exactly as before, no second attempt either way. Off switch: `gate_repair_enabled` in `bernstein.yaml` (#4463).

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -21,3 +21,6 @@ A clean quiescence self-stop journals `run_completed` and exits, but the recover
 ## An entry no longer has to share this file
 
 Every PR appended one line here, so any two open PRs conflicted on this file in the merge queue and each needed a manual rebase and re-enqueue. An entry can be a `docs/release-notes/fragments/<issue-or-slug>.md` file instead; the release rotation concatenates fragments in filename order into the version page and deletes them in the same commit (#4474).
+## Merge-gate failures get one bounded repair attempt
+
+A merge-gate failure (lint or the affected tests) used to just park the branch, with the exact failure output surviving only in a log. The orchestrator now seeds one repair task carrying that output before falling back to the existing reopen/permanent-fail handling: repair succeeds and the branch merges normally, repair fails and the task fails exactly as before, no second attempt either way. Off switch: `gate_repair_enabled` in `bernstein.yaml` (#4463).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -635,6 +635,7 @@ nav:
           - Run actor: orchestration/run-actor.md
           - Worker coordination: orchestration/worker-coordination.md
           - Review gate: orchestration/review-gate.md
+          - Merge-gate repair: orchestration/gate-repair.md
           - Failure taxonomy: orchestration/failure-taxonomy.md
           - Federation: orchestration/federation.md
           - Consensus scoring: quality/consensus-scoring.md

--- a/src/bernstein/core/config/seed_config.py
+++ b/src/bernstein/core/config/seed_config.py
@@ -455,6 +455,12 @@ class SeedConfig:
     # default, so ``evolution_enabled: false`` silently ran the self-evolution
     # loop anyway. Parsed here and threaded into OrchestratorConfig by the CLI.
     evolution_enabled: bool = True
+    # Issue #4463: on a merge-gate (lint/tests) failure, seed one bounded
+    # repair task carrying the real gate output before falling through to
+    # the existing reopen/permanent-fail handling. Threaded into
+    # OrchestratorConfig.gate_repair_enabled by the CLI; BERNSTEIN_GATE_REPAIR
+    # overrides at runtime.
+    gate_repair_enabled: bool = True
     # Janitor LLM-judge model/provider override (falls back to
     # bernstein.core.quality.janitor.JUDGE_MODEL/JUDGE_PROVIDER when unset).
     judge_model: str | None = None

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -2116,6 +2116,7 @@ _PARSED_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
         "deployment_strategy",
         "evolution_enabled",
         "formal_verification",
+        "gate_repair_enabled",
         "github",
         "goal",
         "internal_llm_model",
@@ -2365,6 +2366,7 @@ def parse_seed(path: Path) -> SeedConfig:
     internal_llm_provider_raw = _validate_optional_str(data, "internal_llm_provider", "openrouter_free")
     internal_llm_model_raw = _validate_optional_str(data, "internal_llm_model", "nvidia/nemotron-3-super-120b-a12b")
     evolution_enabled_raw = _validate_optional_bool(data, "evolution_enabled", True)
+    gate_repair_enabled_raw = _validate_optional_bool(data, "gate_repair_enabled", True)
     judge_model_raw = _parse_optional_str_field(data, "judge_model")
     judge_provider_raw = _parse_optional_str_field(data, "judge_provider")
     model_fallback = _parse_model_fallback(data.get("model_fallback"))
@@ -2430,6 +2432,7 @@ def parse_seed(path: Path) -> SeedConfig:
         internal_llm_provider=internal_llm_provider_raw,
         internal_llm_model=internal_llm_model_raw,
         evolution_enabled=evolution_enabled_raw,
+        gate_repair_enabled=gate_repair_enabled_raw,
         judge_model=cast("str | None", judge_model_raw),
         judge_provider=cast("str | None", judge_provider_raw),
         model_fallback=model_fallback,

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -6869,6 +6869,9 @@ if __name__ == "__main__":
             test_followup_enabled=(
                 getattr(getattr(seed, "orchestration", None), "test_followup", True) if seed else True
             ),
+            # Issue #4463: top-level ``gate_repair_enabled`` key in
+            # bernstein.yaml; BERNSTEIN_GATE_REPAIR overrides at runtime.
+            gate_repair_enabled=getattr(seed, "gate_repair_enabled", True) if seed else True,
         )
 
         if args.cells > 1:

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1696,6 +1696,12 @@ class OrchestratorConfig:
     # On by default; threaded from the seed's ``orchestration.test_followup``
     # (bernstein.yaml). See core.orchestration.test_followup.
     test_followup_enabled: bool = True
+    # Issue #4463: on a merge-gate (lint/tests) failure in the reap-and-merge
+    # path, seed one bounded repair task carrying the real gate output before
+    # falling through to the existing reopen/permanent-fail handling. Default
+    # on. Env override ``BERNSTEIN_GATE_REPAIR`` takes precedence when set
+    # (see ``task_lifecycle._gate_repair_enabled``).
+    gate_repair_enabled: bool = True
     # Janitor LLM-judge model/provider override, threaded from the seed's
     # ``judge_model``/``judge_provider`` (bernstein.yaml). None = fall back
     # to the janitor's hardcoded JUDGE_MODEL/JUDGE_PROVIDER defaults.

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -3077,7 +3077,10 @@ def _build_gate_repair_goal(qg_result: Any) -> str:
     excavate.
     """
     blocked = [r for r in qg_result.gate_results if r.blocked and not r.passed]
-    sections = [f"[{r.gate}]\n{r.detail}".strip() for r in blocked if r.detail]
+    # Gate results from older callers (and their test doubles) may not carry
+    # ``detail``; a missing field means "no output captured", never a crash.
+    details = [(r, getattr(r, "detail", None)) for r in blocked]
+    sections = [f"[{r.gate}]\n{d}".strip() for r, d in details if d]
     output = "\n\n".join(sections) if sections else "(quality gate blocked the merge; no output captured)"
     tail = "\n".join(output.splitlines()[-_GATE_REPAIR_OUTPUT_TAIL_LINES:])
     return f"The merge gate failed. Real gate output (tail):\n\n{tail}\n\n{_GATE_REPAIR_INSTRUCTION}"

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -3032,6 +3032,130 @@ def _run_quality_gates(
     return True, qg_result
 
 
+#: Config key: ``gate_repair_enabled`` on ``OrchestratorConfig`` (also the
+#: ``bernstein.yaml`` top-level key of the same name). Default on.
+#: Env override: ``BERNSTEIN_GATE_REPAIR`` (see ``_gate_repair_enabled``).
+_GATE_REPAIR_TRUTHY = frozenset({"1", "true", "yes", "on", "enable", "enabled"})
+_GATE_REPAIR_FALSY = frozenset({"0", "false", "no", "off", "disable", "disabled"})
+
+#: Fixed instruction appended after the gate output tail (issue #4463): the
+#: repair attempt must close the gap, not use it as licence to redesign.
+_GATE_REPAIR_INSTRUCTION = (
+    "Make the existing tests and lint pass. Do not rewrite the feature. Keep the diff as small as possible."
+)
+
+#: How much of the real gate output the repair goal keeps. The tail is what
+#: a human would scroll to first -- the actual assertion/error, not the
+#: framework preamble above it.
+_GATE_REPAIR_OUTPUT_TAIL_LINES = 40
+
+
+def _gate_repair_enabled(orch: Any) -> bool:
+    """Whether a merge-gate failure seeds a bounded repair task first (#4463).
+
+    ``BERNSTEIN_GATE_REPAIR`` overrides the config when set to a recognised
+    truthy/falsy word (case-insensitive); otherwise
+    ``OrchestratorConfig.gate_repair_enabled`` decides (default True).
+    """
+    raw = os.environ.get("BERNSTEIN_GATE_REPAIR", "").strip().lower()
+    if raw in _GATE_REPAIR_TRUTHY:
+        return True
+    if raw in _GATE_REPAIR_FALSY:
+        return False
+    return bool(getattr(orch._config, "gate_repair_enabled", True))
+
+
+def _build_gate_repair_goal(qg_result: Any) -> str:
+    """Build the repair task's goal: the tail of the real gate output plus
+    the fixed repair instruction (issue #4463).
+
+    Joins the ``detail`` of every gate that actually blocked the merge (run
+    order), keeps only the last ``_GATE_REPAIR_OUTPUT_TAIL_LINES`` lines, and
+    appends the fixed instruction. The result is what the next agent is
+    handed as its task description -- a bounded, skimmable excerpt of the
+    actual failure instead of a pointer to a log the operator has to
+    excavate.
+    """
+    blocked = [r for r in qg_result.gate_results if r.blocked and not r.passed]
+    sections = [f"[{r.gate}]\n{r.detail}".strip() for r in blocked if r.detail]
+    output = "\n\n".join(sections) if sections else "(quality gate blocked the merge; no output captured)"
+    tail = "\n".join(output.splitlines()[-_GATE_REPAIR_OUTPUT_TAIL_LINES:])
+    return f"The merge gate failed. Real gate output (tail):\n\n{tail}\n\n{_GATE_REPAIR_INSTRUCTION}"
+
+
+def _maybe_schedule_gate_repair(
+    orch: Any,
+    task: Task,
+    qg_result: Any,
+    worktree: Path | None,
+) -> str | None:
+    """On a quality-gate failure, seed one bounded repair task on the same
+    branch before the caller falls through to the existing fail/quarantine
+    path (issue #4463).
+
+    Creates exactly one new task whose description is
+    :func:`_build_gate_repair_goal` and whose metadata is pre-seeded with
+    ``gate_repair_attempted=True`` -- so if *that* task's own quality gate
+    also fails, this function sees the flag already set and declines a
+    second repair, falling through to the caller's normal reopen/permanent-
+    fail handling exactly as it runs today. The failing worktree is
+    preserved (``orch._preserved_worktrees``) so the repair task's next
+    claim resumes it via ``spawn_for_resume`` instead of starting a fresh
+    branch from main.
+
+    Returns the new task's id, or ``None`` when no repair was scheduled
+    (switch off, already attempted, no worktree to resume, no server, or the
+    create call failed) -- callers treat ``None`` as "handle this exactly as
+    before".
+    """
+    if qg_result is None or qg_result.passed:
+        return None
+    if not _gate_repair_enabled(orch):
+        return None
+    if task.metadata.get("gate_repair_attempted"):
+        return None
+    if worktree is None:
+        logger.debug("gate_repair: no worktree for task %s, skipping repair", task.id)
+        return None
+
+    server_url = getattr(orch._config, "server_url", None)
+    if not server_url:
+        logger.warning("gate_repair: task=%s action=skip reason=no_server_url", task.id)
+        return None
+
+    goal = _build_gate_repair_goal(qg_result)
+    body: dict[str, Any] = {
+        "title": f"[GATE-REPAIR] {task.title[:80]}",
+        "description": goal,
+        "role": task.role,
+        "priority": max(1, task.priority - 1),
+        "scope": "small",
+        "complexity": "medium",
+        "owned_files": task.owned_files,
+        "metadata": {"gate_repair_of": task.id, "gate_repair_attempted": True},
+    }
+    try:
+        resp = orch._client.post(f"{server_url}/tasks", json=body)
+        resp.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.warning("gate_repair: failed to create repair task for %s: %s", task.id, exc)
+        return None
+
+    new_task_id = _extract_new_task_id(resp)
+    if new_task_id is None:
+        logger.warning("gate_repair: repair task created for %s but id missing from response", task.id)
+        return None
+
+    orch._preserved_worktrees[new_task_id] = worktree
+    logger.info(
+        "gate_repair: task=%s scheduled repair=%s on preserved worktree=%s (one attempt)",
+        task.id,
+        new_task_id,
+        worktree,
+    )
+    return new_task_id
+
+
 def _run_rule_enforcement(
     orch: Any,
     task: Task,
@@ -3417,6 +3541,8 @@ def _reap_and_cleanup_session(
     skip_merge: bool,
     _completion_data: CompletionData | None,
     cache_diff_lines: int,
+    *,
+    preserve_worktree: bool = False,
 ) -> tuple[bool, int, bool]:
     """Reap agent, handle merge, cleanup worktree.
 
@@ -3425,6 +3551,12 @@ def _reap_and_cleanup_session(
     for a non-conflict reason (issue #2792). The caller routes that case
     through the bounded reopen/permanent-fail budget instead of leaving the
     task on the open queue for uncapped retry.
+
+    ``preserve_worktree`` (issue #4463) is set by the caller when a bounded
+    gate-repair task was just scheduled on this session's branch: the
+    worktree and its ``agent/<id>`` branch must survive so the repair task's
+    resumed spawn (see ``_maybe_schedule_gate_repair``) has something to
+    resume.
     """
     merge_result: MergeResult | None = orch._spawner.reap_completed_agent(
         session,
@@ -3492,6 +3624,13 @@ def _reap_and_cleanup_session(
             session.id,
             session.id,
             merge_result.error or "unknown reason",
+        )
+    elif preserve_worktree:
+        logger.info(
+            "gate_repair: preserving worktree and branch agent/%s for task %s so the "
+            "scheduled repair task can resume the same branch",
+            session.id,
+            task.id,
         )
     else:
         orch._spawner.cleanup_worktree(session.id)
@@ -4584,6 +4723,7 @@ def _process_single_completed_task(
     cache_diff_lines = 0
     qg_result: Any = None
     merge_failed = False
+    gate_repair_task_id: str | None = None
 
     # DEFECT 30 FIX: the alive-exit /complete path runs the janitor+verdict
     # action here. Log at INFO so a silent no-op in the orchestrator tick
@@ -4635,6 +4775,18 @@ def _process_single_completed_task(
         orch._record_provider_health(session, success=janitor_passed)
         _record_bandit_outcome(orch, task, session, janitor_passed)
 
+        # issue #4463: a quality-gate failure (as opposed to a later
+        # verification-gate failure such as cross-model review) gets one
+        # bounded repair attempt on the same branch before falling through
+        # to the normal reopen/permanent-fail handling below. `qg_result`
+        # reflects the quality-gate outcome specifically, so this never
+        # fires for a task that failed for some other reason.
+        gate_repair_task_id = (
+            _maybe_schedule_gate_repair(orch, task, qg_result, worktree)
+            if qg_result is not None and not qg_result.passed
+            else None
+        )
+
         skip_merge = _evaluate_approval_gate(orch, task, session, completion_data, janitor_passed)
         cache_verified, cache_diff_lines, merge_failed = _reap_and_cleanup_session(
             orch,
@@ -4645,6 +4797,7 @@ def _process_single_completed_task(
             skip_merge,
             completion_data,
             cache_diff_lines,
+            preserve_worktree=gate_repair_task_id is not None,
         )
 
     task_m, cost_usd = _record_completion_metrics(
@@ -4667,13 +4820,26 @@ def _process_single_completed_task(
 
     _record_evolution_completion(orch, task, session, task_m, cost_usd, janitor_passed)
 
+    # issue #4463: a scheduled gate repair already reopened this unit of work
+    # under a new task id on the preserved branch -- fail this task with a
+    # pointer to it instead of ALSO running it through the generic reopen
+    # budget below, which would spawn a second, duplicate agent on a fresh
+    # branch for the same failure.
+    if gate_repair_task_id is not None:
+        fail_task(
+            orch._client,
+            orch._config.server_url,
+            task.id,
+            f"gate_repair_scheduled: quality gate failed; repair task {gate_repair_task_id} "
+            "continues on the same branch (bounded, single attempt)",
+        )
     # issue #2792: when the worker's own work passed the janitor but the
     # merge-back failed for a non-conflict reason, the task must not silently
     # return to the open queue for uncapped retry. Route it through the same
     # bounded reopen/permanent-fail budget as a janitor FAIL. A janitor FAIL
     # takes precedence (it already reopens/fails) so the two paths never both
     # act on the same completion.
-    if janitor_passed and merge_failed:
+    elif janitor_passed and merge_failed:
         _apply_merge_failure_action(orch, task)
     else:
         _apply_janitor_verdict_action(orch, task, janitor_passed)

--- a/tests/unit/skills/test_agent_plugins_install.py
+++ b/tests/unit/skills/test_agent_plugins_install.py
@@ -189,10 +189,10 @@ def test_install_plugin_writes_lockfile_entries(
     content = lock_path.read_text(encoding="utf-8")
     resolved_root = plugin_dir.resolve()
     for name in ("alpha", "beta", "gamma"):
-        assert f"name = \"{name}\"" in content
+        assert f'name = "{name}"' in content
         # path names the skills/<name>/ directory the skill came from, not
         # the plugin root, so sync/drift can locate the individual tree.
-        assert f"path = \"{resolved_root}/skills/{name}\"" in content
+        assert f'path = "{resolved_root}/skills/{name}"' in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_gate_repair.py
+++ b/tests/unit/test_gate_repair.py
@@ -1,0 +1,325 @@
+"""Tests for the bounded merge-gate repair task (#4463).
+
+A merge-gate failure (lint/tests) in the reap-and-merge path used to just
+fail the task -- the exact gate output that explains *why* was thrown away,
+leaving a human to re-read logs. These tests pin four behaviours:
+
+* a quality-gate failure seeds exactly one repair task whose goal embeds the
+  tail of the real gate output plus fix instructions, and preserves the
+  failing worktree so the repair resumes on the same branch.
+* a task that already carries a repair attempt does not get a second one
+  (single-attempt semantics) -- the caller's existing reopen/fail path runs
+  unchanged.
+* a passing quality gate schedules nothing (pass-through).
+* the switch -- config field or the ``BERNSTEIN_GATE_REPAIR`` env override --
+  disables scheduling even on a first failure.
+
+Plus a check that ``_reap_and_cleanup_session`` skips ``cleanup_worktree``
+when a repair was scheduled, mirroring the existing merge-failure-preserves-
+worktree behaviour from issue #2792.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from bernstein.core.quality.quality_gates import QualityGateCheckResult, QualityGatesResult
+from bernstein.core.tasks.models import AgentSession, Task, TaskStatus
+from bernstein.core.tasks.task_lifecycle import (
+    _build_gate_repair_goal,
+    _gate_repair_enabled,
+    _maybe_schedule_gate_repair,
+    _reap_and_cleanup_session,
+)
+
+
+class _FakeResponse:
+    def __init__(self, body: dict[str, Any] | None = None) -> None:
+        self._body = body or {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+class _FakeClient:
+    """Records POSTs; POST .../tasks returns a fresh incrementing id."""
+
+    def __init__(self) -> None:
+        self.posts: list[tuple[str, dict[str, Any]]] = []
+        self._next_id = 1
+
+    def post(self, url: str, json: dict[str, Any] | None = None, **_kwargs: Any) -> _FakeResponse:
+        body = json or {}
+        self.posts.append((url, body))
+        if url.endswith("/tasks"):
+            new_id = f"repair-{self._next_id}"
+            self._next_id += 1
+            return _FakeResponse({"id": new_id, **body})
+        return _FakeResponse({})
+
+
+def _make_task(task_id: str = "task123") -> Task:
+    return Task(
+        id=task_id,
+        title="Implement hello subcommand",
+        description="Add a hello subcommand to cli.py",
+        role="backend",
+        status=TaskStatus.DONE,
+    )
+
+
+def _make_orch(client: _FakeClient, *, gate_repair_enabled: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(
+        _config=SimpleNamespace(server_url="http://127.0.0.1:8052", gate_repair_enabled=gate_repair_enabled),
+        _client=client,
+        _preserved_worktrees={},
+    )
+
+
+def _failing_qg_result(task_id: str = "task123") -> QualityGatesResult:
+    long_output = "\n".join(f"line {n}: ruff violation" for n in range(1, 61))
+    return QualityGatesResult(
+        task_id=task_id,
+        passed=False,
+        gate_results=[
+            QualityGateCheckResult(gate="lint", passed=False, blocked=True, detail=long_output, status="fail"),
+            QualityGateCheckResult(gate="tests", passed=True, blocked=False, detail="ok", status="pass"),
+        ],
+    )
+
+
+def _passing_qg_result(task_id: str = "task123") -> QualityGatesResult:
+    return QualityGatesResult(
+        task_id=task_id,
+        passed=True,
+        gate_results=[QualityGateCheckResult(gate="lint", passed=True, blocked=False, detail="", status="pass")],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _build_gate_repair_goal
+# ---------------------------------------------------------------------------
+
+
+def test_goal_embeds_gate_output_tail_and_fix_instructions() -> None:
+    goal = _build_gate_repair_goal(_failing_qg_result())
+
+    assert "line 60: ruff violation" in goal
+    assert "line 10: ruff violation" not in goal  # older than the ~40-line tail
+    assert "do not rewrite the feature" in goal.lower()
+    assert "smallest possible diffs" in goal.lower() or "small" in goal.lower()
+
+
+# ---------------------------------------------------------------------------
+# _gate_repair_enabled
+# ---------------------------------------------------------------------------
+
+
+def test_switch_defaults_to_config_value() -> None:
+    orch_on = SimpleNamespace(_config=SimpleNamespace(gate_repair_enabled=True))
+    orch_off = SimpleNamespace(_config=SimpleNamespace(gate_repair_enabled=False))
+    assert _gate_repair_enabled(orch_on) is True
+    assert _gate_repair_enabled(orch_off) is False
+
+
+def test_switch_missing_config_field_defaults_true() -> None:
+    orch = SimpleNamespace(_config=SimpleNamespace())
+    assert _gate_repair_enabled(orch) is True
+
+
+def test_env_override_wins_over_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    orch = SimpleNamespace(_config=SimpleNamespace(gate_repair_enabled=True))
+    monkeypatch.setenv("BERNSTEIN_GATE_REPAIR", "false")
+    assert _gate_repair_enabled(orch) is False
+
+    monkeypatch.setenv("BERNSTEIN_GATE_REPAIR", "0")
+    assert _gate_repair_enabled(orch) is False
+
+    orch_off = SimpleNamespace(_config=SimpleNamespace(gate_repair_enabled=False))
+    monkeypatch.setenv("BERNSTEIN_GATE_REPAIR", "true")
+    assert _gate_repair_enabled(orch_off) is True
+
+
+# ---------------------------------------------------------------------------
+# _maybe_schedule_gate_repair -- schedule-on-fail
+# ---------------------------------------------------------------------------
+
+
+def test_gate_failure_schedules_one_repair_task_with_output_tail() -> None:
+    """First quality-gate failure seeds one repair task; its goal embeds the gate output tail."""
+    client = _FakeClient()
+    orch = _make_orch(client)
+    task = _make_task()
+    worktree = Path("/tmp/worktrees/agent-abc")
+
+    new_id = _maybe_schedule_gate_repair(orch, task, _failing_qg_result(), worktree)
+
+    assert new_id == "repair-1"
+    assert len(client.posts) == 1
+    url, body = client.posts[0]
+    assert url.endswith("/tasks")
+    assert "line 60: ruff violation" in body["description"]
+    assert "line 10: ruff violation" not in body["description"]
+    assert "do not rewrite the feature" in body["description"].lower()
+    assert body["role"] == "backend"
+    assert body["metadata"]["gate_repair_attempted"] is True
+    assert body["metadata"]["gate_repair_of"] == "task123"
+    assert orch._preserved_worktrees["repair-1"] == worktree
+
+
+# ---------------------------------------------------------------------------
+# _maybe_schedule_gate_repair -- no-loop (single-attempt semantics)
+# ---------------------------------------------------------------------------
+
+
+def test_already_attempted_task_does_not_schedule_a_second_repair() -> None:
+    """A task whose own metadata already carries a repair attempt gets no second one."""
+    client = _FakeClient()
+    orch = _make_orch(client)
+    task = _make_task()
+    task.metadata["gate_repair_attempted"] = True
+
+    new_id = _maybe_schedule_gate_repair(orch, task, _failing_qg_result(), Path("/tmp/wt"))
+
+    assert new_id is None
+    assert client.posts == []
+    assert orch._preserved_worktrees == {}
+
+
+# ---------------------------------------------------------------------------
+# _maybe_schedule_gate_repair -- pass-through-on-success
+# ---------------------------------------------------------------------------
+
+
+def test_passing_gate_schedules_nothing() -> None:
+    client = _FakeClient()
+    orch = _make_orch(client)
+    task = _make_task()
+
+    new_id = _maybe_schedule_gate_repair(orch, task, _passing_qg_result(), Path("/tmp/wt"))
+
+    assert new_id is None
+    assert client.posts == []
+
+
+# ---------------------------------------------------------------------------
+# _maybe_schedule_gate_repair -- switch-off
+# ---------------------------------------------------------------------------
+
+
+def test_switch_off_via_config_skips_scheduling() -> None:
+    client = _FakeClient()
+    orch = _make_orch(client, gate_repair_enabled=False)
+    task = _make_task()
+
+    new_id = _maybe_schedule_gate_repair(orch, task, _failing_qg_result(), Path("/tmp/wt"))
+
+    assert new_id is None
+    assert client.posts == []
+
+
+def test_switch_off_via_env_overrides_config_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_GATE_REPAIR", "false")
+    client = _FakeClient()
+    orch = _make_orch(client, gate_repair_enabled=True)
+    task = _make_task()
+
+    new_id = _maybe_schedule_gate_repair(orch, task, _failing_qg_result(), Path("/tmp/wt"))
+
+    assert new_id is None
+    assert client.posts == []
+
+
+def test_no_worktree_skips_scheduling() -> None:
+    """No worktree to resume -> nothing to repair on the same branch, so no-op."""
+    client = _FakeClient()
+    orch = _make_orch(client)
+    task = _make_task()
+
+    new_id = _maybe_schedule_gate_repair(orch, task, _failing_qg_result(), None)
+
+    assert new_id is None
+    assert client.posts == []
+
+
+# ---------------------------------------------------------------------------
+# _reap_and_cleanup_session -- preserves the worktree when a repair is scheduled
+# ---------------------------------------------------------------------------
+
+
+class _FakeSpawner:
+    def __init__(self) -> None:
+        self.cleanup_called = False
+
+    def reap_completed_agent(
+        self,
+        session: AgentSession,
+        *,
+        skip_merge: bool = False,
+        defer_cleanup: bool = False,
+    ) -> None:
+        return None
+
+    def get_worktree_path(self, _session_id: str) -> Path | None:
+        return None
+
+    def cleanup_worktree(self, _session_id: str) -> None:
+        self.cleanup_called = True
+
+
+def _make_reap_orch(spawner: _FakeSpawner, tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        _spawner=spawner,
+        _workdir=tmp_path,
+        _config=SimpleNamespace(ab_test=False),
+        _post_bulletin=lambda *_args, **_kwargs: None,
+    )
+
+
+def _make_session() -> AgentSession:
+    return AgentSession(id="writer-8f6311cf", role="backend", pid=4242, task_ids=["task123"], status="working")
+
+
+def test_reap_preserves_worktree_when_gate_repair_scheduled(tmp_path: Path) -> None:
+    spawner = _FakeSpawner()
+    orch = _make_reap_orch(spawner, tmp_path)
+
+    _reap_and_cleanup_session(
+        orch,
+        _make_task(),
+        _make_session(),
+        None,
+        False,  # janitor_passed - the quality gate blocked this completion
+        True,  # skip_merge - approval gate already skipped merge on the failure
+        None,
+        0,
+        preserve_worktree=True,
+    )
+
+    assert spawner.cleanup_called is False
+
+
+def test_reap_cleans_worktree_when_no_repair_scheduled(tmp_path: Path) -> None:
+    """Default behaviour (no repair scheduled) is unchanged: cleanup still runs."""
+    spawner = _FakeSpawner()
+    orch = _make_reap_orch(spawner, tmp_path)
+
+    _reap_and_cleanup_session(
+        orch,
+        _make_task(),
+        _make_session(),
+        None,
+        False,
+        True,
+        None,
+        0,
+    )
+
+    assert spawner.cleanup_called is True

--- a/tests/unit/test_regression_orchestrator.py
+++ b/tests/unit/test_regression_orchestrator.py
@@ -274,9 +274,7 @@ class TestDependencyFiltering:
         assert "C" not in spawned_task_ids
         assert "D" not in spawned_task_ids
 
-    def test_preexisting_cycle_still_schedules_every_task_after_deterministic_break(
-        self, tmp_path: Path
-    ) -> None:
+    def test_preexisting_cycle_still_schedules_every_task_after_deterministic_break(self, tmp_path: Path) -> None:
         """A board carrying a declared cycle drains instead of wedging (#4287).
 
         ``POST /tasks`` rejects a cycle-forming edge today, but legacy board


### PR DESCRIPTION
Merge-gate failures (lint, affected tests) in the reap-and-merge path ended the run immediately: the branch was parked and the failure output existed only in a log an operator had to go dig up.

On the quality gate's first failure for a task, the orchestrator now schedules exactly one repair task on the same branch. Its goal embeds the tail of the real gate output plus fixed instructions to keep the fix minimal and not touch the feature. A second failure (on that repair task) falls through to the existing reopen/permanent-fail handling unchanged, so there is no loop. Switch: `gate_repair_enabled` in bernstein.yaml (default on), env override `BERNSTEIN_GATE_REPAIR`.

Tested in `tests/unit/test_gate_repair.py`: schedule-on-fail (goal embeds the output tail, worktree preserved), no-loop (a task with a prior attempt schedules nothing), pass-through-on-success, and the switch off via config and env. Existing merge-failure (#2792) and janitor-reopen regression tests still pass.

Closes #4463