### PR TITLE
fix(config): resolve run overrides from an untracked overlay

### DIFF
--- a/docs/architecture/quality-pipeline.md
+++ b/docs/architecture/quality-pipeline.md
@@ -101,6 +101,7 @@ Default required gates (only those whose `quality_gates.<flag>: true`):
 | `pii_scan`               | `pii_scan: true`            | `any_changed`      | required            |
 | `dlp_scan`               | `dlp_scan: true`            | `any_changed`      | required            |
 | `merge_conflict`         | `merge_conflict_check`      | `any_changed`      | required            |
+| `run_config`             | `run_config: true`          | `always`           | required            |
 | `coverage_delta`         | `coverage_delta`            | `python_changed`   | required            |
 | `dep_audit`              | `dep_audit`                 | `deps_changed`     | required            |
 | `import_cycle`           | `import_cycle_check`        | `python_changed`   | required            |

--- a/docs/operations/CONFIG.md
+++ b/docs/operations/CONFIG.md
@@ -132,6 +132,78 @@ how a match changes a spawned prompt: see
 
 ---
 
+### 1.1) Run overrides: the untracked overlay
+
+`bernstein.yaml` is a tracked file. A run never writes it.
+
+Overrides that belong to one run - a pinned `role_model_policy`, a different
+`internal_llm_provider`, a quality-gate switch - go to an **overlay** that
+lives outside the work tree, and configuration loading merges the overlay over
+the committed file.
+
+Precedence, lowest first:
+
+| Layer | Where |
+|---|---|
+| 1. committed configuration | `bernstein.yaml` in the work tree |
+| 2. overlay | `$BERNSTEIN_CONFIG_OVERLAY`, else `<git-dir>/bernstein/run-overlay.yaml` |
+| 3. inline override | `$BERNSTEIN_CONFIG_OVERRIDE` (a YAML or JSON mapping) |
+| 4. explicit CLI flags | `--model`, `--cli`, ... applied after the merge |
+
+Nested sections merge key by key, so overriding one role's model leaves the
+other roles at their committed values. Scalars and lists replace wholesale.
+
+```bash
+# one knob, no file
+BERNSTEIN_CONFIG_OVERRIDE='{max_agents: 8}' bernstein run
+
+# a sandbox supplying its own overlay outside a read-only work tree
+BERNSTEIN_CONFIG_OVERLAY=/run/bernstein/overlay.yaml bernstein run
+```
+
+With no overlay and neither variable set, the merge is the identity: a setup
+that edits `bernstein.yaml` directly behaves exactly as it always has.
+
+Two consequences worth knowing:
+
+- The default overlay is inside `.git/`, so `git status` never reports it and
+  `git commit -a` cannot carry it. An overlay path pointed *inside* the work
+  tree is refused rather than written.
+- The orchestrator's config hot-reload watches the newest mtime across both
+  layers, so an overlay write is picked up on the next tick.
+
+#### The one in-tree exemption: `.claude/mcp.json`
+
+Claude Code reads its MCP bridge manifest from `<workdir>/.claude/mcp.json`
+and takes no argument pointing elsewhere, so that file has to be written
+inside the work tree. It is registered in the repository's `info/exclude` for
+the run instead, which keeps a broad `git add -A` from staging it.
+`info/exclude` is used rather than `.gitignore` because `.gitignore` is itself
+a tracked file.
+
+Git ignore rules only apply to untracked paths. If a project already tracks
+`.claude/mcp.json`, the exclude has no effect on it and the `run_config`
+quality gate below is what stops the change.
+
+#### The `run_config` gate
+
+`run_config` is a required quality gate, on by default. It fails any change
+whose diff touches a run-configuration path - `bernstein.yaml`,
+`bernstein.yml`, `.bernstein/bernstein.yaml`, `.bernstein/bernstein.yml`,
+`.mcp.json`, `.claude/mcp.json` - and names the offending file. The same path
+set backs the default-branch merge guard and the per-worktree local excludes,
+so the three cannot drift apart.
+
+Turn it off for a project that genuinely keeps one of those paths as a
+deliverable:
+
+```yaml
+quality_gates:
+  run_config: false
+```
+
+---
+
 ## 2) Workspace runtime defaults: `.sdd/config.yaml`
 
 Created by:
@@ -161,6 +233,8 @@ Environment variables are useful in CI and automation. Common variables:
 | `BERNSTEIN_STORAGE_BACKEND` | Storage backend (`memory`, `postgres`, `redis`) |
 | `BERNSTEIN_DATABASE_URL` | PostgreSQL DSN for `postgres`/`redis` backends |
 | `BERNSTEIN_REDIS_URL` | Redis URL for distributed locking backend |
+| `BERNSTEIN_CONFIG_OVERLAY` | Path to the run-configuration overlay (see §1.1). Must be outside the work tree. |
+| `BERNSTEIN_CONFIG_OVERRIDE` | Inline override mapping (YAML or JSON) merged above the overlay (see §1.1). |
 | `BERNSTEIN_SKIP_GATES` | Skip selected quality gates |
 | `BERNSTEIN_SKIP_GATE_REASON` | Audit reason when gates are skipped |
 | `BERNSTEIN_WORKFLOW` | Workflow mode override |

--- a/docs/release-notes/fragments/4485-run-config-overlay.md
+++ b/docs/release-notes/fragments/4485-run-config-overlay.md
@@ -1,0 +1,14 @@
+## Run overrides no longer land in the repository's configuration
+
+A run used to pin its overrides into the tracked `bernstein.yaml` in the work
+tree, so any agent that committed with a staged tree carried the file and the
+pull request proposed rewriting the repository's configuration for everyone.
+Overrides now resolve from an untracked overlay inside the git directory
+(`BERNSTEIN_CONFIG_OVERLAY` points it elsewhere, `BERNSTEIN_CONFIG_OVERRIDE`
+carries an inline mapping), merged over the committed file at load time in the
+order committed file < overlay < explicit override. The committed file is read
+by a run and never written by one. `.claude/mcp.json` still has to exist in the
+work tree because Claude Code reads it from a fixed path, so it is registered
+in the repository's local git excludes instead. A new required quality gate,
+`run_config`, refuses any change whose diff touches a run-configuration path
+and names the file (#4485).

--- a/src/bernstein/core/config/run_overlay.py
+++ b/src/bernstein/core/config/run_overlay.py
@@ -1,0 +1,465 @@
+"""Untracked overlay layer for run-scoped configuration overrides.
+
+A run needs to override parts of the project's configuration for its own
+duration - the role/model policy it was launched with, the internal LLM
+provider, a quality-gate switch.  Writing those overrides into the tracked
+``bernstein.yaml`` in the work tree made them part of every commit an agent
+produced with a staged tree, so a pull request could propose rewriting the
+repository's committed configuration for everyone.  Restoring the file just
+before publishing only fixed the one publishing path that remembered to do
+it; the leak came back the moment a second path appeared.
+
+This module removes the failure mode instead of compensating for it: run
+overrides are resolved from a layer git does not track.  The overlay lives
+inside the repository's git directory (or wherever :data:`ENV_CONFIG_OVERLAY`
+points, so a sandbox can hand the run a location of its own), never in the
+work tree.  :func:`resolve_effective_mapping` merges it over the mapping
+parsed from the committed file, so the committed file is *read* by a run and
+never *written* by one.
+
+Precedence, lowest to highest:
+
+1. the committed configuration file in the work tree;
+2. the overlay file (:data:`ENV_CONFIG_OVERLAY`, else ``<git-dir>/bernstein/run-overlay.yaml``);
+3. the inline override mapping in :data:`ENV_CONFIG_OVERRIDE`;
+4. explicit CLI flags, which callers apply to the parsed config afterwards.
+
+With no overlay file and neither environment variable set, the merge is the
+identity function: a setup that edits the committed file directly keeps
+working exactly as before.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+logger = logging.getLogger(__name__)
+
+#: Absolute path to the overlay file.  Set by a sandbox (or an operator) that
+#: needs the overlay somewhere other than the repository's git directory - a
+#: read-only bind-mounted work tree, for instance.
+ENV_CONFIG_OVERLAY: Final[str] = "BERNSTEIN_CONFIG_OVERLAY"
+
+#: Inline override mapping, as YAML or JSON.  Highest-precedence layer below
+#: explicit CLI flags; useful when a caller has a single knob to set and no
+#: sensible place to keep a file.
+ENV_CONFIG_OVERRIDE: Final[str] = "BERNSTEIN_CONFIG_OVERRIDE"
+
+#: Overlay location relative to the repository's git directory when
+#: :data:`ENV_CONFIG_OVERLAY` is unset.  Inside ``.git/`` by construction, so
+#: it cannot be staged, cannot show up in ``git status``, and cannot be
+#: carried by ``git commit -a``.
+OVERLAY_RELATIVE_TO_GIT_DIR: Final[str] = "bernstein/run-overlay.yaml"
+
+#: Work-tree paths that carry run configuration and must therefore never
+#: appear in a commit an orchestrated run produces.  This is the single
+#: source of truth for the invariant: the merge-preflight deny list, the
+#: per-worktree local excludes, and the commit gate all derive from it
+#: rather than repeating it, so they cannot drift apart.
+#:
+#: ``.claude/mcp.json`` is the bridge manifest Claude Code reads from a fixed
+#: project-local path; see :func:`bernstein.core.git.local_exclude.register_run_excludes`
+#: for why that one file is written into the work tree anyway and how it is
+#: kept out of the index.
+RUN_CONFIG_PATHS: frozenset[str] = frozenset(
+    {
+        "bernstein.yaml",
+        "bernstein.yml",
+        ".bernstein/bernstein.yaml",
+        ".bernstein/bernstein.yml",
+        ".claude/mcp.json",
+        ".mcp.json",
+    }
+)
+
+#: Marker git leaves in every work tree: a directory in a normal clone, a
+#: file containing ``gitdir: <path>`` in a linked worktree or a submodule.
+_GIT_MARKER = ".git"
+
+
+class RunOverlayError(RuntimeError):
+    """Raised when the overlay layer is present but unusable.
+
+    A malformed or misplaced overlay is never ignored: silently falling back
+    to the committed file would run the job under a configuration nobody
+    asked for.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Git-directory resolution
+# ---------------------------------------------------------------------------
+#
+# Resolved from the filesystem rather than by shelling out to ``git``.
+# :func:`resolve_effective_mapping` runs on every configuration load,
+# including the orchestrator's per-tick hot-reload check, and a subprocess
+# per tick is a cost the overlay does not need to impose. The walk below is
+# what git itself does: look for the ``.git`` marker in the directory and
+# then in each parent.
+
+
+def _git_dir_from_marker(marker: Path) -> Path | None:
+    """Resolve a ``.git`` marker to the git directory it denotes."""
+    if marker.is_dir():
+        return marker
+    if not marker.is_file():
+        return None
+    # Linked worktree / submodule: ``.git`` is a file holding a pointer.
+    try:
+        text = marker.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.debug("Cannot read git marker file %s: %s", marker, exc)
+        return None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("gitdir:"):
+            continue
+        target = Path(stripped.removeprefix("gitdir:").strip())
+        if not target.is_absolute():
+            target = marker.parent / target
+        return Path(os.path.normpath(target))
+    logger.debug("Git marker file %s has no gitdir: pointer", marker)
+    return None
+
+
+def _walk_to_repo(workdir: Path) -> tuple[Path, Path] | None:
+    """Return ``(work_tree_root, git_dir)`` for *workdir*, or ``None``.
+
+    ``$GIT_DIR`` wins when set, matching git's own precedence, so a caller
+    that has redirected git already has the overlay follow it.
+    """
+    try:
+        start = workdir.resolve()
+    except OSError as exc:
+        logger.debug("Cannot resolve %s: %s", workdir, exc)
+        return None
+
+    env_git_dir = os.environ.get("GIT_DIR", "").strip()
+    if env_git_dir:
+        git_dir = Path(env_git_dir).expanduser()
+        if not git_dir.is_absolute():
+            git_dir = start / git_dir
+        env_work_tree = os.environ.get("GIT_WORK_TREE", "").strip()
+        root = Path(env_work_tree).expanduser() if env_work_tree else start
+        if not root.is_absolute():
+            root = start / root
+        return Path(os.path.normpath(root)), Path(os.path.normpath(git_dir))
+
+    for candidate in (start, *start.parents):
+        git_dir = _git_dir_from_marker(candidate / _GIT_MARKER)
+        if git_dir is not None:
+            return candidate, git_dir
+    return None
+
+
+def git_dir_for(workdir: Path) -> Path | None:
+    """Resolve the git directory that owns *workdir*.
+
+    For a linked worktree this is that worktree's own
+    ``.git/worktrees/<id>`` directory, so two worktrees of one clone get two
+    independent overlays rather than fighting over a shared file.
+    """
+    found = _walk_to_repo(workdir)
+    return None if found is None else found[1]
+
+
+def work_tree_root_for(workdir: Path) -> Path | None:
+    """Resolve the work-tree root that owns *workdir*."""
+    found = _walk_to_repo(workdir)
+    return None if found is None else found[0]
+
+
+# ---------------------------------------------------------------------------
+# Overlay location
+# ---------------------------------------------------------------------------
+
+
+def _env_overlay_path() -> Path | None:
+    raw = os.environ.get(ENV_CONFIG_OVERLAY, "").strip()
+    if not raw:
+        return None
+    return Path(raw).expanduser()
+
+
+def resolve_overlay_path(config_path: Path) -> Path | None:
+    """Return the overlay file location for the config at *config_path*.
+
+    ``$BERNSTEIN_CONFIG_OVERLAY`` wins when set.  Otherwise the overlay lives
+    at ``<git-dir>/bernstein/run-overlay.yaml``.  Returns ``None`` when the
+    config file is not inside a git repository and no explicit location was
+    given - there is then no place to put an overlay that the work tree does
+    not also contain, and the caller falls back to the committed file alone.
+
+    The returned path is not required to exist.
+    """
+    explicit = _env_overlay_path()
+    if explicit is not None:
+        return explicit
+    workdir = config_path.parent if config_path.parent != Path("") else Path.cwd()
+    git_dir = git_dir_for(workdir)
+    if git_dir is None:
+        return None
+    return git_dir / OVERLAY_RELATIVE_TO_GIT_DIR
+
+
+def _is_inside(candidate: Path, root: Path) -> bool:
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def assert_outside_work_tree(overlay_path: Path, *, workdir: Path) -> None:
+    """Refuse an overlay location git would report as a work-tree change.
+
+    The whole point of the overlay is that no run can put configuration into
+    a commit, so an overlay pointed at the work tree is not a smaller version
+    of the guarantee - it is the original defect with a new filename.  Paths
+    inside the git directory are fine (git never tracks its own directory);
+    everything else under the work-tree root is refused.
+    """
+    root = work_tree_root_for(workdir)
+    if root is None:
+        return
+    resolved = overlay_path.expanduser()
+    resolved = resolved if resolved.is_absolute() else (workdir / resolved)
+    resolved = Path(os.path.normpath(resolved))
+    git_dir = git_dir_for(workdir)
+    if git_dir is not None and _is_inside(resolved, Path(os.path.normpath(git_dir))):
+        return
+    if _is_inside(resolved, Path(os.path.normpath(root))):
+        raise RunOverlayError(
+            f"Refusing to use {resolved} as the run-configuration overlay: it is inside the work tree "
+            f"({root}), so a run could commit it. Point {ENV_CONFIG_OVERLAY} at a path outside the work "
+            f"tree, or leave it unset to use <git-dir>/{OVERLAY_RELATIVE_TO_GIT_DIR}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Reading and merging
+# ---------------------------------------------------------------------------
+
+
+def deep_merge(base: Mapping[str, Any], over: Mapping[str, Any]) -> dict[str, Any]:
+    """Merge *over* onto *base*, recursing into nested mappings.
+
+    Scalars and sequences replace wholesale; only mappings merge key by key.
+    A list that half-merged with the committed value would be impossible to
+    reason about (``constraints``, ``context_files``, ``org_policies`` are
+    all ordered lists whose meaning depends on the whole sequence), so an
+    overlay that sets a list means exactly that list.
+    """
+    merged: dict[str, Any] = dict(base)
+    for key, value in over.items():
+        current = merged.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            merged[key] = deep_merge(current, value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _as_mapping(loaded: object, *, origin: str) -> dict[str, Any]:
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        raise RunOverlayError(f"{origin} must be a mapping, got {type(loaded).__name__}")
+    return dict(loaded)
+
+
+def load_overlay_mapping(overlay_path: Path | None) -> dict[str, Any]:
+    """Load the overlay file, or ``{}`` when there is none.
+
+    Raises:
+        RunOverlayError: if the file exists but is unreadable or is not a
+            YAML mapping.  A run must not silently proceed on the committed
+            configuration when an overlay was meant to apply.
+    """
+    if overlay_path is None or not overlay_path.exists():
+        return {}
+    try:
+        raw_text = overlay_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RunOverlayError(f"Cannot read configuration overlay {overlay_path}: {exc}") from exc
+    try:
+        loaded: object = yaml.safe_load(raw_text)
+    except yaml.YAMLError as exc:
+        raise RunOverlayError(f"Invalid YAML in configuration overlay {overlay_path}: {exc}") from exc
+    return _as_mapping(loaded, origin=f"Configuration overlay {overlay_path}")
+
+
+def load_inline_override() -> dict[str, Any]:
+    """Load the inline override mapping from :data:`ENV_CONFIG_OVERRIDE`.
+
+    The value is parsed as YAML, which also accepts JSON, so a caller can use
+    whichever is easier to quote.
+
+    Raises:
+        RunOverlayError: if the variable is set to something that is not a
+            mapping.
+    """
+    raw = os.environ.get(ENV_CONFIG_OVERRIDE, "").strip()
+    if not raw:
+        return {}
+    try:
+        loaded: object = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise RunOverlayError(f"Invalid YAML/JSON in ${ENV_CONFIG_OVERRIDE}: {exc}") from exc
+    return _as_mapping(loaded, origin=f"${ENV_CONFIG_OVERRIDE}")
+
+
+def resolve_effective_mapping(base: Mapping[str, Any], *, config_path: Path) -> dict[str, Any]:
+    """Return *base* merged with the overlay and the inline override.
+
+    Args:
+        base: The mapping parsed from the committed configuration file.
+        config_path: Where that file lives; used to locate the overlay.
+
+    Returns:
+        A new mapping.  *base* is never mutated, and the file it came from is
+        never written.
+
+    Raises:
+        RunOverlayError: if an overlay or inline override is present but
+            unusable.
+    """
+    overlay_path = resolve_overlay_path(config_path)
+    overlay = load_overlay_mapping(overlay_path)
+    inline = load_inline_override()
+    if not overlay and not inline:
+        return dict(base)
+    merged = deep_merge(base, overlay)
+    merged = deep_merge(merged, inline)
+    logger.debug(
+        "Applied run-configuration overlay over %s (overlay=%s keys=%s, inline keys=%s)",
+        config_path,
+        overlay_path,
+        sorted(overlay),
+        sorted(inline),
+    )
+    return merged
+
+
+def effective_mtime(config_path: Path) -> float:
+    """Newest mtime across the committed file and its overlay.
+
+    Callers that hot-reload configuration by watching a file's mtime must
+    watch both layers, otherwise an overlay write - the only kind of write a
+    run is allowed to make - would never be noticed.  Missing files
+    contribute ``0.0``.
+    """
+    newest = 0.0
+    for candidate in (config_path, resolve_overlay_path(config_path)):
+        if candidate is None:
+            continue
+        try:
+            newest = max(newest, candidate.stat().st_mtime)
+        except OSError:
+            continue
+    return newest
+
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+
+
+_OVERLAY_HEADER = (
+    "# Bernstein run-configuration overlay - generated, not tracked by git.\n"
+    "# Merged over the committed configuration file at load time so a run\n"
+    "# never has to write the tracked file. Safe to delete when no run is\n"
+    "# active; the next run recreates whatever it needs.\n"
+)
+
+
+def write_overlay(updates: Mapping[str, Any], *, config_path: Path) -> Path:
+    """Merge *updates* into the overlay for *config_path* and persist it.
+
+    This is the only supported way for a run to change its own effective
+    configuration.  The committed file is not opened for writing here, or
+    anywhere else in the run.
+
+    Returns:
+        The overlay path that was written.
+
+    Raises:
+        RunOverlayError: when no overlay location can be resolved (the
+            config file is not in a git repository and ``$BERNSTEIN_CONFIG_OVERLAY``
+            is unset), when the resolved location is inside the work tree, or
+            when the write fails.
+    """
+    overlay_path = resolve_overlay_path(config_path)
+    if overlay_path is None:
+        raise RunOverlayError(
+            f"No configuration overlay location for {config_path}: it is not inside a git repository. "
+            f"Set {ENV_CONFIG_OVERLAY} to a writable path outside the work tree."
+        )
+    workdir = config_path.parent if str(config_path.parent) else Path.cwd()
+    assert_outside_work_tree(overlay_path, workdir=workdir)
+
+    merged = deep_merge(load_overlay_mapping(overlay_path), updates)
+    try:
+        overlay_path.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic replace: a reader mid-run either sees the previous overlay
+        # or the new one, never a half-written document.
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=overlay_path.parent,
+            prefix=overlay_path.name + ".",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(_OVERLAY_HEADER)
+            yaml.safe_dump(merged, handle, default_flow_style=False, sort_keys=True)
+            tmp_path = Path(handle.name)
+        tmp_path.replace(overlay_path)
+    except OSError as exc:
+        raise RunOverlayError(f"Cannot write configuration overlay {overlay_path}: {exc}") from exc
+    return overlay_path
+
+
+# ---------------------------------------------------------------------------
+# Path classification
+# ---------------------------------------------------------------------------
+
+
+def normalize_repo_path(path: str) -> str:
+    """Normalise a git-reported path for comparison against the path set."""
+    norm = path.strip().replace("\\", "/")
+    # Strip only a leading "./", not a stray leading dot: ``lstrip("./")``
+    # would turn ``.bernstein/x`` into ``bernstein/x``.
+    while norm.startswith("./"):
+        norm = norm[2:]
+    return norm
+
+
+def is_run_config_path(path: str) -> bool:
+    """Return True when *path* is one of the run-configuration paths."""
+    return normalize_repo_path(path) in RUN_CONFIG_PATHS
+
+
+def find_run_config_paths(paths: Iterable[str]) -> list[str]:
+    """Return the run-configuration paths among *paths*, order preserved."""
+    return [p for p in (normalize_repo_path(raw) for raw in paths if raw.strip()) if p in RUN_CONFIG_PATHS]
+
+
+def describe_overlay_remedy(paths: Iterable[str]) -> str:
+    """Human-readable remedy naming the offending files."""
+    named = ", ".join(paths)
+    return (
+        f"Run configuration must never be part of a change: {named}. "
+        f"Put run overrides in the untracked overlay instead "
+        f"(<git-dir>/{OVERLAY_RELATIVE_TO_GIT_DIR}, or ${ENV_CONFIG_OVERLAY}), "
+        f"then restore the tracked file with: git restore --staged --worktree -- {named}"
+    )

--- a/src/bernstein/core/config/run_overlay.py
+++ b/src/bernstein/core/config/run_overlay.py
@@ -204,19 +204,18 @@ def resolve_overlay_path(config_path: Path) -> Path | None:
     explicit = _env_overlay_path()
     if explicit is not None:
         return explicit
-    workdir = config_path.parent if config_path.parent != Path("") else Path.cwd()
-    git_dir = git_dir_for(workdir)
+    git_dir = git_dir_for(config_path.parent)
     if git_dir is None:
         return None
     return git_dir / OVERLAY_RELATIVE_TO_GIT_DIR
 
 
-def _is_inside(candidate: Path, root: Path) -> bool:
-    try:
-        candidate.relative_to(root)
-    except ValueError:
-        return False
-    return True
+def _resolved(path: Path, *, relative_to: Path) -> Path:
+    """Absolute, symlink-resolved form of *path* (it need not exist)."""
+    candidate = path.expanduser()
+    if not candidate.is_absolute():
+        candidate = relative_to / candidate
+    return candidate.resolve()
 
 
 def assert_outside_work_tree(overlay_path: Path, *, workdir: Path) -> None:
@@ -231,13 +230,11 @@ def assert_outside_work_tree(overlay_path: Path, *, workdir: Path) -> None:
     root = work_tree_root_for(workdir)
     if root is None:
         return
-    resolved = overlay_path.expanduser()
-    resolved = resolved if resolved.is_absolute() else (workdir / resolved)
-    resolved = Path(os.path.normpath(resolved))
+    resolved = _resolved(overlay_path, relative_to=workdir)
     git_dir = git_dir_for(workdir)
-    if git_dir is not None and _is_inside(resolved, Path(os.path.normpath(git_dir))):
+    if git_dir is not None and resolved.is_relative_to(git_dir.resolve()):
         return
-    if _is_inside(resolved, Path(os.path.normpath(root))):
+    if resolved.is_relative_to(root.resolve()):
         raise RunOverlayError(
             f"Refusing to use {resolved} as the run-configuration overlay: it is inside the work tree "
             f"({root}), so a run could commit it. Point {ENV_CONFIG_OVERLAY} at a path outside the work "
@@ -404,8 +401,7 @@ def write_overlay(updates: Mapping[str, Any], *, config_path: Path) -> Path:
             f"No configuration overlay location for {config_path}: it is not inside a git repository. "
             f"Set {ENV_CONFIG_OVERLAY} to a writable path outside the work tree."
         )
-    workdir = config_path.parent if str(config_path.parent) else Path.cwd()
-    assert_outside_work_tree(overlay_path, workdir=workdir)
+    assert_outside_work_tree(overlay_path, workdir=config_path.parent)
 
     merged = deep_merge(load_overlay_mapping(overlay_path), updates)
     try:

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -21,6 +21,10 @@ import yaml
 
 from bernstein.agents.catalog import CatalogRegistry
 from bernstein.core.compliance import ComplianceConfig, CompliancePreset
+from bernstein.core.config.run_overlay import (
+    RunOverlayError,
+    resolve_effective_mapping,
+)
 from bernstein.core.config.seed_config import (
     CORSConfig,
     DashboardAuthConfig,
@@ -1738,6 +1742,7 @@ def _parse_quality_gates(raw: object) -> QualityGatesConfig | None:
             "pii_allowlist_prefixes",
             ["FAKE", "TEST", "EXAMPLE", "DUMMY", "PLACEHOLDER", "LOCALHOST"],
         ),
+        run_config=_qg_bool("run_config", True),
         security_scan=_qg_bool("security_scan", False),
         security_scan_command=_qg_optional_str("security_scan_command"),
         coverage_delta=_qg_bool("coverage_delta", False),
@@ -2261,7 +2266,17 @@ def parse_seed(path: Path) -> SeedConfig:
     if not isinstance(data_raw, dict):
         raise SeedError(f"Seed file must be a YAML mapping, got {type(data_raw).__name__}")
 
-    data: dict[str, object] = cast("_StrObjDict", data_raw)
+    committed: dict[str, object] = cast("_StrObjDict", data_raw)
+
+    # Run-scoped overrides are merged in from an untracked overlay rather than
+    # written into the file above. The committed file is read by a run and
+    # never written by one, so no commit an agent makes can carry it. With no
+    # overlay and no ``$BERNSTEIN_CONFIG_OVERRIDE`` this is the identity, and
+    # a setup that edits the committed file directly behaves as it always did.
+    try:
+        data: dict[str, object] = cast("_StrObjDict", resolve_effective_mapping(committed, config_path=path))
+    except RunOverlayError as exc:
+        raise SeedError(str(exc)) from exc
 
     _warn_unknown_top_level_keys(data)
 

--- a/src/bernstein/core/git/git_basic.py
+++ b/src/bernstein/core/git/git_basic.py
@@ -232,13 +232,15 @@ def stage_all_except(cwd: Path, exclude: list[str] | None = None) -> None:
         exclude: Paths/globs to unstage after the bulk add.
     """
     run_git(["add", "-A"], cwd)
-    to_unstage = list(exclude or [])
-    # Always unstage never-stage paths that are directories
-    for pat in _NEVER_STAGE:
-        if pat.endswith("/"):
-            to_unstage.append(pat)
-    if to_unstage:
-        run_git(["reset", "HEAD", "--", *to_unstage], cwd)
+    # Every never-stage entry is unstaged, not only the directory prefixes.
+    # The earlier version appended a pattern only when it ended in "/", so
+    # ``bernstein.yaml``, ``.claude/mcp.json`` and ``.env`` survived the bulk
+    # ``git add -A`` and were committed - and this helper's only caller
+    # commits and pushes to the default branch (issue #4485). Git reads the
+    # bare names and the ``*.pid`` / ``*.log`` forms as pathspecs, and a
+    # pathspec that matches nothing is a no-op.
+    to_unstage = list(exclude or []) + sorted(_NEVER_STAGE)
+    run_git(["reset", "HEAD", "--", *to_unstage], cwd)
 
 
 # ------------------------------------------------------------------

--- a/src/bernstein/core/git/git_pr.py
+++ b/src/bernstein/core/git/git_pr.py
@@ -15,6 +15,7 @@ from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from bernstein.core.config.run_overlay import RUN_CONFIG_PATHS
 from bernstein.core.git.git_basic import GitResult, run_git
 from bernstein.core.telemetry import start_span
 
@@ -85,13 +86,12 @@ _MERGE_DENY_PREFIXES: tuple[str, ...] = (
     "auth/",
 )
 # Exact filenames that are runtime artefacts, never part of a deliverable.
-_MERGE_DENY_EXACT: frozenset[str] = frozenset(
-    {
-        "bernstein.yaml",
-        ".claude/mcp.json",
-        ".env",
-    }
-)
+# The run-configuration half is imported from the config layer rather than
+# repeated here: :data:`bernstein.core.config.run_overlay.RUN_CONFIG_PATHS`
+# is the single definition of "this file carries run configuration", shared
+# with the per-worktree local excludes and the commit gate, so the three
+# cannot drift apart.
+_MERGE_DENY_EXACT: frozenset[str] = RUN_CONFIG_PATHS | frozenset({".env"})
 
 
 def _is_forbidden_for_merge(path: str) -> bool:

--- a/src/bernstein/core/git/incremental_merge.py
+++ b/src/bernstein/core/git/incremental_merge.py
@@ -44,6 +44,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.git.git_basic import run_git
+from bernstein.core.quality.run_config_gate import check_paths
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -475,6 +476,28 @@ def _execute_incremental_merge(
             conflicting_files=conflicting,
             commit_sha="",
             error="All files conflicted during checkout",
+        )
+
+    # The file list reaches here from an API caller, so nothing upstream has
+    # decided that these paths are deliverables. A run-configuration path is
+    # refused before it is staged rather than restored after the commit, so
+    # the invariant does not depend on this particular path remembering to
+    # clean up afterwards (issue #4485).
+    run_config_verdict = check_paths(merged)
+    if not run_config_verdict.ok:
+        logger.warning(
+            "Incremental merge for session %s refused: %s",
+            session_id,
+            run_config_verdict.details,
+        )
+        return IncrementalMergeResult(
+            success=False,
+            merged_files=[],
+            skipped_already_merged=already_merged_requested,
+            uncommitted_files=uncommitted,
+            conflicting_files=conflicting,
+            commit_sha="",
+            error=run_config_verdict.details,
         )
 
     run_git(["add", "--", *merged], workdir)

--- a/src/bernstein/core/git/local_exclude.py
+++ b/src/bernstein/core/git/local_exclude.py
@@ -1,0 +1,147 @@
+"""Run-scoped git excludes for in-tree files a run has to write anyway.
+
+Run configuration belongs in the untracked overlay
+(:mod:`bernstein.core.config.run_overlay`), which lives inside the git
+directory and therefore cannot reach a commit.  One file cannot follow that
+rule.
+
+**Why ``.claude/mcp.json`` is exempt.**  It is the bridge manifest Claude
+Code reads to discover Bernstein's MCP tools, and Claude Code looks for it at
+exactly one project-local path: ``<workdir>/.claude/mcp.json``.  The child
+process is not ours to reconfigure, it accepts no path argument for this
+file, and it resolves the path relative to the directory the operator opened
+- which is the work tree.  So the file has to be written inside the work
+tree, and the invariant has to be enforced a second way for it: the path is
+registered in the repository's ``info/exclude`` for the duration of the run,
+so an agent's broad ``git add -A`` cannot stage it and ``git commit -a``
+cannot carry it.
+
+``info/exclude`` is used rather than ``.gitignore`` because ``.gitignore`` is
+itself a tracked file - writing the exclusion into the work tree would swap
+one leaked configuration file for another.
+
+**What this does not cover.**  Git ignore rules apply to untracked paths
+only.  If a target repository already tracks ``.claude/mcp.json``, an exclude
+entry has no effect on it, and the run-configuration commit gate
+(:mod:`bernstein.core.quality.run_config_gate`) is what stops the change from
+being published.  The two layers are deliberate: the exclude keeps the file
+out of the index in the common case, the gate fails loudly in the case the
+exclude cannot reach.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+_GIT_TIMEOUT_S: Final[int] = 10
+
+#: Header written above the block this module manages, so an operator reading
+#: ``info/exclude`` can tell where the entries came from.
+EXCLUDE_BLOCK_HEADER: Final[str] = "# bernstein: run-scoped excludes (see core/git/local_exclude.py)"
+
+#: In-tree paths a run must write for a child process to find, anchored to the
+#: repository root with a leading ``/`` so they cannot shadow a same-named
+#: path a target project legitimately keeps elsewhere.
+RUN_EXCLUDE_ENTRIES: Final[tuple[str, ...]] = ("/.claude/mcp.json",)
+
+
+def resolve_info_exclude_path(workdir: Path) -> Path | None:
+    """Resolve the ``info/exclude`` file that applies to *workdir*.
+
+    Uses ``git rev-parse --git-path`` rather than assuming
+    ``workdir/.git/info/exclude``: inside a linked worktree ``.git`` is a
+    file, and git reads ``info/exclude`` from the *common* git directory
+    shared by every worktree of the clone, not from the per-worktree one.
+    ``--git-path`` resolves both cases the way git itself does.
+
+    Returns ``None`` - logged at debug level - when *workdir* is not inside a
+    git repository or ``git`` is unavailable.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-path", "info/exclude"],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("Could not resolve git info/exclude for %s: %s", workdir, exc)
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        logger.debug(
+            "git rev-parse --git-path info/exclude failed for %s: %s",
+            workdir,
+            result.stderr.strip(),
+        )
+        return None
+    exclude_path = Path(result.stdout.strip())
+    if not exclude_path.is_absolute():
+        exclude_path = workdir / exclude_path
+    return exclude_path
+
+
+def register_run_excludes(
+    workdir: Path,
+    entries: Iterable[str] = RUN_EXCLUDE_ENTRIES,
+) -> tuple[str, ...]:
+    """Idempotently add *entries* to *workdir*'s ``info/exclude``.
+
+    Args:
+        workdir: A directory inside the repository whose index must not pick
+            up the run's in-tree files.
+        entries: Exclude patterns, already anchored (leading ``/``).
+
+    Returns:
+        The entries this call actually appended - empty when they were all
+        present already, or when the exclude file could not be resolved or
+        written.  Registration is best-effort by design: it is a hardening
+        layer in front of the commit gate, and failing to harden must never
+        abort a run that the gate will still protect.
+    """
+    wanted = [entry for entry in entries if entry.strip()]
+    if not wanted:
+        return ()
+
+    exclude_path = resolve_info_exclude_path(workdir)
+    if exclude_path is None:
+        return ()
+
+    try:
+        existing = exclude_path.read_text(encoding="utf-8") if exclude_path.exists() else ""
+    except OSError as exc:
+        logger.debug("Cannot read git exclude file %s: %s", exclude_path, exc)
+        return ()
+
+    present = {line.strip() for line in existing.splitlines()}
+    missing = [entry for entry in wanted if entry not in present]
+    if not missing:
+        return ()
+
+    lines: list[str] = []
+    if existing and not existing.endswith("\n"):
+        lines.append("")
+    if EXCLUDE_BLOCK_HEADER not in present:
+        lines.append(EXCLUDE_BLOCK_HEADER)
+    lines.extend(missing)
+
+    try:
+        exclude_path.parent.mkdir(parents=True, exist_ok=True)
+        with exclude_path.open("a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+    except OSError as exc:
+        logger.debug("Cannot append to git exclude file %s: %s", exclude_path, exc)
+        return ()
+
+    logger.debug("Registered run-scoped git excludes in %s: %s", exclude_path, ", ".join(missing))
+    return tuple(missing)

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -180,13 +180,30 @@ def _register_mcp_discovery(workdir: Path) -> None:
     access to the Bernstein orchestration tools (bernstein_status, etc.)
     without manual configuration.
 
+    The file is written into the work tree because Claude Code reads it from
+    there and nowhere else, and is registered in the repository's local git
+    excludes so it still cannot be staged. See
+    :mod:`bernstein.core.git.local_exclude` for why this path is the sole
+    exemption from "run configuration lives outside the work tree".
+
     Args:
         workdir: Project root directory.
     """
     import json as _json
 
+    from bernstein.core.git.local_exclude import register_run_excludes
+
     mcp_path = workdir / ".claude" / "mcp.json"
     mcp_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # This is the one run-owned file that has to live inside the work tree:
+    # Claude Code resolves it at a fixed project-local path and takes no
+    # argument pointing elsewhere. Registering it in the repository's
+    # ``info/exclude`` keeps a broad ``git add -A`` from staging it, so the
+    # "run configuration is never part of a change" invariant holds for it
+    # too. Done before the early return below so the exclusion is in place
+    # even on the run where the file needed no rewrite (issue #4485).
+    register_run_excludes(workdir)
 
     existing: dict[str, object] = {}
     if mcp_path.exists():

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -53,6 +53,7 @@ from bernstein.core.bandit_router import BanditRouter
 from bernstein.core.batch_api import ProviderBatchManager
 from bernstein.core.bulletin import BulletinBoard, BulletinMessage, SignalActionFailure
 from bernstein.core.cluster import NodeHeartbeatClient
+from bernstein.core.config.run_overlay import effective_mtime
 from bernstein.core.context import refresh_knowledge_base
 from bernstein.core.context_degradation_detector import (
     ContextDegradationConfig,
@@ -819,10 +820,13 @@ class Orchestrator:
         # detect when agents modify its own code and restart in-place.
         self._source_mtime: float = time.time()
 
-        # Config hot-reload: track bernstein.yaml mtime so mutable config
-        # fields (max_agents, budget_usd) are picked up without restart.
+        # Config hot-reload: track the newest mtime across the committed
+        # bernstein.yaml and its untracked overlay, so mutable config fields
+        # (max_agents, budget_usd) are picked up without restart. Both layers
+        # count: an overlay write is the only kind of configuration write a
+        # run is allowed to make (issue #4485).
         self._config_path: Path = resolve_seed_path(workdir)
-        self._config_mtime: float = self._config_path.stat().st_mtime if self._config_path.exists() else 0.0
+        self._config_mtime: float = effective_mtime(self._config_path)
 
         # Memory leak detection: sampled every few ticks
         self._memory_guard = MemoryGuard()
@@ -1058,7 +1062,7 @@ class Orchestrator:
         try:
             if not self._config_path.exists():
                 return False
-            current_mtime = self._config_path.stat().st_mtime
+            current_mtime = effective_mtime(self._config_path)
             if current_mtime <= self._config_mtime:
                 return False
         except OSError:

--- a/src/bernstein/core/orchestration/orchestrator_config.py
+++ b/src/bernstein/core/orchestration/orchestrator_config.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from bernstein.core.config.run_overlay import effective_mtime
+
 logger = logging.getLogger(__name__)
 
 # Key source files whose modification triggers an orchestrator restart.
@@ -63,7 +65,11 @@ def maybe_reload_config(orch: Any) -> bool:
     try:
         if not orch._config_path.exists():
             return False
-        current_mtime = orch._config_path.stat().st_mtime
+        # Both layers count: a run writes its overrides to the untracked
+        # overlay rather than to the tracked file, so watching only the
+        # tracked file's mtime would miss every change a run is allowed to
+        # make (issue #4485).
+        current_mtime = effective_mtime(orch._config_path)
         if current_mtime <= orch._config_mtime:
             return False
     except OSError:

--- a/src/bernstein/core/orchestration/orchestrator_evolve.py
+++ b/src/bernstein/core/orchestration/orchestrator_evolve.py
@@ -499,6 +499,7 @@ def evolve_auto_commit(orch: Any) -> bool:
         stage_all_except,
         status_porcelain,
     )
+    from bernstein.core.quality.run_config_gate import check_commit
 
     try:
         changed = status_porcelain(orch._workdir)
@@ -524,6 +525,16 @@ def evolve_auto_commit(orch: Any) -> bool:
         result = conventional_commit(orch._workdir, evolve=True)
         if not result.ok:
             logger.warning("Evolve: commit failed: %s", result.stderr)
+            return False
+
+        # This is the one path that pushes straight to the default branch, so
+        # the commit is checked before it leaves the machine: a run's own
+        # configuration inside it would rewrite the repository's configuration
+        # for every user of it (issue #4485). The commit stays on the local
+        # branch for an operator to inspect rather than being amended away.
+        run_config_verdict = check_commit(orch._workdir)
+        if not run_config_verdict.ok:
+            logger.error("Evolve: refusing to push - %s", run_config_verdict.details)
             return False
 
         safe_push(orch._workdir, "main")

--- a/src/bernstein/core/quality/AGENTS.md
+++ b/src/bernstein/core/quality/AGENTS.md
@@ -22,12 +22,8 @@ configurable gate pipeline plus the janitor's claim verification.
   come from a registered gate plugin; the runner rejects anything else
   (`gate_runner.py`).
 - Defaults are deliberate: `lint`, `pii_scan`, `dlp_scan`, `run_config` on;
-  `tests`, `type_check`, and the heavier gates off (`quality_gates.py`). Do
-  not flip defaults as a side effect of another change.
-- `run_config` is a safety invariant, not a heuristic: a change whose diff
-  touches a run-configuration path is a leak of the run's own state, never
-  work. Its path set lives in `core/config/run_overlay.RUN_CONFIG_PATHS` and
-  is shared with the merge guard and the worktree excludes.
+  `tests`, `type_check`, heavier gates off (`quality_gates.py`); never flip one
+  as a side effect. `run_config` is a safety invariant (`../config/run_overlay.py`).
 - Blocking vs advisory semantics are per-gate; a new gate must declare
   which it is.
 - No package-level `__getattr__` re-export magic in this package;

--- a/src/bernstein/core/quality/AGENTS.md
+++ b/src/bernstein/core/quality/AGENTS.md
@@ -21,9 +21,13 @@ configurable gate pipeline plus the janitor's claim verification.
 - Gate names are a closed set: a step name must be in `VALID_GATE_NAMES` or
   come from a registered gate plugin; the runner rejects anything else
   (`gate_runner.py`).
-- Defaults are deliberate: `lint`, `pii_scan`, `dlp_scan` on; `tests`,
-  `type_check`, and the heavier gates off (`quality_gates.py`). Do not
-  flip defaults as a side effect of another change.
+- Defaults are deliberate: `lint`, `pii_scan`, `dlp_scan`, `run_config` on;
+  `tests`, `type_check`, and the heavier gates off (`quality_gates.py`). Do
+  not flip defaults as a side effect of another change.
+- `run_config` is a safety invariant, not a heuristic: a change whose diff
+  touches a run-configuration path is a leak of the run's own state, never
+  work. Its path set lives in `core/config/run_overlay.RUN_CONFIG_PATHS` and
+  is shared with the merge guard and the worktree excludes.
 - Blocking vs advisory semantics are per-gate; a new gate must declare
   which it is.
 - No package-level `__getattr__` re-export magic in this package;

--- a/src/bernstein/core/quality/gate_pipeline.py
+++ b/src/bernstein/core/quality/gate_pipeline.py
@@ -66,6 +66,7 @@ VALID_GATE_NAMES = frozenset(
         "comment_quality",
         "import_cycle",
         "merge_conflict",
+        "run_config",
         "benchmark",
         "dep_audit",
         "migration_reversibility",
@@ -227,6 +228,11 @@ _DEFAULT_GATE_SPECS: list[tuple[str, str, bool, str]] = [
     ("import_cycle_check", "import_cycle", True, "python_changed"),
     ("coverage_delta", "coverage_delta", True, "python_changed"),
     ("merge_conflict_check", "merge_conflict", True, "any_changed"),
+    # The run's own configuration is never part of a deliverable; a change
+    # that carries it would rewrite the repository's configuration for
+    # every user of it. Cheap (a set membership test over the changed-file
+    # names) and required, so a leak stops the run instead of shipping.
+    ("run_config", "run_config", True, "always"),
     ("pii_scan", "pii_scan", True, "any_changed"),
     ("dlp_scan", "dlp_scan", True, "any_changed"),
     ("mutation_testing", "mutation_testing", True, "python_changed"),

--- a/src/bernstein/core/quality/gate_runner.py
+++ b/src/bernstein/core/quality/gate_runner.py
@@ -41,6 +41,7 @@ from bernstein.core.quality.gate_pipeline import (
 from bernstein.core.quality.gate_pipeline import (
     is_dep_file as _is_dep_file,
 )
+from bernstein.core.quality.run_config_gate import check_paths
 from bernstein.core.telemetry import start_span
 
 if TYPE_CHECKING:
@@ -434,6 +435,7 @@ class GateRunner:
             "coverage_delta": self._run_coverage_delta_gate_sync,
             "merge_conflict": self._run_merge_conflict_gate_sync,
             "large_file": self._run_large_file_gate_sync,
+            "run_config": self._run_run_config_gate_sync,
         }
         sync_fn = _sync_cf_gates.get(step.name)
         if sync_fn is not None:
@@ -938,6 +940,51 @@ class GateRunner:
             duration_ms=0,
             details=detail,
             metadata={"migration_count": migration_count, "missing_rollback": len(issues)},
+        )
+
+    def _run_run_config_gate_sync(
+        self,
+        step: GatePipelineStep,
+        run_dir: Path,
+        changed_files: list[str],
+    ) -> GateResult:
+        """Block a change that carries one of the run's own configuration files.
+
+        A run resolves its overrides from an untracked overlay, so a
+        configuration path inside a change is never the work that was asked
+        for - it is the run's own state about to be proposed as a rewrite of
+        the repository's configuration for every user of it. The check is a
+        set membership test over the names git already reported, so it costs
+        nothing to run on every task.
+
+        ``run_dir`` is unused: the verdict depends only on which paths the
+        change touches, never on their contents.
+        """
+        del run_dir
+        verdict = check_paths(changed_files)
+        if verdict.ok:
+            return GateResult(
+                name=step.name,
+                status="pass",
+                required=step.required,
+                blocked=False,
+                cached=False,
+                duration_ms=0,
+                details=verdict.details,
+                metadata={"run_config_files": 0},
+            )
+        return GateResult(
+            name=step.name,
+            status="fail",
+            required=step.required,
+            blocked=step.required,
+            cached=False,
+            duration_ms=0,
+            details=verdict.details,
+            metadata={
+                "run_config_files": len(verdict.offending_paths),
+                "paths": list(verdict.offending_paths),
+            },
         )
 
     def _run_large_file_gate_sync(

--- a/src/bernstein/core/quality/quality_gates.py
+++ b/src/bernstein/core/quality/quality_gates.py
@@ -172,6 +172,10 @@ class QualityGatesConfig:
             via AST pattern matching.
         comment_quality_check: Run comment quality gate on changed Python files.
             Checks docstring accuracy, completeness, redundancy, and style.
+        run_config: Block a change that contains one of the run-configuration
+            paths (``bernstein.yaml``, ``.claude/mcp.json``, ...). On by
+            default: run overrides belong in the untracked overlay, so a
+            configuration file inside a change is always a leak, never work.
         comment_quality_docstyle: Expected docstring style for the comment-quality
             gate. One of ``"google"``, ``"numpy"``, ``"rest"``, or ``"auto"``
             (auto-detect per docstring).
@@ -200,6 +204,7 @@ class QualityGatesConfig:
     pii_allowlist_prefixes: list[str] = field(
         default_factory=lambda: ["FAKE", "TEST", "EXAMPLE", "DUMMY", "PLACEHOLDER", "LOCALHOST"]
     )
+    run_config: bool = True
     security_scan: bool = False
     security_scan_command: str | None = None
     coverage_delta: bool = False

--- a/src/bernstein/core/quality/run_config_gate.py
+++ b/src/bernstein/core/quality/run_config_gate.py
@@ -1,0 +1,131 @@
+"""Quality gate: a change must never contain run configuration.
+
+A run reads the project's committed configuration and writes its own
+overrides to an untracked overlay
+(:mod:`bernstein.core.config.run_overlay`), so under normal operation no
+commit can carry a configuration file.  This gate is the backstop for the
+cases the overlay cannot reach on its own:
+
+* a target repository that already **tracks** ``.claude/mcp.json`` - git
+  ignore rules do not apply to tracked paths, so the run-scoped exclude in
+  :mod:`bernstein.core.git.local_exclude` has no effect there;
+* an agent that edits ``bernstein.yaml`` itself, believing it is doing the
+  work it was asked to do;
+* any future code path that writes a configuration file into the work tree
+  before committing.
+
+The check is a set membership test over the names git already reports for
+the change, so it costs one ``git diff`` and no file reads.  It is cheap
+enough to run on every commit the orchestrator makes, which is the point: a
+compensating "restore the file before publishing" step only ever protected
+the one publishing path that remembered to call it.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bernstein.core.config.run_overlay import describe_overlay_remedy, find_run_config_paths
+from bernstein.core.git.git_basic import run_git
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_GIT_TIMEOUT_S = 15
+
+#: Placeholder recorded when git could not be asked what the change contains.
+UNREADABLE = "<diff-read-failed>"
+
+PASS_DETAILS = "No run-configuration path in the change."
+
+
+@dataclass(frozen=True)
+class RunConfigGateResult:
+    """Verdict of the run-configuration gate.
+
+    Attributes:
+        ok: True when the change contains no run-configuration path.
+        offending_paths: The run-configuration paths found, in the order git
+            reported them.  Holds :data:`UNREADABLE` when the diff could not
+            be read at all.
+        details: Message naming every offending file and how to fix it.
+    """
+
+    ok: bool
+    offending_paths: tuple[str, ...]
+    details: str
+
+
+def _passed() -> RunConfigGateResult:
+    return RunConfigGateResult(ok=True, offending_paths=(), details=PASS_DETAILS)
+
+
+def _failed(paths: Sequence[str]) -> RunConfigGateResult:
+    return RunConfigGateResult(ok=False, offending_paths=tuple(paths), details=describe_overlay_remedy(paths))
+
+
+def check_paths(paths: Iterable[str]) -> RunConfigGateResult:
+    """Verdict for an already-known set of changed paths.
+
+    Pure, so the pipeline gate and the commit-time checks below share one
+    definition of what counts as a violation.
+    """
+    offending = find_run_config_paths(paths)
+    return _passed() if not offending else _failed(offending)
+
+
+def _name_only(cwd: Path, args: list[str], *, what: str) -> list[str] | None:
+    """Run a name-only git query, or ``None`` when the answer is unavailable."""
+    try:
+        result = run_git(args, cwd, timeout=_GIT_TIMEOUT_S)
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("run_config gate: could not read %s in %s: %s", what, cwd, exc)
+        return None
+    if not result.ok:
+        logger.warning(
+            "run_config gate: could not read %s in %s (returncode=%d): %s",
+            what,
+            cwd,
+            result.returncode,
+            result.stderr.strip(),
+        )
+        return None
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def check_staged(cwd: Path) -> RunConfigGateResult:
+    """Verdict for what is staged in *cwd* right now.
+
+    Fails closed: a staged set that cannot be read is not a clean bill of
+    health, because the whole reason this gate exists is that an unnoticed
+    configuration file gets published.
+    """
+    names = _name_only(
+        cwd,
+        ["diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+        what="the staged set",
+    )
+    if names is None:
+        return _failed([UNREADABLE])
+    return check_paths(names)
+
+
+def check_commit(cwd: Path, rev: str = "HEAD") -> RunConfigGateResult:
+    """Verdict for the diff of commit *rev*.
+
+    Fails closed for the same reason as :func:`check_staged`.
+    """
+    names = _name_only(
+        cwd,
+        ["show", "--no-commit-id", "--name-only", "--pretty=format:", rev],
+        what=f"the diff of {rev}",
+    )
+    if names is None:
+        return _failed([UNREADABLE])
+    return check_paths(names)

--- a/src/bernstein/core/routes/status_lifecycle.py
+++ b/src/bernstein/core/routes/status_lifecycle.py
@@ -14,6 +14,7 @@ from typing import Any
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, PlainTextResponse
 
+from bernstein.core.config.run_overlay import RunOverlayError, write_overlay
 from bernstein.core.prometheus import (
     generate_latest,
     registry,
@@ -145,24 +146,23 @@ async def update_config(request: Request) -> JSONResponse:
         return JSONResponse(status_code=400, content={"error": "missing max_agents"})
     new_max = max(1, min(int(new_max), 50))  # clamp to sane range
 
-    # Update bernstein.yaml - the orchestrator watches mtime and hot-reloads
+    # Write the run override to the untracked overlay, never to the tracked
+    # file: this endpoint changes configuration for the duration of a run, and
+    # a run that edits bernstein.yaml in the work tree puts that edit into
+    # every commit an agent makes with a staged tree (issue #4485). The
+    # orchestrator's hot-reload watches both layers, so the change is picked
+    # up exactly as it was before.
     yaml_path = Path.cwd() / "bernstein.yaml"
     if not yaml_path.exists():
         return JSONResponse(status_code=404, content={"error": "bernstein.yaml not found"})
 
     try:
-        import yaml as _yaml
-
-        raw = yaml_path.read_text(encoding="utf-8")
-        data: dict[str, Any] = _yaml.safe_load(raw) or {}
-        data["max_agents"] = new_max
-        yaml_path.write_text(_yaml.dump(data, default_flow_style=False, sort_keys=False), encoding="utf-8")
-    # bot-ack: pre-existing-1723 (yaml IO + serialisation can raise broadly)
-    except Exception as exc:
-        logger.error("Failed to update bernstein.yaml: %s", exc)
+        overlay_path = write_overlay({"max_agents": new_max}, config_path=yaml_path)
+    except RunOverlayError as exc:
+        logger.error("Failed to write the run-configuration overlay: %s", exc)
         return JSONResponse(status_code=500, content={"error": "config update failed"})
 
-    logger.info("Config updated via API: max_agents=%d", new_max)
+    logger.info("Config updated via API: max_agents=%d (overlay %s)", new_max, overlay_path)
     return JSONResponse(content={"max_agents": new_max, "status": "updated"})
 
 

--- a/tests/unit/skills/test_agent_plugins_install.py
+++ b/tests/unit/skills/test_agent_plugins_install.py
@@ -189,10 +189,10 @@ def test_install_plugin_writes_lockfile_entries(
     content = lock_path.read_text(encoding="utf-8")
     resolved_root = plugin_dir.resolve()
     for name in ("alpha", "beta", "gamma"):
-        assert f"name = \"{name}\"" in content
+        assert f'name = "{name}"' in content
         # path names the skills/<name>/ directory the skill came from, not
         # the plugin root, so sync/drift can locate the individual tree.
-        assert f"path = \"{resolved_root}/skills/{name}\"" in content
+        assert f'path = "{resolved_root}/skills/{name}"' in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -113,6 +113,7 @@ class TestLintGate:
             tests=False,
             pii_scan=False,
             dlp_scan=False,
+            run_config=False,
         )
         task = _make_task()
         result = run_quality_gates(task, tmp_path, tmp_path, config)
@@ -131,6 +132,7 @@ class TestLintGate:
             tests=False,
             pii_scan=False,
             dlp_scan=False,
+            run_config=False,
         )
         task = _make_task()
         result = run_quality_gates(task, tmp_path, tmp_path, config)
@@ -141,7 +143,13 @@ class TestLintGate:
 
     def test_lint_skipped_when_disabled(self, tmp_path: Path) -> None:
         config = QualityGatesConfig(
-            enabled=True, lint=False, type_check=False, tests=False, pii_scan=False, dlp_scan=False
+            enabled=True,
+            lint=False,
+            type_check=False,
+            tests=False,
+            pii_scan=False,
+            dlp_scan=False,
+            run_config=False,
         )
         task = _make_task()
         with patch("bernstein.core.quality.quality_gates._run_command") as mock_run:
@@ -166,6 +174,7 @@ class TestTypeCheckGate:
             tests=False,
             pii_scan=False,
             dlp_scan=False,
+            run_config=False,
         )
         task = _make_task()
         result = run_quality_gates(task, tmp_path, tmp_path, config)
@@ -181,6 +190,7 @@ class TestTypeCheckGate:
             tests=False,
             pii_scan=False,
             dlp_scan=False,
+            run_config=False,
         )
         task = _make_task()
         result = run_quality_gates(task, tmp_path, tmp_path, config)
@@ -203,6 +213,7 @@ class TestTestGate:
             test_command="exit 0",
             pii_scan=False,
             dlp_scan=False,
+            run_config=False,
         )
         task = _make_task()
         result = run_quality_gates(task, tmp_path, tmp_path, config)
@@ -218,6 +229,7 @@ class TestTestGate:
             test_command="exit 1",
             pii_scan=False,
             dlp_scan=False,
+            run_config=False,
         )
         task = _make_task()
         result = run_quality_gates(task, tmp_path, tmp_path, config)
@@ -242,6 +254,7 @@ class TestMultipleGates:
             test_command="exit 0",
             pii_scan=False,
             dlp_scan=False,
+            run_config=False,
         )
         task = _make_task()
         result = run_quality_gates(task, tmp_path, tmp_path, config)
@@ -263,6 +276,7 @@ class TestMultipleGates:
             test_command="exit 0",
             pii_scan=False,
             dlp_scan=False,
+            run_config=False,
         )
         task = _make_task()
         result = run_quality_gates(task, tmp_path, tmp_path, config)
@@ -285,6 +299,7 @@ class TestMetricsRecording:
             tests=False,
             pii_scan=False,
             dlp_scan=False,
+            run_config=False,
         )
         task = _make_task(id="T-metrics-1")
         run_quality_gates(task, tmp_path, tmp_path, config)
@@ -305,6 +320,7 @@ class TestMetricsRecording:
             tests=False,
             pii_scan=False,
             dlp_scan=False,
+            run_config=False,
         )
         task = _make_task(id="T-metrics-2")
         run_quality_gates(task, tmp_path, tmp_path, config)
@@ -322,6 +338,7 @@ class TestMetricsRecording:
             tests=False,
             pii_scan=False,
             dlp_scan=False,
+            run_config=False,
             cache_enabled=False,
         )
         task = _make_task(id="T-metrics-rich")
@@ -367,6 +384,7 @@ class TestMetricsRecording:
             tests=False,
             pii_scan=False,
             dlp_scan=False,
+            run_config=False,
         )
         task = _make_task(id="T-span")
         fake_span = MagicMock()

--- a/tests/unit/test_quality_gates_v2.py
+++ b/tests/unit/test_quality_gates_v2.py
@@ -48,6 +48,8 @@ def test_default_pipeline_includes_additive_gates() -> None:
         "import_cycle",
         "coverage_delta",
         "merge_conflict",
+        # On by default: run configuration must never be part of a change.
+        "run_config",
         "pii_scan",
         "dlp_scan",
     ]

--- a/tests/unit/test_regression_orchestrator.py
+++ b/tests/unit/test_regression_orchestrator.py
@@ -274,9 +274,7 @@ class TestDependencyFiltering:
         assert "C" not in spawned_task_ids
         assert "D" not in spawned_task_ids
 
-    def test_preexisting_cycle_still_schedules_every_task_after_deterministic_break(
-        self, tmp_path: Path
-    ) -> None:
+    def test_preexisting_cycle_still_schedules_every_task_after_deterministic_break(self, tmp_path: Path) -> None:
         """A board carrying a declared cycle drains instead of wedging (#4287).
 
         ``POST /tasks`` rejects a cycle-forming edge today, but legacy board

--- a/tests/unit/test_run_config_overlay.py
+++ b/tests/unit/test_run_config_overlay.py
@@ -1,0 +1,441 @@
+"""Regression tests for #4485: run configuration is never part of a change.
+
+A run used to pin its own overrides into the tracked ``bernstein.yaml`` in
+the work tree.  Any agent that committed with a staged tree carried the file,
+and the resulting pull request proposed rewriting the repository's committed
+configuration for everyone.  One publishing path restored the file before
+publishing; every other path that pushes commits did not, so the leak
+returned as soon as a second path existed.
+
+These tests hold the invariant itself rather than the compensating step: run
+overrides resolve from a layer git does not track, the one file that must
+live in the work tree cannot be staged, and a change that contains a
+configuration path is refused with the file named.
+
+The work-tree and commit properties run against real temporary git
+repositories - ``git status``, ``git add -A`` and ``git commit -a`` are the
+things under test, and a mock of them would assert nothing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import bernstein.core.git.git_pr as git_pr
+from bernstein.core.config.run_overlay import (
+    ENV_CONFIG_OVERLAY,
+    ENV_CONFIG_OVERRIDE,
+    RUN_CONFIG_PATHS,
+    RunOverlayError,
+    effective_mtime,
+    resolve_overlay_path,
+    write_overlay,
+)
+from bernstein.core.config.seed import SeedError, parse_seed
+from bernstein.core.git.git_basic import stage_all_except
+from bernstein.core.git.local_exclude import RUN_EXCLUDE_ENTRIES, register_run_excludes
+from bernstein.core.quality.gate_pipeline import build_default_pipeline
+from bernstein.core.quality.quality_gates import QualityGatesConfig
+from bernstein.core.quality.run_config_gate import UNREADABLE, check_commit, check_paths, check_staged
+
+COMMITTED_SEED = """goal: "ship the feature"
+max_agents: 3
+budget: "$5"
+internal_llm_provider: none
+role_model_policy:
+  backend:
+    model: sonnet
+  qa:
+    model: haiku
+"""
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    ).stdout
+
+
+def _staged(repo: Path) -> list[str]:
+    out = _git(repo, "diff", "--cached", "--name-only")
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+@pytest.fixture(autouse=True)
+def _isolated_overlay_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neither overlay variable leaks in from the developer's environment."""
+    for name in (ENV_CONFIG_OVERLAY, ENV_CONFIG_OVERRIDE, "GIT_DIR", "GIT_WORK_TREE"):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A real repository with a committed configuration file and one source file."""
+    root = tmp_path / "project"
+    root.mkdir()
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test User")
+    (root / "bernstein.yaml").write_text(COMMITTED_SEED, encoding="utf-8")
+    (root / "src").mkdir()
+    (root / "src" / "feature.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "initial commit")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# The work tree stays clean, and no commit can carry configuration
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_never_dirties_the_work_tree(repo: Path) -> None:
+    """An active overlay leaves ``git status`` with nothing to report."""
+    config_path = repo / "bernstein.yaml"
+    before = config_path.read_text(encoding="utf-8")
+
+    write_overlay({"max_agents": 9, "internal_llm_provider": "anthropic"}, config_path=config_path)
+
+    assert _git(repo, "status", "--porcelain") == "", "an overlay write must not show up as a work-tree change"
+    assert config_path.read_text(encoding="utf-8") == before, "the committed file must be byte-identical after a run override"
+    assert parse_seed(config_path).max_agents == 9, "the override must nevertheless be in effect"
+
+
+def test_commit_all_after_an_overlay_write_contains_no_configuration_file(repo: Path) -> None:
+    """``git commit -a`` over an active overlay produces a config-free commit."""
+    config_path = repo / "bernstein.yaml"
+    write_overlay({"max_agents": 12}, config_path=config_path)
+
+    (repo / "src" / "feature.py").write_text("VALUE = 2\n", encoding="utf-8")
+    _git(repo, "commit", "-a", "-m", "feat: bump the value")
+
+    changed = [line.strip() for line in _git(repo, "show", "--name-only", "--pretty=format:", "HEAD").splitlines() if line.strip()]
+    assert changed == ["src/feature.py"]
+    assert check_commit(repo).ok
+
+
+def test_overlay_lives_inside_the_git_directory_not_the_work_tree(repo: Path) -> None:
+    """The default overlay location is one git can never track."""
+    config_path = repo / "bernstein.yaml"
+    overlay_path = write_overlay({"max_agents": 4}, config_path=config_path)
+
+    assert overlay_path.is_file()
+    assert overlay_path.is_relative_to(repo / ".git"), f"overlay must live inside .git/, got {overlay_path}"
+    tracked_and_untracked = _git(repo, "status", "--porcelain", "--untracked-files=all")
+    assert "run-overlay" not in tracked_and_untracked
+
+
+def test_overlay_path_inside_the_work_tree_is_refused(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An overlay pointed at the work tree is the original defect, renamed."""
+    monkeypatch.setenv(ENV_CONFIG_OVERLAY, str(repo / "run-overlay.yaml"))
+
+    with pytest.raises(RunOverlayError, match="inside the work tree"):
+        write_overlay({"max_agents": 4}, config_path=repo / "bernstein.yaml")
+
+    assert _git(repo, "status", "--porcelain") == ""
+
+
+def test_sandbox_supplied_overlay_path_is_honoured(repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sandbox can place the overlay outside the repository entirely."""
+    sandbox_overlay = tmp_path / "sandbox" / "overlay.yaml"
+    monkeypatch.setenv(ENV_CONFIG_OVERLAY, str(sandbox_overlay))
+    config_path = repo / "bernstein.yaml"
+
+    assert resolve_overlay_path(config_path) == sandbox_overlay
+    write_overlay({"max_agents": 7}, config_path=config_path)
+
+    assert sandbox_overlay.is_file()
+    assert parse_seed(config_path).max_agents == 7
+    assert _git(repo, "status", "--porcelain") == ""
+
+
+# ---------------------------------------------------------------------------
+# Effective configuration and precedence
+# ---------------------------------------------------------------------------
+
+
+def test_effective_config_equals_committed_merged_with_overlay(repo: Path) -> None:
+    """Keys the overlay does not mention keep their committed values."""
+    config_path = repo / "bernstein.yaml"
+    committed = parse_seed(config_path)
+
+    write_overlay({"max_agents": 11}, config_path=config_path)
+    effective = parse_seed(config_path)
+
+    assert effective.max_agents == 11, "the overlay key wins"
+    assert effective.goal == committed.goal
+    assert effective.budget_usd == committed.budget_usd
+    assert effective.role_model_policy == committed.role_model_policy
+
+
+def test_precedence_is_inline_override_then_overlay_then_committed_file(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All three layers set the same key; the documented order decides."""
+    config_path = repo / "bernstein.yaml"
+    assert parse_seed(config_path).max_agents == 3, "committed file alone"
+
+    write_overlay({"max_agents": 5}, config_path=config_path)
+    assert parse_seed(config_path).max_agents == 5, "overlay beats the committed file"
+
+    monkeypatch.setenv(ENV_CONFIG_OVERRIDE, "{max_agents: 8}")
+    assert parse_seed(config_path).max_agents == 8, "an explicit env override beats the overlay"
+
+
+def test_nested_sections_merge_key_by_key_instead_of_being_replaced(repo: Path) -> None:
+    """Overriding one role must not rewrite every entry of ``role_model_policy``."""
+    config_path = repo / "bernstein.yaml"
+    write_overlay({"role_model_policy": {"backend": {"model": "opus"}}}, config_path=config_path)
+
+    policy = parse_seed(config_path).role_model_policy
+
+    assert policy is not None
+    assert policy["backend"]["model"] == "opus"
+    assert policy["qa"]["model"] == "haiku", "roles the overlay did not mention keep their committed values"
+
+
+def test_repeated_overlay_writes_accumulate_rather_than_replace(repo: Path) -> None:
+    """A second override does not silently drop the first."""
+    config_path = repo / "bernstein.yaml"
+    write_overlay({"max_agents": 6}, config_path=config_path)
+    write_overlay({"internal_llm_provider": "anthropic"}, config_path=config_path)
+
+    effective = parse_seed(config_path)
+
+    assert effective.max_agents == 6
+    assert effective.internal_llm_provider == "anthropic"
+
+
+def test_overlay_write_advances_the_hot_reload_mtime(repo: Path) -> None:
+    """Watching only the tracked file would never notice a run's own change."""
+    config_path = repo / "bernstein.yaml"
+    before = effective_mtime(config_path)
+
+    write_overlay({"max_agents": 6}, config_path=config_path)
+
+    overlay_path = resolve_overlay_path(config_path)
+    assert overlay_path is not None
+    assert effective_mtime(config_path) >= before
+    assert effective_mtime(config_path) == max(config_path.stat().st_mtime, overlay_path.stat().st_mtime)
+
+
+# ---------------------------------------------------------------------------
+# Setups that never adopt the overlay keep working
+# ---------------------------------------------------------------------------
+
+
+def test_editing_the_committed_file_directly_still_takes_effect(repo: Path) -> None:
+    """The overlay is additive: with none present, nothing about loading changes."""
+    config_path = repo / "bernstein.yaml"
+    config_path.write_text(COMMITTED_SEED.replace("max_agents: 3", "max_agents: 21"), encoding="utf-8")
+
+    effective = parse_seed(config_path)
+
+    assert resolve_overlay_path(config_path) is not None, "a location exists"
+    assert not resolve_overlay_path(config_path).exists(), "but no overlay file was written"
+    assert effective.max_agents == 21
+    assert effective.role_model_policy == {"backend": {"model": "sonnet"}, "qa": {"model": "haiku"}}
+
+
+def test_config_outside_a_git_repository_loads_without_an_overlay(tmp_path: Path) -> None:
+    """No repository means no overlay location, and the committed file stands alone."""
+    config_path = tmp_path / "bernstein.yaml"
+    config_path.write_text(COMMITTED_SEED, encoding="utf-8")
+
+    assert resolve_overlay_path(config_path) is None
+    assert parse_seed(config_path).max_agents == 3
+
+
+def test_malformed_overlay_fails_loudly_instead_of_falling_back(repo: Path) -> None:
+    """A run must not proceed on a configuration nobody asked for."""
+    config_path = repo / "bernstein.yaml"
+    overlay_path = resolve_overlay_path(config_path)
+    assert overlay_path is not None
+    overlay_path.parent.mkdir(parents=True, exist_ok=True)
+    overlay_path.write_text("max_agents: [unclosed\n", encoding="utf-8")
+
+    with pytest.raises(SeedError, match="overlay"):
+        parse_seed(config_path)
+
+
+def test_overlay_that_is_not_a_mapping_fails_loudly(repo: Path) -> None:
+    """A YAML list where a mapping was expected is an error, not an empty overlay."""
+    config_path = repo / "bernstein.yaml"
+    overlay_path = resolve_overlay_path(config_path)
+    assert overlay_path is not None
+    overlay_path.parent.mkdir(parents=True, exist_ok=True)
+    overlay_path.write_text("- max_agents\n- 4\n", encoding="utf-8")
+
+    with pytest.raises(SeedError, match="must be a mapping"):
+        parse_seed(config_path)
+
+
+# ---------------------------------------------------------------------------
+# The commit gate
+# ---------------------------------------------------------------------------
+
+
+def test_gate_rejects_a_staged_run_configuration_path_and_names_the_file(repo: Path) -> None:
+    """Staging the configuration file stops the commit, with the path in the message."""
+    (repo / "bernstein.yaml").write_text(COMMITTED_SEED.replace("max_agents: 3", "max_agents: 99"), encoding="utf-8")
+    _git(repo, "add", "bernstein.yaml")
+
+    verdict = check_staged(repo)
+
+    assert verdict.ok is False
+    assert verdict.offending_paths == ("bernstein.yaml",)
+    assert "bernstein.yaml" in verdict.details
+
+
+def test_gate_rejects_a_commit_whose_diff_touches_run_configuration(repo: Path) -> None:
+    """A commit that already exists is caught with the same message."""
+    (repo / "bernstein.yaml").write_text(COMMITTED_SEED.replace("max_agents: 3", "max_agents: 99"), encoding="utf-8")
+    _git(repo, "commit", "-a", "-m", "chore: pin the run")
+
+    verdict = check_commit(repo)
+
+    assert verdict.ok is False
+    assert "bernstein.yaml" in verdict.details
+
+
+def test_gate_names_every_run_configuration_path_in_the_change(repo: Path) -> None:
+    """Two leaked files produce two names, not just the first."""
+    (repo / "bernstein.yaml").write_text(COMMITTED_SEED + "cells: 2\n", encoding="utf-8")
+    (repo / ".claude").mkdir()
+    (repo / ".claude" / "mcp.json").write_text("{}\n", encoding="utf-8")
+    _git(repo, "add", "-A", "--force")
+
+    verdict = check_staged(repo)
+
+    assert verdict.ok is False
+    assert set(verdict.offending_paths) == {"bernstein.yaml", ".claude/mcp.json"}
+    for path in (".claude/mcp.json", "bernstein.yaml"):
+        assert path in verdict.details
+
+
+def test_gate_passes_a_change_that_touches_only_deliverables(repo: Path) -> None:
+    """The gate must not stand in the way of the work the run was asked to do."""
+    (repo / "src" / "feature.py").write_text("VALUE = 3\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+
+    assert check_staged(repo).ok is True
+
+
+def test_gate_ignores_a_same_named_file_at_a_nested_path(repo: Path) -> None:
+    """``docs/bernstein.yaml`` is a deliverable, not the run's configuration."""
+    (repo / "docs").mkdir()
+    (repo / "docs" / "bernstein.yaml").write_text("goal: example\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+
+    assert check_staged(repo).ok is True
+
+
+def test_gate_fails_closed_when_the_diff_cannot_be_read(tmp_path: Path) -> None:
+    """An unverifiable change is not a clean bill of health."""
+    verdict = check_staged(tmp_path)
+
+    assert verdict.ok is False
+    assert verdict.offending_paths == (UNREADABLE,)
+
+
+def test_gate_normalises_leading_dot_slash_without_eating_dotfiles(repo: Path) -> None:
+    """``./bernstein.yaml`` matches; ``.bernstein/bernstein.yaml`` is not mangled."""
+    assert check_paths(["./bernstein.yaml"]).ok is False
+    assert check_paths([".bernstein/bernstein.yaml"]).ok is False
+    assert check_paths(["bernstein/bernstein.yaml"]).ok is True
+
+
+def test_run_config_gate_is_registered_and_required_by_default(repo: Path) -> None:
+    """The invariant ships on, with the existing quality gates."""
+    steps = build_default_pipeline(QualityGatesConfig())
+
+    matching = [step for step in steps if step.name == "run_config"]
+    assert len(matching) == 1, "run_config must be part of the default pipeline exactly once"
+    assert matching[0].required is True, "a leak must block, not warn"
+
+
+def test_merge_preflight_deny_list_covers_every_run_configuration_path() -> None:
+    """The merge guard and the commit gate share one definition, so they cannot drift."""
+    assert RUN_CONFIG_PATHS <= git_pr._MERGE_DENY_EXACT
+    for path in RUN_CONFIG_PATHS:
+        assert git_pr._is_forbidden_for_merge(path) is True
+
+
+# ---------------------------------------------------------------------------
+# The one file that must live in the work tree
+# ---------------------------------------------------------------------------
+
+
+def test_registered_run_exclude_keeps_the_bridge_manifest_out_of_a_broad_add(repo: Path) -> None:
+    """``.claude/mcp.json`` is written in-tree but cannot be staged."""
+    (repo / ".claude").mkdir()
+    (repo / ".claude" / "mcp.json").write_text('{"mcpServers": {}}\n', encoding="utf-8")
+    (repo / "src" / "feature.py").write_text("VALUE = 4\n", encoding="utf-8")
+
+    added = register_run_excludes(repo)
+
+    assert added == RUN_EXCLUDE_ENTRIES
+    _git(repo, "add", "-A")
+    staged = _staged(repo)
+    assert ".claude/mcp.json" not in staged, "the bridge manifest must never be staged by a broad add"
+    assert "src/feature.py" in staged, "the agent's real work must still be staged"
+
+
+def test_run_excludes_leave_the_work_tree_reported_clean(repo: Path) -> None:
+    """Writing the manifest plus its exclusion produces nothing for git to report."""
+    (repo / ".claude").mkdir()
+    (repo / ".claude" / "mcp.json").write_text('{"mcpServers": {}}\n', encoding="utf-8")
+    register_run_excludes(repo)
+
+    assert _git(repo, "status", "--porcelain") == ""
+
+
+def test_registering_run_excludes_is_idempotent(repo: Path) -> None:
+    """A second run does not append the same entry again."""
+    first = register_run_excludes(repo)
+    second = register_run_excludes(repo)
+
+    assert first == RUN_EXCLUDE_ENTRIES
+    assert second == ()
+    exclude_text = (repo / ".git" / "info" / "exclude").read_text(encoding="utf-8")
+    assert exclude_text.count(RUN_EXCLUDE_ENTRIES[0]) == 1
+
+
+def test_run_excludes_do_not_hide_a_nested_deliverable_of_the_same_name(repo: Path) -> None:
+    """The entries are anchored, so a project's own nested file is unaffected."""
+    register_run_excludes(repo)
+    nested = repo / "packages" / "app" / ".claude"
+    nested.mkdir(parents=True)
+    (nested / "mcp.json").write_text("{}\n", encoding="utf-8")
+
+    _git(repo, "add", "-A")
+
+    assert "packages/app/.claude/mcp.json" in _staged(repo)
+
+
+# ---------------------------------------------------------------------------
+# Bulk staging
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_staging_unstages_run_configuration_not_only_directories(repo: Path) -> None:
+    """``stage_all_except`` used to drop only the entries ending in ``/``."""
+    (repo / "bernstein.yaml").write_text(COMMITTED_SEED.replace("max_agents: 3", "max_agents: 42"), encoding="utf-8")
+    (repo / ".env").write_text("SECRET=1\n", encoding="utf-8")
+    (repo / "src" / "feature.py").write_text("VALUE = 5\n", encoding="utf-8")
+
+    stage_all_except(repo)
+
+    staged = _staged(repo)
+    assert "src/feature.py" in staged, "real work must still be staged"
+    assert "bernstein.yaml" not in staged
+    assert ".env" not in staged
+    assert check_staged(repo).ok is True

--- a/tests/unit/test_run_config_overlay.py
+++ b/tests/unit/test_run_config_overlay.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -459,3 +460,45 @@ def test_bulk_staging_unstages_run_configuration_not_only_directories(repo: Path
     assert "bernstein.yaml" not in staged
     assert ".env" not in staged
     assert check_staged(repo).ok is True
+
+
+# ---------------------------------------------------------------------------
+# The one path that pushes straight to the default branch
+# ---------------------------------------------------------------------------
+
+
+def test_evolve_refuses_to_push_a_commit_carrying_run_configuration(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gate stops the push even where the staging filter does not reach.
+
+    ``stage_all_except`` unstages the never-stage names, but that list is not
+    the run-configuration set: ``.bernstein/bernstein.yaml`` is a seed file the
+    loader reads and the staging filter has never heard of. The commit gate is
+    what refuses the push.
+    """
+    import bernstein.core.git_ops as git_ops
+
+    from bernstein.core.orchestration.orchestrator_evolve import evolve_auto_commit
+
+    (repo / ".bernstein").mkdir()
+    (repo / ".bernstein" / "bernstein.yaml").write_text(COMMITTED_SEED, encoding="utf-8")
+    (repo / "src" / "feature.py").write_text("VALUE = 6\n", encoding="utf-8")
+
+    real_run = subprocess.run
+
+    def _run(cmd: list[str], **kwargs: object) -> object:
+        if cmd[:3] == ["uv", "run", "pytest"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+
+    pushes: list[str] = []
+    monkeypatch.setattr(git_ops, "safe_push", lambda _cwd, branch: pushes.append(branch))
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    orch = SimpleNamespace(_workdir=repo)
+    pushed = evolve_auto_commit(orch)
+
+    assert pushed is False
+    assert pushes == [], "a commit carrying run configuration must not reach the default branch"
+    assert check_commit(repo).ok is False

--- a/tests/unit/test_run_config_overlay.py
+++ b/tests/unit/test_run_config_overlay.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -487,10 +488,10 @@ def test_evolve_refuses_to_push_a_commit_carrying_run_configuration(
 
     real_run = subprocess.run
 
-    def _run(cmd: list[str], **kwargs: object) -> object:
+    def _run(cmd: list[str], **kwargs: Any) -> Any:
         if cmd[:3] == ["uv", "run", "pytest"]:
             return subprocess.CompletedProcess(cmd, 0, "", "")
-        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+        return real_run(cmd, **kwargs)
 
     pushes: list[str] = []
     monkeypatch.setattr(git_ops, "safe_push", lambda _cwd, branch: pushes.append(branch))

--- a/tests/unit/test_run_config_overlay.py
+++ b/tests/unit/test_run_config_overlay.py
@@ -105,7 +105,9 @@ def test_overlay_never_dirties_the_work_tree(repo: Path) -> None:
     write_overlay({"max_agents": 9, "internal_llm_provider": "anthropic"}, config_path=config_path)
 
     assert _git(repo, "status", "--porcelain") == "", "an overlay write must not show up as a work-tree change"
-    assert config_path.read_text(encoding="utf-8") == before, "the committed file must be byte-identical after a run override"
+    assert config_path.read_text(encoding="utf-8") == before, (
+        "the committed file must be byte-identical after a run override"
+    )
     assert parse_seed(config_path).max_agents == 9, "the override must nevertheless be in effect"
 
 
@@ -117,7 +119,11 @@ def test_commit_all_after_an_overlay_write_contains_no_configuration_file(repo: 
     (repo / "src" / "feature.py").write_text("VALUE = 2\n", encoding="utf-8")
     _git(repo, "commit", "-a", "-m", "feat: bump the value")
 
-    changed = [line.strip() for line in _git(repo, "show", "--name-only", "--pretty=format:", "HEAD").splitlines() if line.strip()]
+    changed = [
+        line.strip()
+        for line in _git(repo, "show", "--name-only", "--pretty=format:", "HEAD").splitlines()
+        if line.strip()
+    ]
     assert changed == ["src/feature.py"]
     assert check_commit(repo).ok
 

--- a/tests/unit/test_run_config_overlay.py
+++ b/tests/unit/test_run_config_overlay.py
@@ -149,6 +149,20 @@ def test_overlay_path_inside_the_work_tree_is_refused(repo: Path, monkeypatch: p
     assert _git(repo, "status", "--porcelain") == ""
 
 
+def test_overlay_path_reaching_the_work_tree_through_a_symlink_is_refused(
+    repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A different spelling of a work-tree path is still a work-tree path."""
+    alias = tmp_path / "alias"
+    alias.symlink_to(repo, target_is_directory=True)
+    monkeypatch.setenv(ENV_CONFIG_OVERLAY, str(alias / "run-overlay.yaml"))
+
+    with pytest.raises(RunOverlayError, match="inside the work tree"):
+        write_overlay({"max_agents": 4}, config_path=repo / "bernstein.yaml")
+
+    assert _git(repo, "status", "--porcelain") == ""
+
+
 def test_sandbox_supplied_overlay_path_is_honoured(repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A sandbox can place the overlay outside the repository entirely."""
     sandbox_overlay = tmp_path / "sandbox" / "overlay.yaml"


### PR DESCRIPTION
## The defect

A run pinned its own overrides into `bernstein.yaml` in the work tree — the
role/model policy, the internal LLM provider, a quality-gate switch. That file
is tracked, so any agent that committed with a staged tree carried it, and the
resulting pull request proposed rewriting the repository's committed
configuration for every user of it.

A compensating "restore the file before publishing" step existed on one
publishing path and not on the others, so the leak came back as soon as a
second path appeared. Compensation per publisher is the wrong shape: the
invariant is *run configuration is never part of a change*, and it has to hold
wherever commits are made.

Two live instances of the same shape were in the tree:

- `POST /config` wrote `max_agents` straight into the tracked `bernstein.yaml`
  and relied on the orchestrator noticing the mtime.
- `stage_all_except` appended a never-stage entry to the unstage list only when
  it ended in `/`, so `bernstein.yaml`, `.claude/mcp.json` and `.env` survived
  its bulk `git add -A`. Its only caller commits and pushes to the default
  branch.

## The change

**Overlay layer.** `parse_seed` merges an untracked overlay over the mapping it
parses from the committed file, so the committed file is read by a run and
never written by one. Precedence, lowest first: committed file, overlay,
`$BERNSTEIN_CONFIG_OVERRIDE` (inline YAML/JSON), explicit CLI flags — which are
already applied after the parse, so they stay on top. Nested sections merge key
by key, which is what the incident needed: overriding one role's model leaves
the other roles at their committed values.

The overlay defaults to `<git-dir>/bernstein/run-overlay.yaml`, inside `.git/`,
so `git status` cannot report it and `git commit -a` cannot carry it.
`$BERNSTEIN_CONFIG_OVERLAY` moves it, which is how a sandbox supplies its own;
a path pointed *inside* the work tree is refused rather than written. Git
resolution is a filesystem walk, not a subprocess, because this runs on the
orchestrator's per-tick hot-reload check.

With no overlay and neither variable set the merge is the identity, so a setup
that edits `bernstein.yaml` directly behaves exactly as before.

Hot-reload now watches the newest mtime across both layers — an overlay write
is the only configuration write a run is allowed to make, and watching only the
tracked file would never notice it. `POST /config` writes the overlay.

**The one unavoidable in-tree file.** Claude Code reads its MCP bridge manifest
from `<workdir>/.claude/mcp.json` and takes no argument pointing elsewhere, so
that file has to be written inside the work tree. It is registered in the
repository's `info/exclude` for the run instead, which keeps a broad `git add
-A` from staging it. `info/exclude` rather than `.gitignore` because
`.gitignore` is itself tracked — that would swap one leaked file for another.
Ignore rules do not apply to tracked paths, so a project that already tracks
`.claude/mcp.json` is covered by the gate below instead; both layers are
documented at the exemption.

**Gate.** `run_config` is a new required quality gate, on by default. It fails a
change whose diff touches a run-configuration path and names the offending
file. The check is a set membership test over the names git already reported,
so it is cheap enough to run on every commit. `RUN_CONFIG_PATHS` is now the
single definition of what counts as run configuration; the merge-preflight deny
list and the per-worktree local excludes derive from it rather than repeating
it, the way the worktree excludes already derived from the merge guard.

`stage_all_except` now unstages every never-stage entry. The incremental merge
path refuses a run-configuration path before staging it. `evolve_auto_commit` —
the one path that pushes straight to the default branch — checks the commit's
own diff before the push, which is where the layers stop overlapping: its
staging filter is the never-stage list, which has never heard of
`.bernstein/bernstein.yaml`.

## Evidence

```
$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
5364 files already formatted

$ uv run lint-imports
Contracts: 3 kept, 0 broken.

$ uv run pytest tests/unit/test_run_config_overlay.py -q
30 passed in 6.65s

$ uv run pytest tests/unit/test_run_config_overlay.py tests/unit/test_seed.py \
    tests/unit/test_quality_gates.py tests/unit/test_quality_gates_v2.py \
    tests/unit/test_quality_gate_regressions.py tests/unit/test_hot_reload.py \
    tests/unit/test_orchestrator_config.py tests/unit/test_incremental_merge.py \
    tests/unit/test_git_ops.py tests/unit/test_git_pr.py tests/unit/test_git_basic.py \
    tests/unit/test_worktree_gitignore.py tests/unit/test_config_schema.py \
    tests/unit/test_config_fuzz.py tests/unit/test_bootstrap.py \
    tests/unit/orchestration/test_orchestrator_standalone_methods.py -q
535 passed, 1 skipped in 63.35s
```

The work-tree and commit properties run against real temporary git
repositories — `git status`, `git add -A` and `git commit -a` are the things
under test, and mocking them would assert nothing. Named for the property each
holds: `test_overlay_never_dirties_the_work_tree`,
`test_commit_all_after_an_overlay_write_contains_no_configuration_file`,
`test_precedence_is_inline_override_then_overlay_then_committed_file`,
`test_gate_rejects_a_staged_run_configuration_path_and_names_the_file`,
`test_editing_the_committed_file_directly_still_takes_effect`, and the rest.

Two of them were checked against their own fix by reverting it: without the
commit gate `test_evolve_refuses_to_push_a_commit_carrying_run_configuration`
fails on `assert True is False`, and with the old directories-only unstage
filter `test_bulk_staging_unstages_run_configuration_not_only_directories`
fails with `bernstein.yaml` in the staged list.

Two existing tests changed because the default gate list did: the ones that
isolate a single gate now disable `run_config` alongside the others they
already disabled, and the pipeline-composition test lists it.

Closes #4485
