### PR TITLE
docs(release-notes): backfill fragments for three undocumented changes

### DIFF
--- a/docs/release-notes/fragments/4473-plan-rendering-digest.md
+++ b/docs/release-notes/fragments/4473-plan-rendering-digest.md
@@ -1,0 +1,7 @@
+## Plan approval binds to the rendering the reviewer saw
+
+Both plan decision routes re-read the stored plan at decision time, so an edit
+made between rendering and approval was invisible to the approver. A plan now
+carries the SHA-256 digest of its deterministic rendering; approve and reject
+recompute it and answer 409 on mismatch, so a decision lands only on the exact
+plan text the reviewer read (#3839).

--- a/docs/release-notes/fragments/4483-audit-mac-domain-separation.md
+++ b/docs/release-notes/fragments/4483-audit-mac-domain-separation.md
@@ -1,0 +1,9 @@
+## Audit MACs are domain-separated per store
+
+Every HMAC-chained store signed with the same raw key, so bytes minted for one
+store could in principle verify in another. New audit entries carry scheme v2:
+the MAC key is HKDF-SHA256-derived per store and the preimage is domain-tagged.
+One place resolves what a scheme authenticates with, so the log verifier, the
+local record check and the runtime startup guard reach the same verdict; v1
+chains keep verifying unchanged, and an unknown scheme is a hard failure on
+every path rather than a silent fall back (#4478).

--- a/docs/release-notes/fragments/4483-audit-mac-domain-separation.md
+++ b/docs/release-notes/fragments/4483-audit-mac-domain-separation.md
@@ -6,4 +6,4 @@ the MAC key is HKDF-SHA256-derived per store and the preimage is domain-tagged.
 One place resolves what a scheme authenticates with, so the log verifier, the
 local record check and the runtime startup guard reach the same verdict; v1
 chains keep verifying unchanged, and an unknown scheme is a hard failure on
-every path rather than a silent fall back (#4478).
+every path rather than a silent fall back (#4212).

--- a/docs/release-notes/fragments/4491-replay-unauthenticated-fields.md
+++ b/docs/release-notes/fragments/4491-replay-unauthenticated-fields.md
@@ -1,0 +1,9 @@
+## Replay names the fields its verdict does not cover
+
+Journal payload hashing excludes the wall-clock envelope by design, so `ts`,
+`elapsed_s` and the derived chain fields on stored rows are not covered by a
+chain-verification pass -- but nothing in the verified output said so, and a
+reader naturally assumed the whole row was attested. `replay --verify` output
+and the portable receipt manifest now name the unauthenticated field set,
+machine-readably in structured output, and the field-coverage contract is
+documented in one table (#4209).

--- a/docs/security/receipt-format-spec.md
+++ b/docs/security/receipt-format-spec.md
@@ -236,10 +236,10 @@ def build_cose_sign1(head_sha256: str, key_id: str, sign) -> bytes:
         {1: -8, 3: "application/vnd.bernstein.audit-receipt+json", 4: key_id.encode()},
         canonical=True,
     )
-    payload = bytes.fromhex(head_sha256)          # raw 32 bytes
+    payload = bytes.fromhex(head_sha256)  # raw 32 bytes
     sig_structure = ["Signature1", protected, b"", payload]
     to_sign = cbor2.dumps(sig_structure, canonical=True)
-    signature = sign(to_sign)                     # Ed25519
+    signature = sign(to_sign)  # Ed25519
     cose = cbor2.CBORTag(18, [protected, {}, payload, signature])
     return cbor2.dumps(cose, canonical=True)
 ```
@@ -279,11 +279,7 @@ PAE(payload_type, payload) =
 def pae(payload_type: str, payload: bytes) -> bytes:
     t = payload_type.encode("utf-8")
     return (
-        b"DSSEv1 "
-        + str(len(t)).encode("ascii") + b" " + t
-        + b" "
-        + str(len(payload)).encode("ascii") + b" "
-        + payload
+        b"DSSEv1 " + str(len(t)).encode("ascii") + b" " + t + b" " + str(len(payload)).encode("ascii") + b" " + payload
     )
 ```
 
@@ -371,7 +367,7 @@ def merkle_root(leaves) -> str:
             if i + 1 < len(level):
                 nxt.append(combine_internal(level[i], level[i + 1]))
             else:
-                nxt.append(level[i])          # lone odd node promoted
+                nxt.append(level[i])  # lone odd node promoted
         level = nxt
     return level[0]
 ```
@@ -382,7 +378,7 @@ The signed tree head binds the Merkle root and the subject digest:
 
 ```python
 sth = {"tree_size": len(leaves), "root_hash": root, "subject_sha256": head_sha256}
-sth_signature = sign(canonical_json(sth))     # Ed25519
+sth_signature = sign(canonical_json(sth))  # Ed25519
 ```
 
 The `signature_b64` is the base64 of that signature. `subject_sha256` must


### PR DESCRIPTION
Three user-visible changes merged without a release-notes fragment: the per-store audit-MAC domain separation (#4483), the replay unauthenticated-field disclosure (#4491), and the plan rendering digest (#4473). The next rotation would have shipped all three undocumented. One fragment each, in the entry format.