### PR TITLE
docs: regenerate adapter last-green table from canary receipts

### DIFF
--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -192,15 +192,15 @@ covered under *Chronic-skip handling*.
 | Adapter | Binary | Last-green version | Verified | Receipt |
 |---|---|---|---|---|
 | agy | `agy` | 1.0.0 | 2026-07-11T05:57:23Z (not probed) | `006fb946868d` |
-| aider | `aider` | 0.86.2 | 2026-08-24T05:26:59Z | `440df6b99b1c` |
-| claude | `claude` | 2.1.241 | 2026-08-24T05:26:59Z | `a99a61e2d0d8` |
-| codex | `codex` | 0.149.1 | 2026-08-24T05:26:59Z | `25bae9a5a2ca` |
-| copilot | `copilot` | 1.0.80 | 2026-08-24T05:26:59Z | `7f6fe7d34f52` |
-| gemini | `gemini` | 0.56.0 | 2026-08-24T05:26:59Z | `ab89cab289ec` |
-| kimi | `kimi` | 1.49.0 | 2026-08-24T05:26:59Z | `62d980416d74` |
-| opencode | `opencode` | 1.18.21 | 2026-08-24T05:26:59Z | `9ce9575ba003` |
-| pydantic_ai | `clai` | 2.33.0 | 2026-08-24T05:26:59Z | `8814865fc47b` |
-| qwen | `qwen` | 0.22.0 | 2026-08-24T05:26:59Z | `cc64a4222a1f` |
+| aider | `aider` | 0.86.2 | 2026-08-25T05:20:53Z | `af66e0e056db` |
+| claude | `claude` | 2.1.245 | 2026-08-25T05:20:53Z | `27e446086834` |
+| codex | `codex` | 0.149.1 | 2026-08-25T05:20:53Z | `e94741234504` |
+| copilot | `copilot` | 1.0.80 | 2026-08-25T05:20:53Z | `45b4347939ba` |
+| gemini | `gemini` | 0.56.0 | 2026-08-25T05:20:53Z | `e93cb1117ef4` |
+| kimi | `kimi` | 1.49.0 | 2026-08-25T05:20:53Z | `41bf236ce80f` |
+| opencode | `opencode` | 1.18.22 | 2026-08-25T05:20:53Z | `64e4ab2728f0` |
+| pydantic_ai | `clai` | 2.34.0 | 2026-08-25T05:20:53Z | `90ad7260188a` |
+| qwen | `qwen` | 0.22.0 | 2026-08-25T05:20:53Z | `659a5231a87e` |
 <!-- last-green:end -->
 
 ## Operator knobs

--- a/docs/security/receipt-format-spec.md
+++ b/docs/security/receipt-format-spec.md
@@ -236,10 +236,10 @@ def build_cose_sign1(head_sha256: str, key_id: str, sign) -> bytes:
         {1: -8, 3: "application/vnd.bernstein.audit-receipt+json", 4: key_id.encode()},
         canonical=True,
     )
-    payload = bytes.fromhex(head_sha256)          # raw 32 bytes
+    payload = bytes.fromhex(head_sha256)  # raw 32 bytes
     sig_structure = ["Signature1", protected, b"", payload]
     to_sign = cbor2.dumps(sig_structure, canonical=True)
-    signature = sign(to_sign)                     # Ed25519
+    signature = sign(to_sign)  # Ed25519
     cose = cbor2.CBORTag(18, [protected, {}, payload, signature])
     return cbor2.dumps(cose, canonical=True)
 ```
@@ -279,11 +279,7 @@ PAE(payload_type, payload) =
 def pae(payload_type: str, payload: bytes) -> bytes:
     t = payload_type.encode("utf-8")
     return (
-        b"DSSEv1 "
-        + str(len(t)).encode("ascii") + b" " + t
-        + b" "
-        + str(len(payload)).encode("ascii") + b" "
-        + payload
+        b"DSSEv1 " + str(len(t)).encode("ascii") + b" " + t + b" " + str(len(payload)).encode("ascii") + b" " + payload
     )
 ```
 
@@ -371,7 +367,7 @@ def merkle_root(leaves) -> str:
             if i + 1 < len(level):
                 nxt.append(combine_internal(level[i], level[i + 1]))
             else:
-                nxt.append(level[i])          # lone odd node promoted
+                nxt.append(level[i])  # lone odd node promoted
         level = nxt
     return level[0]
 ```
@@ -382,7 +378,7 @@ The signed tree head binds the Merkle root and the subject digest:
 
 ```python
 sth = {"tree_size": len(leaves), "root_hash": root, "subject_sha256": head_sha256}
-sth_signature = sign(canonical_json(sth))     # Ed25519
+sth_signature = sign(canonical_json(sth))  # Ed25519
 ```
 
 The `signature_b64` is the base64 of that signature. `subject_sha256` must

--- a/docs/security/receipt-format-spec.md
+++ b/docs/security/receipt-format-spec.md
@@ -236,10 +236,10 @@ def build_cose_sign1(head_sha256: str, key_id: str, sign) -> bytes:
         {1: -8, 3: "application/vnd.bernstein.audit-receipt+json", 4: key_id.encode()},
         canonical=True,
     )
-    payload = bytes.fromhex(head_sha256)  # raw 32 bytes
+    payload = bytes.fromhex(head_sha256)          # raw 32 bytes
     sig_structure = ["Signature1", protected, b"", payload]
     to_sign = cbor2.dumps(sig_structure, canonical=True)
-    signature = sign(to_sign)  # Ed25519
+    signature = sign(to_sign)                     # Ed25519
     cose = cbor2.CBORTag(18, [protected, {}, payload, signature])
     return cbor2.dumps(cose, canonical=True)
 ```
@@ -279,7 +279,11 @@ PAE(payload_type, payload) =
 def pae(payload_type: str, payload: bytes) -> bytes:
     t = payload_type.encode("utf-8")
     return (
-        b"DSSEv1 " + str(len(t)).encode("ascii") + b" " + t + b" " + str(len(payload)).encode("ascii") + b" " + payload
+        b"DSSEv1 "
+        + str(len(t)).encode("ascii") + b" " + t
+        + b" "
+        + str(len(payload)).encode("ascii") + b" "
+        + payload
     )
 ```
 
@@ -367,7 +371,7 @@ def merkle_root(leaves) -> str:
             if i + 1 < len(level):
                 nxt.append(combine_internal(level[i], level[i + 1]))
             else:
-                nxt.append(level[i])  # lone odd node promoted
+                nxt.append(level[i])          # lone odd node promoted
         level = nxt
     return level[0]
 ```
@@ -378,7 +382,7 @@ The signed tree head binds the Merkle root and the subject digest:
 
 ```python
 sth = {"tree_size": len(leaves), "root_hash": root, "subject_sha256": head_sha256}
-sth_signature = sign(canonical_json(sth))  # Ed25519
+sth_signature = sign(canonical_json(sth))     # Ed25519
 ```
 
 The `signature_b64` is the base64 of that signature. `subject_sha256` must

--- a/src/bernstein/adapters/last_green.json
+++ b/src/bernstein/adapters/last_green.json
@@ -8,56 +8,56 @@
     },
     "aider": {
       "binary": "aider",
-      "receipt_sha256": "440df6b99b1c8b2df51d493bacd3a4bb22563b1eaed309e36a3d97f3d3b114a9",
-      "recorded_at": "2026-08-24T05:26:59Z",
+      "receipt_sha256": "af66e0e056dbe2735c0cb9c430d9969e3e021e94c8da9c205f3ff9bc044846af",
+      "recorded_at": "2026-08-25T05:20:53Z",
       "version": "0.86.2"
     },
     "claude": {
       "binary": "claude",
-      "receipt_sha256": "a99a61e2d0d88f913392a899e1b9ddab012f5343ca19a3de726478f79571bfbe",
-      "recorded_at": "2026-08-24T05:26:59Z",
-      "version": "2.1.241"
+      "receipt_sha256": "27e446086834a9d651bf5975ba8245a7bc1eeaec98ba76efe584b17b6080ff8a",
+      "recorded_at": "2026-08-25T05:20:53Z",
+      "version": "2.1.245"
     },
     "codex": {
       "binary": "codex",
-      "receipt_sha256": "25bae9a5a2ca93d8a5f23990df0d240362e9e630be6a5283ed9e247a75f0c4d7",
-      "recorded_at": "2026-08-24T05:26:59Z",
+      "receipt_sha256": "e94741234504a13e7fe1ec02705f3762c2619cbc7fab80fdd7fcf57af80a9ea0",
+      "recorded_at": "2026-08-25T05:20:53Z",
       "version": "0.149.1"
     },
     "copilot": {
       "binary": "copilot",
-      "receipt_sha256": "7f6fe7d34f529df7958e3d19deb2d690e7dc509dd94411e95d85b8437b56c5ec",
-      "recorded_at": "2026-08-24T05:26:59Z",
+      "receipt_sha256": "45b4347939baf3ebe940617c9817524f5b6875b6e38142af9ccdb77e7ba9eace",
+      "recorded_at": "2026-08-25T05:20:53Z",
       "version": "1.0.80"
     },
     "gemini": {
       "binary": "gemini",
-      "receipt_sha256": "ab89cab289ec91ff6a5d2c738c9e9244f81306d994d2f8dfe1e3ccc11de071ad",
-      "recorded_at": "2026-08-24T05:26:59Z",
+      "receipt_sha256": "e93cb1117ef443da84af25faedbf69f134e52f4ac87ba1eb3043c6ff430e08dd",
+      "recorded_at": "2026-08-25T05:20:53Z",
       "version": "0.56.0"
     },
     "kimi": {
       "binary": "kimi",
-      "receipt_sha256": "62d980416d74405ad7dc490d8bd87bb9c1e6e2291c3bd8a11d49160cd959b0f8",
-      "recorded_at": "2026-08-24T05:26:59Z",
+      "receipt_sha256": "41bf236ce80f961c7d049385fb9d04f1e8792ec6ed98cef6754e9636e9095bd1",
+      "recorded_at": "2026-08-25T05:20:53Z",
       "version": "1.49.0"
     },
     "opencode": {
       "binary": "opencode",
-      "receipt_sha256": "9ce9575ba003c9b514d6c1df9d75a202423261147c51a590e005850a1adbc3e4",
-      "recorded_at": "2026-08-24T05:26:59Z",
-      "version": "1.18.21"
+      "receipt_sha256": "64e4ab2728f083e17c6cfed9996cecee9ebad5b86862a6310f70dcf71757a976",
+      "recorded_at": "2026-08-25T05:20:53Z",
+      "version": "1.18.22"
     },
     "pydantic_ai": {
       "binary": "clai",
-      "receipt_sha256": "8814865fc47b27ac3bd9b261a9ee8655e6f041da6c99b29fc24241f2fa292743",
-      "recorded_at": "2026-08-24T05:26:59Z",
-      "version": "2.33.0"
+      "receipt_sha256": "90ad7260188a47de93814f52d768b4df125eb8add1fb88f3b710f3881c2c83da",
+      "recorded_at": "2026-08-25T05:20:53Z",
+      "version": "2.34.0"
     },
     "qwen": {
       "binary": "qwen",
-      "receipt_sha256": "cc64a4222a1f36404e20328ed0576e72142298f20abf8708b2f88c24cff1f1cf",
-      "recorded_at": "2026-08-24T05:26:59Z",
+      "receipt_sha256": "659a5231a87ecaf2f676a8dbb3640c0f268ef39c8a252ffaae3b2b40356aacea",
+      "recorded_at": "2026-08-25T05:20:53Z",
       "version": "0.22.0"
     }
   },


### PR DESCRIPTION
Nightly adapter conformance canary regeneration of the per-adapter last-green projection (packaged last_green.json + the docs table). Every row is anchored to the receipt that attested it; receipts for this run are attached to the workflow run as artifacts.

Workflow run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/32812407544