### PR TITLE
fix(workflow): route DSL manifests in run/list; ship pr-review

### DIFF
--- a/src/bernstein/cli/commands/workflow_cmd.py
+++ b/src/bernstein/cli/commands/workflow_cmd.py
@@ -281,7 +281,7 @@ def list_cmd(search_dir: str | None, bundled_only: bool) -> None:
                         path.parent.as_posix(),
                     )
                 except DSLError as exc:
-                    table.add_row(path.stem, "DSL", "-", "-", f"[red]error: {exc}[/red]")
+                    table.add_row(path.stem, "DSL", "-", "-", f"[red]error: {_one_line_error(exc)}[/red]")
 
     if table.row_count == 0:
         console.print("[dim]No workflows found.[/dim]")
@@ -290,8 +290,33 @@ def list_cmd(search_dir: str | None, bundled_only: bool) -> None:
     _ = WorkflowSpecError  # keep import live for static analysers
 
 
+def _one_line_error(exc: Exception) -> str:
+    """Collapse a (possibly multi-line) error message onto one line.
+
+    Pydantic's ``ValidationError`` prints one paragraph per failed field -
+    left as-is inside a Rich table cell, the embedded newlines render as
+    hard breaks and short lines (a bare field name, say) end up wrapped
+    one word per line.  Joining on ``"; "`` keeps every field's message
+    but guarantees the row stays a single scannable line; a hard cap keeps
+    a pathological message from blowing out the column width.
+    """
+    text = "; ".join(line.strip() for line in str(exc).splitlines() if line.strip())
+    if len(text) > 160:
+        text = text[:157] + "..."
+    return text
+
+
 def _add_spec_row(path: Path, table: Any, *, source: str) -> None:
-    """Append a row for a YAML manifest, capturing parse errors inline."""
+    """Append a row for a YAML manifest, capturing parse errors inline.
+
+    DSL-form manifests (top-level ``phases`` or mapping-style ``nodes``)
+    are skipped here - the legacy DSL section below renders them with
+    their own kind label, and forcing them through the WorkflowSpec
+    loader would surface an unrelated schema-mismatch error (#4461).
+    """
+    if _detect_kind(path) == "dsl":
+        return
+
     from bernstein.core.workflows import WorkflowSpecError, load_workflow_spec
 
     try:
@@ -304,12 +329,82 @@ def _add_spec_row(path: Path, table: Any, *, source: str) -> None:
             source,
         )
     except WorkflowSpecError as exc:
-        table.add_row(path.stem, "manifest", "-", "-", f"[red]error: {exc}[/red]")
+        table.add_row(path.stem, "manifest", "-", "-", f"[red]error: {_one_line_error(exc)}[/red]")
 
 
 # ---------------------------------------------------------------------------
 # run
 # ---------------------------------------------------------------------------
+
+
+def _resolve_manifest_path(name_or_path: str, *, workdir: Path) -> Path | None:
+    """Best-effort locate a manifest file for kind-sniffing before dispatch.
+
+    Mirrors the lookup order :func:`resolve_workflow` uses internally
+    (direct path, then bundled + user-installed directories by name), but
+    returns ``None`` instead of raising so callers can fall back to the
+    existing spec-only resolution - and its existing error messages -
+    unchanged when nothing is found here either.
+    """
+    from bernstein.core.workflows.workflow_spec import discover_workflows
+
+    candidate = Path(name_or_path)
+    if candidate.suffix in {".yaml", ".yml"} or candidate.exists():
+        return candidate if candidate.is_file() else None
+    for name, path in discover_workflows(workdir=workdir):
+        if name == name_or_path:
+            return path
+    return None
+
+
+def _run_dsl_cmd(path: Path, *, dry_run: bool, console: Any) -> None:
+    """Handle ``workflow run`` for a DSL-form (conditional task DAG) manifest.
+
+    DSL manifests describe a governed, phase-gated task DAG that the live
+    orchestrator drives (Task objects, agent spawns, conditional edges
+    evaluated against task state) - there is no standalone way to fire
+    one node at a time the way ``WorkflowRunner`` does for the YAML
+    manifest schema, and instantiating ``WorkflowExecutor`` here just to
+    print a plan would write real files under ``.sdd/runtime/workflow/``
+    for a run that never happens. ``--dry-run`` still parses and validates
+    the DAG and prints its phase/node plan, so schema drift shows up
+    without needing a full orchestrator run; a bare ``run`` names the two
+    invocations that actually work today instead of falling through to
+    the WorkflowSpec loader and its unrelated pydantic wall (#4461).
+    """
+    from bernstein.core.workflow_dsl import DSLError, parse_workflow_yaml, validate_dag
+
+    try:
+        dag = parse_workflow_yaml(path)
+    except DSLError as exc:
+        console.print(f"[bold red]Resolve failed:[/bold red] {_one_line_error(exc)}")
+        raise SystemExit(1) from exc
+
+    result = validate_dag(dag)
+    if not result.is_valid:
+        console.print(f"[bold red]Resolve failed:[/bold red] {'; '.join(result.errors)}")
+        raise SystemExit(1)
+
+    name = dag.definition.name
+    console.print(f"[bold]Workflow:[/bold] {name} ({path})")
+    console.print(
+        f"[dim]DSL conditional-DAG workflow; {len(dag.nodes)} node(s) "
+        f"across {len(dag.definition.phases)} phase(s).[/dim]\n",
+    )
+
+    if dry_run:
+        for phase in dag.definition.phases:
+            ids = ", ".join(node.id for node in dag.nodes if node.phase == phase.name)
+            if ids:
+                console.print(f"  [bold]Phase {phase.name}:[/bold] {ids}")
+        return
+
+    console.print(
+        "[yellow]DSL workflows aren't executable via `workflow run` yet; "
+        f"use `bernstein workflow run {name} --dry-run` for the plan or "
+        f"`bernstein workflow show {name}` for full structure.[/yellow]",
+    )
+    raise SystemExit(1)
 
 
 @workflow_group.command("run")
@@ -329,6 +424,8 @@ def run_cmd(name_or_path: str, goal: str, dry_run: bool) -> None:
     or by filesystem path.  Agent-typed nodes dispatch through the
     existing AgentSpawner; command-typed nodes shell out; loop nodes
     re-fire until their predicate exits 0 or max_iterations is hit.
+    DSL-form manifests (conditional task DAGs) dry-run their plan here;
+    a full run belongs to the live orchestrator, not this command.
 
     \b
     Examples:
@@ -342,6 +439,12 @@ def run_cmd(name_or_path: str, goal: str, dry_run: bool) -> None:
     from bernstein.core.workflows.workflow_spec import resolve_workflow
 
     console = Console()
+
+    sniff_path = _resolve_manifest_path(name_or_path, workdir=Path.cwd())
+    if sniff_path is not None and _detect_kind(sniff_path) == "dsl":
+        _run_dsl_cmd(sniff_path, dry_run=dry_run, console=console)
+        return
+
     try:
         path, spec = resolve_workflow(name_or_path, workdir=Path.cwd())
     except WorkflowSpecError as exc:

--- a/src/bernstein/core/workflows/workflow_runner.py
+++ b/src/bernstein/core/workflows/workflow_runner.py
@@ -43,7 +43,14 @@ logger = logging.getLogger(__name__)
 
 
 class NodeStatus(StrEnum):
-    """Terminal status for a single workflow node execution."""
+    """Terminal status for a single workflow node execution.
+
+    ``SKIPPED`` covers two distinct situations, told apart by
+    :attr:`NodeExecution.condition_skipped`: a node whose ``depends_on``
+    included a failed (or cascade-skipped) node - which keeps blocking
+    anything depending on *it* in turn - versus a node whose own ``when``
+    predicate came back false, which does not.
+    """
 
     SUCCESS = "success"
     FAILED = "failed"
@@ -67,8 +74,10 @@ class NodeExecution:
 
     Attributes:
         node_id: The id of the executed node.
-        status: Terminal status.  ``SKIPPED`` is used when a node is
-            preempted because an upstream dependency failed.
+        status: Terminal status.  ``SKIPPED`` is used both when a node is
+            preempted because an upstream dependency failed, and when
+            the node's own ``when`` predicate came back false - see
+            ``condition_skipped`` to tell them apart.
         iterations: How many times the node fired.  ``1`` for
             non-looping nodes; up to ``loop.max_iterations`` for loops.
         exit_code: Final exit code for command-typed nodes.  Always 0
@@ -80,6 +89,11 @@ class NodeExecution:
             iteration if looping).  Empty string for command nodes.
         error: Human-readable error message when status is FAILED.
         wall_time_seconds: Wall clock spent in this node, end-to-end.
+        condition_skipped: ``True`` only when ``status`` is ``SKIPPED``
+            because this node's own ``when`` predicate was false.  Such a
+            skip was intentional - it does not fail the run and does not
+            block nodes that depend on this one, unlike a skip cascading
+            from a failed (or itself-blocked) dependency.
     """
 
     node_id: str
@@ -91,6 +105,7 @@ class NodeExecution:
     session_id: str = ""
     error: str = ""
     wall_time_seconds: float = 0.0
+    condition_skipped: bool = False
 
 
 @dataclass
@@ -103,8 +118,10 @@ class WorkflowExecution:
             same logical run can be tied together across nodes.
         nodes: Per-node results, in the order they finished.
         wall_time_seconds: Total wall clock for the run.
-        succeeded: ``True`` only if every executed node ended in
-            :attr:`NodeStatus.SUCCESS`.
+        succeeded: ``True`` only if every node ended in
+            :attr:`NodeStatus.SUCCESS` or was intentionally
+            condition-skipped (``NodeExecution.condition_skipped``); a
+            dependency-failure skip still fails the run.
     """
 
     spec_name: str
@@ -221,10 +238,20 @@ class WorkflowRunner:
 
             ready_nodes: list[WorkflowNode] = []
             for node in layer:
-                if not all(results[dep].status == NodeStatus.SUCCESS for dep in node.depends_on if dep in results):
+                if not all(self._dep_satisfied(results.get(dep)) for dep in node.depends_on if dep in results):
                     skipped = NodeExecution(node_id=node.id, status=NodeStatus.SKIPPED)
                     results[node.id] = skipped
                     execution.nodes.append(skipped)
+                    continue
+                if node.when is not None and not self._loop_predicate_passes(node.when):
+                    skipped = NodeExecution(node_id=node.id, status=NodeStatus.SKIPPED, condition_skipped=True)
+                    results[node.id] = skipped
+                    execution.nodes.append(skipped)
+                    self._audit(
+                        "workflow.node_condition_skipped",
+                        node.id,
+                        {"run_id": rid, "when": node.when},
+                    )
                     continue
                 ready_nodes.append(node)
 
@@ -240,7 +267,7 @@ class WorkflowRunner:
 
         execution.wall_time_seconds = time.monotonic() - start
         execution.succeeded = not aborted and all(
-            r.status == NodeStatus.SUCCESS for r in execution.nodes if execution.nodes
+            r.status == NodeStatus.SUCCESS or r.condition_skipped for r in execution.nodes
         )
         self._audit(
             "workflow.finish",
@@ -254,6 +281,22 @@ class WorkflowRunner:
         return execution
 
     # ----- internal helpers -------------------------------------------------
+
+    @staticmethod
+    def _dep_satisfied(dep_result: NodeExecution | None) -> bool:
+        """Whether a dependency's outcome unblocks nodes depending on it.
+
+        A plain success always unblocks.  A condition-gated skip
+        (``when`` was false) unblocks too - it was intentionally not
+        needed, not aborted.  Any other skip (cascading from a failed or
+        itself-blocked dependency) still blocks, exactly as before
+        ``when`` existed.
+        """
+        if dep_result is None:
+            return False
+        if dep_result.status == NodeStatus.SUCCESS:
+            return True
+        return dep_result.status == NodeStatus.SKIPPED and dep_result.condition_skipped
 
     def _execute_layer(
         self,
@@ -379,8 +422,14 @@ class WorkflowRunner:
         return last
 
     def _loop_predicate_passes(self, predicate: str) -> bool:
-        """Return ``True`` when the bash predicate exits with status 0."""
-        # SECURITY: shell=True required because loop predicates are manifest-authored
+        """Return ``True`` when the bash predicate exits with status 0.
+
+        Shared by loop's ``until`` and a node's ``when``: both are
+        manifest-authored bash predicates evaluated the same way (the
+        name predates ``when`` - kept as-is since it's a monkeypatch
+        seam an existing test reaches into directly).
+        """
+        # SECURITY: shell=True required because predicates are manifest-authored
         # bash expressions (e.g. "test -f marker") that rely on shell parsing; not user input.
         proc = subprocess.run(
             predicate,

--- a/src/bernstein/core/workflows/workflow_spec.py
+++ b/src/bernstein/core/workflows/workflow_spec.py
@@ -115,6 +115,14 @@ class WorkflowNode(BaseModel):
         model: Optional provider-specific model identifier for this node.
         effort: Optional reasoning-effort override for this node.
         loop: Optional loop predicate.  When set the node re-fires.
+        when: Optional bash predicate gating whether this node runs at
+            all, evaluated once its ``depends_on`` are satisfied.  Exit
+            0 runs the node normally; non-zero marks it ``SKIPPED``
+            without failing the run, and - unlike a dependency-failure
+            skip - does not block nodes that depend on this one.  Lets a
+            manifest express "run this node only if an earlier one asked
+            for it" (e.g. revise-on-request-changes) without the DSL's
+            conditional-DAG machinery.
         fresh_context: When ``True``, agent-typed nodes get a fresh
             session per iteration (no carryover).  Ignored for command-
             typed nodes.
@@ -139,6 +147,7 @@ class WorkflowNode(BaseModel):
     model: str | None = Field(default=None, min_length=1, max_length=256)
     effort: str | None = Field(default=None, min_length=1, max_length=32)
     loop: LoopSpec | None = None
+    when: str | None = Field(default=None, min_length=1, description="Bash predicate gating whether this node runs.")
     fresh_context: bool = False
     interactive: bool = False
     timeout_seconds: int = Field(default=DEFAULT_NODE_TIMEOUT_SECONDS, ge=1, le=86_400)

--- a/tests/integration/test_workflow_runner.py
+++ b/tests/integration/test_workflow_runner.py
@@ -128,6 +128,125 @@ nodes:
 
 
 # ---------------------------------------------------------------------------
+# Conditional `when` gating (#4464)
+# ---------------------------------------------------------------------------
+
+
+def test_when_false_skips_node_without_failing_the_run(runner_workdir: Path) -> None:
+    """A false `when` predicate skips its node but doesn't abort the DAG."""
+    spec = _spec_from(
+        """
+name: conditional-skip
+description: "A gated node whose predicate never passes"
+version: "1.0.0"
+nodes:
+  - id: setup
+    command: "true"
+  - id: gated
+    depends_on: [setup]
+    command: "echo should-not-run > gated.txt"
+    when: "false"
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir)
+    execution = runner.run(spec)
+
+    by_id = {n.node_id: n for n in execution.nodes}
+    assert by_id["setup"].status == NodeStatus.SUCCESS
+    assert by_id["gated"].status == NodeStatus.SKIPPED
+    assert by_id["gated"].condition_skipped is True
+    assert execution.succeeded is True
+    assert not (runner_workdir / "gated.txt").exists()
+
+
+def test_when_true_runs_the_node_normally(runner_workdir: Path) -> None:
+    """A passing `when` predicate behaves like an ungated node."""
+    spec = _spec_from(
+        """
+name: conditional-run
+description: "A gated node whose predicate always passes"
+version: "1.0.0"
+nodes:
+  - id: gated
+    command: "echo ran > gated.txt"
+    when: "true"
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir)
+    execution = runner.run(spec)
+
+    gated = execution.nodes[0]
+    assert gated.status == NodeStatus.SUCCESS
+    assert gated.condition_skipped is False
+    assert (runner_workdir / "gated.txt").read_text().strip() == "ran"
+
+
+def test_downstream_of_a_condition_skipped_node_still_runs(runner_workdir: Path) -> None:
+    """A node depending on a condition-skipped node is not itself blocked.
+
+    This is what distinguishes `when: false` from a failed dependency: the
+    node was intentionally not needed, not aborted, so anything downstream
+    that only needed the DAG to *reach* this point still proceeds.
+    """
+    spec = _spec_from(
+        """
+name: skip-does-not-cascade
+description: "review -> gated revise -> verify, revise's `when` is false"
+version: "1.0.0"
+nodes:
+  - id: review
+    command: "true"
+  - id: revise
+    depends_on: [review]
+    command: "echo revised > revise.txt"
+    when: "false"
+  - id: verify
+    depends_on: [review, revise]
+    command: "echo verified > verify.txt"
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir)
+    execution = runner.run(spec)
+
+    by_id = {n.node_id: n for n in execution.nodes}
+    assert by_id["review"].status == NodeStatus.SUCCESS
+    assert by_id["revise"].status == NodeStatus.SKIPPED
+    assert by_id["revise"].condition_skipped is True
+    assert by_id["verify"].status == NodeStatus.SUCCESS
+    assert execution.succeeded is True
+    assert (runner_workdir / "verify.txt").read_text().strip() == "verified"
+
+
+def test_failure_skip_still_blocks_downstream_unlike_condition_skip(runner_workdir: Path) -> None:
+    """A cascade skip (from a *failed* dependency) still blocks children.
+
+    Only a `when`-gated skip is "intentionally not needed"; a node skipped
+    because its own dependency failed must keep blocking the DAG exactly
+    as it did before `when` existed.
+    """
+    spec = _spec_from(
+        """
+name: failure-still-cascades
+description: "bad fails; never depends on bad and must stay skipped"
+version: "1.0.0"
+nodes:
+  - id: bad
+    command: "exit 9"
+  - id: never
+    depends_on: [bad]
+    command: "echo nope > never.txt"
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir)
+    execution = runner.run(spec)
+
+    by_id = {n.node_id: n for n in execution.nodes}
+    assert by_id["never"].status == NodeStatus.SKIPPED
+    assert by_id["never"].condition_skipped is False
+    assert execution.succeeded is False
+
+
+# ---------------------------------------------------------------------------
 # Fan-out parallel
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_pr_gen.py
+++ b/tests/unit/test_pr_gen.py
@@ -105,7 +105,9 @@ def test_title_respects_existing_conventional_prefix() -> None:
 
 def test_title_uses_changes_summary_when_provided() -> None:
     changes_summary = "- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect"
-    title = build_pr_title("Add JWT authentication with refresh tokens", role="engineer", changes_summary=changes_summary)
+    title = build_pr_title(
+        "Add JWT authentication with refresh tokens", role="engineer", changes_summary=changes_summary
+    )
     # Outcome derived from changes_summary first line (task title before ": ")
     assert title.startswith("feat: add JWT auth")
     # Conventional type still from goal/role/labels (not changes_summary)
@@ -132,9 +134,7 @@ def test_title_falls_back_to_goal_when_changes_summary_empty() -> None:
 
 
 def test_body_uses_changes_summary_for_change_section() -> None:
-    summary = _fixture_summary(
-        changes_summary="- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect"
-    )
+    summary = _fixture_summary(changes_summary="- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect")
     body = build_pr_body(summary)
     assert "## Change" in body
     assert "Add JWT auth: wired refresh tokens" in body
@@ -149,9 +149,7 @@ def test_body_falls_back_to_diff_stat_when_changes_summary_empty() -> None:
 
 
 def test_body_problem_is_single_line_from_goal() -> None:
-    summary = _fixture_summary(
-        goal="Add JWT authentication with refresh tokens. Also secure cookies and audit logs."
-    )
+    summary = _fixture_summary(goal="Add JWT authentication with refresh tokens. Also secure cookies and audit logs.")
     body = build_pr_body(summary)
     assert "## Problem" in body
     # Only first sentence, no trailing period in the line (since it's the first part)
@@ -160,9 +158,7 @@ def test_body_problem_is_single_line_from_goal() -> None:
 
 
 def test_body_problem_extracts_issue_title_from_goal() -> None:
-    summary = _fixture_summary(
-        goal="Resolve GitHub issue #42: Fix broken login on mobile"
-    )
+    summary = _fixture_summary(goal="Resolve GitHub issue #42: Fix broken login on mobile")
     body = build_pr_body(summary)
     assert "## Problem" in body
     assert "Fix broken login on mobile" in body
@@ -251,9 +247,7 @@ def test_load_session_summary_reads_changes_summary(tmp_path: Path) -> None:
 
     summary = load_session_summary(None, workdir=tmp_path)
 
-    assert summary.changes_summary == (
-        "- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect"
-    )
+    assert summary.changes_summary == ("- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect")
 
 
 def test_load_session_summary_falls_back_to_live_session(tmp_path: Path) -> None:

--- a/tests/unit/test_workflow_cmd.py
+++ b/tests/unit/test_workflow_cmd.py
@@ -1,0 +1,187 @@
+"""CLI regressions for ``bernstein workflow run``/``list`` manifest routing.
+
+Two manifest schemas share ``.bernstein/workflows/``: the WorkflowSpec
+(list-form ``nodes:``) schema and the conditional-DAG DSL (``phases:`` plus
+mapping-form ``nodes:``).  ``run``/``list`` must sniff the kind and route
+each file to its own reader instead of forcing every file through the
+WorkflowSpec loader (#4461).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.workflow_cmd import _one_line_error
+from bernstein.cli.main import cli
+from bernstein.core.workflows.workflow_spec import WorkflowSpecError, load_workflow_spec_from_text
+
+_DSL_MANIFEST = """\
+name: two-phase
+version: "1.0.0"
+phases:
+  - name: build
+  - name: check
+nodes:
+  make:
+    phase: build
+    role: backend
+    description: "Build the thing"
+  test:
+    phase: check
+    role: qa
+    description: "Check the thing"
+    depends_on:
+      - make
+"""
+
+# Valid YAML, but neither a WorkflowSpec (no ``nodes`` list) nor a DSL
+# (no ``phases``) - the "genuinely broken" case `_detect_kind` calls "unknown".
+_BROKEN_MANIFEST = """\
+name: nothing-useful
+"""
+
+
+def _write(tmp_path: Path, name: str, text: str) -> Path:
+    workflows_dir = tmp_path / ".bernstein" / "workflows"
+    workflows_dir.mkdir(parents=True, exist_ok=True)
+    path = workflows_dir / f"{name}.yaml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# `workflow run` on DSL-form manifests
+# ---------------------------------------------------------------------------
+
+
+def test_run_dry_run_on_dsl_manifest_prints_plan_not_pydantic_dump(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A DSL-form manifest dry-runs cleanly instead of hitting the WorkflowSpec wall."""
+    _write(tmp_path, "two-phase", _DSL_MANIFEST)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["workflow", "run", "two-phase", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "validation error" not in result.output.lower()
+    assert "Field required" not in result.output
+    assert "make" in result.output
+    assert "test" in result.output
+
+
+def test_run_without_dry_run_on_dsl_manifest_names_the_working_invocation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A real `run` of a DSL manifest fails with one clean line, not a pydantic dump."""
+    _write(tmp_path, "two-phase", _DSL_MANIFEST)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["workflow", "run", "two-phase"])
+
+    assert result.exit_code != 0
+    assert "validation error" not in result.output.lower()
+    assert "Field required" not in result.output
+    assert "--dry-run" in result.output
+
+
+def test_run_still_resolves_spec_form_manifests_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pre-existing WorkflowSpec `run` path is untouched by kind routing."""
+    _write(
+        tmp_path,
+        "spec-only",
+        """\
+name: spec-only
+description: "One command node"
+version: "1.0.0"
+nodes:
+  - id: only
+    command: "true"
+""",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["workflow", "run", "spec-only", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Layer 1" in result.output
+    assert "only" in result.output
+
+
+def test_run_missing_workflow_reports_not_found_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A name matching nothing on disk keeps the existing not-found message."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "no-home"))
+
+    result = CliRunner().invoke(cli, ["workflow", "run", "does-not-exist-anywhere"])
+
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# `workflow list`
+# ---------------------------------------------------------------------------
+
+
+def test_list_renders_dsl_manifest_exactly_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A DSL-form manifest gets exactly one DSL row, never a duplicate error row."""
+    _write(tmp_path, "two-phase", _DSL_MANIFEST)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        cli, ["workflow", "list", "--dir", str(tmp_path / ".bernstein" / "workflows")]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "validation error" not in result.output.lower()
+    assert result.output.count("two-phase") == 1
+    assert "DSL" in result.output
+
+
+def test_list_broken_manifest_is_not_a_stack_trace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A manifest that fails both parsers still renders (exit 0, one error row)."""
+    _write(tmp_path, "broken", _BROKEN_MANIFEST)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        cli, ["workflow", "list", "--dir", str(tmp_path / ".bernstein" / "workflows")]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "broken" in result.output
+    assert "error" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# `_one_line_error` helper (unit-level, precise about the actual bug)
+# ---------------------------------------------------------------------------
+
+
+def test_one_line_error_collapses_multiline_pydantic_dump() -> None:
+    """The rendered error string never contains a raw newline.
+
+    A raw multi-line ``ValidationError`` str, handed to a Rich table cell,
+    is what produced the one-word-per-line wrapping the issue reports.
+    """
+    with pytest.raises(WorkflowSpecError) as exc_info:
+        load_workflow_spec_from_text("description: only\n")
+
+    rendered = _one_line_error(exc_info.value)
+
+    assert "\n" not in rendered
+    assert rendered  # still says *something* useful, just on one line
+
+
+def test_one_line_error_truncates_very_long_messages() -> None:
+    """A pathological error message is capped so the table stays scannable."""
+    err = WorkflowSpecError("x" * 500)
+    rendered = _one_line_error(err)
+    assert len(rendered) <= 160

--- a/tests/unit/test_workflow_cmd.py
+++ b/tests/unit/test_workflow_cmd.py
@@ -88,9 +88,7 @@ def test_run_without_dry_run_on_dsl_manifest_names_the_working_invocation(
     assert "--dry-run" in result.output
 
 
-def test_run_still_resolves_spec_form_manifests_unchanged(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_still_resolves_spec_form_manifests_unchanged(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The pre-existing WorkflowSpec `run` path is untouched by kind routing."""
     _write(
         tmp_path,
@@ -113,9 +111,7 @@ nodes:
     assert "only" in result.output
 
 
-def test_run_missing_workflow_reports_not_found_unchanged(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_missing_workflow_reports_not_found_unchanged(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A name matching nothing on disk keeps the existing not-found message."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("HOME", str(tmp_path / "no-home"))
@@ -136,9 +132,7 @@ def test_list_renders_dsl_manifest_exactly_once(tmp_path: Path, monkeypatch: pyt
     _write(tmp_path, "two-phase", _DSL_MANIFEST)
     monkeypatch.chdir(tmp_path)
 
-    result = CliRunner().invoke(
-        cli, ["workflow", "list", "--dir", str(tmp_path / ".bernstein" / "workflows")]
-    )
+    result = CliRunner().invoke(cli, ["workflow", "list", "--dir", str(tmp_path / ".bernstein" / "workflows")])
 
     assert result.exit_code == 0, result.output
     assert "validation error" not in result.output.lower()
@@ -151,9 +145,7 @@ def test_list_broken_manifest_is_not_a_stack_trace(tmp_path: Path, monkeypatch: 
     _write(tmp_path, "broken", _BROKEN_MANIFEST)
     monkeypatch.chdir(tmp_path)
 
-    result = CliRunner().invoke(
-        cli, ["workflow", "list", "--dir", str(tmp_path / ".bernstein" / "workflows")]
-    )
+    result = CliRunner().invoke(cli, ["workflow", "list", "--dir", str(tmp_path / ".bernstein" / "workflows")])
 
     assert result.exit_code == 0, result.output
     assert "broken" in result.output


### PR DESCRIPTION
`workflow run` only understood the WorkflowSpec schema, so every conditional-DAG manifest the repo bundles dry-ran into a raw pydantic dump instead of a plan, and `workflow list` rendered the same dump a second time inside a table cell. Both commands now sniff manifest kind and route accordingly, with a one-line message when a kind isn't runnable via `run`.

Ships a runnable `pr-review` workflow (review, conditional revise, verify) gated by a new `when` predicate on the declarative runner, plus a CI smoke test that dry-runs every bundled manifest so schema drift in either format fails the build.

Tested via CliRunner against synthetic and real bundled manifests, and end to end against the actual `pr-review.yaml` with a scripted fake adapter proving `revise` is skipped on approve and runs on request-changes.

Closes #4461
Closes #4464