### PR TITLE
fix(skills): refuse a plugin install that would replace another source's skill

### DIFF
--- a/docs/operations/skills-catalog.md
+++ b/docs/operations/skills-catalog.md
@@ -190,3 +190,17 @@ drift checks treat them like any other local install. A malformed skill
 inside the pack is skipped with a diagnostic naming it rather than
 aborting the whole install. No MCP server registration happens here -
 that is the sibling slice (#3540, out of scope for #3772).
+
+A skill whose name already holds a lock row from a **different** source -
+`bernstein-skills.toml`, or another plugin - is refused the same way, with
+the reason naming the source it would have replaced (#4503). Overwriting it
+would delete an install the operator chose deliberately and flip that row's
+provenance to `"plugin"`, letting a pack shadow a trusted skill without
+saying so. Pass `--force` to take the plugin's copy anyway:
+
+```
+bernstein skills install ./my-pack --force
+```
+
+A same-source reinstall - drift heal, or upgrading a pack already recorded as
+`source = "plugin"` - is unaffected and stays silent.

--- a/docs/operations/skills-catalog.md
+++ b/docs/operations/skills-catalog.md
@@ -192,7 +192,7 @@ aborting the whole install. No MCP server registration happens here -
 that is the sibling slice (#3540, out of scope for #3772).
 
 A skill whose name already holds a lock row from a **different** source -
-`bernstein-skills.toml`, or another plugin - is refused the same way, with
+`bernstein-skills.toml` - is refused, with
 the reason naming the source it would have replaced (#4503). Overwriting it
 would delete an install the operator chose deliberately and flip that row's
 provenance to `"plugin"`, letting a pack shadow a trusted skill without

--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -307,7 +307,16 @@ def skills_init(name: str, scope: str, description: str | None) -> None:
     default=False,
     help="Allow installs that require explicit risk acceptance.",
 )
-def skills_install(source: Path, scope: str, override_name: str | None, strict: bool, accept_risk: bool) -> None:
+@click.option(
+    "--force",
+    "force",
+    is_flag=True,
+    default=False,
+    help="Replace a same-named skill that was installed from a different source.",
+)
+def skills_install(
+    source: Path, scope: str, override_name: str | None, strict: bool, accept_risk: bool, force: bool
+) -> None:
     """Install a skill from a local path.
 
     \b
@@ -331,6 +340,7 @@ def skills_install(source: Path, scope: str, override_name: str | None, strict: 
                 workdir=Path.cwd(),
                 strict_lint=strict,
                 accept_risk=accept_risk,
+                force=force,
             )
             for result in plugin_result.installed:
                 console.print(

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -780,6 +780,7 @@ def install_plugin_local(
     home: Path | None = None,
     strict_lint: bool = False,
     accept_risk: bool = False,
+    force: bool = False,
 ) -> PluginInstallResult:
     """Install every skill under an Agent Plugins directory layout.
 
@@ -789,6 +790,14 @@ def install_plugin_local(
     digest (``source="plugin"``) so a later ``sync`` can detect drift. An
     invalid individual skill is skipped with a diagnostic naming it rather
     than aborting the whole plugin install.
+
+    A skill whose name already holds a lock row from a *different* source -
+    ``bernstein-skills.toml``, or another plugin - is refused the same way,
+    naming the source it would have replaced. Overwriting it would delete an
+    install the operator chose deliberately and silently flip that row's
+    provenance to ``"plugin"``, letting a pack shadow a trusted skill. Pass
+    ``force=True`` to take the replacement anyway. A same-source reinstall
+    (drift heal, upgrade) is untouched and stays silent.
     """
     if not source.is_dir():
         raise SkillLifecycleError(
@@ -826,6 +835,11 @@ def install_plugin_local(
 
     installed: list[InstallResult] = []
     skipped: list[SkippedSkill] = []
+    # Read before the loop: the collision has to be caught *before*
+    # install_local writes, because that call already clobbers the target
+    # directory. Refusing only at lock-write time would leave the previous
+    # skill's tree destroyed with no row describing it.
+    existing_lock = {} if force else _read_lock(workdir / SKILLS_LOCK_FILENAME)
     for skill_dir in sorted(skills_dir.iterdir()):
         if not skill_dir.is_dir():
             continue
@@ -840,6 +854,12 @@ def install_plugin_local(
             # of the pack would install content the operator never saw.
             if _escapes(skills_dir, skill_dir):
                 raise SkillLifecycleError(f"{skill_dir}: skill directory resolves outside the plugin")
+            prior = existing_lock.get(name)
+            if prior is not None and prior.source != _PLUGIN_LOCK_SOURCE:
+                raise SkillLifecycleError(
+                    f"{name}: already installed from source {prior.source!r}; "
+                    f"installing this plugin would replace it. Re-run with --force to take the plugin's copy"
+                )
             parse_skill_md(skill_md)
             installed.append(
                 install_local(

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -792,7 +792,7 @@ def install_plugin_local(
     than aborting the whole plugin install.
 
     A skill whose name already holds a lock row from a *different* source -
-    ``bernstein-skills.toml``, or another plugin - is refused the same way,
+    ``bernstein-skills.toml`` - is refused the same way,
     naming the source it would have replaced. Overwriting it would delete an
     install the operator chose deliberately and silently flip that row's
     provenance to ``"plugin"``, letting a pack shadow a trusted skill. Pass

--- a/tests/unit/skills/test_plugin_cross_source_collision.py
+++ b/tests/unit/skills/test_plugin_cross_source_collision.py
@@ -1,0 +1,170 @@
+"""A plugin must not silently replace a skill that came from elsewhere.
+
+Covers the cross-source guard in ``install_plugin_local``
+(``src/bernstein/core/skills/lifecycle.py``). Before it, ``install_local`` +
+``_record_plugin_lock`` overwrote a same-named skill's install directory and
+lock row regardless of the prior row's ``source``: installing a pack
+containing ``alpha`` replaced an ``alpha`` from ``bernstein-skills.toml`` or
+another plugin with no warning, no refusal, and the row's provenance flipped
+to ``"plugin"``.
+
+That is a shadowing path, not just a tidiness problem - the operator chose the
+skill they installed, and nothing told them it was gone.
+
+The refusal has to bite *before* ``install_local`` runs, because that call
+already clobbers the target directory. A guard that only skipped the lock
+write would leave the previous skill's tree destroyed and unrecorded, which is
+strictly worse than the bug it replaced. ``test_refused_collision_leaves_the_
+previous_install_untouched`` is the assertion that pins that ordering.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.skills.lifecycle import (
+    SKILLS_LOCK_FILENAME,
+    InstallScope,
+    LockEntry,
+    _read_lock,
+    _write_lock,
+    install_plugin_local,
+    scope_root,
+)
+
+TOML_SOURCE = "bernstein-skills.toml"
+
+
+def _write_skill(path: Path, name: str, body: str = "Body content.") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        textwrap.dedent(
+            f"""\
+            ---
+            name: {name}
+            description: Plugin skill for tests.
+            ---
+
+            # {name}
+
+            {body}
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def plugin_dir(tmp_path: Path) -> Path:
+    root = tmp_path / "my-pack"
+    skills = root / "skills"
+    skills.mkdir(parents=True)
+    (root / "plugin.json").write_text(
+        json.dumps({"name": "my-pack", "version": "1.0.0", "skills": "./skills/"}),
+        encoding="utf-8",
+    )
+    for name in ("alpha", "beta"):
+        _write_skill(skills / name / "SKILL.md", name, body=f"From the plugin: {name}.")
+    return root
+
+
+@pytest.fixture
+def workdir_with_toml_alpha(tmp_path: Path) -> Path:
+    """A project whose lock already claims ``alpha`` from the TOML source."""
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    dest = scope_root(InstallScope.PROJECT, workdir=workdir) / "alpha"
+    _write_skill(dest / "SKILL.md", "alpha", body="From bernstein-skills.toml.")
+    _write_lock(
+        workdir / SKILLS_LOCK_FILENAME,
+        [LockEntry(name="alpha", source=TOML_SOURCE, path=str(dest), digest="sha256:deadbeef")],
+    )
+    return workdir
+
+
+def test_cross_source_collision_is_refused(plugin_dir: Path, workdir_with_toml_alpha: Path) -> None:
+    result = install_plugin_local(plugin_dir, scope=InstallScope.PROJECT, workdir=workdir_with_toml_alpha)
+
+    assert [s.name for s in result.skipped] == ["alpha"]
+    assert TOML_SOURCE in result.skipped[0].reason
+    assert "--force" in result.skipped[0].reason
+
+
+def test_non_colliding_skills_still_install(plugin_dir: Path, workdir_with_toml_alpha: Path) -> None:
+    """One refusal must not abort the pack - the per-skill contract holds."""
+    result = install_plugin_local(plugin_dir, scope=InstallScope.PROJECT, workdir=workdir_with_toml_alpha)
+
+    assert [r.name for r in result.installed] == ["beta"]
+
+
+def test_refused_collision_leaves_the_previous_install_untouched(
+    plugin_dir: Path, workdir_with_toml_alpha: Path
+) -> None:
+    """The refusal fires before install_local writes, so nothing is clobbered."""
+    dest = scope_root(InstallScope.PROJECT, workdir=workdir_with_toml_alpha) / "alpha" / "SKILL.md"
+    before = dest.read_text(encoding="utf-8")
+
+    install_plugin_local(plugin_dir, scope=InstallScope.PROJECT, workdir=workdir_with_toml_alpha)
+
+    assert dest.read_text(encoding="utf-8") == before
+    assert "bernstein-skills.toml" in dest.read_text(encoding="utf-8")
+
+
+def test_refused_collision_does_not_flip_lock_provenance(plugin_dir: Path, workdir_with_toml_alpha: Path) -> None:
+    install_plugin_local(plugin_dir, scope=InstallScope.PROJECT, workdir=workdir_with_toml_alpha)
+
+    entries = _read_lock(workdir_with_toml_alpha / SKILLS_LOCK_FILENAME)
+    assert entries["alpha"].source == TOML_SOURCE
+    assert entries["alpha"].digest == "sha256:deadbeef"
+
+
+def test_force_takes_the_plugin_copy(plugin_dir: Path, workdir_with_toml_alpha: Path) -> None:
+    result = install_plugin_local(plugin_dir, scope=InstallScope.PROJECT, workdir=workdir_with_toml_alpha, force=True)
+
+    assert {r.name for r in result.installed} == {"alpha", "beta"}
+    assert result.skipped == []
+    entries = _read_lock(workdir_with_toml_alpha / SKILLS_LOCK_FILENAME)
+    assert entries["alpha"].source == "plugin"
+    dest = scope_root(InstallScope.PROJECT, workdir=workdir_with_toml_alpha) / "alpha" / "SKILL.md"
+    assert "From the plugin" in dest.read_text(encoding="utf-8")
+
+
+def test_same_source_reinstall_stays_silent(plugin_dir: Path, tmp_path: Path) -> None:
+    """Drift heal and upgrade are unchanged: no refusal, no notice."""
+    workdir = tmp_path / "project"
+
+    first = install_plugin_local(plugin_dir, scope=InstallScope.PROJECT, workdir=workdir)
+    second = install_plugin_local(plugin_dir, scope=InstallScope.PROJECT, workdir=workdir)
+
+    assert {r.name for r in first.installed} == {"alpha", "beta"}
+    assert {r.name for r in second.installed} == {"alpha", "beta"}
+    assert second.skipped == []
+
+
+def test_collision_with_another_plugin_source_is_allowed(plugin_dir: Path, tmp_path: Path) -> None:
+    """Pack-over-pack keeps today's behaviour; only cross-*source* is refused.
+
+    Both rows carry ``source="plugin"``, so this is the same-source path. The
+    issue scopes namespacing skills by *pack* out, so a second pack shadowing
+    the first stays as it was rather than being half-fixed here.
+    """
+    workdir = tmp_path / "project"
+    install_plugin_local(plugin_dir, scope=InstallScope.PROJECT, workdir=workdir)
+
+    other = tmp_path / "other-pack"
+    (other / "skills").mkdir(parents=True)
+    (other / "plugin.json").write_text(
+        json.dumps({"name": "other-pack", "version": "1.0.0", "skills": "./skills/"}),
+        encoding="utf-8",
+    )
+    _write_skill(other / "skills" / "alpha" / "SKILL.md", "alpha", body="From other-pack.")
+
+    result = install_plugin_local(other, scope=InstallScope.PROJECT, workdir=workdir)
+
+    assert [r.name for r in result.installed] == ["alpha"]
+    assert result.skipped == []


### PR DESCRIPTION
Closes #4503.

## The decision: refuse, don't notify

The issue left the choice open. **I refuse without `--force`**, for three reasons:

1. **A notice is missable; a refusal is not.** Plugin installs land in CI logs and scrollback. A yellow line saying "replaced `alpha`" scrolls past; a skipped skill with a reason does not.
2. **The overwrite is not reversible.** Once `install_local` has run, the previous skill's tree is gone — there is nothing for the operator to restore *from* after reading the notice. Refusing is reversible in the other direction: add `--force` and re-run.
3. **The lock row's `source` is provenance.** Flipping it silently lets a pack shadow a skill the operator installed deliberately from `bernstein-skills.toml`. That is a shadowing path, not a tidiness problem.

The refusal reuses the existing per-skill skip contract, so it costs no new surface: one refused skill does not abort the pack, exactly as a malformed `SKILL.md` does not.

## The ordering is the substance of the fix

`install_local` clobbers the target directory *before* `_record_plugin_lock` ever runs. A guard placed at lock-write time would refuse the row while the previous skill's tree was already destroyed and now unrecorded — strictly worse than the bug it replaced.

So the lock is read **once, before the install loop**, and the collision is caught before `install_local` is called. `test_refused_collision_leaves_the_previous_install_untouched` reads the prior `SKILL.md` before and after and asserts it is byte-identical; that test fails against a lock-write-time guard.

## Tests

`tests/unit/skills/test_plugin_cross_source_collision.py` — 7 tests, all passing:

- the collision is refused, and the reason names both the previous source and `--force`;
- non-colliding skills in the same pack still install — the per-skill contract holds;
- **the previous install is untouched** (the ordering assertion above);
- the lock row keeps its original `source` *and* digest — provenance does not flip;
- `--force` takes the plugin's copy, flips the row to `"plugin"`, and writes the plugin's content;
- **same-source reinstall stays silent** — installing the same pack twice refuses nothing;
- pack-over-pack is explicitly left as-is, since both rows are `source="plugin"` and namespacing by pack is out of scope per the issue.

Full `tests/unit/skills/` suite: **354 passed**, so the existing sync-idempotence coverage the issue asked me to preserve is intact.

`ruff check` and `ruff format --check` clean.

## Surface

`install_plugin_local(..., force: bool = False)` and a `--force` flag on `bernstein skills install`. Docs updated per the documentation duty: `docs/operations/skills-catalog.md` gains the rule, the `--force` escape hatch, and the explicit statement that same-source reinstall is unaffected.
