### PR TITLE
fix(skills): contain plugin installs one level below the manifest field

### DIFF
--- a/docs/release-notes/fragments/4448-plugin-symlink-containment.md
+++ b/docs/release-notes/fragments/4448-plugin-symlink-containment.md
@@ -1,0 +1,9 @@
+## A plugin's symlinks cannot reach outside the pack
+
+Installing an Agent Plugins directory containment-checked the manifest's
+`skills` field but followed whatever the entries under it pointed at, so a
+skill directory, a bucket or a nested file symlinked out of the pack was
+copied into the install scope -- content the operator never saw in the tree
+they inspected. Every walked path now has to resolve inside the pack: an
+escaping skill directory is skipped and reported, an escaping bucket or file
+refuses the skill's install.

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shutil
 import tomllib
 from dataclasses import dataclass
@@ -834,6 +835,11 @@ def install_plugin_local(
         name = skill_dir.name
         # Per-skill isolation: one bad SKILL.md must not abort the pack.
         try:
+            # The field-level check proved skills_dir is inside the plugin;
+            # this proves the entry is too. A skill directory symlinked out
+            # of the pack would install content the operator never saw.
+            if _escapes(skills_dir, skill_dir):
+                raise SkillLifecycleError(f"{skill_dir}: skill directory resolves outside the plugin")
             parse_skill_md(skill_md)
             installed.append(
                 install_local(
@@ -877,6 +883,18 @@ def _record_plugin_lock(
     _write_lock(lock_path, list(entries.values()))
 
 
+def _escapes(root: Path, candidate: Path) -> bool:
+    """Whether *candidate* resolves outside *root* once symlinks are followed.
+
+    The string-shape half of the containment barrier does not apply here:
+    these paths come from ``iterdir``/``rglob`` over a tree we were handed,
+    so the only lie available is a symlink, and ``realpath`` is the check
+    that sees through it.
+    """
+    prefix = os.path.join(os.path.realpath(root), "")
+    return not os.path.realpath(candidate).startswith(prefix)
+
+
 def _copy_skill_tree(source: Path, dest: Path) -> None:
     """Copy a skill directory tree, preserving SKILL.md + sibling buckets.
 
@@ -884,8 +902,15 @@ def _copy_skill_tree(source: Path, dest: Path) -> None:
     ``scripts``, ``assets``) are mirrored; anything else under the source
     directory is ignored so a dotfile from the author's editor cannot leak
     into the installed copy.
+
+    Every copied path must resolve inside *source*: the tree is untrusted
+    input, and a symlinked bucket or nested file would otherwise publish
+    content from outside the tree the operator inspected -- the same escape
+    :func:`_resolve_plugin_skills_dir` refuses one level up.
     """
     skill_md = source / "SKILL.md"
+    if _escapes(source, skill_md):
+        raise SkillLifecycleError(f"{skill_md}: SKILL.md resolves outside the skill directory")
     shutil.copy2(skill_md, dest / "SKILL.md")
     for bucket in ("references", "scripts", "assets"):
         src_bucket = source / bucket
@@ -900,6 +925,8 @@ def _copy_skill_tree(source: Path, dest: Path) -> None:
         for child in sorted(src_bucket.rglob("*")):
             if not child.is_file():
                 continue
+            if _escapes(source, child):
+                raise SkillLifecycleError(f"{child}: {bucket} entry resolves outside the skill directory")
             rel = child.relative_to(src_bucket)
             target = dst_bucket / rel
             target.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/skills/test_agent_plugins_install.py
+++ b/tests/unit/skills/test_agent_plugins_install.py
@@ -253,3 +253,72 @@ def test_install_plugin_raises_on_escaping_manifest(tmp_path: Path) -> None:
     # Nothing outside the root was walked or copied into scope.
     dest = scope_root(InstallScope.PROJECT, workdir=workdir)
     assert not dest.exists()
+
+
+def _write_pack_manifest(root: Path, name: str = "pack") -> None:
+    _write_manifest(root / "plugin.json", name=name, skills="skills")
+
+
+class TestSymlinksInsideThePack:
+    """The containment barrier one level below the manifest field.
+
+    ``_resolve_plugin_skills_dir`` proves the ``skills`` *field* stays inside
+    the plugin root, but the walk below it follows whatever the directory
+    entries point at. A pack is untrusted input: a symlink one level deeper
+    must not let the install read - or publish into the install scope -
+    anything outside the tree the operator inspected.
+    """
+
+    def test_skill_dir_symlinked_out_of_the_plugin_is_skipped_not_installed(self, tmp_path: Path) -> None:
+        outside = tmp_path / "outside-skill"
+        _write_skill(outside / "SKILL.md", "linked")
+
+        root = tmp_path / "pack"
+        (root / "skills").mkdir(parents=True)
+        _write_pack_manifest(root)
+        (root / "skills" / "linked").symlink_to(outside, target_is_directory=True)
+
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+        result = install_plugin_local(root, scope=InstallScope.PROJECT, workdir=workdir)
+
+        assert [s.name for s in result.skipped] == ["linked"]
+        assert result.installed == []
+        assert not (scope_root(InstallScope.PROJECT, workdir=workdir) / "linked").exists()
+
+    def test_reference_bucket_symlinked_out_of_the_skill_leaks_nothing(self, tmp_path: Path) -> None:
+        secret_dir = tmp_path / "elsewhere"
+        secret_dir.mkdir()
+        (secret_dir / "secret.txt").write_text("s3cret", encoding="utf-8")
+
+        root = tmp_path / "pack"
+        _write_skill(root / "skills" / "good" / "SKILL.md", "good")
+        _write_pack_manifest(root)
+        (root / "skills" / "good" / "references").symlink_to(secret_dir, target_is_directory=True)
+
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+        result = install_plugin_local(root, scope=InstallScope.PROJECT, workdir=workdir)
+
+        assert [s.name for s in result.skipped] == ["good"]
+        leaked = list(scope_root(InstallScope.PROJECT, workdir=workdir).rglob("secret.txt"))
+        assert leaked == []
+
+    def test_nested_file_symlinked_out_of_the_skill_leaks_nothing(self, tmp_path: Path) -> None:
+        secret = tmp_path / "cred"
+        secret.write_text("aws_secret", encoding="utf-8")
+
+        root = tmp_path / "pack"
+        _write_skill(root / "skills" / "good" / "SKILL.md", "good")
+        refs = root / "skills" / "good" / "references"
+        refs.mkdir()
+        (refs / "doc.md").symlink_to(secret)
+        _write_pack_manifest(root)
+
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+        result = install_plugin_local(root, scope=InstallScope.PROJECT, workdir=workdir)
+
+        assert [s.name for s in result.skipped] == ["good"]
+        installed_root = scope_root(InstallScope.PROJECT, workdir=workdir)
+        assert not any(p.read_text() == "aws_secret" for p in installed_root.rglob("*") if p.is_file())


### PR DESCRIPTION
## Problem

Installing an Agent Plugins directory (#3772) containment-checks the manifest's `skills` field, but the walk below it follows whatever the directory entries point at. A skill directory, a bucket, or a nested file that is a symlink out of the pack is copied into the install scope — content the operator never saw in the tree they inspected. The docstring on `_resolve_plugin_skills_dir` names this exact escape; the guard just sat one level too shallow.

## Change

- `_escapes`: realpath containment predicate next to the copier.
- `install_plugin_local`: a skill directory resolving outside the plugin lands in the skipped list.
- `_copy_skill_tree`: an escaping `SKILL.md`, bucket, or nested file refuses that skill's install.

## Verification

Three tests, one per depth, each proven to fail with the predicate neutered (`return False`). Full `tests/unit/skills/` suite: 470 passed.