### PR TITLE
feat: schedule one bounded test-authoring follow-up at run completion

### DIFF
--- a/src/bernstein/core/config/config_schema.py
+++ b/src/bernstein/core/config/config_schema.py
@@ -375,6 +375,22 @@ class GithubSchema(BaseModel):
     )
 
 
+class OrchestrationSchema(BaseModel):
+    """Orchestrator run-lifecycle behaviour configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    test_followup: bool = Field(
+        default=True,
+        description=(
+            "Schedule one bounded test-authoring follow-up task when a run's "
+            "branch diff touches src/ without touching tests/, instead of "
+            "parking at the merge gate for an operator to notice. On by "
+            "default. Overridable at runtime with BERNSTEIN_TEST_FOLLOWUP."
+        ),
+    )
+
+
 class ClusterSchema(BaseModel):
     """Cluster mode configuration."""
 
@@ -853,6 +869,7 @@ class BernsteinConfig(BaseModel):
     sovereign: SovereignProfileSchema | None = None
     session: SessionSchema | None = None
     github: GithubSchema | None = None
+    orchestration: OrchestrationSchema | None = None
     cluster: ClusterSchema | None = None
     remote: RemoteSchema | None = None
     agency: AgencySchema | None = None

--- a/src/bernstein/core/config/seed_config.py
+++ b/src/bernstein/core/config/seed_config.py
@@ -157,6 +157,23 @@ class GithubConfig:
     sync_backlog: bool = False
 
 
+@dataclass(frozen=True)
+class OrchestrationConfig:
+    """Orchestrator run-lifecycle behaviour configuration.
+
+    Attributes:
+        test_followup: When ``True`` (the default), a run whose branch diff
+            touches ``src/*`` without touching ``tests/*`` gets exactly one
+            bounded test-authoring follow-up task scheduled at run
+            completion instead of parking at the merge gate for an operator
+            to notice (issue #4462). The ``BERNSTEIN_TEST_FOLLOWUP`` env var
+            overrides this value at runtime; see
+            ``core.orchestration.test_followup.resolve_test_followup_enabled``.
+    """
+
+    test_followup: bool = True
+
+
 def github_backlog_sync_enabled(
     seed: Any,
     env: dict[str, str] | None = None,
@@ -404,6 +421,7 @@ class SeedConfig:
     workspace: Workspace | None = None
     session: SessionConfig = field(default_factory=SessionConfig)
     github: GithubConfig = field(default_factory=GithubConfig)
+    orchestration: OrchestrationConfig = field(default_factory=OrchestrationConfig)
     worktree_setup: WorktreeSetupConfig | None = None
     quality_gates: QualityGatesConfig | None = None
     formal_verification: FormalVerificationConfig | None = None

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -29,6 +29,7 @@ from bernstein.core.config.seed_config import (
     ModelFallbackSeedConfig,
     NetworkConfig,
     NotifyConfig,
+    OrchestrationConfig,
     RateLimitBucketConfig,
     RateLimitConfig,
     SeedConfig,
@@ -1440,6 +1441,25 @@ def _parse_github(raw: object) -> GithubConfig:
     return GithubConfig(sync_backlog=sync_raw)
 
 
+def _parse_orchestration(raw: object) -> OrchestrationConfig:
+    """Parse the optional ``orchestration`` section.
+
+    Only ``test_followup`` is recognised today (issue #4462): whether a run
+    that finishes having touched ``src/`` without ``tests/`` gets one bounded
+    test-authoring follow-up task. Defaults to ``True`` - an unattended run
+    that trips the merge gate's test-evidence check should not need an
+    operator to notice and re-drive it by hand.
+    """
+    if raw is None:
+        return OrchestrationConfig()
+    if not isinstance(raw, dict):
+        raise SeedError(f"orchestration must be a mapping, got: {type(raw).__name__}")
+    test_followup_raw: object = cast("_StrObjDict", raw).get("test_followup", True)
+    if not isinstance(test_followup_raw, bool):
+        raise SeedError(f"orchestration.test_followup must be a bool, got: {type(test_followup_raw).__name__}")
+    return OrchestrationConfig(test_followup=test_followup_raw)
+
+
 def _parse_workspace(
     workspace_raw: object,
     repos_raw: object,
@@ -2116,6 +2136,7 @@ _PARSED_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
         "model_policy",
         "network",
         "notify",
+        "orchestration",
         "org_policies",
         "provider_availability",
         "quality_gates",
@@ -2323,6 +2344,7 @@ def parse_seed(path: Path) -> SeedConfig:
     cluster = _parse_cluster(data.get("cluster"))
     session_cfg = _parse_session(data.get("session"))
     github_cfg = _parse_github(data.get("github"))
+    orchestration_cfg = _parse_orchestration(data.get("orchestration"))
     workspace = _parse_workspace(data.get("workspace"), data.get("repos"), path.parent)
     worktree_setup = _parse_worktree_setup(data.get("worktree_setup"))
     batch = _parse_batch(data.get("batch"))
@@ -2387,6 +2409,7 @@ def parse_seed(path: Path) -> SeedConfig:
         workspace=workspace,
         session=session_cfg,
         github=github_cfg,
+        orchestration=orchestration_cfg,
         worktree_setup=worktree_setup,
         secrets=secrets,
         key_rotation=key_rotation,

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -462,6 +462,12 @@ class Orchestrator:
         self._last_replenish_ts: float = 0.0
         # Run completion summary state
         self._summary_written: bool = False
+        # One-shot latch (issue #4462): True once this run has scheduled its
+        # one bounded test-authoring follow-up task. Never reset for the
+        # life of this process, so the quiescence the follow-up task's OWN
+        # completion produces can never schedule a second one. See
+        # core.orchestration.test_followup and _maybe_schedule_test_followup.
+        self._test_followup_scheduled: bool = False
         # Guards the FINAL (shutdown-final) retrospective regeneration so it
         # only ever runs once per process, regardless of which terminal path
         # triggers it (tick-loop drain in run(), or the tick-level
@@ -2329,6 +2335,14 @@ class Orchestrator:
                                 self._tick_count,
                                 _hold_reasons,
                             )
+                        elif self._maybe_schedule_test_followup(settled.get("done", [])):
+                            logger.info(
+                                "Quiescence confirmed after %.1fs settle window (tick #%d) but a "
+                                "bounded test-authoring follow-up was just scheduled - "
+                                "deferring self-stop",
+                                _settle_s,
+                                self._tick_count,
+                            )
                         else:
                             logger.info(
                                 "Quiescence confirmed after %.1fs settle window (tick #%d, "
@@ -2657,6 +2671,85 @@ class Orchestrator:
         self._closure_outcome = RunClosureOutcome.FAILED
         self._regenerate_final_retrospective(trigger_path="tick-stalled-run-self-stop")
         self._running = False
+
+    def _maybe_schedule_test_followup(self, done_tasks: list[Task]) -> bool:
+        """Schedule one bounded test-authoring follow-up if this run needs it (#4462).
+
+        Called from the confirmed-quiescence self-stop branch of the tick's
+        step-8b handling, before the run would otherwise stop. Returns True
+        iff a follow-up task was just created - the caller must skip
+        self-stopping this tick when it is, since the run now has one more
+        bounded task to execute before it is actually finished.
+
+        The ``_test_followup_scheduled`` one-shot latch means a later
+        quiescence in this same orchestrator process - including the one the
+        follow-up task's own completion produces - never schedules a second
+        one (no loops), regardless of what that follow-up's own diff looks
+        like.
+        """
+        from bernstein.core.orchestration.test_followup import (
+            build_followup_goal,
+            diff_name_only,
+            evaluate_test_followup,
+            resolve_run_branch,
+            resolve_test_followup_enabled,
+        )
+
+        enabled = resolve_test_followup_enabled(self._config.test_followup_enabled)
+        branch: str | None = None
+        changed: tuple[str, ...] = ()
+        if enabled and not self._test_followup_scheduled:
+            try:
+                from bernstein.core.git.git_basic import resolve_default_branch
+
+                branch = resolve_run_branch(self._workdir, done_tasks)
+                if branch is not None:
+                    base_branch = resolve_default_branch(self._workdir)
+                    changed = diff_name_only(self._workdir, base_branch, branch)
+            except Exception:
+                logger.exception("test_followup: branch-diff lookup failed - skipping")
+                branch = None
+
+        decision = evaluate_test_followup(
+            enabled=enabled,
+            already_scheduled=self._test_followup_scheduled,
+            changed_files=changed,
+        )
+        if not decision.should_schedule:
+            logger.debug("test_followup: not scheduling (%s)", decision.reason)
+            return False
+        if branch is None:
+            # The diff shape says a follow-up is warranted, but no completed
+            # task in this run has a git branch left to diff (already merged
+            # and cleaned up, or a merge_strategy that never leaves one).
+            # Fail closed rather than guessing which branch to target.
+            logger.warning("test_followup: src-without-tests diff detected but no run branch was resolvable")
+            return False
+
+        goal = build_followup_goal(decision.src_files)
+        try:
+            response = self._client.post(
+                f"{self._config.server_url}/tasks",
+                json={
+                    "title": "Add tests for untested source change",
+                    "description": goal,
+                    "role": "qa",
+                    "priority": 2,
+                    "metadata": {"origin": "test_followup", "source_branch": branch},
+                },
+            )
+            response.raise_for_status()
+        except Exception as exc:
+            logger.warning("test_followup: failed to create follow-up task: %s", exc)
+            return False
+
+        self._test_followup_scheduled = True
+        logger.info(
+            "test_followup: scheduled one bounded test-authoring follow-up on %s (%d src file(s) without tests)",
+            branch,
+            len(decision.src_files),
+        )
+        return True
 
     def _regenerate_final_retrospective(self, trigger_path: str) -> None:
         """Regenerate the FINAL retrospective and summary.json from final event state.
@@ -6747,6 +6840,12 @@ if __name__ == "__main__":
             # bernstein.yaml never reached the runtime object and the
             # self-evolution loop ran regardless of the seed (#config-drift).
             evolution_enabled=getattr(seed, "evolution_enabled", True) if seed else True,
+            # Threads ``orchestration.test_followup`` from bernstein.yaml
+            # (issue #4462); see core.orchestration.test_followup for the
+            # env-override resolution applied when this is actually used.
+            test_followup_enabled=(
+                getattr(getattr(seed, "orchestration", None), "test_followup", True) if seed else True
+            ),
         )
 
         if args.cells > 1:

--- a/src/bernstein/core/orchestration/test_followup.py
+++ b/src/bernstein/core/orchestration/test_followup.py
@@ -1,0 +1,285 @@
+"""One bounded test-authoring follow-up for a run that changed src/ without tests/ (#4462).
+
+An unattended run that touches ``src/*`` but never ``tests/*`` is a dead end
+today: the merge gate correctly refuses a source change with no test
+evidence, the branch parks, and nothing re-drives a second run until an
+operator notices. This module supplies the missing step: at the quiescence
+self-stop in ``Orchestrator._tick_internal`` (see
+``core.orchestration.run_stall`` for the sibling terminal-state fix at the
+same call site), decide whether the run's branch needs exactly one bounded
+follow-up task that writes the missing tests, and never more than one.
+
+Two layers, deliberately kept apart so the decision itself needs no git, no
+HTTP client, and no clock:
+
+* :func:`evaluate_test_followup` is the pure criterion. It is the single
+  place the four required behaviors are pinned: trigger on src-without-tests,
+  don't trigger when tests are already present, never trigger a second time
+  in the same run (the ``already_scheduled`` latch), and don't trigger at all
+  when disabled.
+* :func:`resolve_run_branch` and :func:`diff_name_only` do the actual git
+  work an orchestrator needs to turn a completed run into the
+  ``changed_files`` the criterion reads. They are the only impure functions
+  here; everything else takes already-resolved data.
+
+Which way the criterion errs: toward NOT scheduling. A branch whose diff
+cannot be resolved, or a follow-up that itself lands src-only changes, both
+fall through to "run continues to its ordinary self-stop" rather than
+retrying - matching the "one attempt only" requirement in the issue.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bernstein.core.git.git_basic import run_git
+from bernstein.core.path_scope import normalise_repo_path
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+    from pathlib import Path
+
+    from bernstein.core.tasks.models import Task
+
+logger = logging.getLogger(__name__)
+
+#: Overrides ``orchestration.test_followup`` from bernstein.yaml at runtime,
+#: for headless operators who cannot edit the seed file. Same truthy/falsy
+#: vocabulary as every other boolean env override in this project.
+ENV_TEST_FOLLOWUP = "BERNSTEIN_TEST_FOLLOWUP"
+
+_TRUTHY = frozenset({"1", "true", "yes", "on", "enable", "enabled"})
+_FALSY = frozenset({"0", "false", "no", "off", "disable", "disabled"})
+
+
+# ---------------------------------------------------------------------------
+# Pure decision logic
+# ---------------------------------------------------------------------------
+
+
+def _is_src_path(path: str) -> bool:
+    return path == "src" or path.startswith("src/")
+
+
+def _is_test_path(path: str) -> bool:
+    return path == "tests" or path.startswith("tests/")
+
+
+@dataclass(frozen=True)
+class DiffClassification:
+    """Which side of the src/tests boundary each changed path falls on.
+
+    Paths outside both ``src/`` and ``tests/`` (docs, config, workflow files)
+    are dropped: they never satisfy the "tests already present" exemption,
+    so scoping to only these two directories is equivalent to tracking them
+    and ignoring them at every read site.
+    """
+
+    src_files: tuple[str, ...]
+    test_files: tuple[str, ...]
+
+    @property
+    def needs_followup(self) -> bool:
+        """True when the diff touched src/ and never touched tests/."""
+        return bool(self.src_files) and not self.test_files
+
+
+def classify_diff(changed_files: Iterable[str]) -> DiffClassification:
+    """Partition a diff's changed paths into src/tests, deduped and ordered.
+
+    Paths are normalised the same way ``git diff --name-only`` output is
+    normalised everywhere else in this codebase (see
+    :func:`bernstein.core.path_scope.normalise_repo_path`), so a leading
+    ``./`` or a Windows-style backslash cannot hide a path from either
+    bucket.
+    """
+    src: list[str] = []
+    tests: list[str] = []
+    seen: set[str] = set()
+    for raw in changed_files:
+        path = normalise_repo_path(raw)
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        if _is_test_path(path):
+            tests.append(path)
+        elif _is_src_path(path):
+            src.append(path)
+    return DiffClassification(src_files=tuple(src), test_files=tuple(tests))
+
+
+@dataclass(frozen=True)
+class TestFollowupDecision:
+    """Outcome of :func:`evaluate_test_followup`.
+
+    Attributes:
+        should_schedule: True only when a bounded follow-up task should be
+            created. Callers must not self-stop the run this tick when True
+            -- the run just gained one more task to execute.
+        reason: Machine-readable verdict tag, logged by the caller so a
+            grep of the logs always finds an explicit answer for why a run
+            did or did not get a follow-up.
+        src_files: The src/ paths the follow-up's goal should name. Empty
+            unless ``should_schedule`` is True.
+    """
+
+    should_schedule: bool
+    reason: str
+    src_files: tuple[str, ...] = ()
+
+
+def evaluate_test_followup(
+    *,
+    enabled: bool,
+    already_scheduled: bool,
+    changed_files: Iterable[str],
+) -> TestFollowupDecision:
+    """Decide whether this run's completion warrants one test-authoring follow-up.
+
+    Pure: reads only its arguments, performs no IO.
+
+    Args:
+        enabled: Effective ``orchestration.test_followup`` setting (see
+            :func:`resolve_test_followup_enabled`).
+        already_scheduled: True once a follow-up has already been scheduled
+            for this run. This is the bounding latch: it stays True for the
+            rest of the run's lifetime, including across the quiescence the
+            follow-up task's OWN completion produces, so a follow-up that
+            itself lands src-only changes can never trigger a second one.
+        changed_files: The run branch's changed paths (``git diff
+            --name-only`` shape).
+
+    Returns:
+        The verdict. ``should_schedule`` is True only for a first-ever,
+        enabled, src-without-tests diff.
+    """
+    if not enabled:
+        return TestFollowupDecision(should_schedule=False, reason="disabled")
+    if already_scheduled:
+        return TestFollowupDecision(should_schedule=False, reason="already_scheduled")
+
+    classification = classify_diff(changed_files)
+    if not classification.src_files:
+        return TestFollowupDecision(should_schedule=False, reason="no_src_changes")
+    if classification.test_files:
+        return TestFollowupDecision(should_schedule=False, reason="tests_present")
+    return TestFollowupDecision(
+        should_schedule=True,
+        reason="src_without_tests",
+        src_files=classification.src_files,
+    )
+
+
+def build_followup_goal(src_files: Sequence[str]) -> str:
+    """Deterministic goal text for the bounded test-authoring follow-up.
+
+    Carries the file list so the follow-up agent - and anyone reading the
+    task - knows exactly which change needs coverage without re-deriving
+    the diff. Deterministic in file order (callers pass the already-ordered
+    tuple :func:`classify_diff` produced), so the same diff always produces
+    the same goal text.
+    """
+    file_list = "\n".join(f"- {f}" for f in src_files)
+    return (
+        "This branch changed source files with no corresponding test changes. "
+        "Write tests that assert the behavior this diff introduced or changed - "
+        "assert the defect it would leave uncaught, not the implementation. "
+        "Touch only tests/; do not modify src/.\n\n"
+        f"Source files changed without tests:\n{file_list}"
+    )
+
+
+def resolve_test_followup_enabled(config_value: bool, env: Mapping[str, str] | None = None) -> bool:
+    """Resolve whether the test-authoring follow-up is enabled, env-first.
+
+    Precedence: an explicit ``BERNSTEIN_TEST_FOLLOWUP`` env value wins
+    (truthy enables, falsy disables); otherwise ``config_value`` (the seed's
+    ``orchestration.test_followup``, default ``True``) applies.
+
+    Args:
+        config_value: ``OrchestratorConfig.test_followup_enabled``, itself
+            sourced from ``orchestration.test_followup`` in bernstein.yaml.
+        env: Environment mapping to consult; defaults to ``os.environ``.
+
+    Returns:
+        The effective enabled state for this process.
+    """
+    source = os.environ if env is None else env
+    raw = source.get(ENV_TEST_FOLLOWUP)
+    if raw is None:
+        return bool(config_value)
+    lowered = raw.strip().lower()
+    if lowered in _TRUTHY:
+        return True
+    if lowered in _FALSY:
+        return False
+    logger.warning(
+        "%s=%r not understood; using orchestration.test_followup from config",
+        ENV_TEST_FOLLOWUP,
+        raw,
+    )
+    return bool(config_value)
+
+
+# ---------------------------------------------------------------------------
+# Git integration (impure - the only functions here that touch the repo)
+# ---------------------------------------------------------------------------
+
+
+def resolve_run_branch(workdir: Path, done_tasks: Sequence[Task]) -> str | None:
+    """Return the agent branch of the most recently completed task that still exists.
+
+    Each spawned agent works on its own ``agent/<session_id>`` branch (see
+    ``core.git.worktree.WorktreeManager.create``); there is no single branch
+    that spans a whole run. At run completion the most recently completed
+    task's branch is the one a merge gate would currently be evaluating, so
+    that is what "the run's branch" means here. A task whose branch has
+    already been merged and deleted is skipped in favour of an earlier task
+    whose branch still resolves.
+
+    Args:
+        workdir: Repository root to resolve branches in.
+        done_tasks: The run's completed tasks (any status/order).
+
+    Returns:
+        The branch name (``agent/<session_id>``), or ``None`` if no done
+        task has a resolvable branch.
+    """
+    candidates = sorted(
+        (t for t in done_tasks if t.assigned_agent and t.completed_at),
+        key=lambda t: t.completed_at or 0.0,
+        reverse=True,
+    )
+    for task in candidates:
+        branch = f"agent/{task.assigned_agent}"
+        probe = run_git(["rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"], workdir, timeout=5)
+        if probe.ok:
+            return branch
+    return None
+
+
+def diff_name_only(workdir: Path, base_branch: str, branch: str) -> tuple[str, ...]:
+    """Return the paths changed on ``branch`` relative to its merge-base with ``base_branch``.
+
+    Three-dot diff (symmetric difference from the merge base) - the same
+    shape the dashboard's per-task diff view and the merge gate itself read,
+    so this reports exactly what a human or the gate would see for this
+    branch, not a two-dot diff against base's current tip.
+
+    Returns an empty tuple (rather than raising) on any git failure, so a
+    transient git error degrades to "no follow-up this tick" instead of
+    crashing the tick loop.
+    """
+    result = run_git(["diff", "--name-only", f"{base_branch}...{branch}"], workdir, timeout=15)
+    if not result.ok:
+        logger.warning(
+            "test_followup: git diff --name-only %s...%s failed: %s",
+            base_branch,
+            branch,
+            result.stderr.strip(),
+        )
+        return ()
+    return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1691,6 +1691,11 @@ class OrchestratorConfig:
     # is never given unrequested background maintenance tasks; enable only when
     # the target repo declares Python dependencies that should be audited.
     dependency_scan_enabled: bool = False
+    # Whether a run whose branch diff touches src/ without tests/ gets one
+    # bounded test-authoring follow-up task at run completion (issue #4462).
+    # On by default; threaded from the seed's ``orchestration.test_followup``
+    # (bernstein.yaml). See core.orchestration.test_followup.
+    test_followup_enabled: bool = True
     # Janitor LLM-judge model/provider override, threaded from the seed's
     # ``judge_model``/``judge_provider`` (bernstein.yaml). None = fall back
     # to the janitor's hardcoded JUDGE_MODEL/JUDGE_PROVIDER defaults.

--- a/tests/integration/test_test_followup_e2e.py
+++ b/tests/integration/test_test_followup_e2e.py
@@ -221,7 +221,9 @@ class TestTestFollowupEndToEnd:
         assert orch._test_followup_scheduled is False
         assert orch._running is False
 
-    def test_no_followup_when_disabled_via_env(self, tmp_path: Path, fast_settle: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_no_followup_when_disabled_via_env(
+        self, tmp_path: Path, fast_settle: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv("BERNSTEIN_TEST_FOLLOWUP", "0")
         _init_repo_with_agent_branch(tmp_path, session_id="sess-notests", with_tests=False)
         server = _ScriptedServer(session_id="sess-notests")

--- a/tests/integration/test_test_followup_e2e.py
+++ b/tests/integration/test_test_followup_e2e.py
@@ -1,0 +1,235 @@
+"""End-to-end proof that a completed run schedules its bounded test-authoring
+follow-up (issue #4462) through the real ``Orchestrator.tick()`` path.
+
+Drives the orchestrator against a mocked task-server HTTP transport (a
+"scripted adapter": the transport script decides what the server has and
+records what the orchestrator sends it) and a real temporary git repository
+standing in for the run's workdir, so ``resolve_run_branch`` /
+``diff_name_only`` run against real git rather than a fake. This is the one
+integration test the issue's test plan calls for; the decision logic itself
+is unit-tested directly in ``tests/unit/test_orchestration_test_followup.py``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from bernstein.core.models import OrchestratorConfig
+from bernstein.core.orchestrator import Orchestrator
+from bernstein.core.spawner import AgentSpawner
+
+from bernstein.adapters.base import CLIAdapter, SpawnResult
+
+# Ticks any single scenario below is willing to spend. Comfortably above what
+# a settled/no-active-holds quiescence needs, far below anything hang-like.
+_TICK_BUDGET = 10
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_repo_with_agent_branch(workdir: Path, *, session_id: str, with_tests: bool) -> None:
+    """Build a real repo on ``main`` with one completed agent branch."""
+    _git(["init", "-q", "-b", "main", "."], workdir)
+    _git(["config", "user.email", "t@example.com"], workdir)
+    _git(["config", "user.name", "t"], workdir)
+    (workdir / "src").mkdir()
+    (workdir / "tests").mkdir()
+    (workdir / "src" / "foo.py").write_text("print(1)\n")
+    _git(["add", "-A"], workdir)
+    _git(["commit", "-q", "-m", "init"], workdir)
+
+    _git(["checkout", "-q", "-b", f"agent/{session_id}"], workdir)
+    (workdir / "src" / "foo.py").write_text("print(2)\n")
+    if with_tests:
+        (workdir / "tests" / "test_foo.py").write_text("def test_foo(): assert True\n")
+    _git(["add", "-A"], workdir)
+    _git(["commit", "-q", "-m", "agent work"], workdir)
+    _git(["checkout", "-q", "main"], workdir)
+
+
+class _ScriptedServer:
+    """Minimal in-memory task-server double: one done task, records POSTs."""
+
+    def __init__(self, *, session_id: str) -> None:
+        self.session_id = session_id
+        self.task: dict[str, Any] = {
+            "id": "t-run",
+            "title": "Do the thing",
+            "description": "d",
+            "role": "backend",
+            "status": "done",
+            "priority": 1,
+            "created_at": time.time() - 60.0,
+            "completed_at": time.time() - 1.0,
+            "depends_on": [],
+            "owned_files": [],
+            "assigned_agent": session_id,
+            "result_summary": "done",
+            "task_type": "standard",
+            "retry_count": 0,
+            "max_retries": 3,
+        }
+        self.created_tasks: list[dict[str, Any]] = []
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        url = request.url
+        if request.method == "GET" and url.path == "/tasks":
+            status = url.params.get("status")
+            tasks = [dict(self.task)] if status in (None, self.task["status"]) else []
+            return httpx.Response(200, json=tasks)
+        if request.method == "POST" and url.path == "/tasks":
+            body = _json_body(request)
+            self.created_tasks.append(body)
+            return httpx.Response(201, json={"id": f"t-followup-{len(self.created_tasks)}", **body})
+        if request.method == "GET" and url.path == "/orchestrator/holds":
+            return httpx.Response(200, json={"holds": []})
+        return httpx.Response(200, json={})
+
+
+def _json_body(request: httpx.Request) -> dict[str, Any]:
+    import json
+
+    raw = request.read().decode() or "{}"
+    return dict(json.loads(raw))
+
+
+def _wrap_as_paginated(resp: httpx.Response) -> httpx.Response:
+    tasks = resp.json()
+    return httpx.Response(200, json={"tasks": tasks, "total": len(tasks)})
+
+
+def _paginated(inner: httpx.MockTransport) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = request.url
+        if request.method == "GET" and url.path == "/tasks" and "limit" in url.params:
+            plain_params = {k: v for k, v in url.params.items() if k not in ("limit", "offset")}
+            plain_url = url.copy_with(params=plain_params or {})
+            plain = httpx.Request(request.method, plain_url, headers=request.headers)
+            resp = inner.handle_request(plain)
+            return _wrap_as_paginated(resp) if resp.status_code == 200 else resp
+        return inner.handle_request(request)
+
+    return httpx.MockTransport(handler)
+
+
+def _mock_adapter() -> MagicMock:
+    adapter = MagicMock(spec=CLIAdapter)
+    adapter.spawn.return_value = SpawnResult(pid=42, log_path=Path("/tmp/test.log"))
+    adapter.is_alive.return_value = False
+    adapter.is_rate_limited.return_value = False
+    adapter.kill.return_value = None
+    adapter.name.return_value = "MockCLI"
+    return adapter
+
+
+def _build_orchestrator(workdir: Path, server: _ScriptedServer, *, test_followup_enabled: bool = True) -> Orchestrator:
+    cfg = OrchestratorConfig(
+        max_agents=1,
+        poll_interval_s=1,
+        server_url="http://testserver",
+        evolve_mode=False,
+        evolution_enabled=False,
+        test_followup_enabled=test_followup_enabled,
+    )
+    templates_dir = workdir / "templates" / "roles"
+    templates_dir.mkdir(parents=True)
+    spawner = AgentSpawner(_mock_adapter(), templates_dir, workdir, default_model="mock-model")
+    client = httpx.Client(transport=_paginated(httpx.MockTransport(server.handler)), base_url="http://testserver")
+    return Orchestrator(cfg, spawner, workdir, client=client)
+
+
+@pytest.fixture
+def fast_settle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Collapse the real settle window so the test runs in milliseconds."""
+    monkeypatch.setenv("BERNSTEIN_QUIESCENCE_SETTLE_S", "0")
+
+
+def _run_until_stopped_or_budget(orch: Orchestrator) -> int:
+    ticks_used = 0
+    for _ in range(_TICK_BUDGET):
+        ticks_used += 1
+        orch.tick()
+        if not orch._running:
+            break
+    return ticks_used
+
+
+class TestTestFollowupEndToEnd:
+    def test_src_without_tests_schedules_followup_carrying_the_file_list(
+        self, tmp_path: Path, fast_settle: None
+    ) -> None:
+        _init_repo_with_agent_branch(tmp_path, session_id="sess-notests", with_tests=False)
+        server = _ScriptedServer(session_id="sess-notests")
+        orch = _build_orchestrator(tmp_path, server)
+        orch._running = True
+
+        _run_until_stopped_or_budget(orch)
+
+        assert len(server.created_tasks) == 1, "exactly one follow-up task must be scheduled"
+        created = server.created_tasks[0]
+        assert created["role"] == "qa"
+        assert "src/foo.py" in created["description"]
+        assert "tests/" in created["description"]
+        assert created["metadata"]["origin"] == "test_followup"
+        assert created["metadata"]["source_branch"] == "agent/sess-notests"
+        assert orch._test_followup_scheduled is True
+
+    def test_run_still_self_stops_after_scheduling_the_followup(self, tmp_path: Path, fast_settle: None) -> None:
+        _init_repo_with_agent_branch(tmp_path, session_id="sess-notests", with_tests=False)
+        server = _ScriptedServer(session_id="sess-notests")
+        orch = _build_orchestrator(tmp_path, server)
+        orch._running = True
+
+        _run_until_stopped_or_budget(orch)
+
+        # The mock server's task list never changes across ticks (it always
+        # reports the same single done task), so once the latch is set the
+        # orchestrator has nothing left to wait for and must still reach its
+        # ordinary self-stop rather than idling forever.
+        assert orch._running is False
+        assert len(server.created_tasks) == 1, "no second follow-up must be scheduled on a later tick"
+
+    def test_no_followup_when_branch_already_has_tests(self, tmp_path: Path, fast_settle: None) -> None:
+        _init_repo_with_agent_branch(tmp_path, session_id="sess-withtests", with_tests=True)
+        server = _ScriptedServer(session_id="sess-withtests")
+        orch = _build_orchestrator(tmp_path, server)
+        orch._running = True
+
+        _run_until_stopped_or_budget(orch)
+
+        assert server.created_tasks == []
+        assert orch._test_followup_scheduled is False
+        assert orch._running is False
+
+    def test_no_followup_when_disabled_via_config(self, tmp_path: Path, fast_settle: None) -> None:
+        _init_repo_with_agent_branch(tmp_path, session_id="sess-notests", with_tests=False)
+        server = _ScriptedServer(session_id="sess-notests")
+        orch = _build_orchestrator(tmp_path, server, test_followup_enabled=False)
+        orch._running = True
+
+        _run_until_stopped_or_budget(orch)
+
+        assert server.created_tasks == []
+        assert orch._test_followup_scheduled is False
+        assert orch._running is False
+
+    def test_no_followup_when_disabled_via_env(self, tmp_path: Path, fast_settle: None, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_TEST_FOLLOWUP", "0")
+        _init_repo_with_agent_branch(tmp_path, session_id="sess-notests", with_tests=False)
+        server = _ScriptedServer(session_id="sess-notests")
+        # Config says enabled; the env override must win.
+        orch = _build_orchestrator(tmp_path, server, test_followup_enabled=True)
+        orch._running = True
+
+        _run_until_stopped_or_budget(orch)
+
+        assert server.created_tasks == []
+        assert orch._running is False

--- a/tests/unit/test_orchestration_test_followup.py
+++ b/tests/unit/test_orchestration_test_followup.py
@@ -1,0 +1,255 @@
+"""Unit tests for the bounded test-authoring follow-up (issue #4462).
+
+Covers, per the issue's acceptance criteria:
+
+* trigger - a src-without-tests diff schedules exactly one follow-up whose
+  goal carries the file list;
+* non-trigger - a diff that already includes tests never schedules one;
+* no-loop - once a follow-up has been scheduled for a run, a later
+  evaluation (including one fed the follow-up's own diff) never schedules a
+  second one;
+* switch-off - the config/env switch disables the behaviour entirely.
+
+``evaluate_test_followup`` is pure, so these are fed synthetic diffs
+directly rather than driven through a live server - the "stubbed
+ledger/spawner" style the issue's test plan asks for. The git-touching
+helpers (``resolve_run_branch``, ``diff_name_only``) get their own class
+against a real temporary repository, since faking git here would just
+re-implement it. The end-to-end path - a scripted adapter proving the
+follow-up task actually reaches ``POST /tasks`` with the file list in its
+goal - lives in ``tests/integration/test_test_followup_e2e.py``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.orchestration.test_followup import (
+    ENV_TEST_FOLLOWUP,
+    DiffClassification,
+    build_followup_goal,
+    classify_diff,
+    diff_name_only,
+    evaluate_test_followup,
+    resolve_run_branch,
+    resolve_test_followup_enabled,
+)
+from bernstein.core.tasks.models import Task
+
+
+def _task(task_id: str, *, assigned_agent: str | None, completed_at: float | None) -> Task:
+    return Task(
+        id=task_id,
+        title=task_id,
+        description="d",
+        role="backend",
+        assigned_agent=assigned_agent,
+        completed_at=completed_at,
+    )
+
+
+class TestClassifyDiff:
+    def test_partitions_src_and_tests(self) -> None:
+        result = classify_diff(["src/a.py", "src/sub/b.py", "tests/test_a.py"])
+        assert result == DiffClassification(
+            src_files=("src/a.py", "src/sub/b.py"),
+            test_files=("tests/test_a.py",),
+        )
+
+    def test_unrelated_paths_are_dropped(self) -> None:
+        result = classify_diff(["docs/readme.md", "bernstein.yaml", "README.md"])
+        assert result.src_files == ()
+        assert result.test_files == ()
+        assert result.needs_followup is False
+
+    def test_needs_followup_true_only_for_src_without_tests(self) -> None:
+        assert classify_diff(["src/a.py"]).needs_followup is True
+        assert classify_diff(["src/a.py", "tests/t.py"]).needs_followup is False
+        assert classify_diff(["tests/t.py"]).needs_followup is False
+        assert classify_diff([]).needs_followup is False
+
+    def test_normalises_and_dedupes_paths(self) -> None:
+        result = classify_diff(["./src/a.py", "src\\a.py", "src/a.py"])
+        assert result.src_files == ("src/a.py",)
+
+    def test_bare_src_and_tests_directory_entries_count(self) -> None:
+        # A rename/delete can surface the bare directory itself.
+        assert classify_diff(["src"]).src_files == ("src",)
+        assert classify_diff(["tests"]).test_files == ("tests",)
+
+
+class TestEvaluateTestFollowup:
+    """Pins the four required behaviours directly against the pure criterion."""
+
+    def test_trigger_on_src_without_tests(self) -> None:
+        decision = evaluate_test_followup(
+            enabled=True,
+            already_scheduled=False,
+            changed_files=["src/foo.py", "src/bar.py"],
+        )
+        assert decision.should_schedule is True
+        assert decision.reason == "src_without_tests"
+        assert decision.src_files == ("src/foo.py", "src/bar.py")
+
+    def test_non_trigger_when_diff_already_has_tests(self) -> None:
+        decision = evaluate_test_followup(
+            enabled=True,
+            already_scheduled=False,
+            changed_files=["src/foo.py", "tests/test_foo.py"],
+        )
+        assert decision.should_schedule is False
+        assert decision.reason == "tests_present"
+
+    def test_non_trigger_when_no_src_changes(self) -> None:
+        decision = evaluate_test_followup(
+            enabled=True,
+            already_scheduled=False,
+            changed_files=["docs/readme.md"],
+        )
+        assert decision.should_schedule is False
+        assert decision.reason == "no_src_changes"
+
+    def test_no_loop_once_already_scheduled(self) -> None:
+        # Same src-without-tests diff that triggered above, fed again with
+        # already_scheduled=True (as it would be after the follow-up's own
+        # completion re-triggers quiescence) - must never fire twice.
+        decision = evaluate_test_followup(
+            enabled=True,
+            already_scheduled=True,
+            changed_files=["src/foo.py"],
+        )
+        assert decision.should_schedule is False
+        assert decision.reason == "already_scheduled"
+
+    def test_switch_off_disables_even_a_triggering_diff(self) -> None:
+        decision = evaluate_test_followup(
+            enabled=False,
+            already_scheduled=False,
+            changed_files=["src/foo.py"],
+        )
+        assert decision.should_schedule is False
+        assert decision.reason == "disabled"
+
+    def test_disabled_takes_precedence_over_already_scheduled_reason(self) -> None:
+        # Ordering check: disabled must not report "already_scheduled".
+        decision = evaluate_test_followup(enabled=False, already_scheduled=True, changed_files=["src/foo.py"])
+        assert decision.reason == "disabled"
+
+
+class TestBuildFollowupGoal:
+    def test_carries_the_file_list(self) -> None:
+        goal = build_followup_goal(("src/foo.py", "src/bar.py"))
+        assert "src/foo.py" in goal
+        assert "src/bar.py" in goal
+
+    def test_instructs_tests_only_scope(self) -> None:
+        goal = build_followup_goal(("src/foo.py",))
+        assert "tests/" in goal
+        assert "do not modify src/" in goal
+
+    def test_deterministic_for_the_same_input(self) -> None:
+        assert build_followup_goal(("src/a.py", "src/b.py")) == build_followup_goal(("src/a.py", "src/b.py"))
+
+
+class TestResolveTestFollowupEnabled:
+    def test_env_unset_falls_back_to_config_value(self) -> None:
+        assert resolve_test_followup_enabled(True, env={}) is True
+        assert resolve_test_followup_enabled(False, env={}) is False
+
+    def test_env_truthy_overrides_config_false(self) -> None:
+        for word in ("1", "true", "yes", "on", "enabled"):
+            assert resolve_test_followup_enabled(False, env={ENV_TEST_FOLLOWUP: word}) is True
+
+    def test_env_falsy_overrides_config_true(self) -> None:
+        for word in ("0", "false", "no", "off", "disabled"):
+            assert resolve_test_followup_enabled(True, env={ENV_TEST_FOLLOWUP: word}) is False
+
+    def test_env_unrecognised_falls_back_to_config_value(self) -> None:
+        assert resolve_test_followup_enabled(True, env={ENV_TEST_FOLLOWUP: "maybe"}) is True
+        assert resolve_test_followup_enabled(False, env={ENV_TEST_FOLLOWUP: "maybe"}) is False
+
+    def test_reads_real_os_environ_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_TEST_FOLLOWUP, "0")
+        assert resolve_test_followup_enabled(True) is False
+        monkeypatch.delenv(ENV_TEST_FOLLOWUP, raising=False)
+        assert resolve_test_followup_enabled(True) is True
+
+
+# ---------------------------------------------------------------------------
+# Git integration helpers - real temporary repository, no mocking git itself.
+# ---------------------------------------------------------------------------
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo_with_branches(tmp_path: Path) -> Path:
+    """A repo on ``main`` with a src+test change on ``agent/with-tests`` and
+    a src-only change on ``agent/no-tests``, both branched from the same
+    root commit.
+    """
+    _git(["init", "-q", "-b", "main", "."], tmp_path)
+    _git(["config", "user.email", "t@example.com"], tmp_path)
+    _git(["config", "user.name", "t"], tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "src" / "foo.py").write_text("print(1)\n")
+    _git(["add", "-A"], tmp_path)
+    _git(["commit", "-q", "-m", "init"], tmp_path)
+
+    _git(["checkout", "-q", "-b", "agent/no-tests"], tmp_path)
+    (tmp_path / "src" / "foo.py").write_text("print(2)\n")
+    (tmp_path / "src" / "bar.py").write_text("print(3)\n")
+    _git(["add", "-A"], tmp_path)
+    _git(["commit", "-q", "-m", "src only"], tmp_path)
+    _git(["checkout", "-q", "main"], tmp_path)
+
+    _git(["checkout", "-q", "-b", "agent/with-tests"], tmp_path)
+    (tmp_path / "src" / "foo.py").write_text("print(4)\n")
+    (tmp_path / "tests" / "test_foo.py").write_text("def test_foo(): assert True\n")
+    _git(["add", "-A"], tmp_path)
+    _git(["commit", "-q", "-m", "src and tests"], tmp_path)
+    _git(["checkout", "-q", "main"], tmp_path)
+
+    return tmp_path
+
+
+class TestResolveRunBranch:
+    def test_picks_the_most_recently_completed_tasks_branch(self, repo_with_branches: Path) -> None:
+        older = _task("t-old", assigned_agent="with-tests", completed_at=100.0)
+        newer = _task("t-new", assigned_agent="no-tests", completed_at=200.0)
+        assert resolve_run_branch(repo_with_branches, [older, newer]) == "agent/no-tests"
+
+    def test_falls_back_past_a_task_whose_branch_no_longer_exists(self, repo_with_branches: Path) -> None:
+        gone = _task("t-gone", assigned_agent="already-merged-and-deleted", completed_at=999.0)
+        earlier = _task("t-earlier", assigned_agent="no-tests", completed_at=1.0)
+        assert resolve_run_branch(repo_with_branches, [gone, earlier]) == "agent/no-tests"
+
+    def test_none_when_no_task_has_a_resolvable_branch(self, repo_with_branches: Path) -> None:
+        gone = _task("t-gone", assigned_agent="nope", completed_at=1.0)
+        assert resolve_run_branch(repo_with_branches, [gone]) is None
+
+    def test_none_for_empty_task_list(self, repo_with_branches: Path) -> None:
+        assert resolve_run_branch(repo_with_branches, []) is None
+
+    def test_skips_tasks_with_no_assigned_agent(self, repo_with_branches: Path) -> None:
+        unassigned = _task("t-unassigned", assigned_agent=None, completed_at=500.0)
+        assert resolve_run_branch(repo_with_branches, [unassigned]) is None
+
+
+class TestDiffNameOnly:
+    def test_reports_changed_files_on_a_src_only_branch(self, repo_with_branches: Path) -> None:
+        changed = diff_name_only(repo_with_branches, "main", "agent/no-tests")
+        assert set(changed) == {"src/bar.py", "src/foo.py"}
+
+    def test_reports_changed_files_on_a_branch_with_tests(self, repo_with_branches: Path) -> None:
+        changed = diff_name_only(repo_with_branches, "main", "agent/with-tests")
+        assert set(changed) == {"src/foo.py", "tests/test_foo.py"}
+
+    def test_empty_on_git_failure_rather_than_raising(self, repo_with_branches: Path) -> None:
+        assert diff_name_only(repo_with_branches, "main", "branch/does/not/exist") == ()

--- a/tests/unit/test_pr_gen.py
+++ b/tests/unit/test_pr_gen.py
@@ -105,7 +105,9 @@ def test_title_respects_existing_conventional_prefix() -> None:
 
 def test_title_uses_changes_summary_when_provided() -> None:
     changes_summary = "- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect"
-    title = build_pr_title("Add JWT authentication with refresh tokens", role="engineer", changes_summary=changes_summary)
+    title = build_pr_title(
+        "Add JWT authentication with refresh tokens", role="engineer", changes_summary=changes_summary
+    )
     # Outcome derived from changes_summary first line (task title before ": ")
     assert title.startswith("feat: add JWT auth")
     # Conventional type still from goal/role/labels (not changes_summary)
@@ -132,9 +134,7 @@ def test_title_falls_back_to_goal_when_changes_summary_empty() -> None:
 
 
 def test_body_uses_changes_summary_for_change_section() -> None:
-    summary = _fixture_summary(
-        changes_summary="- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect"
-    )
+    summary = _fixture_summary(changes_summary="- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect")
     body = build_pr_body(summary)
     assert "## Change" in body
     assert "Add JWT auth: wired refresh tokens" in body
@@ -149,9 +149,7 @@ def test_body_falls_back_to_diff_stat_when_changes_summary_empty() -> None:
 
 
 def test_body_problem_is_single_line_from_goal() -> None:
-    summary = _fixture_summary(
-        goal="Add JWT authentication with refresh tokens. Also secure cookies and audit logs."
-    )
+    summary = _fixture_summary(goal="Add JWT authentication with refresh tokens. Also secure cookies and audit logs.")
     body = build_pr_body(summary)
     assert "## Problem" in body
     # Only first sentence, no trailing period in the line (since it's the first part)
@@ -160,9 +158,7 @@ def test_body_problem_is_single_line_from_goal() -> None:
 
 
 def test_body_problem_extracts_issue_title_from_goal() -> None:
-    summary = _fixture_summary(
-        goal="Resolve GitHub issue #42: Fix broken login on mobile"
-    )
+    summary = _fixture_summary(goal="Resolve GitHub issue #42: Fix broken login on mobile")
     body = build_pr_body(summary)
     assert "## Problem" in body
     assert "Fix broken login on mobile" in body
@@ -251,9 +247,7 @@ def test_load_session_summary_reads_changes_summary(tmp_path: Path) -> None:
 
     summary = load_session_summary(None, workdir=tmp_path)
 
-    assert summary.changes_summary == (
-        "- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect"
-    )
+    assert summary.changes_summary == ("- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect")
 
 
 def test_load_session_summary_falls_back_to_live_session(tmp_path: Path) -> None:


### PR DESCRIPTION
A run that changes `src/*` without touching `tests/*` currently trips the merge gate's test-evidence check and parks with no way back until an operator notices and re-drives it by hand.

At the quiescence self-stop, the orchestrator now checks the run's branch diff against the base branch. If it touched `src/*` without touching `tests/*`, it schedules exactly one bounded follow-up task on the same branch to write the missing tests, and stops without retrying if that follow-up also lands without tests.

Adds `orchestration.test_followup` (default `true`) to `bernstein.yaml`, with a `BERNSTEIN_TEST_FOLLOWUP` env override for headless operators.

Tested with unit tests pinning the scheduling criterion (trigger, non-trigger, no-loop, disable switch) plus git branch/diff resolution against a real repo, and an end-to-end test driving a real orchestrator tick loop against a scripted task-server transport that asserts the follow-up task reaches `POST /tasks` with the changed-file list in its goal.

Closes #4462