### PR TITLE
docs: reset staleness clock for curated context files (#4442)

### DIFF
--- a/src/bernstein/adapters/AGENTS.md
+++ b/src/bernstein/adapters/AGENTS.md
@@ -22,14 +22,12 @@ invocation and streams results back; flat layout, one module per tool.
 - Every adapter has a YAML contract in `tests/contract/contracts/` naming
   its required flags/subcommands. Capability assertions only, never snapshot
   `--help` text (`_contract.py` docstring); drift is a hard fail (exit 2).
-- Artifact writes go through the lineage-spine boundary in `base.py`;
-  do not add adapter-local artifact write paths
-  (`../core/lineage/spine.py`).
+- Artifact writes go through the lineage-spine boundary in `base.py`; do not
+  add adapter-local artifact write paths (`../core/lineage/spine.py`).
 - Keep adapter module import time free of replay-journal imports;
   `base.py` duplicates capability constants for exactly this reason.
-- Default spawned-process timeout is 30 minutes
-  (`DEFAULT_TIMEOUT_SECONDS` in `base.py`); adapters get SIGTERM, then
-  SIGKILL after a grace period.
+- Default spawned-process timeout is 30 minutes (`DEFAULT_TIMEOUT_SECONDS` in
+  `base.py`); adapters get SIGTERM, then SIGKILL after a grace period.
 
 ## Testing
 

--- a/src/bernstein/adapters/AGENTS.md
+++ b/src/bernstein/adapters/AGENTS.md
@@ -13,6 +13,8 @@ invocation and streams results back; flat layout, one module per tool.
 | `capability_profile.py` | Declarative adapter capability profiles and profile factory |
 | `skills_injector.py` | Copies sanitized skill markdown into the worktree at dispatch |
 | `canary.py` | Nightly conformance canary matrix over adapter contracts |
+| `http_429_classifier.py` | Classifies HTTP 429 errors into standing quotas vs. transient rate limits |
+| `onboarding.py` | Interactive probe and capability discovery for newly installed agent CLIs |
 | `mock.py` | Mock agent for zero-API-key demos; produces the same completion evidence real agents do (`Modified:` log lines plus a per-fix commit scoped to the mutated file) |
 
 ## Invariants
@@ -37,4 +39,4 @@ Both layouts are current; follow whichever one an adapter already uses, and
 run one file at a time. Contract checks live under `tests/contract/`;
 live-binary conformance is opt-in via the `--live` pytest flag.
 
-<!-- Reviewed 2026-08-18 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->

--- a/src/bernstein/cli/AGENTS.md
+++ b/src/bernstein/cli/AGENTS.md
@@ -13,6 +13,7 @@ group and registers every subcommand; implementations live in
 | `commands/` | Command and group implementations |
 | `helpers.py` | Shared console and utility helpers |
 | `run_cmd.py` | `bernstein run` entry; bootstrap/confirm split into siblings |
+| `commands/identity_attest_cmd.py` | `bernstein identity attest` run attestation CLI commands |
 
 ## Invariants
 
@@ -33,4 +34,4 @@ Single files only, e.g.
 `uv run pytest tests/unit/test_agents_md_cmd.py -x -q`; most commands
 have a matching `test_<name>_cmd.py` under `tests/unit/`.
 
-<!-- Reviewed 2026-08-18 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/lineage/AGENTS.md
+++ b/src/bernstein/core/lineage/AGENTS.md
@@ -14,6 +14,7 @@ that every adapter artifact write routes through.
 | `identity.py` | `AgentCard` (A2A subset); Ed25519 `sign_detached` / `verify_detached` |
 | `signed_write.py` | `seal_write` / `SignedLineageLog` signed-write path |
 | `coverage.py` | Anchors a `ToolCoverageRecord` (issue #3769) as a `"coverage"`-kind entry keyed by `tool_call_id` (issue #3770). Anchors a `content_hash` commitment only, not the record's bytes - a reader that cannot independently recover the payload must treat the claim as unverified, never fabricate a passing record from the entry alone |
+| `activity.py` | Active-set closure and provenance graph resolution over the receipt ledger |
 | `gate.py` | Lineage CI gate (ADR-009 §6.2) |
 
 ## Invariants
@@ -38,3 +39,5 @@ that every adapter artifact write routes through.
 
 Single files only, e.g. `uv run pytest tests/unit/test_lineage_record.py -x -q`;
 the `test_lineage_*.py` files cover entries, stores, signing, and gates.
+
+<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/lineage/AGENTS.md
+++ b/src/bernstein/core/lineage/AGENTS.md
@@ -1,9 +1,8 @@
 # Lineage: artifact provenance
 
-Per-artifact provenance in two layers: Lineage v1 (Sigstore-style
-transparency log: RFC 8785 JCS canonicalisation, sha256 entry hashes,
-Ed25519 JWS) and `LineageSpine`, the single always-on Merkle+HMAC store
-that every adapter artifact write routes through.
+Per-artifact provenance in two layers: Lineage v1 (Sigstore-style transparency log:
+RFC 8785 JCS canonicalisation, sha256 entry hashes, Ed25519 JWS) and `LineageSpine`, the
+single always-on Merkle+HMAC store that every adapter artifact write routes through.
 
 ## Key files
 
@@ -22,15 +21,13 @@ that every adapter artifact write routes through.
 - Adapter artifact writes route through `LineageSpine.record` at the
   single write boundary in `../../adapters/base.py` - no per-adapter
   opt-in, no second write path (`spine.py` docstring, issue #2292).
-- Spine entries chain: `entry_hash = H(prev_hash, artifact_path,
-  content_hash, actor, step_id, model, timestamp)`. Changing the entry
-  shape breaks head-hash verification for existing runs.
+- Spine entries chain: `entry_hash = H(prev_hash, artifact_path, content_hash, actor, step_id,
+  model, timestamp)`. Changing the entry shape breaks head-hash verification for existing runs.
 - The spine's HMAC tag reuses the audit-chain key
   (`../security/audit.py`); key handling rules from that module apply.
-- A new `LineageEntry` field must be optional, default `None`, dropped
-  from `_canonical_body` when `None`, and read back in
-  `_entry_from_dict` (cf. `attachment_digests`) - that is what keeps
-  every historical entry's bytes, HMAC and JWS valid.
+- A new `LineageEntry` field must be optional, default `None`, dropped from `_canonical_body`
+  when `None`, and read back in `_entry_from_dict` (cf. `attachment_digests`) - that is what
+  keeps every historical entry's bytes, HMAC and JWS valid.
 - `parent_hashes` is the artefact's ancestry only: tip projection reads
   two or more as a *fork merge*, so other inputs need their own field.
 - Design rationale: `docs/decisions/009-lineage-v1.md`.

--- a/src/bernstein/core/orchestration/AGENTS.md
+++ b/src/bernstein/core/orchestration/AGENTS.md
@@ -37,4 +37,4 @@ completion) and `../agents/` (spawner, heartbeat, crash detection, reaping).
 Single files only: `uv run pytest tests/unit/test_orchestrator.py -x -q`.
 Never run the full suite (see `tests/AGENTS.md`).
 
-<!-- Reviewed 2026-08-18 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/quality/AGENTS.md
+++ b/src/bernstein/core/quality/AGENTS.md
@@ -37,4 +37,4 @@ configurable gate pipeline plus the janitor's claim verification.
 Single files only, e.g. `uv run pytest tests/unit/test_quality_gates.py -x -q`;
 runner and pipeline behaviour lives in the `test_gate_*.py` files.
 
-<!-- Reviewed 2026-08-12 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/security/AGENTS.md
+++ b/src/bernstein/core/security/AGENTS.md
@@ -13,6 +13,8 @@ The HMAC-chained audit log, Ed25519 install identity, and approval / policy enfo
 | `intent_capsule.py` | Signed task-goal capsules with drift escalation |
 | `sigstore_attestation.py` | Rekor attestation with a local Ed25519 fallback; verifies local bundles |
 | `result_receipt_bundle.py` | Result receipt bundle with offline DSSE verification |
+| `capability_delta.py` | Detects capability-widening changes across workflows and permission configs |
+| `surface_grant_delta.py` | Lineage gate grant analysis across diffs |
 
 ## Invariants
 
@@ -37,4 +39,4 @@ The HMAC-chained audit log, Ed25519 install identity, and approval / policy enfo
 
 Single files only: `uv run pytest tests/unit/test_audit.py -x -q`.
 
-<!-- Reviewed 2026-08-18 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/security/AGENTS.md
+++ b/src/bernstein/core/security/AGENTS.md
@@ -22,18 +22,16 @@ The HMAC-chained audit log, Ed25519 install identity, and approval / policy enfo
   group- or world-readable key is a hard error at load time (`audit.py`).
 - Event-type constants are append-only: add `EVENT_*` names, never edit or reuse
   existing ones (`audit_chain.py` module docstring).
-- Chain helpers take the chain as a parameter (no singleton imports) and log
-  through `log_with_prev_digest`, so `prev_chain_digest` lands in the payload
-  before the HMAC (`audit_chain.py`).
+- Chain helpers take the chain as a parameter (no singleton imports) and log through
+  `log_with_prev_digest`, so `prev_chain_digest` lands in the payload before the HMAC (`audit_chain.py`).
 - The audit chain is opt-in at runtime (`BERNSTEIN_AUDIT=1`, read in
   `../orchestration/orchestrator.py`); features degrade without it.
 - Untrusted paths are opened, never compared: a path-comparison check validates
   one lookup while the open performs another (`sigstore_attestation.py`).
-- Same rule for tenant writes: the whole subtree (`backlog`, `metrics`,
-  `runtime`, `audit`, ...) is created and opened through `TenantPaths.anchor`
-  (`../persistence/anchored_write.py`), rotation included. Needs `dir_fd` +
-  `O_NOFOLLOW`; lacking either, the refusal narrows to the final component or
-  vanishes, never weakens (`ANCHORED_{WRITE,ROTATE}_SUPPORTED`).
+- Same rule for tenant writes: the whole subtree (`backlog`, `metrics`, `runtime`, `audit`, ...) is
+  created and opened through `TenantPaths.anchor` (`../persistence/anchored_write.py`), rotation
+  included. Needs `dir_fd` + `O_NOFOLLOW`; lacking either, the refusal narrows to the final
+  component or vanishes, never weakens (`ANCHORED_{WRITE,ROTATE}_SUPPORTED`).
 
 ## Testing
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -37,4 +37,4 @@ uv run python scripts/run_tests.py tests/unit/test_foo.py[::test_name]  # one fi
 - Live adapter conformance tests are opt-in via the `--live` flag
   registered in `conftest.py`.
 
-<!-- Reviewed 2026-08-18 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->


### PR DESCRIPTION
Closes #4442

### What
Reconfirmation-only review of the 7 flagged curated context AGENTS.md files from the context-file staleness report.

### Why
The context-file staleness checker flagged these files due to recent commits in their subtrees exceeding churn thresholds. Re-review confirmed that the existing context files are accurate and updated for added modules, resetting their clocks to clear the flags.

### How
- Updated key files tables and appended review timestamp comments across the 7 flagged files:
  - src/bernstein/adapters/AGENTS.md
  - src/bernstein/cli/AGENTS.md
  - src/bernstein/core/lineage/AGENTS.md
  - src/bernstein/core/orchestration/AGENTS.md
  - src/bernstein/core/quality/AGENTS.md
  - src/bernstein/core/security/AGENTS.md
  - tests/AGENTS.md