### PR TITLE
fix(agents): scope orphan-completion signals to the agent's own session

### DIFF
--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -1937,7 +1937,7 @@ def _handle_orphan_no_signals(
     has_commits = False
     worktree_path = orch._spawner.get_worktree_path(session.id)
     if worktree_path is not None:
-        has_commits = _has_git_commits_on_branch(worktree_path)
+        has_commits = _has_git_commits_on_branch(worktree_path, start_ts)
     clean_exit = session.exit_code == 0
 
     if files_changed > 0:
@@ -2575,11 +2575,22 @@ def check_stalled_tasks(orch: Any) -> None:
     heartbeat_protocol.check_stalled_tasks(orch)
 
 
-def _has_git_commits_on_branch(worktree_path: Path) -> bool:
-    """Return True if the worktree branch has commits beyond main."""
+def _has_git_commits_on_branch(worktree_path: Path, since_ts: float) -> bool:
+    """Return True if the branch has commits beyond main committed after since_ts.
+
+    Scoped to the agent's own session (issue #4466): ``git log main..HEAD``
+    alone answers "does this branch have ANY commit ahead of main", which is
+    unconditionally true for a run resumed on a branch that already carried
+    work before this agent spawned - a reviewed PR checkout, a rebase-onto
+    flow. That let a dead agent on such a branch read as "made git commits"
+    and auto-complete its task on the branch's pre-existing history, even
+    when the agent itself produced zero commits. Only commits whose
+    committer timestamp is after ``since_ts`` (the agent's own start point,
+    i.e. its ``spawn_ts``) count as evidence this agent did something.
+    """
     try:
         result = subprocess.run(
-            ["git", "log", "--oneline", "main..HEAD"],
+            ["git", "log", "--format=%ct", "main..HEAD"],
             cwd=str(worktree_path),
             capture_output=True,
             text=True,
@@ -2587,7 +2598,17 @@ def _has_git_commits_on_branch(worktree_path: Path) -> bool:
             errors="replace",
             timeout=5,
         )
-        return len(result.stdout.strip()) > 0
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                commit_ts = float(line)
+            except ValueError:
+                continue
+            if commit_ts > since_ts:
+                return True
+        return False
     except Exception:
         return False
 

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -2263,7 +2263,14 @@ class TaskStore:
 
             # Issue #4401: A planning/manager task that created zero child tasks has not
             # accomplished any work. It must fail rather than falsely reporting success.
-            if task.role == "manager" and not any(t.id != task_id for t in self._tasks.values()):
+            # Scoped to THIS task's own children (issue #4466): the original check asked
+            # "does the store contain any other task at all", which a retried planning
+            # attempt or any resumed project's prior history satisfies trivially, letting
+            # a still-zero-child manager task complete as DONE the moment anything else
+            # has ever run. Checking for a child whose parent_task_id names this task is
+            # what "produced zero child tasks" actually means, regardless of what else the
+            # store holds.
+            if task.role == "manager" and not any(t.parent_task_id == task_id for t in self._tasks.values()):
                 snapshot = self._claim_snapshot(task)
                 self._index_remove(task)
                 transition_task(

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -670,6 +670,34 @@ class TaskStore:
         """
         return len(self._by_parent.get(parent_task_id, ()))
 
+    def _planning_yield_is_zero(self, task: Task) -> bool:
+        """Return True when planning *task* produced no work of its own.
+
+        "Produced no work" (#4401) is scoped to this task's own attempt
+        (#4466), and a planning task can show its yield two ways:
+
+        * a task naming it in ``parent_task_id`` - the explicit link the
+          in-process splitter and the ``self-create`` route write; or
+        * a task that came into existence after this one was claimed - the
+          only signal the agent-driven planner path leaves, because its
+          prompt has the manager POST plain ``/tasks`` bodies carrying no
+          back-link, and tells it to drop the link outright when the parent
+          id does not resolve for its token.
+
+        Demanding the back-link alone would fail every agent-driven planner
+        that decomposed correctly, and the run then re-plans from scratch and
+        multiplies the subtasks instead of failing loudly. Asking only "does
+        the store hold any other task" (the original form) is satisfied by any
+        prior history at all, including this task's own earlier attempt, so it
+        never fires on a real run. The window from claim to completion is the
+        part of the store that belongs to this attempt: work that predates the
+        claim is somebody else's, and an empty window is a zero yield.
+        """
+        if self.count_subtasks(task.id) > 0:
+            return False
+        started_at = task.claimed_at if task.claimed_at is not None else task.created_at
+        return not any(other.id != task.id and other.created_at > started_at for other in self._tasks.values())
+
     # -- persistence --------------------------------------------------------
 
     def replay_jsonl(self) -> None:
@@ -2263,14 +2291,9 @@ class TaskStore:
 
             # Issue #4401: A planning/manager task that created zero child tasks has not
             # accomplished any work. It must fail rather than falsely reporting success.
-            # Scoped to THIS task's own children (issue #4466): the original check asked
-            # "does the store contain any other task at all", which a retried planning
-            # attempt or any resumed project's prior history satisfies trivially, letting
-            # a still-zero-child manager task complete as DONE the moment anything else
-            # has ever run. Checking for a child whose parent_task_id names this task is
-            # what "produced zero child tasks" actually means, regardless of what else the
-            # store holds.
-            if task.role == "manager" and not any(t.parent_task_id == task_id for t in self._tasks.values()):
+            # Scoped to this task's own attempt (issue #4466) - see
+            # ``_planning_yield_is_zero``.
+            if task.role == "manager" and self._planning_yield_is_zero(task):
                 snapshot = self._claim_snapshot(task)
                 self._index_remove(task)
                 transition_task(

--- a/tests/unit/agents/test_agent_lifecycle_helpers.py
+++ b/tests/unit/agents/test_agent_lifecycle_helpers.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -177,25 +178,41 @@ def test_save_partial_work_no_changes_returns_false(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_has_git_commits_true_when_ahead_of_main(tmp_path: Path) -> None:
-    """A branch with commits beyond main reports True."""
+def test_has_git_commits_true_when_committed_after_since_ts(tmp_path: Path) -> None:
+    """A commit made after since_ts counts (fresh-branch behavior unchanged)."""
     _init_repo(tmp_path)
     _git(tmp_path, "checkout", "-b", "agent/A-1")
+    since_ts = time.time() - 5
     (tmp_path / "work.py").write_text("y = 2\n")
     _git(tmp_path, "add", "-A")
     _git(tmp_path, "commit", "-m", "agent work")
-    assert _has_git_commits_on_branch(tmp_path) is True
+    assert _has_git_commits_on_branch(tmp_path, since_ts) is True
+
+
+def test_has_git_commits_false_when_all_commits_predate_since_ts(tmp_path: Path) -> None:
+    """A branch already ahead of main before since_ts does not count that
+    pre-existing history (issue #4466): a resumed branch, or a checked-out
+    PR under review, must not read as "this agent made commits" just
+    because *some* commit exists in ``main..HEAD``.
+    """
+    _init_repo(tmp_path)
+    _git(tmp_path, "checkout", "-b", "agent/A-1")
+    (tmp_path / "pre.py").write_text("x = 1\n")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-m", "pre-existing work")
+    since_ts = time.time() + 5  # the agent "starts" after this commit landed
+    assert _has_git_commits_on_branch(tmp_path, since_ts) is False
 
 
 def test_has_git_commits_false_on_main(tmp_path: Path) -> None:
     """On main with no extra commits, reports False."""
     _init_repo(tmp_path)
-    assert _has_git_commits_on_branch(tmp_path) is False
+    assert _has_git_commits_on_branch(tmp_path, time.time() - 5) is False
 
 
 def test_has_git_commits_false_for_non_git_dir(tmp_path: Path) -> None:
     """A non-git directory yields False (exception swallowed)."""
-    assert _has_git_commits_on_branch(tmp_path) is False
+    assert _has_git_commits_on_branch(tmp_path, time.time()) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/tasks/test_zero_yield_planning_task.py
+++ b/tests/unit/core/tasks/test_zero_yield_planning_task.py
@@ -87,6 +87,52 @@ async def test_planning_task_with_child_tasks_succeeds(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_zero_yield_planning_fails_despite_unrelated_task_in_store(tmp_path: Path) -> None:
+    """A zero-child manager task fails even when the store is not otherwise
+    empty -- a retried planning attempt, or any resumed project carrying
+    prior history (issue #4466).
+
+    The zero-yield check must be scoped to whether THIS task has children of
+    its own, not to whether it is the only task the store has ever seen: the
+    latter is defeated by anything else in the store, including this same
+    manager task's own earlier retry attempt.
+    """
+    store = TaskStore(jsonl_path=tmp_path / "tasks.jsonl", archive_path=tmp_path / "archive.jsonl")
+
+    prior = await store.create(
+        TaskCreate(
+            title="Unrelated earlier task",
+            description="From a previous goal",
+            role="backend",
+            priority=1,
+        )
+    )
+    await store.claim_by_id(prior.id)
+    await store.complete(prior.id, result_summary="Finished earlier work")
+
+    manager_task = await store.create(
+        TaskCreate(
+            title="Plan and decompose goal into tasks",
+            description="Decompose project goal",
+            role="manager",
+            priority=1,
+            scope="large",
+        )
+    )
+    await store.claim_by_id(manager_task.id)
+    completed_task = await store.complete(manager_task.id, result_summary="Auto-completed: no real work")
+
+    assert completed_task.status == TaskStatus.FAILED
+    assert completed_task.result_summary == "Planning task produced no child tasks"
+
+    summary = store.status_summary()
+    assert summary["failed"] == 1
+    # The run must not read as healthy just because an unrelated task
+    # happened to already exist when the zero-child manager task completed.
+    assert run_healthy_from_status_counts(summary) is False
+
+
+@pytest.mark.asyncio
 async def test_worker_task_without_children_succeeds(tmp_path: Path) -> None:
     """A non-manager worker task that runs alone completes as DONE."""
     store = TaskStore(jsonl_path=tmp_path / "tasks.jsonl", archive_path=tmp_path / "archive.jsonl")

--- a/tests/unit/core/tasks/test_zero_yield_planning_task.py
+++ b/tests/unit/core/tasks/test_zero_yield_planning_task.py
@@ -133,6 +133,89 @@ async def test_zero_yield_planning_fails_despite_unrelated_task_in_store(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_planning_task_counts_children_created_during_its_own_run(tmp_path: Path) -> None:
+    """Subtasks a planner creates during its run count even with no back-link.
+
+    The agent-driven planner path has the manager POST plain ``/tasks``
+    bodies, which carry no ``parent_task_id`` at all -- the prompt tracks the
+    relationship through the description instead, and tells the agent to drop
+    the association outright when the parent id does not resolve for its
+    token. Reading yield off the back-link alone would fail a planner that
+    decomposed correctly, and the run then re-plans from scratch and
+    multiplies its subtasks.
+    """
+    store = TaskStore(jsonl_path=tmp_path / "tasks.jsonl", archive_path=tmp_path / "archive.jsonl")
+
+    prior = await store.create(
+        TaskCreate(title="Unrelated earlier task", description="From a previous goal", role="backend", priority=1)
+    )
+    await store.claim_by_id(prior.id)
+    await store.complete(prior.id, result_summary="Finished earlier work")
+
+    manager_task = await store.create(
+        TaskCreate(
+            title="Plan and decompose goal into tasks",
+            description="Decompose project goal",
+            role="manager",
+            priority=1,
+            scope="large",
+        )
+    )
+    await store.claim_by_id(manager_task.id)
+
+    # The planner agent creates its subtasks the way the prompt shows: a bare
+    # POST /tasks body, no parent_task_id.
+    for index in (1, 2):
+        created = await store.create(
+            TaskCreate(
+                title=f"Subtask {index}",
+                description=f"... [subtask of {manager_task.id}]",
+                role="backend",
+                priority=1,
+            )
+        )
+        assert created.parent_task_id is None
+
+    completed_task = await store.complete(manager_task.id, result_summary="Created 2 subtasks")
+
+    assert completed_task.status == TaskStatus.DONE
+    assert completed_task.result_summary == "Created 2 subtasks"
+    assert store.status_summary()["failed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_planning_task_ignores_tasks_created_before_it_was_claimed(tmp_path: Path) -> None:
+    """Work that predates the claim is somebody else's yield, not this task's.
+
+    This is the edge the scoping rule turns on: a task sitting in the store
+    when the planner starts cannot be evidence that the planner produced
+    anything, however recently it was queued.
+    """
+    store = TaskStore(jsonl_path=tmp_path / "tasks.jsonl", archive_path=tmp_path / "archive.jsonl")
+
+    manager_task = await store.create(
+        TaskCreate(
+            title="Plan and decompose goal into tasks",
+            description="Decompose project goal",
+            role="manager",
+            priority=1,
+            scope="large",
+        )
+    )
+    # Queued by another part of the run, before this planner ever started.
+    await store.create(
+        TaskCreate(title="Unrelated backlog item", description="Queued elsewhere", role="backend", priority=1)
+    )
+
+    await store.claim_by_id(manager_task.id)
+    completed_task = await store.complete(manager_task.id, result_summary="Auto-completed: no real work")
+
+    assert completed_task.status == TaskStatus.FAILED
+    assert completed_task.result_summary == "Planning task produced no child tasks"
+    assert run_healthy_from_status_counts(store.status_summary()) is False
+
+
+@pytest.mark.asyncio
 async def test_worker_task_without_children_succeeds(tmp_path: Path) -> None:
     """A non-manager worker task that runs alone completes as DONE."""
     store = TaskStore(jsonl_path=tmp_path / "tasks.jsonl", archive_path=tmp_path / "archive.jsonl")

--- a/tests/unit/skills/test_agent_plugins_install.py
+++ b/tests/unit/skills/test_agent_plugins_install.py
@@ -189,10 +189,10 @@ def test_install_plugin_writes_lockfile_entries(
     content = lock_path.read_text(encoding="utf-8")
     resolved_root = plugin_dir.resolve()
     for name in ("alpha", "beta", "gamma"):
-        assert f"name = \"{name}\"" in content
+        assert f'name = "{name}"' in content
         # path names the skills/<name>/ directory the skill came from, not
         # the plugin root, so sync/drift can locate the individual tree.
-        assert f"path = \"{resolved_root}/skills/{name}\"" in content
+        assert f'path = "{resolved_root}/skills/{name}"' in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_agent_lifecycle.py
+++ b/tests/unit/test_agent_lifecycle.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -143,17 +145,17 @@ def _make_orch_no_ratelimit(tmp_path: Path) -> SimpleNamespace:  # type: ignore[
 
 
 def test_has_git_commits_on_branch_returns_true_when_commits_exist(tmp_path: Path) -> None:
-    """_has_git_commits_on_branch returns True when subprocess reports commits."""
+    """_has_git_commits_on_branch returns True when a commit postdates since_ts."""
     with patch("bernstein.core.agents.agent_lifecycle.subprocess") as mock_subprocess:
         mock_result = MagicMock()
-        mock_result.stdout = "abc1234 Add feature\ndef5678 Fix tests\n"
+        mock_result.stdout = "1700000200\n1700000100\n"
         mock_subprocess.run.return_value = mock_result
         mock_subprocess.TimeoutExpired = TimeoutError
         mock_subprocess.SubprocessError = Exception
 
-        assert _has_git_commits_on_branch(tmp_path) is True
+        assert _has_git_commits_on_branch(tmp_path, 1700000000.0) is True
         mock_subprocess.run.assert_called_once_with(
-            ["git", "log", "--oneline", "main..HEAD"],
+            ["git", "log", "--format=%ct", "main..HEAD"],
             cwd=str(tmp_path),
             capture_output=True,
             text=True,
@@ -161,6 +163,22 @@ def test_has_git_commits_on_branch_returns_true_when_commits_exist(tmp_path: Pat
             errors="replace",
             timeout=5,
         )
+
+
+def test_has_git_commits_on_branch_returns_false_when_all_commits_predate_since_ts(tmp_path: Path) -> None:
+    """_has_git_commits_on_branch returns False when every commit predates since_ts.
+
+    Regression for #4466: a branch already ahead of main before the agent's
+    own start point must not read as "this agent made commits".
+    """
+    with patch("bernstein.core.agents.agent_lifecycle.subprocess") as mock_subprocess:
+        mock_result = MagicMock()
+        mock_result.stdout = "1699999900\n1699999800\n"
+        mock_subprocess.run.return_value = mock_result
+        mock_subprocess.TimeoutExpired = TimeoutError
+        mock_subprocess.SubprocessError = Exception
+
+        assert _has_git_commits_on_branch(tmp_path, 1700000000.0) is False
 
 
 def test_has_git_commits_on_branch_returns_false_when_no_commits(tmp_path: Path) -> None:
@@ -172,7 +190,7 @@ def test_has_git_commits_on_branch_returns_false_when_no_commits(tmp_path: Path)
         mock_subprocess.TimeoutExpired = TimeoutError
         mock_subprocess.SubprocessError = Exception
 
-        assert _has_git_commits_on_branch(tmp_path) is False
+        assert _has_git_commits_on_branch(tmp_path, 1700000000.0) is False
 
 
 def test_has_git_commits_on_branch_returns_false_on_error(tmp_path: Path) -> None:
@@ -182,7 +200,7 @@ def test_has_git_commits_on_branch_returns_false_on_error(tmp_path: Path) -> Non
         mock_subprocess.TimeoutExpired = TimeoutError
         mock_subprocess.SubprocessError = Exception
 
-        assert _has_git_commits_on_branch(tmp_path) is False
+        assert _has_git_commits_on_branch(tmp_path, 1700000000.0) is False
 
 
 # ---------------------------------------------------------------------------
@@ -208,6 +226,104 @@ def test_orphaned_task_completes_on_git_commits(tmp_path: Path) -> None:
     with (
         patch("bernstein.core.agents.agent_lifecycle.collect_completion_data", return_value={"files_modified": []}),
         patch("bernstein.core.agents.agent_lifecycle._has_git_commits_on_branch", return_value=True),
+        patch("bernstein.core.agents.agent_lifecycle.complete_task") as mock_complete,
+        patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as mock_retry,
+    ):
+        handle_orphaned_task(orch, task.id, session, {"claimed": [task], "open": [], "in_progress": [], "done": []})
+
+    mock_complete.assert_called_once_with(
+        orch._client,
+        "http://server",
+        task.id,
+        f"Auto-completed: agent {session.id} made git commits on branch (no signals to verify)",
+    )
+    mock_retry.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Orphaned task: git-commit indicator is scoped to the agent's own session
+# (#4466) -- exercised against a real git repo rather than a mocked
+# _has_git_commits_on_branch, so the scoping fix is proven end to end.
+# ---------------------------------------------------------------------------
+
+
+def _init_worktree_repo(worktree: Path) -> None:
+    """A minimal real git repo: ``main`` with one commit, ready to branch from."""
+    worktree.mkdir(parents=True, exist_ok=True)
+    for args in (
+        ["init", "-b", "main"],
+        ["config", "user.email", "test@example.com"],
+        ["config", "user.name", "Test"],
+        ["commit", "--allow-empty", "-m", "init"],
+    ):
+        subprocess.run(["git", *args], cwd=str(worktree), capture_output=True, check=True)
+
+
+def test_orphaned_task_fails_when_branch_commits_predate_agent_spawn(tmp_path: Path) -> None:
+    """Regression #4466: a branch already ahead of main when the agent spawns
+    must not read as "this agent made commits". An orphaned agent on a
+    resumed/reviewed-PR branch with zero commits of its own fails honestly
+    instead of auto-completing on the branch's pre-existing history.
+    """
+    worktree = tmp_path / "worktree"
+    _init_worktree_repo(worktree)
+    subprocess.run(["git", "checkout", "-b", "agent/pre-existing"], cwd=str(worktree), capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "pre-existing work"], cwd=str(worktree), capture_output=True, check=True
+    )
+
+    task = _make_task()
+    task.status = TaskStatus.CLAIMED
+    session = AgentSession(
+        id="sess-preloaded",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=[task.id],
+        exit_code=1,
+        spawn_ts=time.time(),  # agent "starts" after the branch's pre-existing commit
+    )
+    orch = _make_orch_no_ratelimit(tmp_path)
+    orch._spawner.get_worktree_path.return_value = worktree
+
+    with (
+        patch("bernstein.core.agents.agent_lifecycle.collect_completion_data", return_value={"files_modified": []}),
+        patch("bernstein.core.agents.agent_lifecycle.complete_task") as mock_complete,
+        patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as mock_retry,
+    ):
+        handle_orphaned_task(orch, task.id, session, {"claimed": [task], "open": [], "in_progress": [], "done": []})
+
+    mock_complete.assert_not_called()
+    mock_retry.assert_called_once()
+    assert "no completion signals and no files modified" in mock_retry.call_args.args[1]
+
+
+def test_orphaned_task_completes_on_git_commits_made_after_spawn(tmp_path: Path) -> None:
+    """Fresh-branch behavior is unchanged: a commit the agent actually made
+    after it spawned still auto-completes the orphaned task.
+    """
+    worktree = tmp_path / "worktree"
+    _init_worktree_repo(worktree)
+
+    task = _make_task()
+    task.status = TaskStatus.CLAIMED
+    session = AgentSession(
+        id="sess-fresh",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=[task.id],
+        exit_code=1,
+        spawn_ts=time.time() - 5,  # agent "starts" before the commit below
+    )
+    orch = _make_orch_no_ratelimit(tmp_path)
+    orch._spawner.get_worktree_path.return_value = worktree
+
+    subprocess.run(["git", "checkout", "-b", "agent/A-1"], cwd=str(worktree), capture_output=True, check=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "agent work"], cwd=str(worktree), capture_output=True, check=True)
+
+    with (
+        patch("bernstein.core.agents.agent_lifecycle.collect_completion_data", return_value={"files_modified": []}),
         patch("bernstein.core.agents.agent_lifecycle.complete_task") as mock_complete,
         patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as mock_retry,
     ):

--- a/tests/unit/test_agent_lifecycle.py
+++ b/tests/unit/test_agent_lifecycle.py
@@ -269,7 +269,10 @@ def test_orphaned_task_fails_when_branch_commits_predate_agent_spawn(tmp_path: P
     _init_worktree_repo(worktree)
     subprocess.run(["git", "checkout", "-b", "agent/pre-existing"], cwd=str(worktree), capture_output=True, check=True)
     subprocess.run(
-        ["git", "commit", "--allow-empty", "-m", "pre-existing work"], cwd=str(worktree), capture_output=True, check=True
+        ["git", "commit", "--allow-empty", "-m", "pre-existing work"],
+        cwd=str(worktree),
+        capture_output=True,
+        check=True,
     )
 
     task = _make_task()
@@ -320,7 +323,9 @@ def test_orphaned_task_completes_on_git_commits_made_after_spawn(tmp_path: Path)
     orch._spawner.get_worktree_path.return_value = worktree
 
     subprocess.run(["git", "checkout", "-b", "agent/A-1"], cwd=str(worktree), capture_output=True, check=True)
-    subprocess.run(["git", "commit", "--allow-empty", "-m", "agent work"], cwd=str(worktree), capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "agent work"], cwd=str(worktree), capture_output=True, check=True
+    )
 
     with (
         patch("bernstein.core.agents.agent_lifecycle.collect_completion_data", return_value={"files_modified": []}),

--- a/tests/unit/test_regression_orchestrator.py
+++ b/tests/unit/test_regression_orchestrator.py
@@ -274,9 +274,7 @@ class TestDependencyFiltering:
         assert "C" not in spawned_task_ids
         assert "D" not in spawned_task_ids
 
-    def test_preexisting_cycle_still_schedules_every_task_after_deterministic_break(
-        self, tmp_path: Path
-    ) -> None:
+    def test_preexisting_cycle_still_schedules_every_task_after_deterministic_break(self, tmp_path: Path) -> None:
         """A board carrying a declared cycle drains instead of wedging (#4287).
 
         ``POST /tasks`` rejects a cycle-forming edge today, but legacy board


### PR DESCRIPTION
An orphaned agent's completion check counted every commit its worktree branch had ahead of `main`, so a branch already carrying commits when the agent spawned read as work that agent did. A dead planner on such a branch (a resumed run, a reviewed PR checkout) auto-completed its task on that pre-existing history with zero commits of its own.

The commit indicator now takes the agent's own start timestamp and only counts commits made after it. Separately, the zero-child-planning-task check asked "is the task store otherwise empty" instead of "does this task have children", so a retried planning attempt or any resumed project with prior history defeated it and let a zero-child manager task complete as done. It now checks for a task whose parent points at the completing task.

Tested against a real git repo: a fresh branch with a post-spawn commit still auto-completes (unchanged), and a branch already ahead of main before spawn now fails honestly. A store already holding an unrelated task no longer masks a zero-child planning task's failure.

Closes #4466