### PR TITLE
chore(ci): ratchet coverage baseline up to 84.14%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
   "diff_coverage_floor_percent": 88,
-  "head_sha": "c1c805d57b23a5def49f3dc8b9672818b9cc431a",
-  "line_rate": 0.8408,
-  "run_id": "32646126357",
-  "total_coverage_percent": 84.08,
-  "updated_at": "2026-08-24T08:07:58+00:00"
+  "head_sha": "a6b0c3382eed7141b697bdeacaedd711aea0b17a",
+  "line_rate": 0.8414,
+  "run_id": "32774754848",
+  "total_coverage_percent": 84.14,
+  "updated_at": "2026-08-24T21:25:34+00:00"
 }


### PR DESCRIPTION
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **84.14%**.

Measured on `a6b0c3382eed7141b697bdeacaedd711aea0b17a` from the
`coverage-report` artifact of CI run
[32774754848](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/32774754848).
Those, and the raw Cobertura `line-rate` the percentage was
rounded from, are recorded in the baseline, so the number in the
diff can be re-derived from the file itself:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.