### PR TITLE
feat(release-notes): per-change fragment files instead of a single append-file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,15 @@ Every PR that adds or changes a feature MUST update docs in the same PR:
 
 PRs without the matching docs change will be sent back. Docs and code ship together.
 
+### Release notes
+
+Add `docs/release-notes/fragments/<issue-or-slug>.md` describing a
+user-visible change: a `## <title>` heading and a short paragraph, same as
+any existing entry. One file per PR means two PRs never conflict on the
+same line the way appending to `docs/release-notes/unreleased.md` did.
+Editing `unreleased.md` directly still works during the transition; see
+`docs/release-notes/README.md`.
+
 ### Pre-push hook
 
 Install the versioned pre-push hook to catch lint and architecture-contract

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -1,0 +1,43 @@
+# Release notes
+
+This directory holds three kinds of file:
+
+| File | What it is |
+|---|---|
+| `vX.Y.Z.md` | A tagged release's page. Immutable once shipped. |
+| `unreleased.md` | Entries that landed since the newest tag, added by hand. Kept only for the fragments transition; see below. |
+| `fragments/<issue-or-slug>.md` | One pending entry, one file. The current way to add an entry (#4474). |
+
+## Adding an entry
+
+Add `docs/release-notes/fragments/<issue-or-slug>.md` in the same PR as the
+change. Name it for the issue or PR it documents (`4474-notes-fragments.md`
+is fine; so is a short slug when there is no issue). Content is exactly what
+an entry has always been: a `## <title>` heading and a short prose paragraph,
+the issue or PR number in parens at the end.
+
+```markdown
+## Two independent entries no longer share a file
+
+Every PR appended one line to `unreleased.md`, so any two open PRs conflicted
+on that file in the merge queue. An entry is a fragment file now (#4474).
+```
+
+One file per entry means two PRs that each add a fragment never touch the
+same line, so they merge through the queue in either order with nothing to
+rebase.
+
+Editing `unreleased.md` directly still works during the transition -- the
+release-notes gate (`scripts/rotate_release_notes.py check-gate`) accepts
+either form.
+
+## Cutting a release
+
+`scripts/rotate_release_notes.py rotate docs/release-notes/vX.Y.Z.md`
+concatenates the fragments in deterministic filename order, appends the
+rendered section to the version page, and deletes the consumed fragments --
+commit both edits together, the same way emptying `unreleased.md` has always
+been a step of the release PR itself (`docs/operations/release.md`).
+Entries still carried in `unreleased.md` continue to move onto the version
+page by hand, exactly as before; `tests/unit/test_unreleased_notes_rotation.py`
+fails the build if one gets left behind.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -18,3 +18,6 @@ The nightly full-closure audit runs `pip-audit --strict` over the dev closure an
 ## Watchdog no longer restarts a run that already finished
 
 A clean quiescence self-stop journals `run_completed` and exits, but the recovery watchdog's stand-down check only recognised teardown in progress, so it restarted the orchestrator anyway — five times, until it gave up and logged a spurious error. The check now reads the run's own completion record before restarting it (#4445).
+## An entry no longer has to share this file
+
+Every PR appended one line here, so any two open PRs conflicted on this file in the merge queue and each needed a manual rebase and re-enqueue. An entry can be a `docs/release-notes/fragments/<issue-or-slug>.md` file instead; the release rotation concatenates fragments in filename order into the version page and deletes them in the same commit (#4474).

--- a/scripts/rotate_release_notes.py
+++ b/scripts/rotate_release_notes.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Rotate per-change release-notes fragments into a versioned notes page.
+
+Every PR used to append its own line to the single
+``docs/release-notes/unreleased.md`` file. Any two open PRs therefore
+conflicted on that one shared anchor in the merge queue: the first merge
+invalidated every other queued PR, and each needed a manual rebase and
+re-enqueue.
+
+A PR now has the option to add one file instead: ``docs/release-notes/
+fragments/<issue-or-slug>.md``, holding the same ``## <title>`` heading and
+prose paragraph an entry has always used. One entry, one file -- no shared
+anchor, no conflicts.
+
+This script is the rotation step that used to be entirely by hand (see
+``docs/operations/release.md``, "Release notes"): it concatenates the
+fragments in deterministic filename order, appends the rendered section onto
+the version page a release cuts, and deletes the consumed fragments so the
+version-page edit and the cleanup land in the same commit. Editing
+``docs/release-notes/unreleased.md`` directly still works during the
+transition; ``notes_gate_ok`` accepts either form.
+
+Usage::
+
+    python scripts/rotate_release_notes.py rotate docs/release-notes/v3.18.0.md
+    python scripts/rotate_release_notes.py check-gate <changed-file> [<changed-file> ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FRAGMENTS_DIR = REPO_ROOT / "docs" / "release-notes" / "fragments"
+
+# Repo-relative paths the notes gate recognises. Compared against
+# forward-slash-normalized input so it works with paths from either a POSIX
+# or a Windows checkout.
+_UNRELEASED_REL = "docs/release-notes/unreleased.md"
+_FRAGMENTS_REL_PREFIX = "docs/release-notes/fragments/"
+
+
+@dataclass
+class RotationResult:
+    """Outcome of folding fragments into a version page."""
+
+    consumed: list[Path] = field(default_factory=list)
+    rendered: str = ""
+
+
+def collect_fragments(fragments_dir: Path) -> list[Path]:
+    """Return fragment files under ``fragments_dir`` in deterministic order.
+
+    Ordered by filename, not by write time or directory-listing order: two
+    PRs that each add one fragment merge in either order and still render
+    the same combined section, so there is nothing for the merge queue to
+    conflict on.
+
+    Args:
+        fragments_dir: Directory holding one ``.md`` file per entry.
+
+    Returns:
+        Matching files sorted by filename. Empty when the directory is
+        missing, empty, or holds no ``.md`` files.
+    """
+    if not fragments_dir.is_dir():
+        return []
+    return sorted(p for p in fragments_dir.iterdir() if p.is_file() and p.suffix == ".md")
+
+
+def render_fragments(fragments_dir: Path) -> str:
+    """Concatenate fragment bodies into one rendered section.
+
+    Each fragment holds one whole entry -- the same ``## <title>`` heading
+    plus prose paragraph a contributor previously appended to
+    ``unreleased.md`` by hand. Bodies are stripped of surrounding blank
+    lines and joined with exactly one blank line between them, matching the
+    spacing every tagged release page already uses between its ``## ``
+    sections.
+
+    Args:
+        fragments_dir: Directory holding fragment files.
+
+    Returns:
+        The rendered section text, or ``""`` when there are no fragments.
+    """
+    bodies = [p.read_text(encoding="utf-8").strip() for p in collect_fragments(fragments_dir)]
+    return "\n\n".join(bodies)
+
+
+def rotate_into(version_page: Path, fragments_dir: Path) -> RotationResult:
+    """Append the rendered fragments section to ``version_page`` and delete them.
+
+    Both edits happen in this one call -- the version page gains the
+    section and the consumed fragments are removed from disk -- so a
+    release PR commits them together and never carries a page section with
+    no matching fragment, or a fragment nothing rendered.
+
+    Args:
+        version_page: The ``vX.Y.Z.md`` page the release is cutting.
+            Created if it does not yet exist; appended to (after a blank
+            line) if it does.
+        fragments_dir: Directory holding fragment files to consume.
+
+    Returns:
+        A ``RotationResult`` naming the consumed fragment paths and the
+        rendered text. Both are empty when there was nothing to rotate.
+    """
+    fragments = collect_fragments(fragments_dir)
+    if not fragments:
+        return RotationResult()
+
+    section = render_fragments(fragments_dir)
+    existing = version_page.read_text(encoding="utf-8") if version_page.exists() else ""
+    updated = existing.rstrip("\n") + "\n\n" + section + "\n" if existing.strip() else section + "\n"
+    version_page.write_text(updated, encoding="utf-8")
+
+    for fragment in fragments:
+        fragment.unlink()
+
+    return RotationResult(consumed=fragments, rendered=section)
+
+
+def notes_gate_ok(changed_files: Iterable[str]) -> bool:
+    """Return whether a change set satisfies the release-notes gate.
+
+    Accepts either form during the fragments transition window: an edit to
+    ``docs/release-notes/unreleased.md``, or a new or changed fragment
+    under ``docs/release-notes/fragments/``. Editing a tagged version page
+    (``docs/release-notes/vX.Y.Z.md``) does not count -- that documents
+    what already shipped, not the change this PR makes.
+
+    Args:
+        changed_files: Repo-relative paths, e.g. from
+            ``git diff --name-only``. Windows-style separators are
+            normalized before matching.
+
+    Returns:
+        True if at least one path satisfies the gate.
+    """
+    for raw in changed_files:
+        path = raw.replace("\\", "/")
+        if path == _UNRELEASED_REL:
+            return True
+        if path.startswith(_FRAGMENTS_REL_PREFIX) and path.endswith(".md"):
+            return True
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    rotate_p = sub.add_parser("rotate", help="Concatenate fragments into a version page and delete them.")
+    rotate_p.add_argument("version_page", type=Path, help="The vX.Y.Z.md page being cut.")
+    rotate_p.add_argument("--fragments-dir", type=Path, default=FRAGMENTS_DIR)
+
+    gate_p = sub.add_parser("check-gate", help="Exit 0 if the given changed files satisfy the release-notes gate.")
+    gate_p.add_argument("changed_files", nargs="*", help="Repo-relative changed file paths.")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "rotate":
+        result = rotate_into(args.version_page, args.fragments_dir)
+        if result.consumed:
+            names = ", ".join(p.name for p in result.consumed)
+            print(f"Rotated {len(result.consumed)} fragment(s) into {args.version_page}: {names}")
+        else:
+            print(f"No fragments in {args.fragments_dir}; nothing to rotate.")
+        return 0
+
+    if notes_gate_ok(args.changed_files):
+        print("Release-notes gate: OK")
+        return 0
+    print(
+        "Release-notes gate: FAIL - no edit to docs/release-notes/unreleased.md "
+        "and no fragment under docs/release-notes/fragments/. Add one of the two.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_rotate_release_notes.py
+++ b/tests/unit/scripts/test_rotate_release_notes.py
@@ -1,0 +1,311 @@
+"""Unit tests for ``scripts/rotate_release_notes.py`` - the fragments rotation (#4474).
+
+Every PR used to append its release-notes entry to the single
+``docs/release-notes/unreleased.md`` file, so any two open PRs conflicted on
+that one anchor in the merge queue. These tests pin the fragment-file
+alternative: one entry, one file under ``docs/release-notes/fragments/``,
+concatenated in deterministic (filename) order by the release rotation and
+deleted once folded into the versioned page.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "rotate_release_notes.py"
+
+
+@pytest.fixture
+def rotate_module() -> Generator[ModuleType, None, None]:
+    """Load scripts/rotate_release_notes.py as an importable module."""
+    spec = importlib.util.spec_from_file_location("rotate_release_notes_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+_ENTRY_A = (
+    "## Nightly dependency audit is green again\n\n"
+    "The nightly full-closure audit runs `pip-audit --strict` over the dev closure "
+    "and had failed since 2026-08-22 on `pip` 26.1.2 (PYSEC-2026-3721). `pip` is "
+    "bumped to 26.2.1 in the lockfile.\n"
+)
+_ENTRY_B = (
+    "## Two independent release-notes entries no longer share a file\n\n"
+    "Every PR appended one line to `unreleased.md`, so any two open PRs conflicted "
+    "on that file in the merge queue. An entry is a fragment file under "
+    "`docs/release-notes/fragments/` now (#4474).\n"
+)
+
+
+# --- collect_fragments ---
+
+
+class TestCollectFragments:
+    def test_returns_empty_list_for_missing_directory(self, rotate_module: ModuleType, tmp_path: Path) -> None:
+        assert rotate_module.collect_fragments(tmp_path / "does-not-exist") == []
+
+    def test_returns_empty_list_for_empty_directory(self, rotate_module: ModuleType, tmp_path: Path) -> None:
+        fragments_dir = tmp_path / "fragments"
+        fragments_dir.mkdir()
+        assert rotate_module.collect_fragments(fragments_dir) == []
+
+    def test_orders_by_filename_not_write_order(self, rotate_module: ModuleType, tmp_path: Path) -> None:
+        """Two PRs land in either order; the combined output must not depend on which."""
+        fragments_dir = tmp_path / "fragments"
+        fragments_dir.mkdir()
+        # Write "second" (by name) before "first" to prove the sort key is the
+        # filename, not filesystem write order.
+        (fragments_dir / "0002-second.md").write_text(_ENTRY_B, encoding="utf-8")
+        (fragments_dir / "0001-first.md").write_text(_ENTRY_A, encoding="utf-8")
+
+        names = [p.name for p in rotate_module.collect_fragments(fragments_dir)]
+        assert names == ["0001-first.md", "0002-second.md"]
+
+    def test_ignores_non_markdown_files(self, rotate_module: ModuleType, tmp_path: Path) -> None:
+        fragments_dir = tmp_path / "fragments"
+        fragments_dir.mkdir()
+        (fragments_dir / ".gitkeep").write_text("", encoding="utf-8")
+        (fragments_dir / "4474-fragments.md").write_text(_ENTRY_B, encoding="utf-8")
+
+        names = [p.name for p in rotate_module.collect_fragments(fragments_dir)]
+        assert names == ["4474-fragments.md"]
+
+    def test_ignores_subdirectories(self, rotate_module: ModuleType, tmp_path: Path) -> None:
+        fragments_dir = tmp_path / "fragments"
+        fragments_dir.mkdir()
+        (fragments_dir / "nested").mkdir()
+        (fragments_dir / "4474-fragments.md").write_text(_ENTRY_B, encoding="utf-8")
+
+        names = [p.name for p in rotate_module.collect_fragments(fragments_dir)]
+        assert names == ["4474-fragments.md"]
+
+
+# --- render_fragments (golden test against the current hand-append flow) ---
+
+
+class TestRenderFragments:
+    def test_empty_directory_renders_empty_string(self, rotate_module: ModuleType, tmp_path: Path) -> None:
+        fragments_dir = tmp_path / "fragments"
+        fragments_dir.mkdir()
+        assert rotate_module.render_fragments(fragments_dir) == ""
+
+    def test_single_fragment_renders_its_stripped_body(self, rotate_module: ModuleType, tmp_path: Path) -> None:
+        fragments_dir = tmp_path / "fragments"
+        fragments_dir.mkdir()
+        (fragments_dir / "4474-fragments.md").write_text(f"\n\n{_ENTRY_A}\n\n", encoding="utf-8")
+
+        assert rotate_module.render_fragments(fragments_dir) == _ENTRY_A.strip()
+
+    def test_matches_the_current_hand_append_flow(self, rotate_module: ModuleType, tmp_path: Path) -> None:
+        """Golden test: concatenated fragments == entries hand-appended to unreleased.md in order.
+
+        Every existing versioned page (e.g. v3.17.2.md) separates its
+        ``## `` sections with exactly one blank line. That is also what a
+        contributor produces today by hand-appending a new section at the
+        end of unreleased.md. The fragment rotation must reproduce it
+        byte-for-byte, not merely "close enough".
+        """
+        fragments_dir = tmp_path / "fragments"
+        fragments_dir.mkdir()
+        (fragments_dir / "0001-first.md").write_text(_ENTRY_A, encoding="utf-8")
+        (fragments_dir / "0002-second.md").write_text(_ENTRY_B, encoding="utf-8")
+
+        rendered = rotate_module.render_fragments(fragments_dir)
+
+        hand_appended = _ENTRY_A.strip() + "\n\n" + _ENTRY_B.strip()
+        assert rendered == hand_appended
+
+
+# --- rotate_into (deletes consumed fragments in the same call) ---
+
+
+class TestRotateInto:
+    def test_no_fragments_is_a_noop(self, rotate_module: ModuleType, tmp_path: Path) -> None:
+        fragments_dir = tmp_path / "fragments"
+        fragments_dir.mkdir()
+        version_page = tmp_path / "v3.18.0.md"
+        version_page.write_text("# v3.18.0\n\nExisting content.\n", encoding="utf-8")
+
+        result = rotate_module.rotate_into(version_page, fragments_dir)
+
+        assert result.consumed == []
+        assert version_page.read_text(encoding="utf-8") == "# v3.18.0\n\nExisting content.\n"
+
+    def test_appends_rendered_section_to_existing_page(self, rotate_module: ModuleType, tmp_path: Path) -> None:
+        fragments_dir = tmp_path / "fragments"
+        fragments_dir.mkdir()
+        (fragments_dir / "0001-first.md").write_text(_ENTRY_A, encoding="utf-8")
+        version_page = tmp_path / "v3.18.0.md"
+        version_page.write_text("# v3.18.0\n\nA patch release.\n", encoding="utf-8")
+
+        rotate_module.rotate_into(version_page, fragments_dir)
+
+        assert version_page.read_text(encoding="utf-8") == (
+            "# v3.18.0\n\nA patch release.\n\n" + _ENTRY_A.strip() + "\n"
+        )
+
+    def test_writes_into_a_page_that_does_not_exist_yet(self, rotate_module: ModuleType, tmp_path: Path) -> None:
+        fragments_dir = tmp_path / "fragments"
+        fragments_dir.mkdir()
+        (fragments_dir / "0001-first.md").write_text(_ENTRY_A, encoding="utf-8")
+        version_page = tmp_path / "v3.18.0.md"
+
+        rotate_module.rotate_into(version_page, fragments_dir)
+
+        assert version_page.read_text(encoding="utf-8") == _ENTRY_A.strip() + "\n"
+
+    def test_deletes_consumed_fragments(self, rotate_module: ModuleType, tmp_path: Path) -> None:
+        fragments_dir = tmp_path / "fragments"
+        fragments_dir.mkdir()
+        first = fragments_dir / "0001-first.md"
+        second = fragments_dir / "0002-second.md"
+        first.write_text(_ENTRY_A, encoding="utf-8")
+        second.write_text(_ENTRY_B, encoding="utf-8")
+        version_page = tmp_path / "v3.18.0.md"
+        version_page.write_text("# v3.18.0\n\nA patch release.\n", encoding="utf-8")
+
+        result = rotate_module.rotate_into(version_page, fragments_dir)
+
+        assert not first.exists()
+        assert not second.exists()
+        assert rotate_module.collect_fragments(fragments_dir) == []
+        assert {p.name for p in result.consumed} == {"0001-first.md", "0002-second.md"}
+
+    def test_returns_the_rendered_section(self, rotate_module: ModuleType, tmp_path: Path) -> None:
+        fragments_dir = tmp_path / "fragments"
+        fragments_dir.mkdir()
+        (fragments_dir / "0001-first.md").write_text(_ENTRY_A, encoding="utf-8")
+        version_page = tmp_path / "v3.18.0.md"
+        version_page.write_text("# v3.18.0\n", encoding="utf-8")
+
+        result = rotate_module.rotate_into(version_page, fragments_dir)
+
+        assert result.rendered == _ENTRY_A.strip()
+
+
+# --- notes_gate_ok (dual-accept during the fragments transition) ---
+
+
+class TestNotesGateOk:
+    def test_passes_on_unreleased_edit(self, rotate_module: ModuleType) -> None:
+        changed = ["src/bernstein/core/foo.py", "docs/release-notes/unreleased.md"]
+        assert rotate_module.notes_gate_ok(changed) is True
+
+    def test_passes_on_new_fragment(self, rotate_module: ModuleType) -> None:
+        changed = ["src/bernstein/core/foo.py", "docs/release-notes/fragments/4474-fragments.md"]
+        assert rotate_module.notes_gate_ok(changed) is True
+
+    def test_fails_with_neither(self, rotate_module: ModuleType) -> None:
+        changed = ["src/bernstein/core/foo.py", "tests/unit/test_foo.py"]
+        assert rotate_module.notes_gate_ok(changed) is False
+
+    def test_fails_on_empty_changeset(self, rotate_module: ModuleType) -> None:
+        assert rotate_module.notes_gate_ok([]) is False
+
+    def test_a_versioned_page_edit_alone_does_not_satisfy_the_gate(self, rotate_module: ModuleType) -> None:
+        """Editing a tagged release page is not the same as documenting a new change."""
+        changed = ["docs/release-notes/v3.17.2.md"]
+        assert rotate_module.notes_gate_ok(changed) is False
+
+    def test_a_non_markdown_file_under_fragments_does_not_satisfy_the_gate(self, rotate_module: ModuleType) -> None:
+        changed = ["docs/release-notes/fragments/.gitkeep"]
+        assert rotate_module.notes_gate_ok(changed) is False
+
+    def test_passes_with_both(self, rotate_module: ModuleType) -> None:
+        changed = ["docs/release-notes/unreleased.md", "docs/release-notes/fragments/4474-fragments.md"]
+        assert rotate_module.notes_gate_ok(changed) is True
+
+    def test_windows_style_separators_are_normalized(self, rotate_module: ModuleType) -> None:
+        changed = ["docs\\release-notes\\fragments\\4474-fragments.md"]
+        assert rotate_module.notes_gate_ok(changed) is True
+
+
+# --- CLI ---
+
+
+class TestMain:
+    def test_rotate_subcommand_exits_zero(
+        self, rotate_module: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        fragments_dir = tmp_path / "fragments"
+        fragments_dir.mkdir()
+        (fragments_dir / "0001-first.md").write_text(_ENTRY_A, encoding="utf-8")
+        version_page = tmp_path / "v3.18.0.md"
+        version_page.write_text("# v3.18.0\n", encoding="utf-8")
+
+        rc = rotate_module.main(["rotate", str(version_page), "--fragments-dir", str(fragments_dir)])
+
+        assert rc == 0
+        assert not (fragments_dir / "0001-first.md").exists()
+        out = capsys.readouterr().out
+        assert "0001-first.md" in out
+
+    def test_check_gate_subcommand_exits_zero_on_pass(self, rotate_module: ModuleType) -> None:
+        rc = rotate_module.main(["check-gate", "docs/release-notes/unreleased.md"])
+        assert rc == 0
+
+    def test_check_gate_subcommand_exits_nonzero_on_fail(self, rotate_module: ModuleType) -> None:
+        rc = rotate_module.main(["check-gate", "src/bernstein/core/foo.py"])
+        assert rc != 0
+
+
+# --- Merge-queue conflict freedom (acceptance criterion, exercised with real git) ---
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=True)
+
+
+class TestTwoFragmentPRsMergeWithNoConflict:
+    def test_two_branches_each_adding_a_fragment_merge_cleanly(self, tmp_path: Path) -> None:
+        """Two PRs that each add their own fragment file never touch the same line.
+
+        Reproduces the merge-queue shape from #4474 with real git: branch
+        one adds fragment A, branch two (cut from the same base, unaware of
+        branch one) adds fragment B, and both merge into main with no
+        conflict -- unlike two PRs that each appended a line to the same
+        ``unreleased.md``.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git("init", "-q", "-b", "main", cwd=repo)
+        _git("config", "user.email", "test@example.invalid", cwd=repo)
+        _git("config", "user.name", "Test", cwd=repo)
+
+        fragments = repo / "docs" / "release-notes" / "fragments"
+        fragments.mkdir(parents=True)
+        (fragments / ".gitkeep").write_text("", encoding="utf-8")
+        _git("add", "-A", cwd=repo)
+        _git("commit", "-q", "-m", "chore: seed fragments dir", cwd=repo)
+        base_sha = _git("rev-parse", "HEAD", cwd=repo).stdout.strip()
+
+        _git("checkout", "-q", "-b", "pr-a", cwd=repo)
+        (fragments / "4474-a.md").write_text(_ENTRY_A, encoding="utf-8")
+        _git("add", "-A", cwd=repo)
+        _git("commit", "-q", "-m", "docs: add fragment a", cwd=repo)
+
+        _git("checkout", "-q", "-b", "pr-b", base_sha, cwd=repo)
+        (fragments / "4474-b.md").write_text(_ENTRY_B, encoding="utf-8")
+        _git("add", "-A", cwd=repo)
+        _git("commit", "-q", "-m", "docs: add fragment b", cwd=repo)
+
+        _git("checkout", "-q", "main", cwd=repo)
+        _git("merge", "-q", "--no-ff", "pr-a", "-m", "merge pr-a", cwd=repo)
+        # If this raised CalledProcessError, the merge conflicted -- the
+        # exact failure mode fragments are meant to remove.
+        _git("merge", "-q", "--no-ff", "pr-b", "-m", "merge pr-b", cwd=repo)
+
+        assert (fragments / "4474-a.md").exists()
+        assert (fragments / "4474-b.md").exists()


### PR DESCRIPTION
Every PR appended one line to docs/release-notes/unreleased.md, so any two open PRs conflicted on that shared file in the merge queue: the first merge invalidated every other queued PR and each needed a manual rebase and re-enqueue.

An entry can now be its own file under docs/release-notes/fragments/. scripts/rotate_release_notes.py concatenates fragments in deterministic filename order into a version page and deletes the consumed files in the same call, and a gate check accepts either a fragment or a direct unreleased.md edit during the transition. Editing unreleased.md directly still works.

Tested with unit tests covering fragment ordering, the rendered-output golden test against the current hand-append format, fragment deletion, and the gate's pass/fail cases, plus a real two-branch git merge proving two fragment PRs never conflict. CONTRIBUTING.md and a new docs/release-notes/README.md document the convention.

Closes #4474