### PR TITLE
fix(ci): reject committed text files that start with a UTF-8 BOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,6 +440,12 @@ jobs:
             printf '%s\n' "$TRACKED"
             exit 1
           fi
+      - name: Reject committed text files starting with a UTF-8 BOM
+        # A BOM is invisible in an editor and in a GitHub diff, so three PRs
+        # in a row (#4429, #4430, #4493) landed one in a release-notes
+        # fragment and review caught it each time. Paths .gitattributes marks
+        # -text are exempt: those are byte-exact signed fixtures.
+        run: python3 scripts/check_bom.py --repo-root .
       - name: Check for merge conflict markers in source files
         run: |
           CONFLICTS=""

--- a/scripts/check_bom.py
+++ b/scripts/check_bom.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+"""Repo-hygiene sweep: reject committed text files starting with a UTF-8 BOM.
+
+Three pull requests in a row (#4429, #4430, #4493) arrived with ``EF BB BF``
+at the head of a committed release-notes fragment, mangled by a contributor's
+shell. ``Repo hygiene`` passed all three; the BOM was caught only in review,
+and one of those fragments would otherwise have rendered a stray ``\\ufeff``
+onto a release page.
+
+A BOM is invisible in most editors and in a GitHub diff, so this is exactly
+the class of fault that has to be machine-checked - reading the file cannot
+find it.
+
+Scope
+-----
+
+Only paths git tracks, and only the text extensions listed in
+:data:`TEXT_SUFFIXES`. Anything ``.gitattributes`` marks ``-text`` is exempt:
+those are byte-exact fixtures (the demo receipt, the committed receipt
+vectors) whose signatures are over the bytes, so their leading bytes are not
+this check's business.
+
+Exit status is 1 when any file is flagged, 0 otherwise. Findings are printed
+as GitHub Actions ``::error file=…::`` annotations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+#: The UTF-8 encoding of U+FEFF.
+BOM = b"\xef\xbb\xbf"
+
+#: Extensions swept. Deliberately a list rather than "everything not binary":
+#: a new binary format should not start failing this check by default.
+TEXT_SUFFIXES = frozenset({".md", ".py", ".yaml", ".yml", ".toml", ".json", ".txt", ".cfg", ".ini"})
+
+
+def tracked_text_files(repo_root: Path) -> list[Path]:
+    """Every git-tracked file whose suffix is in :data:`TEXT_SUFFIXES`."""
+    out = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=repo_root,
+        capture_output=True,
+        check=True,
+        text=False,
+    ).stdout
+    names = [n.decode("utf-8", "surrogateescape") for n in out.split(b"\0") if n]
+    return [repo_root / n for n in names if Path(n).suffix.lower() in TEXT_SUFFIXES]
+
+
+def binary_marked_paths(repo_root: Path, paths: list[Path]) -> set[Path]:
+    """Paths ``.gitattributes`` marks ``-text`` (or binary).
+
+    Asks git rather than parsing ``.gitattributes``, so pattern semantics -
+    precedence, negation, directory scoping - stay git's to define.
+    """
+    if not paths:
+        return set()
+    rel = [str(p.relative_to(repo_root)) for p in paths]
+    proc = subprocess.run(
+        ["git", "check-attr", "--stdin", "-z", "text"],
+        cwd=repo_root,
+        input="\0".join(rel).encode("utf-8"),
+        capture_output=True,
+        check=True,
+    )
+    fields = proc.stdout.split(b"\0")
+    marked: set[Path] = set()
+    # git emits <path>\0<attr>\0<value>\0 triples under -z.
+    for i in range(0, len(fields) - 2, 3):
+        path, _attr, value = fields[i], fields[i + 1], fields[i + 2]
+        if value in (b"unset", b"set-binary"):
+            marked.add(repo_root / path.decode("utf-8", "surrogateescape"))
+    return marked
+
+
+def find_bom_files(repo_root: Path) -> list[Path]:
+    """Tracked, non-exempt text files whose first bytes are a UTF-8 BOM."""
+    candidates = tracked_text_files(repo_root)
+    exempt = binary_marked_paths(repo_root, candidates)
+    flagged: list[Path] = []
+    for path in candidates:
+        if path in exempt or not path.is_file():
+            continue
+        try:
+            with path.open("rb") as handle:
+                if handle.read(len(BOM)) == BOM:
+                    flagged.append(path)
+        except OSError:
+            # An unreadable tracked path is a different fault; hygiene is not
+            # the place to fail the build over it.
+            continue
+    return sorted(flagged)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+
+    flagged = find_bom_files(args.repo_root.resolve())
+    for path in flagged:
+        rel = path.relative_to(args.repo_root.resolve())
+        print(f"::error file={rel}::{rel} starts with a UTF-8 byte-order mark (EF BB BF); strip it")
+    if flagged:
+        print(f"{len(flagged)} file(s) start with a UTF-8 BOM", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_bom_hygiene.py
+++ b/tests/unit/test_bom_hygiene.py
@@ -1,0 +1,123 @@
+"""A committed text file must not start with a UTF-8 byte-order mark.
+
+Covers ``scripts/check_bom.py``. Three pull requests in a row (#4429, #4430,
+#4493) landed a release-notes fragment prefixed with ``EF BB BF``; ``Repo
+hygiene`` passed all three and review caught it each time. One of those
+fragments would have rendered a stray ``\\ufeff`` onto a release page.
+
+A BOM is invisible in an editor and in a GitHub diff, which is why this is
+asserted by a test rather than trusted to a reader. The exemption half matters
+just as much: the demo receipt and the committed receipt vectors are
+byte-exact fixtures whose signatures are over the bytes, so a check that
+"helpfully" flagged their leading bytes would be a false positive nobody could
+fix without invalidating the evidence.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from check_bom import BOM, find_bom_files, main
+
+CLEAN = "# Heading\n\nBody text.\n"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(("git", *args), cwd=repo, capture_output=True, check=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A git repo with one exempt fixture path marked ``-text``."""
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "t@example.invalid")
+    _git(tmp_path, "config", "user.name", "T")
+    (tmp_path / "tests" / "fixtures" / "receipt-vectors").mkdir(parents=True)
+    (tmp_path / ".gitattributes").write_text("tests/fixtures/receipt-vectors/*.json -text\n", encoding="utf-8")
+    return tmp_path
+
+
+def _commit(repo: Path, relpath: str, data: bytes) -> Path:
+    path = repo / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", f"add {relpath}")
+    return path
+
+
+def test_bom_file_is_flagged(repo: Path) -> None:
+    _commit(repo, "notes.md", BOM + CLEAN.encode("utf-8"))
+
+    flagged = find_bom_files(repo)
+
+    assert [p.name for p in flagged] == ["notes.md"]
+
+
+def test_same_file_without_the_bom_passes(repo: Path) -> None:
+    """The content is identical; only the three leading bytes differ."""
+    _commit(repo, "notes.md", CLEAN.encode("utf-8"))
+
+    assert find_bom_files(repo) == []
+
+
+def test_text_marked_fixture_with_arbitrary_leading_bytes_passes(repo: Path) -> None:
+    """A ``-text`` fixture is exempt even when it does start with a BOM.
+
+    These are byte-exact signed vectors. Flagging them would be a finding no
+    one could act on without invalidating the evidence they exist to pin.
+    """
+    _commit(repo, "tests/fixtures/receipt-vectors/vec.json", BOM + b'{"a":1}\n')
+
+    assert find_bom_files(repo) == []
+
+
+def test_untracked_bom_file_is_ignored(repo: Path) -> None:
+    """The check is about what is *committed*, not what is lying around."""
+    (repo / "scratch.md").write_bytes(BOM + CLEAN.encode("utf-8"))
+
+    assert find_bom_files(repo) == []
+
+
+def test_non_text_suffix_is_not_swept(repo: Path) -> None:
+    _commit(repo, "blob.bin", BOM + b"\x00\x01\x02")
+
+    assert find_bom_files(repo) == []
+
+
+def test_bom_midway_through_a_file_is_not_flagged(repo: Path) -> None:
+    """Only a *leading* BOM breaks a renderer; U+FEFF elsewhere is content."""
+    _commit(repo, "notes.md", CLEAN.encode("utf-8") + BOM + b"tail\n")
+
+    assert find_bom_files(repo) == []
+
+
+def test_multiple_offenders_are_all_reported(repo: Path) -> None:
+    _commit(repo, "a.md", BOM + b"a\n")
+    _commit(repo, "b.toml", BOM + b'x = "y"\n')
+
+    flagged = sorted(p.name for p in find_bom_files(repo))
+
+    assert flagged == ["a.md", "b.toml"]
+
+
+def test_main_exits_nonzero_and_names_the_file(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _commit(repo, "notes.md", BOM + CLEAN.encode("utf-8"))
+
+    rc = main(["--repo-root", str(repo)])
+
+    assert rc == 1
+    assert "notes.md" in capsys.readouterr().out
+
+
+def test_main_exits_zero_on_a_clean_repo(repo: Path) -> None:
+    _commit(repo, "notes.md", CLEAN.encode("utf-8"))
+
+    assert main(["--repo-root", str(repo)]) == 0


### PR DESCRIPTION
Closes #4500.

## Why a check and not a reviewer

Three pull requests in a row (#4429, #4430, #4493) arrived with `EF BB BF` at the head of a committed release-notes fragment. `Repo hygiene` passed all three, and review caught it every time — one of those fragments would otherwise have rendered a stray `﻿` onto a release page.

A BOM is invisible in an editor and in a GitHub diff. That is precisely the class of fault that has to be machine-checked, because reading the file cannot find it.

## What it does

`scripts/check_bom.py` sweeps git-tracked files whose suffix is in a fixed text list (`.md`, `.py`, `.yaml`, `.yml`, `.toml`, `.json`, `.txt`, `.cfg`, `.ini`) and fails with the path named when one starts with a UTF-8 BOM. Wired into the `Repo hygiene` job next to the existing file-level checks.

Two deliberate choices:

- **A suffix allow-list, not "everything that isn't binary."** A new binary format should not start failing this check the day it lands.
- **Exemptions come from `git check-attr`, not from parsing `.gitattributes`.** Pattern precedence, negation and directory scoping stay git's to define rather than being re-implemented approximately.

## The exemption is the half that could go wrong quietly

`docs/assets/demo-run/*` and `tests/fixtures/receipt-vectors/*` are marked `-text` because their signatures are over the bytes. A check that flagged their leading bytes would be a finding nobody could act on without invalidating the evidence those fixtures exist to pin — so `test_text_marked_fixture_with_arbitrary_leading_bytes_passes` commits a `-text` fixture that *does* start with a BOM and asserts it passes.

## Tests

`tests/unit/test_bom_hygiene.py` — 9 tests against real git repositories, all passing. The three from the acceptance criteria, plus five that pin the boundaries:

- a BOM file is flagged; the byte-identical file without the BOM passes; a `-text` fixture with a leading BOM passes.
- an **untracked** BOM file is ignored — the check is about what is committed, not what is lying around a working tree.
- a non-text suffix is not swept.
- a BOM **midway through** a file is not flagged: only a leading one breaks a renderer, and U+FEFF elsewhere is content.
- multiple offenders are all reported, not just the first.
- `main` exits 1 naming the file, and 0 on a clean repo.

Run against this repository as it stands, the check exits 0 — the three historical offenders were fixed in review, so this is a guard against recurrence rather than a cleanup.

`ruff check` and `ruff format --check` clean; the workflow YAML parses.

## Out of scope

Line-ending normalisation (pre-commit owns it) and rewriting contributor history, per the issue.
