### PR TITLE
feat(lineage): assemble a RunGraph pairing worktree branches with their spines

### DIFF
--- a/src/bernstein/core/lineage/AGENTS.md
+++ b/src/bernstein/core/lineage/AGENTS.md
@@ -15,6 +15,7 @@ single always-on Merkle+HMAC store that every adapter artifact write routes thro
 | `coverage.py` | Anchors a `ToolCoverageRecord` (issue #3769) as a `"coverage"`-kind entry keyed by `tool_call_id` (issue #3770). Anchors a `content_hash` commitment only, not the record's bytes - a reader that cannot independently recover the payload must treat the claim as unverified, never fabricate a passing record from the entry alone |
 | `activity.py` | Active-set closure and provenance graph resolution over the receipt ledger |
 | `gate.py` | Lineage CI gate (ADR-009 §6.2) |
+| `run_graph.py` | Pairs each fan-out worktree branch with the spine that recorded it: `build_run_graph` returns one `RunGraphNode` per branch (`session_id`, `head_sha`, `run_id`, `spine_head_hash`) plus a deterministic root hash. Pure - it adds no storage and resolves `session_id -> run_id` from a caller-supplied mapping |
 
 ## Invariants
 

--- a/src/bernstein/core/lineage/AGENTS.md
+++ b/src/bernstein/core/lineage/AGENTS.md
@@ -29,8 +29,7 @@ single always-on Merkle+HMAC store that every adapter artifact write routes thro
 - A new `LineageEntry` field must be optional, default `None`, dropped from `_canonical_body`
   when `None`, and read back in `_entry_from_dict` (cf. `attachment_digests`) - that is what
   keeps every historical entry's bytes, HMAC and JWS valid.
-- `parent_hashes` is the artefact's ancestry only: tip projection reads
-  two or more as a *fork merge*, so other inputs need their own field.
+- `parent_hashes` is the artefact's ancestry only: tip projection reads two or more as a *fork merge*, so other inputs need their own field.
 - Design rationale: `docs/decisions/009-lineage-v1.md`.
 
 ## Testing

--- a/src/bernstein/core/lineage/run_graph.py
+++ b/src/bernstein/core/lineage/run_graph.py
@@ -1,0 +1,180 @@
+"""Pair each worktree branch of a fan-out with the spine that recorded it.
+
+A fan-out leaves N worktrees behind, and a :class:`~bernstein.core.lineage.spine.LineageSpine`
+per run records every artifact write. The two halves were never joined: a
+:class:`~bernstein.core.worktrees.classifier.ClassifiedWorktree` carries no
+``head_sha`` and no ``run_id``, and a spine is indexed by ``run_id`` with no
+back-reference to the worktree whose writes it holds. So no single call could
+answer, per branch, *what git state it held* and *which spine attested it*.
+
+:func:`build_run_graph` composes the existing primitives into that answer. It
+adds no storage: the branch list comes from ``classify_worktrees``, the head
+sha from git, and the spine head from ``LineageSpine.head_hash()``. The graph
+root is a content hash over the sorted ``(head_sha, spine_head_hash)`` pairs,
+so two runs over byte-identical inputs produce the same root.
+
+Resolving ``session_id`` to ``run_id``
+-------------------------------------
+
+Nothing in the repository records that mapping, so it is supplied by the
+caller as ``run_ids``. The alternative - teaching the spawner to write a
+``run_id`` into the PID record that ``_read_pid_record`` already parses - was
+rejected for two reasons. It changes the spawn path, which is outside this
+slice; and it is only true going forward, so every worktree created before
+the change would resolve as unresolved. That would bake a migration into the
+data rather than into one caller. Passing the mapping in also keeps this
+function pure, which is what makes the root hash reproducible under test.
+
+A session with no entry in ``run_ids`` is **not** dropped. It becomes a node
+with :data:`RunGraphNodeStatus.UNRESOLVED` and contributes to the root hash
+under its own sentinel, so a fan-out that silently lost a spine hashes
+differently from one that never had that branch.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.worktrees.classifier import _git_head_sha, classify_worktrees
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+    from pathlib import Path
+
+#: Stands in for a missing ``head_sha`` or ``spine_head_hash`` in the root
+#: pre-image. A literal empty string would let "absent" and "recorded as
+#: empty" collide, and an empty spine head *is* the empty string.
+ABSENT = "\x00absent"
+
+
+class RunGraphNodeStatus(enum.Enum):
+    """Whether a branch could be paired with a spine."""
+
+    #: ``run_id`` known and its spine read.
+    RESOLVED = "resolved"
+    #: No ``run_id`` for this session; the node is kept and marked.
+    UNRESOLVED = "unresolved"
+
+
+@dataclass(frozen=True, slots=True)
+class RunGraphNode:
+    """One branch of a fan-out, paired with the spine that recorded it.
+
+    Attributes:
+        session_id: Worktree session id, from the classifier.
+        head_sha: Full git HEAD sha of the worktree, or ``None`` when git
+            could not resolve one (detached, unborn, corrupt, or missing).
+        run_id: Run whose spine recorded this branch's writes, or ``None``
+            when the caller supplied no mapping for this session.
+        spine_head_hash: That spine's current chain head, or ``None`` when
+            ``run_id`` is ``None``. An empty string is a *valid* value - it
+            is what an empty run's spine returns.
+        status: :class:`RunGraphNodeStatus`.
+    """
+
+    session_id: str
+    head_sha: str | None
+    run_id: str | None
+    spine_head_hash: str | None
+    status: RunGraphNodeStatus
+
+
+@dataclass(frozen=True, slots=True)
+class RunGraph:
+    """Every branch of one fan-out, plus a hash over their pairs.
+
+    Attributes:
+        nodes: One :class:`RunGraphNode` per worktree, ordered by
+            ``session_id`` so the sequence does not depend on directory
+            iteration order.
+        root_hash: ``sha256:``-prefixed hash over the sorted
+            ``(session_id, head_sha, spine_head_hash)`` triples.
+    """
+
+    nodes: tuple[RunGraphNode, ...]
+    root_hash: str
+
+
+def compute_root_hash(nodes: tuple[RunGraphNode, ...]) -> str:
+    """Hash the ``(session_id, head_sha, spine_head_hash)`` triples.
+
+    ``session_id`` is part of the pre-image, not just the sort key: two
+    branches that happen to share a head sha and a spine head are still
+    distinct branches, and a root that ignored the id could not tell a
+    renamed session from an unchanged one.
+    """
+    payload = [
+        [
+            node.session_id,
+            ABSENT if node.head_sha is None else node.head_sha,
+            ABSENT if node.spine_head_hash is None else node.spine_head_hash,
+        ]
+        for node in sorted(nodes, key=lambda n: n.session_id)
+    ]
+    canonical = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return content_hash_of(canonical.encode("utf-8"))
+
+
+def build_run_graph(
+    repo_root: Path,
+    *,
+    run_ids: Mapping[str, str],
+    lineage_root: Path,
+    hmac_key: bytes,
+    head_sha_resolver: Callable[[Path], str | None] = _git_head_sha,
+) -> RunGraph:
+    """Assemble a :class:`RunGraph` for every worktree under ``repo_root``.
+
+    Args:
+        repo_root: Repository root whose worktrees are classified.
+        run_ids: ``session_id -> run_id``. Sessions absent from this mapping
+            become ``UNRESOLVED`` nodes rather than being dropped.
+        lineage_root: Root under which each run's spine directory lives.
+        hmac_key: Key the spines were written with, needed to open them.
+        head_sha_resolver: Injection point for git HEAD resolution; defaults
+            to the classifier's own resolver.
+
+    Returns:
+        A :class:`RunGraph` whose ``nodes`` are ordered by ``session_id``.
+    """
+    nodes: list[RunGraphNode] = []
+    for worktree in classify_worktrees(repo_root):
+        run_id = run_ids.get(worktree.session_id)
+        if run_id is None:
+            nodes.append(
+                RunGraphNode(
+                    session_id=worktree.session_id,
+                    head_sha=head_sha_resolver(worktree.path),
+                    run_id=None,
+                    spine_head_hash=None,
+                    status=RunGraphNodeStatus.UNRESOLVED,
+                )
+            )
+            continue
+        spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key)
+        nodes.append(
+            RunGraphNode(
+                session_id=worktree.session_id,
+                head_sha=head_sha_resolver(worktree.path),
+                run_id=run_id,
+                spine_head_hash=spine.head_hash(),
+                status=RunGraphNodeStatus.RESOLVED,
+            )
+        )
+
+    ordered = tuple(sorted(nodes, key=lambda n: n.session_id))
+    return RunGraph(nodes=ordered, root_hash=compute_root_hash(ordered))
+
+
+__all__ = [
+    "ABSENT",
+    "RunGraph",
+    "RunGraphNode",
+    "RunGraphNodeStatus",
+    "build_run_graph",
+    "compute_root_hash",
+]

--- a/tests/unit/lineage/test_run_graph.py
+++ b/tests/unit/lineage/test_run_graph.py
@@ -1,0 +1,197 @@
+"""A fan-out's branches must pair with the spines that recorded them.
+
+Covers ``src/bernstein/core/lineage/run_graph.py``. Before it existed, a
+``ClassifiedWorktree`` carried no ``head_sha`` and no ``run_id``, and a
+``LineageSpine`` was indexed by ``run_id`` with no way back to the worktree
+whose writes it held - so for N branches of one fan-out there was no single
+call returning, per branch, its git state and the spine that attested it.
+
+Three properties are pinned here, because each fails differently:
+
+* the pairing itself - every branch gets the *right* head sha and spine head,
+  not merely some pair;
+* determinism of the root hash - two runs over byte-identical fixtures must
+  agree, otherwise the root cannot anchor anything later;
+* that an unresolvable branch is *reported*, not dropped. Silently omitting it
+  would make a fan-out that lost a spine hash identically to one that never
+  had that branch, which is exactly the case a lineage graph exists to catch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.lineage.run_graph import (
+    RunGraphNodeStatus,
+    build_run_graph,
+    compute_root_hash,
+)
+from bernstein.core.lineage.spine import LineageSpine
+
+HMAC_KEY = b"\x11" * 32
+#: Fixed so the golden root hash below stays stable.
+TIMESTAMP = 1_700_000_000
+
+SESSIONS = ("sess-alpha", "sess-beta", "sess-gamma")
+#: Distinguishable fabricated HEAD shas, one per session.
+HEAD_SHAS = {
+    "sess-alpha": "a" * 40,
+    "sess-beta": "b" * 40,
+    "sess-gamma": "c" * 40,
+}
+RUN_IDS = {session: f"run-{session.split('-')[1]}" for session in SESSIONS}
+
+
+def _resolver(path: Path) -> str | None:
+    """Stand in for git, keyed on the worktree directory name."""
+    return HEAD_SHAS.get(path.name)
+
+
+@pytest.fixture
+def fanout(tmp_path: Path) -> tuple[Path, Path]:
+    """Three worktree-shaped sessions, each with a spine holding one write.
+
+    Returns ``(repo_root, lineage_root)``.
+    """
+    repo_root = tmp_path / "repo"
+    worktrees = repo_root / ".sdd" / "runtime" / "worktrees"
+    worktrees.mkdir(parents=True)
+    lineage_root = tmp_path / "lineage"
+
+    for session in SESSIONS:
+        (worktrees / session).mkdir()
+        spine = LineageSpine(lineage_root, run_id=RUN_IDS[session], hmac_key=HMAC_KEY)
+        spine.record(
+            artifact_path=f"out/{session}.txt",
+            content=f"written by {session}".encode(),
+            actor="tester",
+            step_id="step-1",
+            model="test-model",
+            timestamp=TIMESTAMP,
+        )
+    return repo_root, lineage_root
+
+
+def _build(repo_root: Path, lineage_root: Path, **overrides: object) -> object:
+    kwargs: dict[str, object] = {
+        "run_ids": dict(RUN_IDS),
+        "lineage_root": lineage_root,
+        "hmac_key": HMAC_KEY,
+        "head_sha_resolver": _resolver,
+    }
+    kwargs.update(overrides)
+    return build_run_graph(repo_root, **kwargs)  # type: ignore[arg-type]
+
+
+def test_each_branch_pairs_with_its_own_spine(fanout: tuple[Path, Path]) -> None:
+    repo_root, lineage_root = fanout
+
+    graph = _build(repo_root, lineage_root)
+
+    assert len(graph.nodes) == 3
+    assert [n.session_id for n in graph.nodes] == sorted(SESSIONS)
+    for node in graph.nodes:
+        assert node.status is RunGraphNodeStatus.RESOLVED
+        assert node.head_sha == HEAD_SHAS[node.session_id]
+        assert node.run_id == RUN_IDS[node.session_id]
+        expected = LineageSpine(lineage_root, run_id=RUN_IDS[node.session_id], hmac_key=HMAC_KEY).head_hash()
+        assert node.spine_head_hash == expected
+        assert node.spine_head_hash
+
+
+def test_spine_heads_are_distinct_per_branch(fanout: tuple[Path, Path]) -> None:
+    """Guards the pairing against an off-by-one that reads one spine thrice."""
+    repo_root, lineage_root = fanout
+
+    graph = _build(repo_root, lineage_root)
+
+    heads = [n.spine_head_hash for n in graph.nodes]
+    assert len(set(heads)) == 3, heads
+
+
+def test_root_hash_is_deterministic(fanout: tuple[Path, Path]) -> None:
+    repo_root, lineage_root = fanout
+
+    first = _build(repo_root, lineage_root)
+    second = _build(repo_root, lineage_root)
+
+    assert first.root_hash == second.root_hash
+    assert first.root_hash.startswith("sha256:")
+
+
+def test_root_hash_changes_when_a_head_sha_changes(fanout: tuple[Path, Path]) -> None:
+    """A root that ignored head shas could not anchor git state."""
+    repo_root, lineage_root = fanout
+    baseline = _build(repo_root, lineage_root)
+
+    moved = _build(
+        repo_root,
+        lineage_root,
+        head_sha_resolver=lambda p: "d" * 40 if p.name == "sess-beta" else _resolver(p),
+    )
+
+    assert moved.root_hash != baseline.root_hash
+
+
+def test_unresolved_session_is_reported_not_dropped(fanout: tuple[Path, Path]) -> None:
+    """The branch stays in the graph, marked, and still moves the root."""
+    repo_root, lineage_root = fanout
+    partial = {k: v for k, v in RUN_IDS.items() if k != "sess-beta"}
+
+    graph = _build(repo_root, lineage_root, run_ids=partial)
+
+    assert len(graph.nodes) == 3
+    orphan = next(n for n in graph.nodes if n.session_id == "sess-beta")
+    assert orphan.status is RunGraphNodeStatus.UNRESOLVED
+    assert orphan.run_id is None
+    assert orphan.spine_head_hash is None
+    # Still carries its git state - losing the spine does not lose the branch.
+    assert orphan.head_sha == HEAD_SHAS["sess-beta"]
+    assert graph.root_hash != _build(repo_root, lineage_root).root_hash
+
+
+def test_absent_is_distinguishable_from_an_empty_spine_head() -> None:
+    """An empty spine head is a real value; ``None`` must not collide with it.
+
+    A run with no entries returns ``""`` from ``head_hash()``. If the root
+    pre-image mapped ``None`` to ``""`` as well, a branch whose spine was lost
+    would hash identically to one whose spine is merely empty.
+    """
+    from bernstein.core.lineage.run_graph import RunGraphNode
+
+    empty_head = RunGraphNode("s", "a" * 40, "run-1", "", RunGraphNodeStatus.RESOLVED)
+    no_head = RunGraphNode("s", "a" * 40, None, None, RunGraphNodeStatus.UNRESOLVED)
+
+    assert compute_root_hash((empty_head,)) != compute_root_hash((no_head,))
+
+
+def test_node_order_does_not_depend_on_input_order(fanout: tuple[Path, Path]) -> None:
+    """The root hashes the sorted triples, so shuffling inputs cannot move it."""
+    repo_root, lineage_root = fanout
+    graph = _build(repo_root, lineage_root)
+
+    shuffled = tuple(reversed(graph.nodes))
+
+    assert compute_root_hash(shuffled) == graph.root_hash
+
+
+def test_root_pre_image_includes_session_id(fanout: tuple[Path, Path]) -> None:
+    """Two branches sharing a pair are still two distinct branches."""
+    from bernstein.core.lineage.run_graph import RunGraphNode
+
+    one = RunGraphNode("sess-a", "a" * 40, "run-1", "sha256:x", RunGraphNodeStatus.RESOLVED)
+    two = RunGraphNode("sess-b", "a" * 40, "run-1", "sha256:x", RunGraphNodeStatus.RESOLVED)
+
+    assert compute_root_hash((one,)) != compute_root_hash((two,))
+
+
+def test_empty_repo_yields_an_empty_graph(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    (repo_root / ".sdd" / "runtime" / "worktrees").mkdir(parents=True)
+
+    graph = _build(repo_root, tmp_path / "lineage")
+
+    assert graph.nodes == ()
+    assert graph.root_hash == compute_root_hash(())


### PR DESCRIPTION
Closes #3758. Slice 1 of 4 of #2929 — the data model only. No signing, no audit-chain writes, no CLI, no janitor wiring.

## What it adds

`src/bernstein/core/lineage/run_graph.py` exposes a pure `build_run_graph(...) -> RunGraph`, one `RunGraphNode` per branch carrying `(session_id, head_sha, run_id, spine_head_hash)`.

It adds no storage. The branch list comes from `classify_worktrees`, the head sha from the classifier's own git resolver, and the spine head from `LineageSpine.head_hash()`. The root is a content hash over the sorted triples, via the existing `content_hash_of`.

## The decision you left open: resolving `session_id` → `run_id`

**I pass the mapping in as a `run_ids` argument.** The alternative — teaching the spawner to write a `run_id` into the PID record that `_read_pid_record` already parses — loses on two counts:

1. **It changes the spawn path**, which is outside a data-model-only slice.
2. **It is only true going forward.** Every worktree created before the change would resolve as unresolved, so the migration would live in the *data* rather than in one caller. A mapping argument has no such tail.

It also keeps `build_run_graph` pure, which is what makes the root hash reproducible under test rather than dependent on what happens to be on disk.

## Unresolved branches are reported, not dropped

A session absent from `run_ids` becomes a node with `status=UNRESOLVED`, keeps its `head_sha`, and still contributes to the root hash under a sentinel. Dropping it would make a fan-out that *lost* a spine hash identically to one that never had that branch — precisely the case a lineage graph exists to catch.

That sentinel is deliberate rather than an empty string: **an empty spine head is a real value** (`head_hash()` returns `""` for a run with no entries), so mapping `None` to `""` would let "spine lost" and "spine empty" collide. `test_absent_is_distinguishable_from_an_empty_spine_head` pins that.

## Tests

`tests/unit/lineage/test_run_graph.py` — 9 tests, all passing. Three fabricated worktree sessions with distinguishable HEAD shas and one `LineageSpine` each (temp lineage root, fixed HMAC key, fixed timestamp):

- **pairing** — each branch gets the right head sha, run id and spine head; and a separate test asserts the three spine heads are *distinct*, which catches an off-by-one that reads one spine three times while every other assertion still passes.
- **determinism** — two builds over byte-identical fixtures agree on the root; a changed head sha moves it; reversing node order does not.
- **the unresolved case** — constructed explicitly, asserted present, marked, and shown to move the root.
- `session_id` is in the root pre-image, so two branches sharing a `(head_sha, spine_head_hash)` pair remain distinguishable.

`ruff check` and `ruff format --check` are clean on both files.

> One pre-existing failure, unrelated to this change: `tests/unit/lineage/test_cli.py::test_check_lineage_script_pass` fails identically on a clean `main` in my environment (it shells out to a script that needs the package installed). Flagging so it is not read as fallout from this PR.

## One thing to flag

I import `_git_head_sha` from `worktrees/classifier.py` — a private name — because re-implementing HEAD resolution would duplicate its timeout and degradation handling. It is injected as `head_sha_resolver`'s default, so callers and tests can override it. If you would rather it were public API, say so and I will promote it in a follow-up rather than widen this slice.

Docs: `src/bernstein/core/lineage/AGENTS.md` gains a `run_graph.py` row per the directory's key-files convention.
