### PR TITLE
fix(pr): describe the pull request from the change, not the session

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1415,12 +1415,21 @@ See [`reference/mcp-catalog.md`](mcp-catalog.md) for the full reference.
 
 #### `bernstein pr`
 
+The title names the commit that changed the most under `src/`; merge, `[WIP]`,
+`style:`/`chore:`, formatter and lint-repair commits and generated-context-file
+syncs are excluded, so a run that ends with upkeep is still titled after the
+change it made. The body is composed from the linked issue's problem statement,
+the files the diff touches and the gates that ran, and carries a Provenance
+block naming the diff hash and the run's journal head; `bernstein review-receipt
+verify` recomputes both and rejects a description whose diff has since changed.
+
 | Flag | Default | Meaning |
 |---|---|---|
 | `--session-id ID` | most recent completed session | Session to publish. |
 | `--base BRANCH` | main | Base branch for the pull request. |
-| `--issue N\|URL` | none | Title the PR from a GitHub issue and open its body with `Closes #N`. Reads the issue, so `--dry-run` makes that one request. |
-| `--title TEXT` | auto-generated | Override the PR title. |
+| `--issue N\|URL` | none | Link the PR to a GitHub issue: the issue's problem statement opens the body, `Closes #N` links it, and its title names the PR when the run left only housekeeping commits. Reads the issue, so `--dry-run` makes that one request. |
+| `--title TEXT` | the dominant commit's subject | Override the PR title. |
+| `--body TEXT` | generated from the diff | Override the PR body. `Closes #N` is still prepended with `--issue`. |
 | `--draft` | off | Open as a draft PR. |
 | `--dry-run` | off | Print the would-be title and body without calling `gh`. Reads the issue when `--issue` is given. |
 | `--no-push` | off | Skip `git push`; assume the branch is already on origin. |

--- a/docs/release-notes/fragments/4484-pr-description-from-the-change.md
+++ b/docs/release-notes/fragments/4484-pr-description-from-the-change.md
@@ -1,0 +1,18 @@
+## Pull requests are described from the change, not from the session
+
+`bernstein pr` took its title from whatever the run committed last, so a run
+that ended with a lint repair or a formatting pass named the whole pull request
+after that upkeep and the feature it had implemented was invisible to reviewers
+and to the changelog. The body had the same problem from the other end: it
+opened with the session's own status text instead of saying what the diff does.
+
+The title now names the commit that changed the most under `src/`, skipping
+merge, `[WIP]`, `style:`/`chore:`, formatter and lint-repair commits and
+generated-context-file syncs, and falls back to the linked issue's title when a
+run left nothing but upkeep. The body is composed from the issue's problem
+statement, the files the diff touches and the gates that ran, and carries a
+Provenance block naming the diff hash and the run's journal head. Opening a pull
+request anchors that description through the existing review-receipt machinery,
+so `bernstein review-receipt verify` accepts a description that matches its diff
+and rejects one whose diff has since changed. `--title` and the new `--body`
+still override everything (#4484).

--- a/src/bernstein/cli/commands/pr_cmd.py
+++ b/src/bernstein/cli/commands/pr_cmd.py
@@ -1,9 +1,13 @@
 """``bernstein pr`` - open a pull request from a completed session.
 
-This command reads the newest (or a specific) session's wrap-up state,
-derives a conventional-commit title, composes a markdown body with the
-janitor quality-gate verdict and cost breakdown, pushes the session
-branch if needed, and calls ``gh pr create`` to open the PR.
+This command describes the *change*, not the run that made it: it reads the
+branch's commits and diff, titles the pull request after the commit that
+altered ``src/`` most (skipping merges, WIP and formatting upkeep), composes
+a body from the linked issue's problem statement, the files the diff touches
+and the gates that ran, pushes the session branch if needed, and calls ``gh
+pr create``. Once the PR exists, the posted description is anchored against
+its diff through the review-receipt machinery, so a reader can check offline
+that the description belongs to this diff.
 
 All pure logic lives in :mod:`bernstein.core.integrations.pr_gen`; this
 module is a thin click wrapper that also handles subprocess calls to
@@ -18,15 +22,20 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+from dataclasses import replace
 from pathlib import Path
 
 import click
 
 from bernstein.core.integrations.pr_gen import (
+    COMMIT_LOG_FORMAT,
     SessionSummary,
+    attest_pr_description,
     build_pr_body,
     build_pr_title,
+    build_provenance,
     load_session_summary,
+    parse_commit_log,
 )
 from bernstein.core.integrations.tickets import (
     TicketAuthError,
@@ -80,8 +89,41 @@ def _diff_stat(cwd: Path, base: str, head: str) -> str:
     return result.stdout
 
 
+def _diff_bytes(cwd: Path, base: str, head: str) -> bytes:
+    """Return ``git diff base..head`` as raw bytes (empty on failure).
+
+    Bytes, not text: the diff is hashed, and decoding it would make the hash
+    depend on this process's error handling rather than on the diff.
+    """
+    result = subprocess.run(
+        ["git", "diff", f"{base}..{head}"],
+        cwd=cwd,
+        capture_output=True,
+        timeout=60,
+        check=False,
+    )
+    if result.returncode != 0:
+        return b""
+    return result.stdout
+
+
+def _commit_log(cwd: Path, base: str, head: str) -> str:
+    """Return the branch's commits with per-file churn, for ranking."""
+    result = _run_git(
+        ["log", f"--format={COMMIT_LOG_FORMAT}", "--numstat", "--no-color", f"{base}..{head}"],
+        cwd=cwd,
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
 def _enrich_summary_with_git(summary: SessionSummary, cwd: Path) -> SessionSummary:
-    """Fill in the branch + diff-stat from git when the state file lacked them.
+    """Fill in the git-derived fields the state file could not supply.
+
+    Branch and diff-stat as before, plus the two the description is composed
+    from: the branch's commits (which commit the pull request is about) and
+    the provenance binding (which diff the description describes).
 
     Args:
         summary: The summary loaded from persisted state.
@@ -91,15 +133,15 @@ def _enrich_summary_with_git(summary: SessionSummary, cwd: Path) -> SessionSumma
         A new :class:`SessionSummary` with git-derived fields populated
         when they were missing from the original.
     """
-    from dataclasses import replace
-    from typing import cast
-
     branch = summary.branch if summary.branch not in ("", "HEAD") else _current_branch(cwd)
     diff_stat = summary.diff_stat or _diff_stat(cwd, summary.base_branch, branch)
-    if branch == summary.branch and diff_stat == summary.diff_stat:
-        return summary
+    commits = summary.commits or parse_commit_log(_commit_log(cwd, summary.base_branch, branch))
+    provenance = summary.provenance or build_provenance(
+        diff=_diff_bytes(cwd, summary.base_branch, branch),
+        journal_head=summary.journal_head,
+    )
 
-    return cast("SessionSummary", replace(summary, branch=branch, diff_stat=diff_stat))
+    return replace(summary, branch=branch, diff_stat=diff_stat, commits=commits, provenance=provenance)
 
 
 def _push_branch(branch: str, cwd: Path) -> tuple[bool, str]:
@@ -257,6 +299,12 @@ def _resolve_issue(ref: str, workdir: Path) -> tuple[int, TicketPayload]:
     help="Override the auto-generated PR title.",
 )
 @click.option(
+    "--body",
+    "body_override",
+    default=None,
+    help="Override the auto-generated PR body. `Closes #N` is still prepended with --issue.",
+)
+@click.option(
     "--draft",
     is_flag=True,
     default=False,
@@ -281,11 +329,17 @@ def pr_cmd(
     base: str,
     issue_ref: str | None,
     title_override: str | None,
+    body_override: str | None,
     draft: bool,
     dry_run: bool,
     no_push: bool,
 ) -> None:
     """Open a GitHub pull request from a completed Bernstein session.
+
+    The title names the commit that changed the most under ``src/``, so a run
+    that ends with a lint or formatting pass is still titled after the change
+    it made; a run that left nothing but upkeep falls back to the linked
+    issue's title. ``--title`` and ``--body`` override both.
 
     The command is safe to re-run: on ``--dry-run`` it touches the network
     only to read the issue named by ``--issue`` (nothing at all without it),
@@ -299,22 +353,28 @@ def pr_cmd(
 
     issue_number: int | None = None
     issue_title = ""
+    issue_body = ""
     issue_labels: tuple[str, ...] = ()
     if issue_ref is not None:
         issue_number, ticket = _resolve_issue(issue_ref, workdir)
         issue_title = ticket.title
+        issue_body = ticket.description
         issue_labels = ticket.labels
 
+    summary = replace(summary, issue_problem=issue_body)
+
     # The issue title is a cleaner source than the goal, which carries the
-    # instructions handed to the run. Its labels come along so the PR does not
-    # announce a change type the issue it closes contradicts.
+    # instructions handed to the run; the branch's commits are cleaner still,
+    # because they say what actually landed. Labels come along so the PR does
+    # not announce a change type the issue it closes contradicts.
     title = title_override or build_pr_title(
         issue_title or summary.goal or summary.session_id,
         summary.primary_role,
         issue_labels,
         changes_summary=summary.changes_summary,
+        commits=summary.commits,
     )
-    body = build_pr_body(summary)
+    body = body_override or build_pr_body(summary)
     if issue_number is not None:
         # GitHub links an issue from the body or a commit message only.
         body = f"Closes #{issue_number}\n\n{body}"
@@ -345,3 +405,73 @@ def pr_cmd(
         raise click.ClickException(f"gh pr create failed: {message}")
 
     click.echo(message)
+    _attest_description(
+        summary=summary,
+        pr_url=_pr_url_from_output(message),
+        description=f"{title}\n\n{body}",
+        issue_body=issue_body,
+        cwd=workdir,
+    )
+
+
+def _pr_url_from_output(message: str) -> str:
+    """Return the PR url ``gh pr create`` printed, or ``""``."""
+    for line in reversed(message.splitlines()):
+        candidate = line.strip()
+        if candidate.startswith(("http://", "https://")):
+            return candidate
+    return ""
+
+
+def _repo_slug_from_pr_url(pr_url: str) -> str:
+    """Return ``owner/repo`` for a GitHub pull-request url, or ``""``."""
+    parts = pr_url.rstrip("/").split("/")
+    if len(parts) < 5:
+        return ""
+    return f"{parts[-4]}/{parts[-3]}"
+
+
+def _attest_description(
+    *,
+    summary: SessionSummary,
+    pr_url: str,
+    description: str,
+    issue_body: str,
+    cwd: Path,
+) -> None:
+    """Anchor the posted description against the diff it describes.
+
+    Runs after the pull request exists, so the receipt names a real url. The
+    diff is re-read and its hash checked against the one the body published:
+    if the branch moved between composing the description and opening the PR,
+    the description no longer describes this diff and attesting it would
+    assert something false, so the receipt is skipped and the operator told.
+
+    Failure to attest never fails the command - the pull request is already
+    open by this point, and an unanchored description is a smaller problem
+    than a command that reports failure for work that succeeded.
+    """
+    if not pr_url or summary.provenance is None:
+        return
+    try:
+        diff = _diff_bytes(cwd, summary.base_branch, summary.branch)
+        recomputed = build_provenance(diff=diff, journal_head=summary.journal_head)
+        if recomputed.diff_hash != summary.provenance.diff_hash:
+            click.echo(
+                "note: the branch changed while the pull request was being opened; "
+                "the description was not anchored to a diff.",
+                err=True,
+            )
+            return
+        attest_pr_description(
+            workdir=cwd,
+            pr_url=pr_url,
+            repo=_repo_slug_from_pr_url(pr_url),
+            issue_body=issue_body,
+            description=description,
+            diff=diff,
+            journal_head=summary.journal_head,
+            task_id=summary.session_id,
+        )
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        click.echo(f"note: could not anchor the pull-request description: {exc}", err=True)

--- a/src/bernstein/core/integrations/pr_gen.py
+++ b/src/bernstein/core/integrations/pr_gen.py
@@ -157,7 +157,7 @@ _WIP_SUBJECT_RE = re.compile(r"^\s*(?:\[wip\]|wip\b|fixup!|squash!|amend!)", re.
 _HOUSEKEEPING_PHRASE_RE = re.compile(
     r"\b(?:"
     r"lint|linter|linting|ruff|black|isort|prettier|eslint|gofmt|rustfmt"
-    r"|formatter|formatting|reformat(?:ted|ting)?|auto-?formatt?(?:ed|ing)?"
+    r"|formatter|formatting|(?:re|auto-?)format(?:s|ted|ting)?"
     r"|pre-commit|whitespace|typos?|regenerat(?:e|ed|es|ing|ion)"
     r")\b",
     re.IGNORECASE,

--- a/src/bernstein/core/integrations/pr_gen.py
+++ b/src/bernstein/core/integrations/pr_gen.py
@@ -6,6 +6,19 @@ markdown body of a GitHub pull request.  It is deliberately free of
 isolation; the CLI wrapper in :mod:`bernstein.cli.commands.pr_cmd`
 handles I/O, git push and ``gh`` invocation.
 
+The description is composed from the *change*, not from the run that made
+it. A run's last commit is often housekeeping - a lint repair, a formatting
+pass, a regenerated context file - so titling the pull request after the
+newest subject names the wrong change; :func:`rank_commits` orders the
+branch's commits by how much they alter ``src/`` and drops the structurally
+housekeeping ones, and the surviving dominant subject titles the pull
+request. The body follows the same rule: the linked issue's problem
+statement, the files the diff touches, and the gates that actually ran.
+:func:`build_provenance` binds the result to the diff hash and the run's
+journal head, and :func:`attest_pr_description` anchors that binding through
+the existing review-receipt machinery so a reader can check offline that the
+description belongs to this diff.
+
 The module reuses existing Bernstein state:
 
 * :class:`bernstein.core.persistence.session.SessionState` - run-level
@@ -25,12 +38,15 @@ from __future__ import annotations
 
 import json
 import re
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
+
+    from bernstein.core.review.receipt import ReviewReceipt
 
 
 _WRAPUP_GLOB = "*-wrapup.json"
@@ -49,13 +65,22 @@ _EVENT_TASK_DIFF_CAPTURED = "task_diff_captured"
 
 
 __all__ = [
+    "ChangeProvenance",
+    "CommitRecord",
     "EvidenceSummary",
+    "FileChange",
     "GateResult",
     "MergedChange",
     "SessionSummary",
+    "attest_pr_description",
     "build_pr_body",
     "build_pr_title",
+    "build_provenance",
+    "dominant_commit",
+    "is_housekeeping_commit",
     "load_session_summary",
+    "parse_commit_log",
+    "rank_commits",
 ]
 
 
@@ -113,6 +138,69 @@ _LABEL_TYPES: Mapping[str, str] = {
 # Fixed order rather than label order, so the same issue always produces the
 # same title however the tracker happens to list its labels.
 _LABEL_TYPE_PRECEDENCE = ("fix", "docs", "perf", "refactor", "test", "build", "ci", "chore", "feat")
+
+# Where behaviour lives. Commits are ranked by how much they change under this
+# prefix, so a large test or docs commit never outranks the feature it covers.
+_SRC_PREFIX = "src/"
+
+# Conventional-commit types that state outright that a commit is upkeep.
+_HOUSEKEEPING_TYPES = frozenset({"style", "chore"})
+
+_CC_SUBJECT_RE = re.compile(r"^(?P<type>[a-z]+)(?:\([^)]*\))?!?:\s", re.IGNORECASE)
+
+# Markers for a commit that was never meant to describe anything.
+_WIP_SUBJECT_RE = re.compile(r"^\s*(?:\[wip\]|wip\b|fixup!|squash!|amend!)", re.IGNORECASE)
+
+# The wording a repair commit uses whatever conventional-commit type it
+# claims. ``fix: resolve lint gate failures`` is typed ``fix`` and is still
+# upkeep, so the type check alone cannot catch it.
+_HOUSEKEEPING_PHRASE_RE = re.compile(
+    r"\b(?:"
+    r"lint|linter|linting|ruff|black|isort|prettier|eslint|gofmt|rustfmt"
+    r"|formatter|formatting|reformat(?:ted|ting)?|auto-?formatt?(?:ed|ing)?"
+    r"|pre-commit|whitespace|typos?|regenerat(?:e|ed|es|ing|ion)"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Agent-context files a run regenerates. A commit that touches only these
+# synced nothing but its own instructions.
+_GENERATED_CONTEXT_NAMES = frozenset(
+    {
+        "AGENTS.md",
+        "CLAUDE.md",
+        "CONVENTIONS.md",
+        "GEMINI.md",
+        ".clinerules",
+        ".cursorrules",
+        ".windsurfrules",
+        "copilot-instructions.md",
+    }
+)
+_GENERATED_CONTEXT_DIRS = (".cursor/", ".github/instructions/")
+
+#: Separators the commit-log format uses. ASCII record/unit separators cannot
+#: occur in a commit subject, so parsing never has to guess.
+_COMMIT_RECORD_SEP = "\x1e"
+_COMMIT_FIELD_SEP = "\x1f"
+
+#: Newline split for commit-log parsing. ``str.splitlines`` also breaks on the
+#: ASCII record separator the format uses, which would consume every marker.
+_LINE_SPLIT_RE = re.compile(r"\r?\n")
+
+#: The ``git log --format`` string :func:`parse_commit_log` expects. Exported
+#: so the CLI asks for exactly the shape the parser reads.
+COMMIT_LOG_FORMAT = f"format:{_COMMIT_RECORD_SEP}%H{_COMMIT_FIELD_SEP}%P{_COMMIT_FIELD_SEP}%s"
+
+# How many files the Change section names before it stops listing them.
+_MAX_FILES_LISTED = 20
+
+# How much of the linked issue's body the Problem section quotes.
+_PROBLEM_MAX_CHARS = 600
+
+#: Verdict recorded on a receipt that attests a pull-request description
+#: rather than a code review, so the two are told apart on read-back.
+DESCRIPTION_VERDICT = "description"
 
 
 @dataclass(frozen=True)
@@ -188,6 +276,82 @@ class MergedChange:
 
 
 @dataclass(frozen=True)
+class FileChange:
+    """One file a commit touched, with the line churn git reported.
+
+    Attributes:
+        path: Repository-relative path.
+        added: Lines added; ``0`` for a binary change, which git reports as
+            ``-`` rather than a count.
+        removed: Lines removed; ``0`` for a binary change.
+    """
+
+    path: str
+    added: int = 0
+    removed: int = 0
+
+    @property
+    def churn(self) -> int:
+        """Lines the file gained plus lines it lost."""
+        return self.added + self.removed
+
+
+@dataclass(frozen=True)
+class CommitRecord:
+    """One commit on the branch a pull request is opened from.
+
+    Attributes:
+        sha: Full commit hash.
+        subject: The commit's first line.
+        is_merge: Whether the commit has more than one parent.
+        files: The files the commit touched, with their churn. Merge commits
+            and empty commits carry none.
+    """
+
+    sha: str
+    subject: str
+    is_merge: bool = False
+    files: tuple[FileChange, ...] = ()
+
+    @property
+    def short_sha(self) -> str:
+        """The abbreviated hash shown next to the subject in the body."""
+        return self.sha[:7]
+
+    @property
+    def src_churn(self) -> int:
+        """Lines this commit changed under :data:`_SRC_PREFIX`."""
+        return sum(f.churn for f in self.files if f.path.startswith(_SRC_PREFIX))
+
+    @property
+    def total_churn(self) -> int:
+        """Lines this commit changed anywhere in the tree."""
+        return sum(f.churn for f in self.files)
+
+
+@dataclass(frozen=True)
+class ChangeProvenance:
+    """The binding between a pull-request description and what it describes.
+
+    A description is prose, and prose can be written about any diff. These two
+    values are what make it checkable: the diff the description was composed
+    from, and the run journal head identifying every step that produced it.
+    Both are recomputable, so a reader can tell a description that belongs to
+    this diff from one that does not.
+
+    Attributes:
+        diff_hash: ``sha256:`` content hash of the diff bytes, computed by
+            :func:`bernstein.core.review.receipt.compute_diff_hash` - the same
+            function ``review-receipt verify`` recomputes with.
+        journal_head: The run journal's Merkle head, or ``""`` when the run
+            left no journal.
+    """
+
+    diff_hash: str
+    journal_head: str = ""
+
+
+@dataclass(frozen=True)
 class SessionSummary:
     """Everything the PR generator needs from one completed session.
 
@@ -210,6 +374,15 @@ class SessionSummary:
         cost: Aggregate cost figures for the session.
         evidence: Sealed evidence bundle for the task, or ``None`` when the
             task declared no evidence producers.
+        issue_problem: The linked issue's body. Its first paragraph is the
+            Problem section, so the pull request states the problem the issue
+            states rather than the instructions the run was handed.
+        commits: The branch's commits, newest first. When present they are
+            what the title and the Change section are derived from.
+        journal_head: The run journal's Merkle head, carried into
+            :class:`ChangeProvenance`.
+        provenance: The description's binding to the diff it describes, or
+            ``None`` when no diff was available to hash.
     """
 
     session_id: str
@@ -223,6 +396,186 @@ class SessionSummary:
     gates: tuple[GateResult, ...] = ()
     cost: CostBreakdown = field(default_factory=CostBreakdown)
     evidence: EvidenceSummary | None = None
+    issue_problem: str = ""
+    commits: tuple[CommitRecord, ...] = ()
+    journal_head: str = ""
+    provenance: ChangeProvenance | None = None
+
+
+# ---------------------------------------------------------------------------
+# Commit ranking - which commit the pull request is about
+# ---------------------------------------------------------------------------
+
+
+def _is_generated_context_path(path: str) -> bool:
+    """Whether ``path`` is an agent-context file a run regenerates."""
+    name = path.rsplit("/", 1)[-1]
+    return name in _GENERATED_CONTEXT_NAMES or path.startswith(_GENERATED_CONTEXT_DIRS)
+
+
+def is_housekeeping_commit(commit: CommitRecord) -> bool:
+    """Whether ``commit`` is structural upkeep rather than the change itself.
+
+    Housekeeping is decided from the commit's shape and its subject, never
+    from its position in the branch - the failure this guards against is a run
+    that *ends* with upkeep, and "last commit wins" is exactly what named the
+    whole pull request after a lint repair.
+
+    A commit is housekeeping when any of the following holds:
+
+    * it is a merge commit, or it touches no files at all;
+    * its subject is a work-in-progress or rebase marker (``[WIP]``,
+      ``fixup!``, ``squash!``, ``amend!``);
+    * its conventional-commit type is ``style`` or ``chore``;
+    * its subject names a formatter, a linter or a regeneration - the wording
+      a repair commit uses whatever type it claims, which is how ``fix:
+      resolve lint gate failures`` slipped through a type-only check;
+    * every file it touches is a generated agent-context file.
+
+    The wording rule can misread a genuine change to the lint setup itself.
+    That misread is benign: a run whose *only* substantive commit is
+    classified away falls back to the linked issue's title, which for such a
+    run says the same thing.
+
+    Args:
+        commit: The commit to classify.
+
+    Returns:
+        ``True`` when the commit must not name the pull request.
+    """
+    if commit.is_merge or not commit.files:
+        return True
+
+    subject = commit.subject.strip()
+    if not subject or _WIP_SUBJECT_RE.match(subject):
+        return True
+
+    conventional = _CC_SUBJECT_RE.match(subject)
+    if conventional is not None and conventional.group("type").lower() in _HOUSEKEEPING_TYPES:
+        return True
+
+    if _HOUSEKEEPING_PHRASE_RE.search(subject):
+        return True
+
+    return all(_is_generated_context_path(f.path) for f in commit.files)
+
+
+def rank_commits(commits: Iterable[CommitRecord]) -> tuple[CommitRecord, ...]:
+    """Return the substantive commits, the one that changed the most first.
+
+    Ranking is by ``src/`` churn, because that is where behaviour lives; ties
+    break on whole-tree churn and then on input order, so the same branch
+    always produces the same ranking however git happened to list it.
+    Housekeeping commits are dropped rather than ranked last: they are not
+    candidates to name the pull request at all.
+
+    Args:
+        commits: The branch's commits, in any order.
+
+    Returns:
+        The substantive commits, most-changed first. Empty when every commit
+        is housekeeping.
+    """
+    substantive = [(index, commit) for index, commit in enumerate(commits) if not is_housekeeping_commit(commit)]
+    substantive.sort(key=lambda pair: (-pair[1].src_churn, -pair[1].total_churn, pair[0]))
+    return tuple(commit for _, commit in substantive)
+
+
+def dominant_commit(commits: Iterable[CommitRecord]) -> CommitRecord | None:
+    """Return the commit the pull request is about, or ``None``.
+
+    Args:
+        commits: The branch's commits, in any order.
+
+    Returns:
+        The highest-ranked substantive commit, or ``None`` when the run left
+        nothing but housekeeping and the caller must fall back to the issue.
+    """
+    ranked = rank_commits(commits)
+    return ranked[0] if ranked else None
+
+
+def parse_commit_log(raw: str) -> tuple[CommitRecord, ...]:
+    """Parse ``git log --format=<record> --numstat`` output into records.
+
+    The expected format is the one :data:`COMMIT_LOG_FORMAT` asks for: each
+    commit opens with an ASCII record separator followed by
+    ``<sha>\x1f<parents>\x1f<subject>``, and its ``--numstat`` rows follow
+    until the next separator. Anything that does not parse is skipped rather
+    than raising, so a malformed row costs one commit and not the whole
+    description.
+
+    Args:
+        raw: Raw stdout from the git invocation.
+
+    Returns:
+        One :class:`CommitRecord` per commit, in git's output order.
+    """
+    records: list[CommitRecord] = []
+    sha = ""
+    subject = ""
+    is_merge = False
+    files: list[FileChange] = []
+    started = False
+
+    def flush() -> None:
+        if started and sha:
+            records.append(CommitRecord(sha=sha, subject=subject, is_merge=is_merge, files=tuple(files)))
+
+    # ``str.splitlines`` treats the ASCII record separator as a line boundary
+    # and would eat the very marker the format uses, so split on newlines only.
+    for line in _LINE_SPLIT_RE.split(raw):
+        if line.startswith(_COMMIT_RECORD_SEP):
+            flush()
+            fields = line[len(_COMMIT_RECORD_SEP) :].split(_COMMIT_FIELD_SEP)
+            sha = fields[0].strip() if fields else ""
+            parents = fields[1].split() if len(fields) > 1 else []
+            subject = fields[2].strip() if len(fields) > 2 else ""
+            is_merge = len(parents) > 1
+            files = []
+            started = True
+            continue
+        if not started or not line.strip():
+            continue
+        parsed = _parse_numstat_row(line)
+        if parsed is not None:
+            files.append(parsed)
+    flush()
+    return tuple(records)
+
+
+def _parse_numstat_row(line: str) -> FileChange | None:
+    """Parse one ``<added>\\t<removed>\\t<path>`` row, or return ``None``."""
+    parts = line.split("\t")
+    if len(parts) < 3:
+        return None
+    added, removed, path = parts[0].strip(), parts[1].strip(), parts[2].strip()
+    if not path:
+        return None
+    return FileChange(path=_normalise_rename(path), added=_numstat_count(added), removed=_numstat_count(removed))
+
+
+def _numstat_count(value: str) -> int:
+    """Return a numstat count, mapping git's ``-`` (binary) to ``0``."""
+    try:
+        return max(int(value), 0)
+    except ValueError:
+        return 0
+
+
+def _normalise_rename(path: str) -> str:
+    """Return the destination path of a git rename notation.
+
+    ``git`` renders a rename as ``old => new`` or ``dir/{old => new}/file``;
+    the destination is the path the pull request actually changed.
+    """
+    if "=>" not in path:
+        return path
+    if "{" in path and "}" in path:
+        prefix, rest = path.split("{", 1)
+        inner, suffix = rest.split("}", 1)
+        return f"{prefix}{inner.split('=>', 1)[-1].strip()}{suffix}"
+    return path.split("=>", 1)[-1].strip()
 
 
 # ---------------------------------------------------------------------------
@@ -352,40 +705,53 @@ def build_pr_title(
     labels: Iterable[str] = (),
     *,
     changes_summary: str = "",
+    commits: Iterable[CommitRecord] = (),
 ) -> str:
     """Compose a conventional-commit pull-request title.
 
     The result is truncated to :data:`_TITLE_MAX_CHARS` characters with a
-    trailing ellipsis when the cleaned goal is longer.  The shape is
+    trailing ellipsis when the cleaned outcome is longer.  The shape is
     always ``"<type>: <outcome>"``.
 
-    When ``changes_summary`` is non-empty the outcome is derived from the
-    first change line (what landed) rather than the goal (what was asked).
-    The conventional-commit type still uses the goal, labels and role so a
-    ``bug``-labelled issue never opens a ``feat:`` PR regardless of wording.
+    The outcome names the dominant change. When ``commits`` are supplied they
+    settle it: :func:`dominant_commit` picks the commit that altered ``src/``
+    most among the non-housekeeping ones, and its subject is the outcome. A
+    run that left nothing but housekeeping has no substantive subject to
+    offer, so the title falls back to ``task_goal`` - the linked issue's
+    title, as the CLI passes it. Only when no commits are known at all does
+    the wrap-up's ``changes_summary`` get a say.
+
+    The conventional-commit type comes from the same string the outcome does,
+    then labels, then role - so a ``bug``-labelled issue never opens a
+    ``feat:`` PR on wording alone.
 
     Args:
-        task_goal: Session goal or first-task title.
+        task_goal: Session goal or, when one is linked, the issue title.
         role: Primary role for the session, used as a classification
-            hint when the goal offers no other signal.
+            hint when nothing stronger is available.
         labels: Labels on the linked issue. They outrank both the wording
             and the role, so a PR never announces a change type the issue
             it closes contradicts.
         changes_summary: Newline-separated change bullets from the wrap-up.
-            When non-empty, the outcome is derived from the first line
-            instead of the goal.
+            Consulted only when ``commits`` is empty.
+        commits: The branch's commits. When non-empty they decide the
+            outcome.
 
     Returns:
         A title at most :data:`_TITLE_MAX_CHARS` characters long.
     """
-    prefix = _classify(task_goal, role, labels)
+    known = tuple(commits)
+    dominant = dominant_commit(known) if known else None
 
-    outcome_source = task_goal
-    if changes_summary.strip():
-        extracted = _outcome_from_changes_summary(changes_summary)
-        if extracted:
-            outcome_source = extracted
+    if dominant is not None:
+        outcome_source = dominant.subject
+    elif known:
+        # Every commit was housekeeping: none of them may name the PR.
+        outcome_source = task_goal
+    else:
+        outcome_source = _outcome_from_changes_summary(changes_summary) or task_goal
 
+    prefix = _classify(outcome_source if dominant is not None else task_goal, role, labels)
     outcome = _shape_outcome(outcome_source)
 
     full = f"{prefix}: {outcome}"
@@ -405,9 +771,11 @@ def build_pr_title(
 def _problem_line(goal: str) -> str:
     """Reduce a goal to a single one-line problem statement.
 
-    Only the first sentence (split on ``.`` or ``;``) is kept so the full
-    issue body is never pasted verbatim.  For a goal like ``Resolve GitHub
-    issue #N: <issue title>`` the title portion after the colon is returned.
+    A run's goal is the brief it was handed, so everything after the first
+    blank line is standing instructions ("Work only inside this repository")
+    rather than the problem; it is dropped before the first sentence is taken.
+    For a goal like ``Resolve GitHub issue #N: <issue title>`` the title
+    portion after the colon is returned.
 
     Args:
         goal: The raw goal string.
@@ -417,12 +785,52 @@ def _problem_line(goal: str) -> str:
     """
     stripped = goal.strip()
     if not stripped:
-        return "Automated session completed with no explicit goal."
-    first = re.split(r"[.;]\s+", stripped, maxsplit=1)[0].strip()
+        return "No linked issue and no recorded goal; the change is described below."
+    lead = re.split(r"\n\s*\n", stripped, maxsplit=1)[0].strip()
+    first = re.split(r"[.;]\s+", lead, maxsplit=1)[0].strip()
     # A ``Resolve GitHub issue #N: <title>`` goal: the title is the problem.
     if ": " in first:
         first = first.split(": ", 1)[1].strip()
-    return first or stripped
+    return first or lead
+
+
+def _problem_statement(session: SessionSummary) -> str:
+    """Return the Problem section's text.
+
+    The linked issue states the problem; the run's goal only restates it,
+    wrapped in the instructions the run was given. So the issue body's first
+    paragraph wins whenever there is one, and the goal is the fallback for an
+    unlinked run.
+
+    Args:
+        session: The session being described.
+
+    Returns:
+        The problem statement, never empty.
+    """
+    paragraph = _first_paragraph(session.issue_problem)
+    return paragraph or _problem_line(session.goal)
+
+
+def _first_paragraph(text: str) -> str:
+    """Return the first prose paragraph of ``text``, capped in length.
+
+    Leading markdown headings ("## Problem") and blockquote markers are
+    skipped so an issue that opens with a heading still yields prose.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return ""
+    for block in re.split(r"\n\s*\n", stripped):
+        lines = [line.strip() for line in block.splitlines()]
+        kept = [line for line in lines if line and not line.startswith("#")]
+        paragraph = " ".join(kept).strip()
+        if not paragraph:
+            continue
+        if len(paragraph) > _PROBLEM_MAX_CHARS:
+            return paragraph[:_PROBLEM_MAX_CHARS].rstrip() + "…"
+        return paragraph
+    return ""
 
 
 def _format_gates(gates: tuple[GateResult, ...]) -> str:
@@ -479,15 +887,71 @@ def _format_merged_changes(merged: tuple[MergedChange, ...]) -> str:
     return "\n".join(lines)
 
 
-def _format_changes(session: SessionSummary) -> str:
-    """Render the Changes section from the diff-stat and the merged tasks.
+def _format_file_lines(files: Iterable[FileChange]) -> list[str]:
+    """Render the files a commit touched, largest change first."""
+    ordered = sorted(files, key=lambda f: (-f.churn, f.path))
+    lines = [f"- `{change.path}` (+{change.added}/-{change.removed})" for change in ordered[:_MAX_FILES_LISTED]]
+    remaining = len(ordered) - len(lines)
+    if remaining > 0:
+        lines.append(f"- _…and {remaining} more file(s)._")
+    return lines
 
-    A run whose branch has already been folded into the base leaves ``git
-    diff`` with nothing to report, which is how a PR full of merged work came
-    to say no changes were recorded. The journal knows better, so both are
-    shown and the fallback line is reached only when neither has anything.
+
+def _format_commit_changes(commits: tuple[CommitRecord, ...]) -> str:
+    """Render the Change section from the branch's commits.
+
+    The dominant commit leads with the files it altered, so a reader sees the
+    change the pull request is about before anything else. Remaining
+    substantive commits follow as one line each, and housekeeping commits are
+    listed last and labelled, so they are visible without being mistaken for
+    the point of the branch.
+
+    Args:
+        commits: The branch's commits, in git's order.
+
+    Returns:
+        The rendered section, or ``""`` when there are no commits to render.
+    """
+    if not commits:
+        return ""
+
+    ranked = rank_commits(commits)
+    housekeeping = [commit for commit in commits if is_housekeeping_commit(commit) and not commit.is_merge]
+
+    lines: list[str] = []
+    if ranked:
+        lead, *rest = ranked
+        lines.append(f"{lead.subject.strip()} (`{lead.short_sha}`)")
+        lines.append("")
+        lines.extend(_format_file_lines(lead.files))
+        if rest:
+            lines.append("")
+            lines.append("Also in this branch:")
+            lines.extend(f"- {commit.subject.strip()} (`{commit.short_sha}`)" for commit in rest)
+
+    if housekeeping:
+        if lines:
+            lines.append("")
+        lines.append("Housekeeping, not what this pull request is about:")
+        lines.extend(f"- {commit.subject.strip()} (`{commit.short_sha}`)" for commit in housekeeping)
+
+    return "\n".join(lines)
+
+
+def _format_changes(session: SessionSummary) -> str:
+    """Render the Changes section from the commits, diff-stat and merged tasks.
+
+    The commits are the primary source: they say what the diff does and which
+    files it alters. The diff-stat and the run journal's merge rows follow as
+    corroboration - a run whose branch has already been folded into the base
+    leaves ``git diff`` with nothing to report, which is how a PR full of
+    merged work came to say no changes were recorded. The fallback line is
+    reached only when none of the three has anything.
     """
     blocks: list[str] = []
+    commit_block = _format_commit_changes(session.commits)
+    if commit_block:
+        blocks.append(commit_block)
     if session.diff_stat.strip():
         blocks.append(_format_diff_stat(session.diff_stat))
     if session.merged_changes:
@@ -495,6 +959,17 @@ def _format_changes(session: SessionSummary) -> str:
     if not blocks:
         return _format_diff_stat("")
     return "\n\n".join(blocks)
+
+
+def _format_provenance(provenance: ChangeProvenance) -> str:
+    """Render the Provenance block binding the description to its diff."""
+    return "\n".join(
+        [
+            f"- **Diff:** `{provenance.diff_hash}`",
+            f"- **Journal head:** `{provenance.journal_head or 'unrecorded'}`",
+            "- **Verify:** `bernstein review-receipt verify --pr <this PR> --issue <issue.md> --diff <pr.diff>`",
+        ]
+    )
 
 
 def _format_evidence(evidence: EvidenceSummary) -> str:
@@ -525,6 +1000,13 @@ def build_pr_body(session: SessionSummary) -> str:
     Change, Verification and Cost - are always present even when the
     underlying data is empty, so tests can rely on their presence.
 
+    Every section is projected from the change: the linked issue states the
+    problem, the commits and their files state what the diff does, and the
+    gates state what was actually run. The session's own status text - the
+    wrap-up's task-completion lines - is deliberately not a source: it
+    describes the run, and a reader of the pull request is asking about the
+    diff.
+
     Args:
         session: The fully-populated session summary.
 
@@ -537,14 +1019,12 @@ def build_pr_body(session: SessionSummary) -> str:
     # with a single regex.
     short_id = session.session_id[:12] if session.session_id else "unknown"
 
-    change_block = session.changes_summary.strip() or _format_changes(session)
-
     parts: list[str] = [
         "## Problem",
-        _problem_line(session.goal),
+        _problem_statement(session),
         "",
         "## Change",
-        change_block,
+        _format_changes(session),
         "",
         "## Verification",
         _format_gates(session.gates),
@@ -559,6 +1039,16 @@ def build_pr_body(session: SessionSummary) -> str:
             _format_evidence(session.evidence),
             "",
         ]
+    # The description is prose about a diff, and prose can be written about
+    # any diff. The block below is what makes this one checkable: the diff it
+    # was composed from and the journal head of the run that produced it, both
+    # recomputable by ``review-receipt verify``.
+    if session.provenance is not None:
+        parts += [
+            "## Provenance",
+            _format_provenance(session.provenance),
+            "",
+        ]
     parts += [
         "## Cost",
         _format_cost(session.cost),
@@ -569,6 +1059,92 @@ def build_pr_body(session: SessionSummary) -> str:
         f"bernstein-session-id: {short_id}",
     ]
     return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Provenance - binding the description to the diff it describes
+# ---------------------------------------------------------------------------
+
+
+def build_provenance(*, diff: bytes, journal_head: str = "") -> ChangeProvenance:
+    """Bind a description to its diff and to the run that produced it.
+
+    The diff hash comes from
+    :func:`bernstein.core.review.receipt.compute_diff_hash` - the same
+    function ``review-receipt verify`` recomputes with, so there is one
+    hashing path and a description cannot be bound by a rule the verifier
+    does not apply.
+
+    Args:
+        diff: The pull request's diff bytes.
+        journal_head: The run journal's Merkle head, when the run left one.
+
+    Returns:
+        The :class:`ChangeProvenance` the body renders.
+    """
+    from bernstein.core.review.receipt import compute_diff_hash
+
+    return ChangeProvenance(diff_hash=compute_diff_hash(diff), journal_head=journal_head)
+
+
+def attest_pr_description(
+    *,
+    workdir: Path,
+    pr_url: str,
+    repo: str,
+    issue_body: str,
+    description: str,
+    diff: bytes,
+    journal_head: str = "",
+    task_id: str = "",
+    timestamp: int | None = None,
+    hmac_key: bytes | None = None,
+) -> ReviewReceipt:
+    """Anchor a pull-request description against the diff it describes.
+
+    The description takes the receipt's ``plan`` slot: the receipt then binds
+    ``{issue, description, journal head, diff}`` in one signed, spine-anchored
+    record, which is exactly the question a reader of the description has -
+    does this text belong to this diff. ``bernstein review-receipt verify``
+    answers it offline and rejects a diff that has since changed.
+
+    Args:
+        workdir: Project root; the receipt lands under ``.sdd/reviews/``.
+        pr_url: The pull request the description was posted to.
+        repo: ``owner/repo`` slug.
+        issue_body: The linked issue's body, or ``""`` when unlinked.
+        description: The posted description (title and body).
+        diff: The diff the description describes.
+        journal_head: The run journal's Merkle head.
+        task_id: Task the run is attributed to.
+        timestamp: Receipt timestamp; defaults to now. Passing one makes the
+            receipt byte-identical across runs of the same inputs.
+        hmac_key: Audit-chain key; defaults to the install's own.
+
+    Returns:
+        The signed, anchored receipt.
+    """
+    from bernstein.core.review.receipt import emit_review_receipt, load_or_create_review_identity
+    from bernstein.core.security.audit import load_or_create_audit_key
+
+    private_pem, public_pem = load_or_create_review_identity(workdir / ".sdd" / "identity")
+    return emit_review_receipt(
+        workdir=workdir,
+        lineage_root=workdir / ".sdd" / "lineage",
+        hmac_key=hmac_key if hmac_key is not None else load_or_create_audit_key(),
+        private_key_pem=private_pem,
+        public_key_pem=public_pem,
+        pr_url=pr_url,
+        repo=repo,
+        issue_body=issue_body,
+        plan=description,
+        journal_head=journal_head,
+        diff=diff,
+        findings=(),
+        verdict=DESCRIPTION_VERDICT,
+        task_id=task_id,
+        timestamp=timestamp if timestamp is not None else int(time.time()),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -793,6 +1369,38 @@ def _merged_changes_from_journal(run_dir: Path) -> tuple[MergedChange, ...]:
     return tuple(changes)
 
 
+def _journal_head(run_dir: Path) -> str:
+    """Return the run journal's Merkle head, or ``""`` when unreadable.
+
+    The head is the ``event_hash`` of the journal's last row - the same value
+    :meth:`bernstein.core.replay.journal.EventJournal.head` reports, read off
+    disk here because the run has already finished by the time a PR is opened.
+
+    Args:
+        run_dir: The run's directory under ``.sdd/runs/``.
+
+    Returns:
+        The head hash, or ``""`` when the journal is missing or empty.
+    """
+    journal = run_dir / _RUN_JOURNAL_FILENAME
+    try:
+        lines = journal.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ""
+    for line in reversed(lines):
+        if not line.strip():
+            continue
+        try:
+            row: object = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(row, dict):
+            head = {str(k): v for k, v in row.items()}.get("event_hash")  # type: ignore[reportUnknownVariableType]
+            if isinstance(head, str) and head:
+                return head
+    return ""
+
+
 def _as_count(value: object) -> int:
     """Coerce a journal count field to a non-negative int."""
     if isinstance(value, bool) or not isinstance(value, (int, float)):
@@ -905,6 +1513,7 @@ def load_session_summary(
     evidence = _evidence_summary_for_task(root, _candidate_task_ids(wrapup))
 
     merged_changes = _merged_changes_from_journal(run_dir) if run_dir else ()
+    journal_head = _journal_head(run_dir) if run_dir else ""
 
     return SessionSummary(
         session_id=resolved_id,
@@ -918,4 +1527,5 @@ def load_session_summary(
         gates=gates,
         cost=cost,
         evidence=evidence,
+        journal_head=journal_head,
     )

--- a/tests/unit/test_pr_description_from_change.py
+++ b/tests/unit/test_pr_description_from_change.py
@@ -1,0 +1,440 @@
+"""A pull request is described from its change, not from the session (#4484).
+
+The run that implemented per-store key derivation opened its pull request
+titled ``fix: resolve lint gate failures — SIM108 ternary operator and F841
+unused variable``, because the title came from the run's newest commit and the
+run happened to end with a lint repair. The body opened with the session's own
+status text. Reviewers and the changelog both saw a lint cleanup; the feature
+was invisible.
+
+Each test below is named for the property it protects: which commit may name a
+pull request, what the body may contain, and whether a reader can check that a
+description belongs to the diff it claims to describe.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+from bernstein.core.integrations.pr_gen import (
+    COMMIT_LOG_FORMAT,
+    ChangeProvenance,
+    CommitRecord,
+    CostBreakdown,
+    FileChange,
+    GateResult,
+    SessionSummary,
+    attest_pr_description,
+    build_pr_body,
+    build_pr_title,
+    build_provenance,
+    dominant_commit,
+    is_housekeeping_commit,
+    load_session_summary,
+    parse_commit_log,
+    rank_commits,
+)
+from bernstein.core.integrations.tickets import TicketPayload
+from bernstein.core.review.receipt import verify_review_receipt
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+ISSUE_TITLE = "Per-store key derivation reuses one key across every store"
+ISSUE_BODY = (
+    "## Problem\n"
+    "\n"
+    "Every store opens with the same key, so a leak of one store's key reads them all.\n"
+    "\n"
+    "## Proposal\n"
+    "\n"
+    "Derive a per-store key with HKDF-SHA256.\n"
+)
+
+
+def _commit(
+    sha: str,
+    subject: str,
+    files: Iterable[tuple[str, int, int]] = (),
+    *,
+    is_merge: bool = False,
+) -> CommitRecord:
+    """Build a :class:`CommitRecord` from ``(path, added, removed)`` triples."""
+    return CommitRecord(
+        sha=sha,
+        subject=subject,
+        is_merge=is_merge,
+        files=tuple(FileChange(path=path, added=added, removed=removed) for path, added, removed in files),
+    )
+
+
+FEATURE_COMMIT = _commit(
+    "aaaaaaaaaaaa",
+    "feat(storage): derive a per-store key with HKDF-SHA256",
+    [("src/bernstein/core/storage/keys.py", 120, 4), ("tests/unit/test_store_keys.py", 90, 0)],
+)
+LINT_COMMIT = _commit(
+    "bbbbbbbbbbbb",
+    "fix: resolve lint gate failures — SIM108 ternary operator and F841 unused variable",
+    [("src/bernstein/core/storage/keys.py", 6, 8)],
+)
+FORMAT_COMMIT = _commit(
+    "cccccccccccc",
+    "style: reformat storage package",
+    [("src/bernstein/core/storage/store.py", 40, 40)],
+)
+WIP_COMMIT = _commit("dddddddddddd", "[WIP] key derivation", [("src/bernstein/core/storage/keys.py", 10, 0)])
+MERGE_COMMIT = _commit("eeeeeeeeeeee", "Merge branch 'main' into agent/run-1", is_merge=True)
+CONTEXT_SYNC_COMMIT = _commit("ffffffffffff", "docs: refresh agent context", [("AGENTS.md", 12, 3)])
+
+
+def _summary(**overrides: object) -> SessionSummary:
+    base: dict[str, object] = {
+        "session_id": "abcdef1234567890",
+        "goal": f"Resolve GitHub issue #4484: {ISSUE_TITLE}\n\nWork only inside this repository.",
+        "branch": "agent/abcdef12",
+        "base_branch": "main",
+        "primary_role": "engineer",
+        "diff_stat": " src/bernstein/core/storage/keys.py | 124 +++++\n 1 file changed",
+        "gates": (
+            GateResult(name="lint", passed=True, detail="ruff: 0 findings"),
+            GateResult(name="tests", passed=True, detail="pytest: 812 passed"),
+        ),
+        "cost": CostBreakdown(total_usd=1.0, total_tokens=1000, by_role={}),
+    }
+    base.update(overrides)
+    return SessionSummary(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Which commit may name a pull request
+# ---------------------------------------------------------------------------
+
+
+def test_a_lint_repair_at_the_tip_does_not_title_the_pull_request() -> None:
+    """The incident: the run's newest commit was a lint repair, not the change."""
+    title = build_pr_title(ISSUE_TITLE, "engineer", ("bug",), commits=(LINT_COMMIT, FEATURE_COMMIT))
+
+    assert "HKDF-SHA256" in title
+    assert "lint" not in title.lower()
+
+
+def test_a_formatting_commit_at_the_tip_does_not_title_the_pull_request() -> None:
+    """A ``style:`` pass changes many lines and describes none of them."""
+    title = build_pr_title(ISSUE_TITLE, "engineer", (), commits=(FORMAT_COMMIT, FEATURE_COMMIT))
+
+    assert "HKDF-SHA256" in title
+    assert "reformat" not in title.lower()
+
+
+def test_an_all_housekeeping_run_falls_back_to_the_issue_title() -> None:
+    """No substantive commit means no commit may name the pull request."""
+    title = build_pr_title(ISSUE_TITLE, "engineer", (), commits=(LINT_COMMIT, FORMAT_COMMIT, MERGE_COMMIT))
+
+    assert "per-store key derivation" in title.lower()
+    assert "lint" not in title.lower()
+
+
+def test_the_dominant_commit_is_the_one_that_changed_src_most() -> None:
+    """Ranking is by ``src/`` churn, not by recency or by whole-tree size."""
+    small_feature = _commit("111111111111", "feat: add a flag", [("src/a.py", 5, 0)])
+    big_docs = _commit("222222222222", "docs: rewrite the guide", [("docs/guide.md", 900, 400)])
+
+    assert dominant_commit((big_docs, small_feature, FEATURE_COMMIT)) == FEATURE_COMMIT
+
+
+def test_a_docs_only_run_still_gets_a_real_title() -> None:
+    """With no ``src/`` churn anywhere, whole-tree churn decides."""
+    small = _commit("111111111111", "docs: fix a link", [("docs/a.md", 1, 1)])
+    large = _commit("222222222222", "docs: rewrite the deployment guide", [("docs/b.md", 300, 90)])
+
+    assert dominant_commit((small, large)) == large
+
+
+@pytest.mark.parametrize(
+    ("commit", "why"),
+    [
+        (MERGE_COMMIT, "merge commit"),
+        (WIP_COMMIT, "work-in-progress marker"),
+        (FORMAT_COMMIT, "style: type"),
+        (LINT_COMMIT, "lint-repair wording under a fix: type"),
+        (CONTEXT_SYNC_COMMIT, "generated agent-context file only"),
+        (_commit("999999999999", "chore: bump the pin", [("uv.lock", 4, 4)]), "chore: type"),
+        (_commit("888888888888", "fixup! feat: keys", [("src/a.py", 3, 0)]), "rebase marker"),
+        (_commit("777777777777", "empty", []), "touches no files"),
+    ],
+)
+def test_structural_housekeeping_never_names_a_pull_request(commit: CommitRecord, why: str) -> None:
+    assert is_housekeeping_commit(commit), f"{why} should be housekeeping"
+
+
+def test_a_substantive_commit_is_not_mistaken_for_housekeeping() -> None:
+    assert not is_housekeeping_commit(FEATURE_COMMIT)
+
+
+def test_ranking_is_deterministic_when_churn_ties() -> None:
+    """Two equal commits must rank the same way on every run."""
+    first = _commit("111111111111", "feat: one", [("src/a.py", 10, 0)])
+    second = _commit("222222222222", "feat: two", [("src/b.py", 10, 0)])
+
+    assert rank_commits((first, second)) == (first, second)
+    assert rank_commits((second, first)) == (second, first)
+
+
+def test_a_run_with_no_commits_still_titles_from_the_issue() -> None:
+    """Nothing to rank is not the same as everything ranked away."""
+    assert "per-store key derivation" in build_pr_title(ISSUE_TITLE, "engineer", ()).lower()
+
+
+# ---------------------------------------------------------------------------
+# Reading commits out of git
+# ---------------------------------------------------------------------------
+
+
+def test_commit_log_parsing_reads_shas_subjects_merges_and_churn() -> None:
+    raw = (
+        "\x1eaaa111\x1fbbb222 ccc333\x1fMerge branch 'main'\n"
+        "\x1ebbb222\x1fddd444\x1ffeat(storage): derive a per-store key\n"
+        "120\t4\tsrc/bernstein/core/storage/keys.py\n"
+        "-\t-\ttests/fixtures/blob.bin\n"
+    )
+
+    parsed = parse_commit_log(raw)
+
+    assert [c.sha for c in parsed] == ["aaa111", "bbb222"]
+    assert parsed[0].is_merge is True
+    assert parsed[1].is_merge is False
+    assert parsed[1].subject == "feat(storage): derive a per-store key"
+    assert parsed[1].src_churn == 124
+    # A binary file counts as a touched path with no line churn.
+    assert parsed[1].files[1] == FileChange(path="tests/fixtures/blob.bin", added=0, removed=0)
+
+
+def test_commit_log_parsing_takes_the_destination_of_a_rename() -> None:
+    raw = "\x1eaaa111\x1fbbb222\x1frefactor: move the module\n10\t2\tsrc/{old => new}/keys.py\n"
+
+    assert parse_commit_log(raw)[0].files[0].path == "src/new/keys.py"
+
+
+def test_the_commit_log_format_is_the_one_the_parser_reads() -> None:
+    """Drift between the git invocation and the parser would empty the title."""
+    assert COMMIT_LOG_FORMAT == "format:\x1e%H\x1f%P\x1f%s"
+
+
+# ---------------------------------------------------------------------------
+# What the body may contain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("banned", ["Automated session", "Completed:"])
+@pytest.mark.parametrize(
+    "summary",
+    [
+        _summary(),
+        _summary(goal="", diff_stat="", gates=()),
+        _summary(changes_summary="- Fix lint errors in run_receipt.py: Completed: Fix lint errors"),
+        _summary(commits=(LINT_COMMIT, FEATURE_COMMIT)),
+    ],
+    ids=["typical", "empty-session", "status-laden-wrapup", "with-commits"],
+)
+def test_generated_bodies_never_carry_session_status_lines(summary: SessionSummary, banned: str) -> None:
+    """The body answers "what does this diff do", never "how did the run go"."""
+    assert banned not in build_pr_body(summary)
+
+
+def test_the_change_section_names_the_dominant_commit_and_its_files() -> None:
+    body = build_pr_body(_summary(commits=(LINT_COMMIT, FEATURE_COMMIT)))
+    change = body.split("## Change", 1)[1].split("## Verification", 1)[0]
+
+    assert "derive a per-store key with HKDF-SHA256" in change
+    assert "src/bernstein/core/storage/keys.py" in change
+    assert "+120/-4" in change
+
+
+def test_the_change_section_labels_housekeeping_rather_than_hiding_it() -> None:
+    change = build_pr_body(_summary(commits=(LINT_COMMIT, FEATURE_COMMIT))).split("## Change", 1)[1]
+
+    assert "Housekeeping" in change
+    assert "SIM108" in change
+
+
+def test_the_problem_section_comes_from_the_issue_not_the_run_instructions() -> None:
+    body = build_pr_body(_summary(issue_problem=ISSUE_BODY))
+    problem = body.split("## Problem", 1)[1].split("## Change", 1)[0]
+
+    assert "a leak of one store's key reads them all" in problem
+    assert "Work only inside this repository" not in problem
+
+
+def test_the_problem_section_drops_the_standing_instructions_of_a_goal() -> None:
+    """Without a linked issue the goal is the source, minus its brief."""
+    problem = build_pr_body(_summary()).split("## Problem", 1)[1].split("## Change", 1)[0]
+
+    assert ISSUE_TITLE in problem
+    assert "Work only inside this repository" not in problem
+
+
+def test_the_verification_section_reports_the_gates_that_ran() -> None:
+    verification = build_pr_body(_summary()).split("## Verification", 1)[1]
+
+    assert "lint" in verification
+    assert "ruff: 0 findings" in verification
+    assert "pytest: 812 passed" in verification
+
+
+# ---------------------------------------------------------------------------
+# Provenance: does this description belong to this diff?
+# ---------------------------------------------------------------------------
+
+DIFF = b"diff --git a/src/keys.py b/src/keys.py\n+derive()\n"
+OTHER_DIFF = b"diff --git a/src/keys.py b/src/keys.py\n+something-else()\n"
+
+
+def test_the_body_carries_the_diff_hash_and_the_journal_head() -> None:
+    provenance = build_provenance(diff=DIFF, journal_head="sha256:deadbeef")
+    body = build_pr_body(_summary(provenance=provenance, journal_head="sha256:deadbeef"))
+
+    assert "## Provenance" in body
+    assert provenance.diff_hash in body
+    assert "sha256:deadbeef" in body
+
+
+def test_the_diff_hash_is_the_one_the_verifier_recomputes() -> None:
+    """One hashing path: the body publishes what ``review-receipt`` checks."""
+    from bernstein.core.review.receipt import compute_diff_hash
+
+    assert build_provenance(diff=DIFF).diff_hash == compute_diff_hash(DIFF)
+
+
+def test_a_body_without_provenance_omits_the_block() -> None:
+    assert "## Provenance" not in build_pr_body(_summary())
+
+
+def _attest(workdir: Path, description: str, diff: bytes) -> None:
+    attest_pr_description(
+        workdir=workdir,
+        pr_url="https://github.com/sipyourdrink-ltd/bernstein/pull/4485",
+        repo="sipyourdrink-ltd/bernstein",
+        issue_body=ISSUE_BODY,
+        description=description,
+        diff=diff,
+        journal_head="sha256:deadbeef",
+        task_id="T-1",
+        timestamp=1_700_000_000,
+        hmac_key=b"k" * 32,
+    )
+
+
+def test_review_receipt_verify_accepts_a_description_matching_its_diff(tmp_path: Path) -> None:
+    provenance = build_provenance(diff=DIFF, journal_head="sha256:deadbeef")
+    description = build_pr_body(_summary(provenance=provenance, journal_head="sha256:deadbeef"))
+    _attest(tmp_path, description, DIFF)
+
+    result = verify_review_receipt(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=b"k" * 32,
+        pr_url="https://github.com/sipyourdrink-ltd/bernstein/pull/4485",
+        issue_body=ISSUE_BODY,
+        diff=DIFF,
+    )
+
+    assert result.ok, result.reason
+
+
+def test_review_receipt_verify_rejects_a_description_whose_diff_changed(tmp_path: Path) -> None:
+    provenance = build_provenance(diff=DIFF, journal_head="sha256:deadbeef")
+    description = build_pr_body(_summary(provenance=provenance, journal_head="sha256:deadbeef"))
+    _attest(tmp_path, description, DIFF)
+
+    result = verify_review_receipt(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=b"k" * 32,
+        pr_url="https://github.com/sipyourdrink-ltd/bernstein/pull/4485",
+        issue_body=ISSUE_BODY,
+        diff=OTHER_DIFF,
+    )
+
+    assert not result.ok
+    assert "diff_hash mismatch" in result.reason
+
+
+def test_the_journal_head_is_read_from_the_run_journal(tmp_path: Path) -> None:
+    run_dir = tmp_path / ".sdd" / "runs" / "run-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "metadata.json").write_text(json.dumps({"run_id": "run-1"}), encoding="utf-8")
+    (run_dir / "journal.jsonl").write_text(
+        json.dumps({"event": "run_started", "event_hash": "sha256:first"})
+        + "\n"
+        + json.dumps({"event": "run_finished", "event_hash": "sha256:last"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert load_session_summary(None, workdir=tmp_path).journal_head == "sha256:last"
+
+
+# ---------------------------------------------------------------------------
+# Explicit overrides
+# ---------------------------------------------------------------------------
+
+
+TICKET = TicketPayload(
+    id="sipyourdrink-ltd/bernstein#4484",
+    title=ISSUE_TITLE,
+    description=ISSUE_BODY,
+    labels=("bug",),
+    url="https://github.com/sipyourdrink-ltd/bernstein/issues/4484",
+    source="github",
+)
+
+
+def _run_pr(args: list[str], *, commits: tuple[CommitRecord, ...] = (LINT_COMMIT, FEATURE_COMMIT)) -> str:
+    """Invoke ``bernstein pr --dry-run`` with git and the tracker stubbed."""
+    summary = _summary(commits=commits, provenance=ChangeProvenance(diff_hash="sha256:abc", journal_head="sha256:h"))
+    slug = MagicMock(stdout="sipyourdrink-ltd/bernstein\n")
+    with (
+        patch("bernstein.cli.commands.pr_cmd.load_session_summary", return_value=summary),
+        patch("bernstein.cli.commands.pr_cmd._enrich_summary_with_git", side_effect=lambda s, _w: s),
+        patch("bernstein.cli.commands.pr_cmd.fetch_ticket", return_value=TICKET),
+        patch("bernstein.cli.commands.pr_cmd.shutil.which", return_value="/usr/bin/gh"),
+        patch("bernstein.cli.commands.pr_cmd.subprocess.run", return_value=slug),
+    ):
+        return CliRunner().invoke(cli, ["pr", "--dry-run", *args]).output
+
+
+def test_the_dominant_commit_titles_the_pull_request_end_to_end() -> None:
+    out = _run_pr(["--issue", "4484"])
+
+    assert "HKDF-SHA256" in out.splitlines()[0]
+    assert "SIM108" not in out.splitlines()[0]
+
+
+def test_explicit_title_overrides_the_dominant_commit() -> None:
+    out = _run_pr(["--issue", "4484", "--title", "fix: something else"])
+
+    assert out.splitlines()[0] == "Title: fix: something else"
+
+
+def test_explicit_body_overrides_the_generated_description() -> None:
+    out = _run_pr(["--issue", "4484", "--body", "hand-written body"])
+
+    assert "hand-written body" in out
+    assert "## Provenance" not in out
+    # The issue link survives an overridden body: without it merging leaves the
+    # issue open, which is not something --body should be able to switch off.
+    assert "Closes #4484" in out
+
+
+def test_body_is_a_registered_pr_option() -> None:
+    from bernstein.cli.commands.pr_cmd import pr_cmd
+
+    assert "--body" in {param.opts[0] for param in pr_cmd.params}

--- a/tests/unit/test_pr_gen.py
+++ b/tests/unit/test_pr_gen.py
@@ -133,12 +133,21 @@ def test_title_falls_back_to_goal_when_changes_summary_empty() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_body_uses_changes_summary_for_change_section() -> None:
-    summary = _fixture_summary(changes_summary="- Add JWT auth: wired refresh tokens\n- Fix login: patched redirect")
+def test_body_describes_the_diff_not_the_wrapups_task_status() -> None:
+    """The Change section is projected from the diff, never from run telemetry.
+
+    The wrap-up's change bullets are task rows whose result summaries are
+    whatever an agent typed on completion -- usually ``Completed: <the task
+    title again>``. Rendering them made the pull request describe the session
+    (#4484), so the section now comes from the diff and the summary reaches
+    only the title, and then only when no commits are known.
+    """
+    summary = _fixture_summary(changes_summary="- Add JWT auth: Completed: Add JWT auth\n- Fix login: patched redirect")
     body = build_pr_body(summary)
     assert "## Change" in body
-    assert "Add JWT auth: wired refresh tokens" in body
-    assert "Fix login: patched redirect" in body
+    assert "src/auth.py" in body  # from diff_stat in code fence
+    assert "Completed:" not in body
+    assert "patched redirect" not in body
 
 
 def test_body_falls_back_to_diff_stat_when_changes_summary_empty() -> None:


### PR DESCRIPTION
Closes #4484

## Problem

`bernstein pr` composed the pull-request title and body from whatever the finishing run left behind, so both named the wrong thing.

The title was derived from the run's newest commit subject. A run that ends with housekeeping — a lint repair, a formatting pass, a regenerated context file — titled the whole pull request after that housekeeping. A run implementing per-store key derivation opened as *"fix: resolve lint gate failures — SIM108 ternary operator and F841 unused variable"*: the reviewer saw a lint cleanup, the changelog recorded a lint cleanup, and the feature was invisible.

The body had the same problem from the other end. It opened with the session's own status text and continued with task-completion lines (`Completed: <the task title again>`, which is literally what the spawn prompt tells an agent to write on completion). That is run telemetry; a reader wants to know what the diff does.

## Change

**Title — from the dominant commit.** `rank_commits` orders the branch's commits by how much they change under `src/` and drops the ones that are structurally housekeeping: merge commits, `[WIP]`/`fixup!`/`squash!` markers, `style:`/`chore:` types, subjects naming a formatter or a linter (the wording a repair commit uses whatever type it claims — `fix: resolve lint gate failures` is typed `fix` and is still upkeep), and commits touching only generated agent-context files. The dominant subject names the pull request; a run that left nothing but housekeeping falls back to the linked issue's title. Ties break on whole-tree churn then input order, so the same branch always ranks the same way.

**Body — from the diff.** The Problem section quotes the linked issue rather than the brief the run was handed (everything after the goal's first blank line is standing instructions, not a problem). The Change section leads with the dominant commit and the files it alters, lists the remaining substantive commits, and lists housekeeping commits under a label so they are visible without being mistaken for the point of the branch. Verification reports the gates that ran with their results. The wrap-up's task-status text is no longer a source for the body at all.

**Provenance.** A Provenance block names the diff hash and the run's journal head. The hash comes from `compute_diff_hash` in `core/review/receipt.py` — the same function the verifier recomputes with, so there is one hashing path rather than two. Once the pull request exists, the posted description is anchored through `emit_review_receipt` with the description in the receipt's `plan` slot, binding `{issue, description, journal head, diff}` in one signed, spine-anchored record. `bernstein review-receipt verify` then accepts a description matching its diff and rejects one whose diff has since changed. Attestation re-reads the diff and skips itself with a note if the branch moved while the PR was being opened, so a receipt is never emitted for a description that no longer describes the diff; failing to attest never fails the command, since the pull request is already open by then.

**Overrides.** `--title` behaves as before. `--body` is new and overrides the generated body; `Closes #N` is still prepended with `--issue`, since a body override should not be able to switch off issue linking.

Ranking and rendering live next to the summary generator in `core/integrations/pr_gen.py`; the CLI only runs `git log --numstat` / `git diff` and hands the output over.

## Files

| File | What changes |
|---|---|
| `src/bernstein/core/integrations/pr_gen.py` | `CommitRecord` / `FileChange` / `ChangeProvenance`, `rank_commits`, `dominant_commit`, `is_housekeeping_commit`, `parse_commit_log`, `build_provenance`, `attest_pr_description`; title and body rebuilt from the change |
| `src/bernstein/cli/commands/pr_cmd.py` | collects commits and diff bytes, passes them through, adds `--body`, anchors the posted description |
| `docs/reference/cli-reference.md` | `--body` row, `--title`/`--issue` rows updated, section note on how the title is chosen |
| `tests/unit/test_pr_description_from_change.py` | new suite (42 tests) |
| `tests/unit/test_pr_gen.py` | one test re-pinned: the Change section is projected from the diff, not from the wrap-up's task rows |

## Verification

`uv run ruff check .` — all checks passed.
`uv run ruff format --check src/` — 1910 files already formatted.
`uv run pytest` on the new suite plus every existing `pr`/CLI-docs test file — 805 passed, 1 skipped.
`uv run lint-imports` — 3 kept, 0 broken.
`uv run pyright` on both touched modules — no new diagnostics (`pr_cmd.py` goes from 1 to 0).

Dogfooded on this branch: the generator titles it `fix: describe the pull request from the change, not the session` and its Change section lists `pr_gen.py (+642/-32)` first.

## Notes for review

One existing test changed contract rather than being deleted: `test_body_uses_changes_summary_for_change_section` pinned the behaviour this issue reports as the second failure mode (the body rendering the wrap-up's task rows). It is now `test_body_describes_the_diff_not_the_wrapups_task_status` and asserts the opposite. The wrap-up summary still feeds the *title* as a last resort, so #4459's title work is untouched.

The housekeeping wording rule can misread a genuine change to the lint setup itself (`feat: add a lint gate`). That misread is benign by construction: a run whose only substantive commit is classified away falls back to the linked issue's title, which for such a run says the same thing.

Out of scope, as the issue states: how the run journal is written, and any GitHub API work beyond what `pr` already does. The orchestrator's separate auto-PR body builder (`orchestrator._build_pr_body`) is untouched.
