### PR TITLE
feat(hygiene): reject committed text files that start with a UTF-8 BOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,6 +452,11 @@ jobs:
           if [ -n "$CONFLICTS" ]; then
             exit 1
           fi
+      - name: Reject a UTF-8 BOM in a committed text file (#4500)
+        # Three fragments in a row (#4429, #4430, #4493) arrived BOM-prefixed
+        # and this job passed all three. Pure stdlib and git, so it runs here
+        # ahead of the bootstrap step rather than waiting on the toolchain.
+        run: python3 scripts/check_bom.py
       - name: Check Python syntax in scripts/
         run: |
           ERRORS=""

--- a/scripts/check_bom.py
+++ b/scripts/check_bom.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+"""Repo-hygiene gate for issue #4500: a UTF-8 BOM in a committed text file.
+
+Three pull requests in a row (#4429, #4430, #4493) arrived with ``EF BB BF``
+at the start of a release-notes fragment. ``Repo hygiene`` passed all three:
+the BOM was caught in review, and one such fragment would otherwise have
+rendered into a release page with a stray glyph ahead of its first heading.
+
+Scans the tracked files whose suffix we treat as text and fails if any begins
+with the mark. Paths whose ``text`` attribute git reports as unset are exempt,
+which is how ``.gitattributes`` spells "these bytes are not ours to police":
+the demo receipt and its vectors are byte-exact fixtures whose signature dies
+on any rewrite. The ``binary`` macro expands to ``-diff -merge -text``, so the
+one query covers both spellings.
+
+Run locally::
+
+    uv run python scripts/check_bom.py
+
+Exit codes:
+  0 = no tracked text file starts with a BOM.
+  1 = at least one does.
+
+Root and path overrides for tests::
+
+    uv run python scripts/check_bom.py --root path/to/repo
+    uv run python scripts/check_bom.py --paths fragment.md pyproject.toml
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+BOM = b"\xef\xbb\xbf"
+
+# Deliberately a suffix allowlist rather than a binary sniff. The gate exists
+# for hand-written text that renders somewhere, and a sniff would have to
+# guess about the fixtures ``.gitattributes`` already answers for.
+TEXT_SUFFIXES = frozenset({".md", ".py", ".yaml", ".yml", ".toml", ".json"})
+
+REMEDY = (
+    "Strip the mark before committing. UTF-8 needs no byte-order mark, and a\n"
+    "file that carries one renders it as a stray glyph ahead of its first\n"
+    "line. Most editors offer 'UTF-8' against 'UTF-8 with BOM'; from a shell::\n"
+    "\n"
+    "    sed -i '1s/^\\xef\\xbb\\xbf//' <path>\n"
+    "\n"
+    "If the file is a byte-exact fixture whose leading bytes are load-bearing,\n"
+    "mark it '-text' in .gitattributes instead, next to the demo-run vectors."
+)
+
+
+def starts_with_bom(path: Path) -> bool:
+    """Return True if *path* begins with the UTF-8 byte-order mark."""
+    try:
+        with path.open("rb") as handle:
+            return handle.read(len(BOM)) == BOM
+    except OSError as exc:
+        print(f"warning: could not read {path}: {exc}", file=sys.stderr)
+        return False
+
+
+def tracked_text_files(root: Path) -> list[Path]:
+    """Tracked paths under *root* whose suffix is in :data:`TEXT_SUFFIXES`.
+
+    NUL-separated so a path containing a newline cannot split one entry into
+    two, which would silently drop it from the sweep.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        capture_output=True,
+        check=True,
+    )
+    names = [chunk for chunk in result.stdout.split(b"\0") if chunk]
+    paths = [Path(name.decode("utf-8", "surrogateescape")) for name in names]
+    return [path for path in paths if path.suffix in TEXT_SUFFIXES]
+
+
+def exempt_paths(root: Path, paths: list[Path]) -> set[Path]:
+    """Of *paths*, those whose ``text`` attribute git reports as unset."""
+    if not paths:
+        return set()
+    stdin = b"\0".join(str(path).encode("utf-8", "surrogateescape") for path in paths)
+    result = subprocess.run(
+        ["git", "-C", str(root), "check-attr", "-z", "--stdin", "text"],
+        input=stdin,
+        capture_output=True,
+        check=True,
+    )
+    # ``-z`` emits a flat NUL-separated stream of (path, attribute, value)
+    # triples, so step through it three fields at a time.
+    fields = result.stdout.split(b"\0")
+    exempt: set[Path] = set()
+    for index in range(0, len(fields) - 2, 3):
+        name, _attribute, value = fields[index : index + 3]
+        if value == b"unset":
+            exempt.add(Path(name.decode("utf-8", "surrogateescape")))
+    return exempt
+
+
+def check(root: Path, paths: list[Path] | None = None) -> int:
+    """Report tracked text files under *root* that begin with a BOM."""
+    candidates = tracked_text_files(root) if paths is None else paths
+    exempt = exempt_paths(root, candidates)
+    findings = [path for path in candidates if path not in exempt and starts_with_bom(root / path)]
+
+    if not findings:
+        print("check_bom: OK (no tracked text file starts with a UTF-8 BOM)")
+        return 0
+
+    print(
+        "check_bom: UTF-8 byte-order mark at the start of a committed text file:",
+        file=sys.stderr,
+    )
+    for path in findings:
+        print(f"  {path}", file=sys.stderr)
+    print(f"\n{REMEDY}", file=sys.stderr)
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("."),
+        help="Repository to scan (default: the current directory).",
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        type=Path,
+        default=None,
+        help="Paths relative to --root to scan instead of every tracked text file.",
+    )
+    args = parser.parse_args(argv)
+    return check(args.root, args.paths)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_check_bom.py
+++ b/tests/unit/test_check_bom.py
@@ -1,0 +1,152 @@
+"""Tests for the UTF-8 BOM hygiene gate (#4500).
+
+Every case builds its own throwaway repository. None of them read the real
+tree: the three fragments that motivated the gate (#4429, #4430, #4493) were
+cleaned in review, so a test asserting against the real files would pass from
+that moment on whether or not the check still worked.
+
+Files are staged but never committed. ``git ls-files`` reports the index and
+``git check-attr`` reads the working tree, so staging is the whole setup and
+no committer identity is needed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from scripts.check_bom import BOM, check, starts_with_bom
+
+# A fragment shaped like the ones that arrived mangled: the first line is a
+# heading, which is exactly where a stray glyph shows up on a release page.
+FRAGMENT = "# Fixed\n\n- A release-notes fragment.\n"
+
+
+def make_repo(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+def add(root: Path, name: str, content: bytes, *, gitattributes: str | None = None) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    if gitattributes is not None:
+        (root / ".gitattributes").write_text(gitattributes, encoding="utf-8")
+        subprocess.run(["git", "add", ".gitattributes"], cwd=root, check=True)
+    subprocess.run(["git", "add", "--", name], cwd=root, check=True)
+    return path
+
+
+class TestTheGateCatchesTheDriftItWasBuiltFor:
+    def test_a_bom_prefixed_fragment_fails_and_names_the_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        root = make_repo(tmp_path)
+        add(root, "docs/releases/4429.md", BOM + FRAGMENT.encode("utf-8"))
+
+        assert check(root) == 1
+        # Naming the path is the point. "a file has a BOM" costs a bisect.
+        assert "docs/releases/4429.md" in capsys.readouterr().err
+
+    def test_the_same_fragment_without_the_bom_passes(self, tmp_path: Path) -> None:
+        root = make_repo(tmp_path)
+        add(root, "docs/releases/4429.md", FRAGMENT.encode("utf-8"))
+
+        assert check(root) == 0
+
+    @pytest.mark.parametrize("suffix", [".md", ".py", ".yaml", ".yml", ".toml", ".json"])
+    def test_every_text_suffix_in_scope_is_swept(self, tmp_path: Path, suffix: str) -> None:
+        root = make_repo(tmp_path)
+        add(root, f"fixture{suffix}", BOM + b"x\n")
+
+        assert check(root) == 1
+
+
+class TestByteExactFixturesStayOutOfScope:
+    def test_a_minus_text_path_with_arbitrary_leading_bytes_passes(self, tmp_path: Path) -> None:
+        # The demo receipt in miniature: '-text' is how .gitattributes says a
+        # file's bytes are load-bearing, and a signature dies on any rewrite.
+        root = make_repo(tmp_path)
+        add(
+            root,
+            "docs/assets/demo-run/run-receipt.json",
+            BOM + b'{"signature": "..."}\n',
+            gitattributes="docs/assets/demo-run/run-receipt.json -text linguist-generated\n",
+        )
+
+        assert check(root) == 0
+
+    def test_the_binary_macro_exempts_too(self, tmp_path: Path) -> None:
+        # 'binary' expands to '-diff -merge -text', so the same query has to
+        # cover it. Spelling the exemption two ways is a real thing people do.
+        root = make_repo(tmp_path)
+        add(
+            root,
+            "vectors/frame.json",
+            BOM + b"{}\n",
+            gitattributes="vectors/frame.json binary\n",
+        )
+
+        assert check(root) == 0
+
+    def test_a_plain_text_path_is_still_caught_when_others_are_exempt(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The exemption must be per-path, not a switch that disarms the sweep.
+        root = make_repo(tmp_path)
+        add(
+            root,
+            "vectors/frame.json",
+            BOM + b"{}\n",
+            gitattributes="vectors/frame.json -text\n",
+        )
+        add(root, "docs/releases/4430.md", BOM + FRAGMENT.encode("utf-8"))
+
+        assert check(root) == 1
+        err = capsys.readouterr().err
+        assert "docs/releases/4430.md" in err
+        assert "vectors/frame.json" not in err
+
+
+class TestTheSweepBoundary:
+    def test_an_untracked_bom_file_is_not_swept(self, tmp_path: Path) -> None:
+        # The gate is about what lands in the repository. A scratch file in a
+        # working tree is the contributor's business.
+        root = make_repo(tmp_path)
+        (root / "scratch.md").write_bytes(BOM + b"# scratch\n")
+
+        assert check(root) == 0
+
+    def test_a_suffix_outside_the_allowlist_is_not_swept(self, tmp_path: Path) -> None:
+        root = make_repo(tmp_path)
+        add(root, "docs/assets/demo.cast", BOM + b"[0.0, 'o', 'x']\n")
+
+        assert check(root) == 0
+
+    def test_an_empty_repository_passes(self, tmp_path: Path) -> None:
+        assert check(make_repo(tmp_path)) == 0
+
+
+class TestTheBomProbe:
+    def test_a_bare_bom_with_no_content_is_still_a_bom(self, tmp_path: Path) -> None:
+        path = tmp_path / "empty-but-marked.md"
+        path.write_bytes(BOM)
+
+        assert starts_with_bom(path) is True
+
+    def test_a_bom_later_in_the_file_is_not_a_leading_bom(self, tmp_path: Path) -> None:
+        # Only the leading mark renders as a stray glyph. A U+FEFF mid-file is
+        # a zero-width no-break space and a different argument entirely.
+        path = tmp_path / "midway.md"
+        path.write_bytes(b"# Fixed\n" + BOM + b"more\n")
+
+        assert starts_with_bom(path) is False
+
+    def test_a_short_file_does_not_false_positive(self, tmp_path: Path) -> None:
+        # Two bytes cannot be a three-byte mark, and the read must not raise.
+        path = tmp_path / "short.md"
+        path.write_bytes(b"\xef\xbb")
+
+        assert starts_with_bom(path) is False


### PR DESCRIPTION
Closes #4500.

## Problem

Three pull requests in a row (#4429, #4430, #4493) arrived with a UTF-8
byte-order mark at the start of a release-notes fragment. `Repo hygiene` passed
all three. The mark was caught in review, and a fragment that slipped through
would have rendered into a release page with a stray glyph ahead of its first
heading.

## Change

Two commits.

**`scripts/check_bom.py`** sweeps the tracked `.md`/`.py`/`.yaml`/`.yml`/`.toml`/
`.json` files and fails naming any that begins with `EF BB BF`.

Paths whose `text` attribute git reports as unset are exempt. Rather than parse
`.gitattributes`, the script asks `git check-attr`, which means the `binary`
macro is covered for free: it expands to `-diff -merge -text`, so one query
handles both spellings of the exemption. That keeps the demo receipt and its
vectors out of scope, since their bytes are load-bearing and a signature dies on
any rewrite.

Enumeration and the attribute query are both NUL-separated, so a path containing
a newline cannot split into two entries and drop out of the sweep. The failure
carries the remedy, including the `-text` escape hatch for a fixture whose
leading bytes are deliberate.

**The CI step** goes in `repo-hygiene` next to the merge-conflict-marker sweep it
most resembles, ahead of the bootstrap step. The script is pure stdlib plus git,
so it can fail fast without waiting on the toolchain the later drift checks need.

## Verification

`tests/unit/test_check_bom.py`, 17 cases, each on its own throwaway repository.
The three acceptance criteria are covered directly: a BOM fragment fails and
names its path, the same fragment without the mark passes, and a `-text` fixture
with arbitrary leading bytes passes. Beyond those, the `binary` macro spelling is
pinned separately, and the exemption is checked to be per-path rather than a
switch that disarms the sweep.

Boundaries: an untracked file is not swept, an out-of-scope suffix is not swept,
an empty repository passes, a bare mark with no content is still a mark, a mark
occurring mid-file is not a leading mark, and a two-byte file does not
false-positive.

None of the cases read the real tree. The three fragments that motivated this
were cleaned in review, so a test asserting against the real files would pass
from that moment on whether or not the check still worked.

Also run:

- `python3 scripts/check_bom.py` from the repository root, the exact invocation
  the step uses and under the system interpreter rather than the venv: OK, no
  findings.
- `ruff check` and `ruff format --check` on both new files: clean.
- The workflow parses and `repo-hygiene` reports the new step in order.
- `pytest tests/unit/ -k "script or hygiene or docs_drift or manifest"`: 1281
  passed, 1 skipped. Nothing enumerates `scripts/` in a way the new file breaks.

## Out of scope

Line-ending normalisation, which pre-commit already owns, and rewriting
contributor history.
