### PR TITLE
test(planning): pin which fields the plan rendering digest is sensitive to

### DIFF
--- a/tests/unit/planning/test_plan_rendering.py
+++ b/tests/unit/planning/test_plan_rendering.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import fields, replace
+
 import pytest
 
 from bernstein.core.planning.plan_rendering import PlanRendering, compute_plan_rendering
@@ -265,3 +267,181 @@ def test_plan_rendering_is_frozen() -> None:
     r = PlanRendering(text="x", rendering_hash="y")
     with pytest.raises(AttributeError):
         r.text = "z"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Per-field digest sensitivity (#4502)
+# ---------------------------------------------------------------------------
+#
+# The determinism and ordering properties above prove the digest is *stable*.
+# They say nothing about what it is stable *over*: dropping ``title`` from
+# ``_estimate_dict`` passed this entire file before these cases existed, and a
+# refactor that quietly narrows the hashed payload narrows what plan approval
+# protects without anything going red.
+
+
+# Each pair mutates exactly one field of a task estimate to a value that must
+# move the digest. ``estimated_cost_usd`` is rounded to six places in the
+# payload, so its mutation has to clear that precision to mean anything.
+ESTIMATE_FIELD_MUTATIONS = [
+    # "t-0" not "t-9": the estimates are sorted by task_id before
+    # serialisation, so a mutation that reorders them would move the digest
+    # through position alone and pass even with task_id out of the payload.
+    ("task_id", "t-0"),
+    ("title", "Implement something else"),
+    ("role", "frontend"),
+    ("model", "opus"),
+    ("estimated_tokens", 5001),
+    ("estimated_cost_usd", 0.51),
+    ("risk_level", "high"),
+    ("risk_reasons", ["touches billing"]),
+]
+
+# Plan-level fields the payload carries, and a mutation for each.
+PLAN_FIELD_MUTATIONS = [
+    ("plan_id", "plan-002"),
+    ("goal", "Ship feature Y"),
+    ("total_cost", 1.75),
+    ("total_minutes", 121),
+    ("high_risk", ["t-1"]),
+]
+
+# Lifecycle fields the payload deliberately omits. ``verify_rendering_hash``
+# recomputes the digest at approve/reject time, so binding any of these would
+# make verification fail at exactly the moment it runs.
+UNHASHED_PLAN_FIELDS = frozenset({"status", "created_at", "decided_at", "decision_reason", "rendering_hash"})
+
+
+def _digest(plan: TaskPlan) -> str:
+    return compute_plan_rendering(plan).rendering_hash
+
+
+@pytest.mark.parametrize(("field_name", "new_value"), ESTIMATE_FIELD_MUTATIONS)
+def test_every_estimate_field_is_bound_into_the_digest(field_name: str, new_value: object) -> None:
+    baseline = _make_plan()
+    original = baseline.task_estimates[0]
+    # A "mutation" that matches the baseline would pass whatever the payload
+    # contained, which is the failure mode this whole sweep exists to catch.
+    assert getattr(original, field_name) != new_value, f"{field_name} mutation does not change the value"
+
+    mutated = replace(original, **{field_name: new_value})
+    plan = _make_plan(estimates=[mutated, baseline.task_estimates[1]])
+
+    assert _digest(plan) != _digest(baseline), (
+        f"mutating {field_name} left the digest unchanged, so plan approval does not bind that field"
+    )
+
+
+def test_the_estimate_sweep_covers_every_field_of_the_dataclass() -> None:
+    """A new field on TaskCostEstimate must fail here until someone decides.
+
+    Without this, adding a field is silently a decision to leave it out of
+    the digest, taken by whoever adds it and reviewed by nobody.
+    """
+    covered = {name for name, _ in ESTIMATE_FIELD_MUTATIONS}
+    declared = {f.name for f in fields(TaskCostEstimate)}
+
+    assert covered == declared, f"uncovered: {declared - covered}; stale: {covered - declared}"
+
+
+@pytest.mark.parametrize(("kwarg", "new_value"), PLAN_FIELD_MUTATIONS)
+def test_every_plan_level_field_is_bound_into_the_digest(kwarg: str, new_value: object) -> None:
+    baseline = _make_plan()
+    plan = _make_plan(**{kwarg: new_value})
+
+    assert _digest(plan) != _digest(baseline), f"mutating {kwarg} left the digest unchanged"
+
+
+@pytest.mark.parametrize("field_name", sorted(UNHASHED_PLAN_FIELDS))
+def test_lifecycle_fields_stay_out_of_the_digest(field_name: str) -> None:
+    """The digest has to survive the plan being approved.
+
+    ``PlanStore.verify_rendering_hash`` recomputes it before promoting a
+    plan, by which point status and the decision fields have moved. Binding
+    them would refuse every plan at the gate they exist to protect.
+    """
+    baseline = _make_plan()
+    moved = {
+        "status": PlanStatus.APPROVED,
+        "created_at": 1_700_000_000.0,
+        "decided_at": 1_700_000_001.0,
+        "decision_reason": "looks fine",
+        "rendering_hash": "0" * 64,
+    }[field_name]
+    plan = replace(baseline, **{field_name: moved})
+
+    assert _digest(plan) == _digest(baseline), (
+        f"{field_name} moved the digest, so a plan cannot be verified after its own approval"
+    )
+
+
+def test_a_cost_change_below_the_rounding_precision_does_not_move_the_digest() -> None:
+    """Six decimal places is the payload's stated precision, not an accident.
+
+    Pinning it keeps the sensitivity sweep above honest: its cost mutation
+    has to clear this threshold, and a future change to the rounding shows
+    up here rather than as a mysteriously flaky sensitivity case.
+    """
+    baseline = _make_plan()
+    original = baseline.task_estimates[0]
+    nudged = replace(original, estimated_cost_usd=original.estimated_cost_usd + 1e-9)
+    plan = _make_plan(estimates=[nudged, baseline.task_estimates[1]])
+
+    assert _digest(plan) == _digest(baseline)
+
+
+# ---------------------------------------------------------------------------
+# Golden digest (#4502)
+# ---------------------------------------------------------------------------
+
+
+def _frozen_plan() -> TaskPlan:
+    """A plan with every hashed field set to a literal.
+
+    Deliberately not built from ``_make_plan``: the golden digest should move
+    only when the payload format moves, and a helper other cases tune would
+    make it move for reasons that have nothing to do with the format.
+    """
+    return TaskPlan(
+        id="plan-golden",
+        goal="Freeze the rendering payload",
+        task_estimates=[
+            TaskCostEstimate(
+                task_id="t-a",
+                title="First",
+                role="backend",
+                model="sonnet",
+                estimated_tokens=1000,
+                estimated_cost_usd=0.125,
+                risk_level="low",
+                risk_reasons=["one", "two"],
+            ),
+            TaskCostEstimate(
+                task_id="t-b",
+                title="Second",
+                role="qa",
+                model="haiku",
+                estimated_tokens=2000,
+                estimated_cost_usd=0.25,
+                risk_level="high",
+                risk_reasons=[],
+            ),
+        ],
+        total_estimated_cost_usd=0.375,
+        total_estimated_minutes=42,
+        high_risk_tasks=["t-b"],
+        status=PlanStatus.PENDING,
+    )
+
+
+GOLDEN_DIGEST = "eece8526b7ab3159251b471c5f7b048764e8bdf56be921b7b26c3763e5765081"
+
+
+def test_the_frozen_plan_still_hashes_to_the_recorded_digest() -> None:
+    """An accidental format change should be loud rather than merely different.
+
+    Every stored ``rendering_hash`` predating the change stops verifying, so
+    a payload edit is a migration. If this case fails on a deliberate one,
+    update the constant in the same commit that changes the format.
+    """
+    assert _digest(_frozen_plan()) == GOLDEN_DIGEST


### PR DESCRIPTION
Closes #4502.

## Problem

`compute_plan_rendering` hashes the plan payload, and plan approval binds to
that digest (#3839). The determinism and ordering properties are well covered.
What the digest is sensitive *to* was not: dropping `title` from
`_estimate_dict` passed the entire suite, and the route-level tamper tests only
mutate `plan.goal`.

A refactor that quietly narrows the hashed payload also narrows what the
approval gate protects, and nothing goes red.

## Change

Test-only. Adds to `tests/unit/planning/test_plan_rendering.py`:

- **A parametrised case per `TaskCostEstimate` field**, mutating exactly that
  field and asserting the digest moves. Each case first asserts its mutation
  actually differs from the baseline, so a stale pair cannot pass by mutating
  nothing.
- **A coverage guard**: the sweep's field set must equal the dataclass's. A new
  field on `TaskCostEstimate` fails here until someone decides whether it
  belongs in the digest, instead of being left out by whoever added it and
  reviewed by nobody.
- **The same per-field treatment for the plan-level payload fields.**
- **The complement.** `status`, `created_at`, `decided_at`, `decision_reason`
  and `rendering_hash` must *not* move the digest. `verify_rendering_hash`
  recomputes it at approve/reject time, by which point those fields have moved,
  so binding one would refuse every plan at the gate it exists to protect.
- **A rounding boundary case**: a cost change below the payload's six decimal
  places does not move the digest. That is what makes the sensitivity sweep's
  cost mutation meaningful rather than incidental, and a future change to the
  rounding shows up here rather than as a mysteriously flaky sensitivity case.
- **A golden digest** over a frozen plan built from literals rather than the
  shared `_make_plan` helper, so it moves only when the payload format moves and
  not when another case tunes the helper.

One detail worth flagging for review: the `task_id` mutation is `t-0`, not
`t-9`. Estimates are sorted by `task_id` before serialisation, so a mutation
that reorders them moves the digest through position alone and would pass even
with `task_id` absent from the payload. I had `t-9` first and the drop
verification below is what caught it.

## Verification

The check the issue asks for, run for all eight fields rather than one. Each
field was dropped from `_estimate_dict` in turn and its case confirmed to fail:

```
drop task_id             -> test FAILS as required
drop title               -> test FAILS as required
drop role                -> test FAILS as required
drop model               -> test FAILS as required
drop estimated_tokens    -> test FAILS as required
drop estimated_cost_usd  -> test FAILS as required
drop risk_level          -> test FAILS as required
drop risk_reasons        -> test FAILS as required
```

`src/bernstein/core/planning/plan_rendering.py` was restored byte-identical
afterwards and `git status` shows only the test file modified.

38 cases pass in the file, 52 with `tests/unit/test_plan_approval.py` alongside.
`ruff check` and `ruff format --check` clean.

## Out of scope

Changing the rendering format or the hash algorithm, per the issue.
