### PR TITLE
fix(ci): build canary proposal branch on the fetched default branch

### DIFF
--- a/.github/workflows/adapter-conformance-canary.yml
+++ b/.github/workflows/adapter-conformance-canary.yml
@@ -239,9 +239,16 @@ jobs:
           git config user.email "canary@users.noreply.github.com"
           git config user.name "Bernstein Canary"
           BRANCH=bot/adapter-canary-last-green
-          git checkout -B "$BRANCH"
-          git add src/bernstein/adapters/last_green.json docs/adapters/conformance-canary.md
-          git commit -m "docs: regenerate adapter last-green table from canary receipts"
+          # Rebuild the branch on origin/main as fetched *now*, not on the
+          # workflow checkout: the checkout predates the matrix run, and a
+          # night that regenerates nothing exits before pushing, so the
+          # long-lived branch drifts behind main and anything merged in that
+          # window reads as a revert in the proposal (#4496). The script also
+          # asserts the staged set against the merge base and fails on a
+          # stray path rather than dropping it.
+          uv run python scripts/canary_propose_branch.py \
+            --branch "$BRANCH" \
+            --base-ref main
           git push --force -u origin "$BRANCH"
           EXISTING=$(gh pr list \
             --repo "${{ github.repository }}" \

--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -71,6 +71,28 @@ Running the check against a **downloaded** artifact bundle instead is
 bounded by the receipts artifact's 30-day retention. The in-workflow step
 has no such limit; it never touches the artifact store.
 
+## The proposal carries only what the canary regenerates
+
+The regeneration reaches `main` through a long-lived pull request on
+`bot/adapter-canary-last-green`. That branch is rebuilt each night by
+`scripts/canary_propose_branch.py` on `origin/main` **as fetched at commit
+time**, not on the workflow checkout.
+
+The distinction matters because the checkout is taken before the matrix
+probes every adapter, and a night that regenerates nothing exits before
+pushing, so the branch can sit at an older commit across nights. Anything
+merged into `main` inside that window then appears in the proposal as a
+*revert* of work the canary never touched, and a squash merge would land it.
+That is #4496: `docs/security/receipt-format-spec.md` came back to a form
+predating the edits #4489 had landed.
+
+Rebuilding on the fetched base removes the drift; the script then asserts the
+staged changed-file set against the merge base and fails if it is anything
+other than `src/bernstein/adapters/last_green.json` and
+`docs/adapters/conformance-canary.md`. A stray path stops the proposal rather
+than being dropped with a warning - dropping it would let a genuine projection
+bug leave the tree unnoticed, which is the fault this check exists to surface.
+
 ## What `last_green.json` rows must look like
 
 `load_last_green` validates each row at the JSON boundary instead of

--- a/scripts/canary_propose_branch.py
+++ b/scripts/canary_propose_branch.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Build the canary's proposal branch on a freshly fetched default branch.
+
+The nightly adapter-conformance canary proposes its regeneration through a
+long-lived pull request on ``bot/adapter-canary-last-green``. The step used to
+build that branch with ``git checkout -B`` off the *workflow checkout*, then
+force-push. The checkout is taken at the start of the run; the default branch
+keeps moving while the matrix probes every adapter. A night that regenerates
+nothing exits before pushing, so the branch can also sit at an older commit
+across nights.
+
+Either way the branch's base drifts behind the default branch, and anything
+merged in that window shows up in the pull request as a *revert* of work the
+canary never touched. #4496 caught exactly that: `docs/security/receipt-format-
+spec.md` came back to a form predating the edits #4489 landed, and a squash
+merge would have shipped the revert.
+
+So the branch is rebuilt here off ``origin/<default>`` as fetched at commit
+time, the regenerated blobs are replayed onto that tree, and the resulting
+changed-file set is asserted against the merge base before anything is
+committed. A stray path fails the step: the alternative - dropping it with a
+warning - would let a genuine projection bug leave the tree silently, which is
+the failure mode this exists to stop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+#: Paths the canary regenerates, and the only paths its proposal may carry.
+PROJECTION_PATHS = (
+    "src/bernstein/adapters/last_green.json",
+    "docs/adapters/conformance-canary.md",
+)
+
+
+class ProposalError(RuntimeError):
+    """The proposal branch could not be built safely."""
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> str:
+    """Run ``git`` inside ``repo`` and return stdout stripped."""
+    proc = subprocess.run(
+        ("git", *args),
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if check and proc.returncode != 0:
+        raise ProposalError(f"git {' '.join(args)} failed ({proc.returncode}): {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def changed_paths(repo: Path, base_ref: str) -> tuple[str, ...]:
+    """Paths that differ between ``base_ref``'s merge base and the index."""
+    merge_base = _git(repo, "merge-base", base_ref, "HEAD")
+    out = _git(repo, "diff", "--cached", "--name-only", merge_base)
+    return tuple(sorted(line for line in out.splitlines() if line))
+
+
+def build_proposal(
+    repo: Path,
+    *,
+    branch: str,
+    base_ref: str,
+    remote: str = "origin",
+    expected: tuple[str, ...] = PROJECTION_PATHS,
+    fetch: bool = True,
+) -> tuple[str, ...]:
+    """Rebuild ``branch`` on a freshly fetched ``base_ref`` carrying only ``expected``.
+
+    Reads the regenerated blobs out of the working tree first, resets the
+    branch onto the fetched base, replays them, and returns the staged
+    changed-file set. Raises :class:`ProposalError` if that set is not a
+    subset of ``expected`` - a path the canary does not regenerate must never
+    ride along.
+    """
+    staged = {path: (repo / path).read_bytes() for path in expected if (repo / path).exists()}
+    if not staged:
+        raise ProposalError(f"none of the projection paths exist under {repo}: {expected}")
+
+    if fetch:
+        _git(repo, "fetch", remote, base_ref)
+        base = f"{remote}/{base_ref}"
+    else:
+        base = base_ref
+
+    _git(repo, "checkout", "-B", branch, base)
+
+    for path, blob in staged.items():
+        target = repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(blob)
+
+    _git(repo, "add", *staged)
+    changed = changed_paths(repo, base)
+
+    stray = tuple(path for path in changed if path not in expected)
+    if stray:
+        raise ProposalError(
+            "proposal would carry paths the canary does not regenerate: "
+            + ", ".join(stray)
+            + f" (expected only {', '.join(expected)})"
+        )
+    return changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--branch", default="bot/adapter-canary-last-green")
+    parser.add_argument("--base-ref", default="main")
+    parser.add_argument("--remote", default="origin")
+    parser.add_argument("--message", default="docs: regenerate adapter last-green table from canary receipts")
+    parser.add_argument(
+        "--no-commit",
+        action="store_true",
+        help="Build and check the branch but leave the commit to the caller.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        changed = build_proposal(
+            args.repo,
+            branch=args.branch,
+            base_ref=args.base_ref,
+            remote=args.remote,
+        )
+    except ProposalError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    if not changed:
+        print("projection matches the fetched base; nothing to propose")
+        return 0
+
+    print("proposal carries exactly: " + ", ".join(changed))
+    if not args.no_commit:
+        _git(args.repo, "commit", "-m", args.message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_canary_propose_branch.py
+++ b/tests/unit/test_canary_propose_branch.py
@@ -1,0 +1,149 @@
+"""The canary proposal branch must carry only what the canary regenerates.
+
+Covers ``scripts/canary_propose_branch.py``, which exists because the workflow
+step used to build its branch off the *workflow checkout* rather than off the
+default branch as it stands at commit time. The checkout is taken before the
+matrix probes every adapter, and a night that regenerates nothing exits before
+pushing, so the long-lived ``bot/adapter-canary-last-green`` branch drifts
+behind ``main``. Anything merged into ``main`` in that window then appears in
+the proposal as a revert - #4496 caught ``docs/security/receipt-format-spec.md``
+being reverted to a pre-#4489 form, which a squash merge would have shipped.
+
+Reading the workflow cannot show that: the ``git add`` line was already
+correct, and the revert arrived through the branch's *base*. So the drift is
+reproduced here against real git repositories - a clone whose origin has moved
+on since it was taken - and the assertion is on the resulting changed-file set,
+not on the YAML.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from canary_propose_branch import (
+    PROJECTION_PATHS,
+    ProposalError,
+    build_proposal,
+)
+
+LAST_GREEN, CANARY_DOC = PROJECTION_PATHS
+#: A file the canary never regenerates, standing in for #4496's real victim.
+UNRELATED = "docs/security/receipt-format-spec.md"
+
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(("git", *args), cwd=repo, capture_output=True, text=True, check=True)
+    return proc.stdout.strip()
+
+
+def _write(repo: Path, path: str, text: str) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+
+
+def _commit_all(repo: Path, message: str) -> None:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", message)
+
+
+@pytest.fixture
+def drifted_clone(tmp_path: Path) -> tuple[Path, Path]:
+    """A clone taken before ``origin/main`` gained an unrelated commit.
+
+    Returns ``(clone, origin)``. The clone still has the regenerated
+    projection in its working tree, exactly as the workflow leaves it after
+    ``--update-docs``; origin has since moved on.
+    """
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "canary@example.invalid")
+    _git(origin, "config", "user.name", "Canary Test")
+    _write(origin, LAST_GREEN, '{"adapters": {}}\n')
+    _write(origin, CANARY_DOC, "# conformance canary\n\nold table\n")
+    _write(origin, UNRELATED, "original spec\n")
+    _commit_all(origin, "seed")
+
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", "-q", str(origin), str(clone))
+    _git(clone, "config", "user.email", "canary@example.invalid")
+    _git(clone, "config", "user.name", "Canary Test")
+
+    # main moves on after the clone was taken - this is the drift window.
+    _write(origin, UNRELATED, "spec edited by another PR\n")
+    _commit_all(origin, "docs: edit the spec the canary never touches")
+
+    # ...and the canary regenerates its projection in the stale checkout.
+    _write(clone, LAST_GREEN, '{"adapters": {"claude": "green"}}\n')
+    _write(clone, CANARY_DOC, "# conformance canary\n\nfresh table\n")
+    return clone, origin
+
+
+def test_proposal_carries_only_the_regenerated_paths(drifted_clone: tuple[Path, Path]) -> None:
+    """The unrelated file must not appear, as a revert or otherwise."""
+    clone, _ = drifted_clone
+
+    changed = build_proposal(clone, branch="bot/adapter-canary-last-green", base_ref="main")
+
+    assert changed == tuple(sorted(PROJECTION_PATHS))
+    assert UNRELATED not in changed
+
+
+def test_proposal_base_is_the_fetched_default_branch(drifted_clone: tuple[Path, Path]) -> None:
+    """Rebuilding off origin/main keeps the newer commit in the branch's history.
+
+    This is the property that stops the revert: if the branch were still based
+    on the stale checkout, origin's later commit would be absent from its
+    ancestry and would read as a deletion in the diff.
+    """
+    clone, origin = drifted_clone
+    head_after_drift = _git(origin, "rev-parse", "main")
+
+    build_proposal(clone, branch="bot/adapter-canary-last-green", base_ref="main")
+
+    ancestry = _git(clone, "rev-list", "HEAD")
+    assert head_after_drift in ancestry.splitlines()
+    assert (clone / UNRELATED).read_text(encoding="utf-8") == "spec edited by another PR\n"
+
+
+def test_stray_path_fails_instead_of_being_dropped(drifted_clone: tuple[Path, Path]) -> None:
+    """A staged path outside the projection stops the proposal.
+
+    Staged changes survive ``git checkout -B``, so anything an earlier step
+    left in the index rides into the proposal even though this script only
+    adds the projection paths itself. That is the shape of #4496 - a path the
+    canary never regenerates reaching review - so the check asserts the whole
+    staged set against the merge base rather than trusting its own ``git add``.
+
+    Failing is deliberate. Dropping the path with a warning would let a real
+    projection bug leave the working tree unnoticed, which is the class of
+    fault this check exists to surface.
+    """
+    clone, _ = drifted_clone
+    _write(clone, UNRELATED, "staged by some other step\n")
+    _git(clone, "add", UNRELATED)
+
+    with pytest.raises(ProposalError) as excinfo:
+        build_proposal(clone, branch="bot/adapter-canary-last-green", base_ref="main")
+
+    assert UNRELATED in str(excinfo.value)
+
+
+def test_unchanged_projection_proposes_nothing(drifted_clone: tuple[Path, Path]) -> None:
+    """A night that regenerates nothing must not manufacture a commit."""
+    clone, _origin = drifted_clone
+    # Put the projection back to what origin already has.
+    _write(clone, LAST_GREEN, '{"adapters": {}}\n')
+    _write(clone, CANARY_DOC, "# conformance canary\n\nold table\n")
+
+    changed = build_proposal(clone, branch="bot/adapter-canary-last-green", base_ref="main")
+
+    assert changed == ()


### PR DESCRIPTION
Closes #4496.

## The drift

The canary proposes its regeneration through a long-lived pull request on `bot/adapter-canary-last-green`. The step built that branch with `git checkout -B` off the **workflow checkout** and force-pushed.

The checkout is taken before the matrix probes every adapter, and a night that regenerates nothing exits before pushing, so the branch can also sit at an older commit across nights. Either way its base falls behind `main`, and anything merged in that window reads as a *revert* in the proposal — which is how `docs/security/receipt-format-spec.md` came back to a pre-#4489 form in #4494.

The `git add` line was already correct, which is why reading the step doesn't show the bug: the extra hunk arrives through the branch's **base**, not through what the step stages.

## The fix

`scripts/canary_propose_branch.py` rebuilds the branch on `origin/main` as fetched at commit time, replays the regenerated blobs onto that tree, and asserts the staged changed-file set against the merge base before committing.

Per the acceptance criteria:

- **Branch built from the default branch as fetched at commit time** — `git fetch origin main` then `checkout -B <branch> origin/main`, rather than off the checkout.
- **Projection re-derived against that tree** — the blobs are read from the working tree and replayed onto the fetched base. The projection is a pure function of the receipts (that is exactly what the existing `--verify-projection` step proves), so it does not depend on the rest of the tree; replaying it onto the newer base yields the same content re-running `--update-docs` would, without needing to re-probe every adapter at commit time.
- **Changed-file set proven against the merge base** — anything other than `src/bernstein/adapters/last_green.json` and `docs/adapters/conformance-canary.md` fails the step.

## The decision you left open

I took **fail outright** rather than drop-with-a-warning, matching the acceptance criteria's wording. Dropping a stray path silently would let a genuine projection bug leave the working tree unnoticed, which is the class of fault the check exists to surface. The reasoning is recorded in the script's module docstring and in the test, so a later change has to argue with it rather than just flip it.

## Tests

`tests/unit/test_canary_propose_branch.py` stands up real git repositories — a clone whose origin has moved on since it was taken — and asserts on behaviour, not on the YAML:

- `test_proposal_carries_only_the_regenerated_paths` — the unrelated file does not appear, as a revert or otherwise.
- `test_proposal_base_is_the_fetched_default_branch` — origin's later commit is in the branch's ancestry, and the unrelated file still holds its newer content. This is the property that stops the revert.
- `test_stray_path_fails_instead_of_being_dropped` — staged changes survive `git checkout -B`, so a path left in the index by an earlier step would ride along; the check asserts the whole staged set rather than trusting its own `git add`.
- `test_unchanged_projection_proposes_nothing` — a night that regenerates nothing does not manufacture a commit.

All four pass. `ruff check` and `ruff format --check` are clean on both new files.

## Out of scope

What the canary regenerates, and how the projection is derived, are untouched — this is only about the branch the proposal is built on.

Docs updated per the documentation duty: `docs/adapters/conformance-canary.md` gains a section explaining the drift and why a stray path fails.
