### PR TITLE
feat(review): run the fix-until-green contour inside review --pipeline (#4481)

### DIFF
--- a/docs/operations/review-pipeline.md
+++ b/docs/operations/review-pipeline.md
@@ -19,6 +19,7 @@ runner, and aggregation logic live in `core/quality/review_pipeline/`
 bernstein review --pipeline review.yaml --validate-only
 bernstein review --pipeline review.yaml --pr 42 --dry-run
 bernstein review --pipeline templates/review/default-3-phase.yaml --pr 42
+bernstein review --pipeline review.yaml --pr 42 --fix --until-checks-green --max-passes 3
 ```
 
 Flags (all part of the existing `bernstein review` command,
@@ -37,9 +38,18 @@ Flags (all part of the existing `bernstein review` command,
 - `--dry-run` - print the resolved pipeline (stages, parallelism,
   aggregator, agents) without spawning any agent or calling any LLM.
 - `--workdir PATH` (default `.`) - repository root used to run `gh`.
+- `--fix` - run a fix pass between review passes. See
+  [the contour](#the-fix-until-green-contour).
+- `--until-checks-green` - withhold approval while the PR's check rollup is
+  not green.
+- `--max-passes N` (default `3`) - review budget for the contour.
+- `--fix-command CMD` - the command a fix pass runs; falls back to
+  `$BERNSTEIN_REVIEW_FIX_COMMAND`.
 
-Fetching the diff shells out to `gh pr view` and `gh pr diff`, so the
-`gh` CLI must be installed and authenticated against the target repo.
+Fetching the diff shells out to `gh pr view` and `gh pr diff`, and the check
+rollup goes through the same `gh pr view` helper
+(`runner.py:gh_pr_view_json`), so the `gh` CLI must be installed and
+authenticated against the target repo. There is no second HTTP path.
 
 ---
 
@@ -96,6 +106,7 @@ final gatekeeper) ships at `templates/review/default-3-phase.yaml`.
 | `pass_threshold` | `0.5` | Default pass fraction used by the `weighted` strategy when a stage doesn't override it. |
 | `block_on_fail` | `true` | When true, a `request_changes` pipeline verdict blocks the janitor/merge gate, the same way the legacy cross-model verifier does. |
 | `stages` | required, min 1 | Sequential - no diamond joins. Stage names must be unique. |
+| `rules` | `null` | Where the review ruleset lives: a path string, or a mapping with `path` / `raise` / `guard`. `null` falls back to `.bernstein/review-rules.md`. |
 
 ### Stage fields (`StageSpec`)
 
@@ -122,6 +133,108 @@ type mismatches fail validation rather than being silently ignored.
 `load_pipeline()` re-parses the YAML to attach the originating line
 number to validation errors, so `--validate-only` output points at the
 offending line rather than just a Pydantic path.
+
+---
+
+## The review ruleset
+
+A review drifts when its standard lives only in a prompt. A repository can
+declare that standard in `.bernstein/review-rules.md` (or wherever the
+pipeline's `rules:` key points) with two kinds of entry:
+
+- **raise rules** - a defect class the reviewer must flag;
+- **guard rules** - a finding the reviewer must *not* raise, because an
+  operator already rejected it as a false positive. Without them every
+  unattended pass re-reports the same rejected finding and the fix pass
+  chases it.
+
+Bullets under a heading starting with `Raise` or `Guard` become rules;
+everything else on the page is prose the parser ignores. A worked example
+ships at `templates/review/review-rules.example.md`.
+
+```markdown
+## Raise
+
+- A bare `except:` that swallows the traceback.
+
+## Guard
+
+- `assert` inside `tests/` is not a security finding.
+```
+
+The pipeline's `rules:` key accepts either form:
+
+```yaml
+rules: review/house-rules.md          # a path, resolved against the YAML's dir
+```
+
+```yaml
+rules:                                 # or a mapping, which may also extend a file
+  path: review/house-rules.md
+  guard:
+    - The vendored parser is exempt from the style rules.
+```
+
+`ReviewRuleset.digest` is a SHA-256 over the *canonical* rule set - sorted and
+de-duplicated - so reordering the file leaves the digest alone while editing a
+rule moves it. That digest goes into every review receipt, so a verdict names
+the standard it was produced under, and into the pipeline's audit events.
+
+**With no rules file the pipeline is unchanged.** The ruleset is empty, it
+renders to no prompt section (the reviewer prompt is byte-identical to what
+the pipeline sent before rulesets existed), and the digest is the stable
+digest of the empty set. A `rules:` key that names a file which does not
+exist is an error rather than a silent fallback - a typo there would review
+against no standard at all.
+
+---
+
+## The fix-until-green contour
+
+`--fix` / `--until-checks-green` turn the single verdict into a bounded loop
+(`core/quality/review_pipeline/contour.py`):
+
+1. wait, bounded, for the PR's check rollup to settle;
+2. run the pipeline against the PR's current diff;
+3. stop when the pipeline approves and - under `--until-checks-green` - the
+   checks are green;
+4. otherwise run a fix pass whose inputs are the verdict *and* the failing
+   checks' log excerpts (fetched with the existing `gh run view --log-failed`
+   wrapper), then start the next pass;
+5. at `--max-passes`, stop with an explicit `needs-operator` outcome and a
+   non-zero exit code - never an approval.
+
+The fix pass is an operator-supplied command: `--fix-command` (or
+`$BERNSTEIN_REVIEW_FIX_COMMAND`) is invoked with the rendered prompt's path as
+its last argument, and counts as a pass only when it exits 0 *and* `HEAD`
+moved. A command that changed nothing cannot change the next rollup, so the
+contour stops rather than burning the rest of the budget. `--fix` without a
+command reviews once and hands back to the operator; the contour never
+approves by default.
+
+### Per-pass receipts
+
+Every pass emits a review receipt through the existing `review-receipt`
+machinery, binding the reviewed diff hash, the ruleset digest, the pass index
+and the verdict, signed with the install's Ed25519 identity and anchored in
+the review lineage spine. Each pass records the previous pass's anchor, so the
+passes form a chain:
+
+```
+bernstein review-receipt verify --chain --pr <url> \
+    --issue issue.md --diff pr.diff --rules .bernstein/review-rules.md
+```
+
+`verify --chain` walks every pass offline: each one must recompute, carry the
+previous pass's anchor, and name the same ruleset, and `--diff` is checked
+against the last pass. Exit codes are the single-receipt ones - 0 verified,
+1 no chain, 2 mismatch. Editing a receipt's stored diff hash or ruleset digest
+breaks that pass's signature; presenting a different diff or a different rules
+file breaks the comparison.
+
+A single-pass receipt keeps the path and the binding it always had: the three
+contour fields are omitted from the signed binding while unset, so receipts
+emitted before the contour existed still verify.
 
 ---
 
@@ -176,9 +289,11 @@ replacement behaviour.
   an `AuditLog` into `run_pipeline_sync()` - stage-level HMAC-chained
   audit entries are only emitted when the pipeline is invoked
   programmatically with an `audit_log` argument (see `runner.py:run_pipeline`,
-  the `audit_log` parameter). Running the DSL from the CLI does not by
-  itself produce an audit trail beyond whatever the janitor's own gate
-  recording does.
+  the `audit_log` parameter). The contour path is the exception: it emits a
+  signed, spine-anchored receipt per pass and mirrors each into the audit
+  chain.
+- The contour does not merge and does not handle auth. The caller supplies an
+  authenticated `gh`, and landing the PR stays a separate decision.
 - There is no `bernstein review --pipeline ... --task` shortcut in the
   CLI today; `diff_from_task()` exists but is only reachable from
   orchestrator/janitor integration code, not from the `review` command
@@ -202,7 +317,14 @@ replacement behaviour.
   execution, prompt assembly, diff sourcing.
 - `src/bernstein/core/quality/review_pipeline/verdict.py` - aggregation
   strategies and pipeline-level verdict rollup.
+- `src/bernstein/core/quality/review_pipeline/ruleset.py` - the raise / guard
+  rules, their canonical digest, and the prompt section they render to.
+- `src/bernstein/core/quality/review_pipeline/contour.py` - the check rollup,
+  the bounded wait, the fix pass, the loop, and the per-pass receipt emitter.
+- `src/bernstein/core/review/receipt.py` - `verify_review_chain` and the
+  per-pass receipt fields.
 - `templates/review/default-3-phase.yaml` - shipped example pipeline.
+- `templates/review/review-rules.example.md` - shipped example ruleset.
 
 See also [Fresh-context review gate](../orchestration/review-gate.md) for
 the single-stage gate contract (fresh session, distinct model, restricted

--- a/docs/operations/review-receipts.md
+++ b/docs/operations/review-receipts.md
@@ -30,6 +30,34 @@ The tracker comment posted on a PR is a *projection* of the receipt — a
 short verdict plus the `verify` invocation a reviewer can run — never the
 receipt body itself.
 
+## Per-pass receipts from the review contour
+
+`bernstein review --pipeline ... --fix --until-checks-green` reviews a PR
+repeatedly until it approves with green checks or its budget is spent, and
+emits one receipt per pass. Those receipts additionally bind the pass index,
+the digest of the ruleset the verdict was produced under, and the previous
+pass's spine anchor, so the passes form a chain:
+
+```
+bernstein review-receipt verify --chain --pr <url> \
+    --issue <issue.md> --diff <pr.diff> [--rules <rules.md>] [--workdir DIR]
+```
+
+`--chain` walks every pass in order. Each one must recompute its issue hash,
+carry a valid Ed25519 signature over its own binding, re-anchor against the
+spine, and record the previous pass's anchor; all passes must name the same
+ruleset, and `--rules` checks that ruleset against the file presented. The
+`--diff` is checked against the last pass. Exit codes match the single-receipt
+form: `0` verified, `1` no chain found, `2` mismatch.
+
+Editing a stored `diff_hash` or `ruleset_digest` breaks that pass's signature,
+so a receipt cannot be re-pointed at a different diff or a laxer standard.
+A single-pass receipt keeps its historical path and binding — the three
+contour fields are omitted from the signed preimage while unset — so
+receipts emitted before the contour existed still verify unchanged.
+
+See [Review pipeline DSL](review-pipeline.md) for the loop that produces them.
+
 ## Autofix receipts
 
 An `AutofixReceipt` links a reviewer *finding* to the commit that fixed it
@@ -61,5 +89,8 @@ several other receipt families documented separately:
 ## Source
 
 `src/bernstein/core/review/receipt.py` (`ReviewReceipt`, `AutofixReceipt`,
-emit/verify logic), `src/bernstein/cli/commands/review_receipt_cmd.py`
-(`bernstein review-receipt`).
+`verify_review_chain`, emit/verify logic),
+`src/bernstein/cli/commands/review_receipt_cmd.py`
+(`bernstein review-receipt`),
+`src/bernstein/core/quality/review_pipeline/contour.py`
+(`receipt_emitter`, the per-pass emitter the contour wires).

--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -188,7 +188,7 @@ test, and a row naming a command the CLI no longer registers fails it too.
 | [Fleet dashboard](../operations/fleet.md) | Full | 3 | `bernstein fleet [--web HOST:PORT]` cross-session multi-instance view (`core/fleet/`) |
 | [Notification sinks](../operations/notifications.md) | Full | 3 | `bernstein notify test --sink <id>` pluggable notification backends (`core/notifications/`) |
 | [PR review responder](../operations/review-responder.md) | Full | 3 | `bernstein review-responder start/status/tick` auto-responds to PR review comments (`core/review_responder/`) |
-| [Review pipeline DSL](../operations/review-pipeline.md) | Full | 3 | `bernstein review --pipeline review.yaml` YAML-driven multi-phase review (`core/quality/review_pipeline/`) |
+| [Review pipeline DSL](../operations/review-pipeline.md) | Full | 3 | `bernstein review --pipeline review.yaml` YAML-driven multi-phase review, plus the bounded `--fix --until-checks-green` contour and its per-pass receipts (`core/quality/review_pipeline/`) |
 | [Plan archival](../operations/plan-archival.md) | Full | 3 | `bernstein plan ls/show` list and inspect archived plans (`core/planning/lifecycle.py`) |
 | [Slack integration](../operations/slack-webhooks.md) | Full | 3 | Slash commands and events API endpoints |
 | [Webhook ingestion](../integrations/automation-bridge.md) | Full | 3 | `POST /webhooks/` for external event routing |

--- a/docs/release-notes/fragments/4481-review-pipeline-contour.md
+++ b/docs/release-notes/fragments/4481-review-pipeline-contour.md
@@ -1,0 +1,16 @@
+## Review runs to an outcome, and every pass leaves a receipt
+
+`bernstein review --pipeline` stopped at a verdict, so the loop that turns a
+verdict into an outcome on the pull request lived in whatever shell an operator
+wrote around the CLI, each with its own stop condition and no record of what was
+reviewed. `--fix --until-checks-green --max-passes N` now runs that loop inside
+the product: wait for the check rollup to settle, review the current diff, hand
+the verdict and the failing checks' log excerpts to a fix pass, repeat. A spent
+budget exits non-zero with a `needs-operator` outcome rather than an approval. A
+repository can declare the standard the review is held to in
+`.bernstein/review-rules.md` -- defect classes to raise, plus the findings not to
+raise -- and every pass emits a signed, spine-anchored receipt binding the
+reviewed diff hash, that ruleset's digest, the pass index and the verdict.
+`review-receipt verify --chain` walks the sequence offline and rejects a pass
+whose diff or ruleset moved. With no rules file the pipeline behaves exactly as
+before (#4481).

--- a/src/bernstein/cli/commands/review_pipeline_cmd.py
+++ b/src/bernstein/cli/commands/review_pipeline_cmd.py
@@ -1,16 +1,23 @@
 """CLI handler for ``bernstein review --pipeline ...``.
 
 Glue between the Click frontend in :mod:`bernstein.cli.commands.task_cmd`
-and the review pipeline runner.  Handles three modes:
+and the review pipeline runner.  Handles four modes:
 
 * ``--validate-only``: parse the YAML, exit 0/1 with a friendly message.
 * ``--dry-run``: print the resolved pipeline as a verdict table; no LLM.
+* ``--fix`` / ``--until-checks-green``: run the fix-until-green contour and
+  print one row per pass.
 * default: fetch the PR's diff, run the pipeline, print the verdict table.
+
+The contour itself lives in
+:mod:`bernstein.core.quality.review_pipeline.contour`; this module only
+assembles its inputs and forwards its exit code.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -23,15 +30,28 @@ from bernstein.core.quality.review_pipeline import (
     PipelineVerdict,
     ReviewPipeline,
     ReviewPipelineError,
+    ReviewRulesetError,
+    check_log_fetcher,
+    check_rollup_from_pr,
+    command_fix_runner,
     diff_from_pr,
+    gh_pr_view_json,
     load_pipeline,
+    load_ruleset,
+    receipt_emitter,
     run_pipeline_sync,
+    run_review_contour,
 )
 
 if TYPE_CHECKING:
+    from bernstein.core.quality.review_pipeline.contour import ContourResult
+    from bernstein.core.quality.review_pipeline.ruleset import ReviewRuleset
     from bernstein.core.quality.review_pipeline.verdict import StageVerdict
 
 logger = logging.getLogger(__name__)
+
+#: Environment fallback for ``--fix-command``.
+FIX_COMMAND_ENV = "BERNSTEIN_REVIEW_FIX_COMMAND"
 
 
 def run_review_pipeline_cli(
@@ -41,10 +61,28 @@ def run_review_pipeline_cli(
     validate_only: bool,
     dry_run: bool,
     workdir: str = ".",
+    fix: bool = False,
+    until_checks_green: bool = False,
+    max_passes: int = 3,
+    fix_command: str | None = None,
 ) -> int:
     """Drive the review pipeline CLI flow.
 
-    Returns the process exit code (0 on approve, 1 on request_changes or error).
+    Args:
+        pipeline_path: Path to the pipeline YAML.
+        pr_number: PR under review.
+        validate_only: Validate the YAML and stop.
+        dry_run: Print the resolved pipeline and stop.
+        workdir: Repository root ``gh`` runs in.
+        fix: Run a fix pass between review passes.
+        until_checks_green: Withhold approval while the checks are not green.
+        max_passes: Review budget for the contour.
+        fix_command: Command the fix pass runs; falls back to
+            ``$BERNSTEIN_REVIEW_FIX_COMMAND``.
+
+    Returns:
+        The process exit code (0 on approve, 1 on request_changes,
+        ``needs-operator``, or error; 2 on a usage mistake).
     """
     if pipeline_path is None:
         console.print("[red]--pipeline is required when using --validate-only / --dry-run / --pr.[/red]")
@@ -82,8 +120,31 @@ def run_review_pipeline_cli(
         console.print("[red]--pr <N> is required to run the pipeline.[/red]")
         return 2
 
+    root = Path(workdir)
     try:
-        diff_src = diff_from_pr(pr_number, repo_root=Path(workdir))
+        ruleset = load_ruleset(
+            repo_root=root,
+            rules=pipeline.rules,
+            base_dir=Path(pipeline_path).parent,
+        )
+    except ReviewRulesetError as exc:
+        console.print(Panel(f"[bold red]{exc}[/bold red]", border_style="red", expand=False))
+        return 1
+
+    if fix or until_checks_green:
+        return _run_contour(
+            pipeline,
+            ruleset=ruleset,
+            pr_number=pr_number,
+            root=root,
+            fix=fix,
+            until_checks_green=until_checks_green,
+            max_passes=max_passes,
+            fix_command=fix_command,
+        )
+
+    try:
+        diff_src = diff_from_pr(pr_number, repo_root=root)
     except RuntimeError as exc:
         console.print(
             Panel(
@@ -94,9 +155,114 @@ def run_review_pipeline_cli(
         )
         return 1
 
-    verdict = run_pipeline_sync(pipeline, diff_src)
+    verdict = run_pipeline_sync(pipeline, diff_src, ruleset=ruleset)
     _print_verdict_table(pipeline, verdict, diff_src)
     return 0 if verdict.verdict == "approve" else 1
+
+
+def _repo_slug(pr_url: str) -> str:
+    """Derive ``owner/repo`` from a pull-request url, offline."""
+    parts = [p for p in pr_url.split("/") if p]
+    if len(parts) >= 4 and parts[-2] == "pull":
+        return f"{parts[-4]}/{parts[-3]}"
+    return ""
+
+
+def _run_contour(
+    pipeline: ReviewPipeline,
+    *,
+    ruleset: ReviewRuleset,
+    pr_number: int,
+    root: Path,
+    fix: bool,
+    until_checks_green: bool,
+    max_passes: int,
+    fix_command: str | None,
+) -> int:
+    """Assemble the contour's collaborators and forward its exit code."""
+    try:
+        meta = gh_pr_view_json(pr_number, "url,body", repo_root=root)
+    except RuntimeError as exc:
+        console.print(
+            Panel(
+                f"[bold red]Could not read PR #{pr_number}[/bold red]\n{exc}",
+                border_style="red",
+                expand=False,
+            )
+        )
+        return 1
+
+    pr_url = str(meta.get("url", ""))
+    emit = None
+    if pr_url:
+        emit = receipt_emitter(
+            workdir=root,
+            pr_url=pr_url,
+            repo=_repo_slug(pr_url),
+            issue_body=str(meta.get("body", "")),
+        )
+    else:
+        console.print("[yellow]No PR url available - passes will run without receipts.[/yellow]")
+
+    command = fix_command or os.environ.get(FIX_COMMAND_ENV, "")
+    fix_runner = command_fix_runner(command, repo_root=root) if (fix and command) else None
+    if fix and fix_runner is None:
+        console.print(
+            f"[yellow]--fix needs a fix command (--fix-command or ${FIX_COMMAND_ENV}); "
+            "the contour will review once and hand back.[/yellow]"
+        )
+
+    result = run_review_contour(
+        pipeline,
+        fetch_diff=lambda: diff_from_pr(pr_number, repo_root=root),
+        read_rollup=lambda: check_rollup_from_pr(pr_number, repo_root=root),
+        review=lambda diff_src: run_pipeline_sync(pipeline, diff_src, ruleset=ruleset),
+        ruleset=ruleset,
+        fetch_logs=check_log_fetcher(),
+        fix_runner=fix_runner,
+        emit_receipt=emit,
+        max_passes=max_passes,
+        until_checks_green=until_checks_green,
+        pr_number=pr_number,
+    )
+    _print_contour_table(result, pr_number=pr_number, ruleset=ruleset)
+    return result.exit_code
+
+
+def _print_contour_table(result: ContourResult, *, pr_number: int, ruleset: ReviewRuleset) -> None:
+    """Render one row per pass plus the contour's single outcome."""
+    approved = result.outcome == "approved"
+    headline = "[bold green]APPROVED[/bold green]" if approved else "[bold red]NEEDS OPERATOR[/bold red]"
+    console.print(
+        Panel(
+            f"{headline}  target=[bold]PR #{pr_number}[/bold]  ruleset=[bold]{ruleset.digest}[/bold]",
+            border_style="green" if approved else "red",
+            expand=False,
+        )
+    )
+
+    table = Table(title="Review passes")
+    table.add_column("#", style="dim", width=3)
+    table.add_column("Verdict")
+    table.add_column("Checks")
+    table.add_column("Diff")
+    table.add_column("Receipt")
+    table.add_column("Fix pushed")
+    for record in result.passes:
+        marker = "[green]approve[/green]" if record.verdict == "approve" else "[red]request_changes[/red]"
+        table.add_row(
+            str(record.index),
+            marker,
+            record.checks_state,
+            record.diff_hash[:19],
+            record.receipt_entry_hash[:19] or "-",
+            "yes" if record.fix_pushed else "no",
+        )
+    console.print(table)
+
+    if result.reason:
+        console.print()
+        console.print(f"[yellow]{result.reason}[/yellow]")
 
 
 def _print_pipeline_summary(pipeline: ReviewPipeline) -> None:

--- a/src/bernstein/cli/commands/review_receipt_cmd.py
+++ b/src/bernstein/cli/commands/review_receipt_cmd.py
@@ -155,6 +155,19 @@ def review_receipt_emit_cmd(
 @click.option("--issue", "issue_file", required=True, type=click.Path(exists=True, dir_okay=False))
 @click.option("--diff", "diff_file", required=True, type=click.Path(exists=True, dir_okay=False))
 @click.option(
+    "--chain",
+    is_flag=True,
+    default=False,
+    help="Verify every pass of a review contour, not just the single-pass receipt.",
+)
+@click.option(
+    "--rules",
+    "rules_file",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Rules file whose digest every pass must have been reviewed under (--chain only).",
+)
+@click.option(
     "--workdir",
     "-w",
     type=click.Path(file_okay=False, exists=True),
@@ -162,18 +175,31 @@ def review_receipt_emit_cmd(
     show_default=True,
     help="Project root containing .sdd/.",
 )
-def review_receipt_verify_cmd(pr_url: str, issue_file: str, diff_file: str, workdir: str) -> None:
+def review_receipt_verify_cmd(
+    pr_url: str,
+    issue_file: str,
+    diff_file: str,
+    chain: bool,
+    rules_file: str | None,
+    workdir: str,
+) -> None:
     """Prove offline that the PR's diff was reviewed against the issue.
 
     Recomputes ``issue_hash`` and ``diff_hash`` from the presented inputs and
-    checks the Ed25519 signature and spine anchor. Exit codes: 0 = verified,
-    1 = no receipt / bad input, 2 = mismatch (tamper).
+    checks the Ed25519 signature and spine anchor. With ``--chain`` the whole
+    fix-until-green sequence is walked: every pass must recompute, carry the
+    previous pass's anchor, and name the same ruleset, and ``--diff`` is
+    checked against the last pass. Exit codes: 0 = verified, 1 = no receipt /
+    bad input, 2 = mismatch (tamper).
     """
     from bernstein.core.review.receipt import verify_review_receipt
 
     root = Path(workdir).resolve()
     issue_body = Path(issue_file).read_text(encoding="utf-8")
     diff = Path(diff_file).read_bytes()
+
+    if chain:
+        _verify_chain(root, pr_url=pr_url, issue_body=issue_body, diff=diff, rules_file=rules_file)
 
     result = verify_review_receipt(
         workdir=root,
@@ -191,6 +217,46 @@ def review_receipt_verify_cmd(pr_url: str, issue_file: str, diff_file: str, work
         raise SystemExit(0)
     if result.receipt is None:
         console.print(f"[yellow]NO RECEIPT[/yellow] -- {result.reason}")
+        raise SystemExit(1)
+    console.print(f"[red]MISMATCH[/red] -- {result.reason}")
+    raise SystemExit(2)
+
+
+def _verify_chain(
+    root: Path,
+    *,
+    pr_url: str,
+    issue_body: str,
+    diff: bytes,
+    rules_file: str | None,
+) -> None:
+    """Walk every pass of a review contour and exit with its verdict."""
+    from bernstein.core.quality.review_pipeline.ruleset import parse_ruleset
+    from bernstein.core.review.receipt import verify_review_chain
+
+    digest = None
+    if rules_file is not None:
+        digest = parse_ruleset(Path(rules_file).read_text(encoding="utf-8"), source=rules_file).digest
+
+    result = verify_review_chain(
+        workdir=root,
+        lineage_root=_lineage_root(root),
+        hmac_key=_load_hmac_key(),
+        pr_url=pr_url,
+        issue_body=issue_body,
+        diff=diff,
+        ruleset_digest=digest,
+    )
+    console.print()
+    console.print(f"[bold]Review chain verify[/bold] pr={pr_url}")
+    console.print(f"  passes  {result.passes}")
+    if result.ok:
+        console.print(f"  verdict {result.verdict}")
+        console.print(f"  ruleset {result.ruleset_digest or '(none)'}")
+        console.print("[green]OK[/green] -- every pass recomputed and the chain holds.")
+        raise SystemExit(0)
+    if result.passes == 0:
+        console.print(f"[yellow]NO CHAIN[/yellow] -- {result.reason}")
         raise SystemExit(1)
     console.print(f"[red]MISMATCH[/red] -- {result.reason}")
     raise SystemExit(2)

--- a/src/bernstein/cli/commands/task_cmd.py
+++ b/src/bernstein/cli/commands/task_cmd.py
@@ -421,12 +421,43 @@ def cancel(task_id: str, reason: str) -> None:
     default=False,
     help="Print the resolved pipeline without spawning agents or hitting any LLM.",
 )
+@click.option(
+    "--fix",
+    is_flag=True,
+    default=False,
+    help="Run a fix pass between review passes, fed the verdict and the failing checks' logs.",
+)
+@click.option(
+    "--until-checks-green",
+    "until_checks_green",
+    is_flag=True,
+    default=False,
+    help="Withhold approval until the PR's check rollup is green.",
+)
+@click.option(
+    "--max-passes",
+    "max_passes",
+    default=3,
+    show_default=True,
+    type=int,
+    help="Review budget; the contour stops with a needs-operator outcome once it is spent.",
+)
+@click.option(
+    "--fix-command",
+    "fix_command",
+    default=None,
+    help="Command the fix pass runs, given the rendered prompt's path as its last argument.",
+)
 def review_cmd(
     workdir: str,
     pipeline_path: str | None,
     pr_number: int | None,
     validate_only: bool,
     dry_run: bool,
+    fix: bool,
+    until_checks_green: bool,
+    max_passes: int,
+    fix_command: str | None,
 ) -> None:
     """Trigger a manager queue review or run a YAML review pipeline.
 
@@ -439,12 +470,18 @@ def review_cmd(
     verdict table.  ``--validate-only`` exits after schema validation;
     ``--dry-run`` prints the resolved pipeline without spawning any agent.
 
+    With ``--fix`` / ``--until-checks-green``: runs review, fix and re-check
+    in a loop bounded by ``--max-passes``, emits one chained review receipt
+    per pass, and exits non-zero with a ``needs-operator`` outcome rather
+    than an approval when the budget is spent.
+
     \b
     Examples:
       bernstein review
       bernstein review --pipeline review.yaml --validate-only
       bernstein review --pipeline review.yaml --pr 42 --dry-run
       bernstein review --pipeline templates/review/default-3-phase.yaml --pr 42
+      bernstein review --pipeline review.yaml --pr 42 --fix --until-checks-green --max-passes 3
     """
     if pipeline_path is not None or validate_only or dry_run or pr_number is not None:
         # Lazy import - keep the legacy fast path zero-cost.
@@ -456,6 +493,10 @@ def review_cmd(
             validate_only=validate_only,
             dry_run=dry_run,
             workdir=workdir,
+            fix=fix,
+            until_checks_green=until_checks_green,
+            max_passes=max_passes,
+            fix_command=fix_command,
         )
         raise SystemExit(exit_code)
 

--- a/src/bernstein/core/quality/AGENTS.md
+++ b/src/bernstein/core/quality/AGENTS.md
@@ -13,7 +13,7 @@ configurable gate pipeline plus the janitor's claim verification.
 | `janitor.py` | Claim verification: did the agent do what its result claims |
 | `absence_coverage.py` | Absence-claim coverage verification: classifies a completion built on an absence claim (`glob_exists`/`file_contains` "not found", or a journal read) as `unverified` unless a coverage record backs it (#3650/#3769/#3770/#3771) |
 | `verifier_ladder.py` | Multi-tier verifier ladder with signed, re-derivable per-tier receipts (#2927) |
-| `review_pipeline/` | Fresh-context cross-model review gate |
+| `review_pipeline/` | Fresh-context cross-model review gate, the ruleset a verdict is produced under (`ruleset.py`), and the bounded review -> fix -> re-check contour with one chained receipt per pass (`contour.py`, #4481) |
 | `formal_verification.py` | Z3/Lean4 checks over scalar task metadata |
 
 ## Invariants
@@ -31,6 +31,12 @@ configurable gate pipeline plus the janitor's claim verification.
 - Absence-claim coverage fails closed: a coverage record that cannot be read
   back (missing, malformed, or a dangling lineage reference) must classify as
   no-coverage, never as a fabricated passing record (`absence_coverage.py`).
+- The review contour fails closed too: a spent budget, a missing fix runner, or
+  a fix pass that landed no commit ends in `needs-operator` with a non-zero
+  exit code, never in an approval (`review_pipeline/contour.py`).
+- An empty review ruleset must leave the reviewer prompt byte-identical to the
+  pre-ruleset prompt, so a repository without `.bernstein/review-rules.md`
+  reviews exactly as it did before (`review_pipeline/ruleset.py`).
 
 ## Testing
 

--- a/src/bernstein/core/quality/AGENTS.md
+++ b/src/bernstein/core/quality/AGENTS.md
@@ -13,30 +13,24 @@ configurable gate pipeline plus the janitor's claim verification.
 | `janitor.py` | Claim verification: did the agent do what its result claims |
 | `absence_coverage.py` | Absence-claim coverage verification: classifies a completion built on an absence claim (`glob_exists`/`file_contains` "not found", or a journal read) as `unverified` unless a coverage record backs it (#3650/#3769/#3770/#3771) |
 | `verifier_ladder.py` | Multi-tier verifier ladder with signed, re-derivable per-tier receipts (#2927) |
-| `review_pipeline/` | Fresh-context cross-model review gate, the ruleset a verdict is produced under (`ruleset.py`), and the bounded review -> fix -> re-check contour with one chained receipt per pass (`contour.py`, #4481) |
+| `review_pipeline/` | Fresh-context cross-model review gate, the ruleset a verdict is produced under (`review_pipeline/ruleset.py`), and the bounded review -> fix -> re-check contour with one chained receipt per pass (`review_pipeline/contour.py`, #4481) |
 | `formal_verification.py` | Z3/Lean4 checks over scalar task metadata |
 
 ## Invariants
 
-- Gate names are a closed set: a step name must be in `VALID_GATE_NAMES` or
-  come from a registered gate plugin; the runner rejects anything else
-  (`gate_runner.py`).
+- Gate names are a closed set: a step name must be in `VALID_GATE_NAMES` or come
+  from a registered gate plugin; anything else is rejected (`gate_runner.py`).
 - Defaults are deliberate: `lint`, `pii_scan`, `dlp_scan`, `run_config` on;
-  `tests`, `type_check`, heavier gates off (`quality_gates.py`); never flip one
-  as a side effect. `run_config` is a safety invariant (`../config/run_overlay.py`).
-- Blocking vs advisory semantics are per-gate; a new gate must declare
-  which it is.
-- No package-level `__getattr__` re-export magic in this package;
-  import submodules by full path (`__init__.py` explains why).
-- Absence-claim coverage fails closed: a coverage record that cannot be read
-  back (missing, malformed, or a dangling lineage reference) must classify as
-  no-coverage, never as a fabricated passing record (`absence_coverage.py`).
-- The review contour fails closed too: a spent budget, a missing fix runner, or
-  a fix pass that landed no commit ends in `needs-operator` with a non-zero
-  exit code, never in an approval (`review_pipeline/contour.py`).
-- An empty review ruleset must leave the reviewer prompt byte-identical to the
-  pre-ruleset prompt, so a repository without `.bernstein/review-rules.md`
-  reviews exactly as it did before (`review_pipeline/ruleset.py`).
+  `tests`, `type_check`, heavier gates off (`quality_gates.py`); never flip one as
+  a side effect. `run_config` is a safety invariant (`../config/run_overlay.py`).
+- Blocking vs advisory semantics are per-gate; a new gate declares which. No
+  package-level `__getattr__` re-export magic here (`__init__.py` explains why).
+- Absence-claim coverage fails closed: a coverage record that cannot be read back
+  classifies as no-coverage, never as a fabricated pass (`absence_coverage.py`).
+- The review contour fails closed too: a spent budget, a missing fix runner, or a
+  fix pass that landed no commit ends in `needs-operator` and a non-zero exit
+  code, never in an approval (`review_pipeline/contour.py`); an empty ruleset
+  leaves the reviewer prompt byte-identical (`review_pipeline/ruleset.py`).
 
 ## Testing
 

--- a/src/bernstein/core/quality/review_pipeline/__init__.py
+++ b/src/bernstein/core/quality/review_pipeline/__init__.py
@@ -13,6 +13,10 @@ Public API:
 * :class:`AgentVerdict` / :class:`StageVerdict` / :class:`PipelineVerdict`
 * :func:`run_pipeline` / :func:`run_pipeline_sync`
 * :func:`should_block_merge` / :func:`to_cross_model_verdict`
+* :class:`ReviewRuleset` / :func:`load_ruleset` - the raise and guard rules a
+  verdict is produced under, and the digest that names them.
+* :func:`run_review_contour` - the review -> fix -> re-check loop, its bounded
+  budget, and one chained review receipt per pass.
 """
 
 from __future__ import annotations
@@ -20,6 +24,26 @@ from __future__ import annotations
 from bernstein.core.quality.review_pipeline.ast_chunker import (
     ReviewChunk,
     chunk_for_review,
+)
+from bernstein.core.quality.review_pipeline.contour import (
+    CheckLogExcerpt,
+    CheckRollup,
+    CheckRun,
+    CheckState,
+    ContourOutcome,
+    ContourResult,
+    FixOutcome,
+    FixRequest,
+    FixRunner,
+    PassReceiptEmitter,
+    PassReceiptRequest,
+    PassRecord,
+    check_log_fetcher,
+    command_fix_runner,
+    receipt_emitter,
+    rollup_from_payload,
+    run_review_contour,
+    wait_for_checks,
 )
 from bernstein.core.quality.review_pipeline.review_gate import (
     EvalGateConfigError,
@@ -32,10 +56,21 @@ from bernstein.core.quality.review_pipeline.review_gate import (
     ReviewVerdict,
     parse_structured_verdict,
 )
+from bernstein.core.quality.review_pipeline.ruleset import (
+    EMPTY_RULESET,
+    ReviewRule,
+    ReviewRuleset,
+    ReviewRulesetError,
+    RulesSpec,
+    load_ruleset,
+    parse_ruleset,
+)
 from bernstein.core.quality.review_pipeline.runner import (
     DiffSource,
+    check_rollup_from_pr,
     diff_from_pr,
     diff_from_task,
+    gh_pr_view_json,
     run_pipeline,
     run_pipeline_sync,
     should_block_merge,
@@ -64,37 +99,64 @@ from bernstein.core.quality.review_pipeline.verdict import (
 
 __all__ = [
     "DEFAULT_PASS_THRESHOLD",
+    "EMPTY_RULESET",
     "AgentSpec",
     "AgentVerdict",
     "AggregatorConfig",
     "AggregatorStrategy",
+    "CheckLogExcerpt",
+    "CheckRollup",
+    "CheckRun",
+    "CheckState",
+    "ContourOutcome",
+    "ContourResult",
     "DiffSource",
     "EffortLevel",
     "EvalGateConfigError",
     "FinalVerdict",
+    "FixOutcome",
+    "FixRequest",
+    "FixRunner",
     "FreshContextViolation",
     "ImplementerContext",
     "ModelSelection",
+    "PassReceiptEmitter",
+    "PassReceiptRequest",
+    "PassRecord",
     "PipelineVerdict",
     "ReviewChunk",
     "ReviewGate",
     "ReviewInputs",
     "ReviewPipeline",
     "ReviewPipelineError",
+    "ReviewRule",
+    "ReviewRuleset",
+    "ReviewRulesetError",
     "ReviewState",
     "ReviewVerdict",
+    "RulesSpec",
     "StageSpec",
     "StageVerdict",
     "aggregate_pipeline",
     "aggregate_stage",
+    "check_log_fetcher",
+    "check_rollup_from_pr",
     "chunk_for_review",
+    "command_fix_runner",
     "diff_from_pr",
     "diff_from_task",
+    "gh_pr_view_json",
     "load_pipeline",
+    "load_ruleset",
     "parse_pipeline_yaml",
+    "parse_ruleset",
     "parse_structured_verdict",
+    "receipt_emitter",
+    "rollup_from_payload",
     "run_pipeline",
     "run_pipeline_sync",
+    "run_review_contour",
     "should_block_merge",
     "to_cross_model_verdict",
+    "wait_for_checks",
 ]

--- a/src/bernstein/core/quality/review_pipeline/contour.py
+++ b/src/bernstein/core/quality/review_pipeline/contour.py
@@ -1,0 +1,737 @@
+"""The fix-until-green review contour and its per-pass provenance.
+
+``bernstein review --pipeline`` used to stop at a verdict, leaving the part
+that turns a verdict into an outcome on the pull request to a shell loop
+around the CLI.  Every such loop invented its own stop condition, its own
+idea of "red", and its own (usually absent) provenance, so two operators
+reviewing the same PR could not compare results.
+
+This module owns that loop:
+
+1. wait, bounded, for the PR's check rollup to settle;
+2. run the review pipeline against the PR's current diff;
+3. stop when the pipeline approves and (under ``until_checks_green``) the
+   checks are green;
+4. otherwise run a fix pass whose inputs are the verdict *and* the failing
+   checks' log excerpts, then start the next pass;
+5. stop at ``max_passes`` with an explicit ``needs-operator`` outcome -- never
+   an approval -- and a non-zero exit code.
+
+Every pass emits a review receipt binding the reviewed diff hash, the ruleset
+digest, the pass index and the verdict, each one carrying the previous pass's
+spine anchor.  The artefact the operator ends up with *is* the proof: strip
+the chain and there is no record that the PR was reviewed at all, let alone
+under which standard.
+
+The loop takes its collaborators as callables so the CLI stays thin and the
+stop condition is testable without a network: ``fetch_diff``, ``read_rollup``,
+``review``, ``fetch_logs``, ``fix_runner`` and ``emit_receipt``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+import subprocess
+import time
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
+
+from bernstein.core.quality.review_pipeline.ruleset import EMPTY_RULESET
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+
+    from bernstein.core.quality.review_pipeline.ruleset import ReviewRuleset
+    from bernstein.core.quality.review_pipeline.runner import DiffSource
+    from bernstein.core.quality.review_pipeline.schema import ReviewPipeline
+    from bernstein.core.quality.review_pipeline.verdict import FinalVerdict, PipelineVerdict
+
+logger = logging.getLogger(__name__)
+
+#: State of a PR's aggregate check rollup.
+CheckState = Literal["green", "red", "pending"]
+
+#: How the contour ended.  ``needs-operator`` is never an approval.
+ContourOutcome = Literal["approved", "needs-operator"]
+
+#: Check conclusions that count as red.  Everything else (``SUCCESS``,
+#: ``NEUTRAL``, ``SKIPPED``) leaves the rollup green.
+_FAILING_CONCLUSIONS = frozenset(
+    {"FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE", "ERROR"}
+)
+
+#: Statuses that mean the check has not produced a conclusion yet.
+_PENDING_STATUSES = frozenset({"QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED", "EXPECTED"})
+
+#: Bytes of failing-check log handed to one fix pass, per check.
+DEFAULT_LOG_BYTE_BUDGET = 16_000
+
+_RUN_ID_RE = re.compile(r"/runs/(\d+)")
+
+
+# ---------------------------------------------------------------------------
+# Check rollup
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CheckRun:
+    """One entry of a PR's check rollup.
+
+    Attributes:
+        name: Check name as GitHub reports it.
+        status: Lifecycle status (``QUEUED`` / ``IN_PROGRESS`` / ``COMPLETED``).
+        conclusion: Terminal conclusion (``SUCCESS`` / ``FAILURE`` / ...).
+        run_id: Workflow run id parsed out of the details url, used to fetch
+            the failing log; empty when the entry is not an Actions run.
+        url: The check's details url.
+    """
+
+    name: str
+    status: str = ""
+    conclusion: str = ""
+    run_id: str = ""
+    url: str = ""
+
+    @property
+    def is_pending(self) -> bool:
+        """True while the check has not reached a conclusion."""
+        return not self.conclusion and self.status.upper() != "COMPLETED"
+
+    @property
+    def is_failing(self) -> bool:
+        """True when the check reached a conclusion the merge gate rejects."""
+        return self.conclusion.upper() in _FAILING_CONCLUSIONS
+
+
+@dataclass(frozen=True)
+class CheckRollup:
+    """A PR's aggregate check state.
+
+    Attributes:
+        state: ``pending`` while any check is unfinished, then ``red`` if any
+            check failed, else ``green``.  A PR with no checks is green.
+        checks: Every rollup entry, in the order GitHub returned them.
+    """
+
+    state: CheckState
+    checks: tuple[CheckRun, ...] = ()
+
+    @property
+    def failing(self) -> tuple[CheckRun, ...]:
+        """The checks that concluded red."""
+        return tuple(c for c in self.checks if c.is_failing)
+
+
+def _coerce_check(row: Mapping[str, Any]) -> CheckRun:
+    """Build a :class:`CheckRun` from one ``statusCheckRollup`` entry.
+
+    Handles both shapes GitHub returns: Actions ``CheckRun`` entries and
+    legacy ``StatusContext`` entries.
+    """
+    name = str(row.get("name") or row.get("context") or "")
+    url = str(row.get("detailsUrl") or row.get("targetUrl") or "")
+    if "state" in row and "status" not in row:
+        # Legacy StatusContext: one ``state`` field carries both meanings.
+        state = str(row.get("state") or "").upper()
+        if not state or state in _PENDING_STATUSES:
+            status, conclusion = state or "PENDING", ""
+        else:
+            status, conclusion = "COMPLETED", state
+    else:
+        status = str(row.get("status") or "")
+        conclusion = str(row.get("conclusion") or "")
+    match = _RUN_ID_RE.search(url)
+    return CheckRun(
+        name=name,
+        status=status,
+        conclusion=conclusion,
+        run_id=match.group(1) if match else "",
+        url=url,
+    )
+
+
+def rollup_from_payload(payload: Mapping[str, Any]) -> CheckRollup:
+    """Parse ``gh pr view --json statusCheckRollup`` output into a rollup.
+
+    Args:
+        payload: The decoded ``gh`` JSON object.
+
+    Returns:
+        The aggregate :class:`CheckRollup`.
+    """
+    raw: object = payload.get("statusCheckRollup")
+    rows: list[object] = cast("list[object]", raw) if isinstance(raw, list) else []
+    checks = tuple(_coerce_check(cast("Mapping[str, Any]", row)) for row in rows if isinstance(row, dict))
+    if any(c.is_pending for c in checks):
+        state: CheckState = "pending"
+    elif any(c.is_failing for c in checks):
+        state = "red"
+    else:
+        state = "green"
+    return CheckRollup(state=state, checks=checks)
+
+
+def wait_for_checks(
+    read_rollup: Callable[[], CheckRollup],
+    *,
+    timeout_s: float,
+    poll_interval_s: float,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> CheckRollup:
+    """Poll until the rollup settles, or until the budget is spent.
+
+    The wait is bounded on purpose: an unattended review that blocks forever on
+    a stuck queue is worse than one that reports ``pending`` and hands back to
+    the operator.
+
+    Args:
+        read_rollup: Reads the PR's current rollup.
+        timeout_s: Total wall-clock budget for the wait.
+        poll_interval_s: Delay between reads.
+        sleep: Injected for tests.
+        monotonic: Injected for tests.
+
+    Returns:
+        The settled rollup, or the last ``pending`` one when the budget ran out.
+    """
+    start = monotonic()
+    while True:
+        rollup = read_rollup()
+        if rollup.state != "pending":
+            return rollup
+        if monotonic() - start >= timeout_s:
+            logger.info("review contour: check rollup still pending after %.0fs", timeout_s)
+            return rollup
+        sleep(poll_interval_s)
+
+
+# ---------------------------------------------------------------------------
+# The fix pass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CheckLogExcerpt:
+    """The failing tail of one check's log.
+
+    Attributes:
+        check: The check the excerpt came from.
+        body: The log text, already truncated to the caller's byte budget.
+        truncated: Whether the original log was longer than the budget.
+        error: Why the log could not be fetched; empty on success.
+    """
+
+    check: str
+    body: str = ""
+    truncated: bool = False
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class FixRequest:
+    """Everything a fix pass is told, and the prompt it renders to.
+
+    Attributes:
+        pass_index: 1-based index of the review pass that produced the verdict.
+        pr_number: The PR under review, when known.
+        feedback: The pipeline's summary line.
+        issues: The reviewer's issues, one per entry.
+        failing_checks: The checks that were red at the time of the review.
+        logs: Log excerpts for those checks -- the fixer is told *why* CI is
+            red rather than guessing from the diff.
+        ruleset: The ruleset the verdict was produced under; its guard rules
+            keep the fixer off findings an operator already rejected.
+    """
+
+    pass_index: int
+    pr_number: int | None = None
+    feedback: str = ""
+    issues: tuple[str, ...] = ()
+    failing_checks: tuple[CheckRun, ...] = ()
+    logs: tuple[CheckLogExcerpt, ...] = ()
+    ruleset: ReviewRuleset = EMPTY_RULESET
+
+    def to_prompt(self) -> str:
+        """Render the fix pass's input as one prompt."""
+        target = f"PR #{self.pr_number}" if self.pr_number is not None else "this branch"
+        lines: list[str] = [
+            f"# Fix pass {self.pass_index} for {target}",
+            "",
+            "A review pass did not approve, or the checks are red. Land the smallest",
+            "change that answers the findings below and turns the checks green, then",
+            "commit and push it to the pull request's branch.",
+            "",
+            "## Review verdict",
+            "",
+            self.feedback or "(no summary)",
+            "",
+        ]
+        if self.issues:
+            lines.append("### Issues raised")
+            lines.extend(f"- {issue}" for issue in self.issues)
+            lines.append("")
+        if self.failing_checks:
+            lines.append("## Failing checks")
+            lines.extend(f"- {c.name} ({c.conclusion or c.status or 'unknown'})" for c in self.failing_checks)
+            lines.append("")
+        for excerpt in self.logs:
+            lines.append(f"### Log: {excerpt.check}")
+            lines.append("")
+            if excerpt.error:
+                lines.append(f"(log unavailable: {excerpt.error})")
+            else:
+                lines.append("```")
+                lines.append(excerpt.body.rstrip("\n"))
+                lines.append("```")
+                if excerpt.truncated:
+                    lines.append("(truncated)")
+            lines.append("")
+        section = self.ruleset.to_prompt_section()
+        if section:
+            lines.append(section.lstrip("\n"))
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class FixOutcome:
+    """What a fix pass reports back.
+
+    Attributes:
+        pushed: True when the pass landed a new commit on the PR's branch.
+            A pass that changed nothing cannot change the next rollup, so the
+            contour stops rather than burning the rest of the budget.
+        summary: Short human-readable note, surfaced in the stop reason.
+    """
+
+    pushed: bool
+    summary: str = ""
+
+
+class FixRunner(Protocol):
+    """Runs one fix pass."""
+
+    def __call__(self, request: FixRequest, /) -> FixOutcome: ...
+
+
+# ---------------------------------------------------------------------------
+# Per-pass receipts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PassReceiptRequest:
+    """The binding one pass's receipt records.
+
+    Attributes:
+        pass_index: 1-based pass index.
+        diff: The exact diff bytes this pass reviewed.
+        verdict: The pass's verdict.
+        ruleset_digest: Digest of the ruleset the verdict was produced under.
+        prev_entry_hash: The previous pass's spine anchor; empty on pass 1.
+    """
+
+    pass_index: int
+    diff: bytes
+    verdict: str
+    ruleset_digest: str
+    prev_entry_hash: str = ""
+
+
+class PassReceiptEmitter(Protocol):
+    """Emits one pass's receipt and returns its spine anchor."""
+
+    def __call__(self, request: PassReceiptRequest, /) -> str: ...
+
+
+def receipt_emitter(
+    *,
+    workdir: Path,
+    pr_url: str,
+    repo: str,
+    issue_body: str,
+    plan: str = "",
+    task_id: str = "",
+    journal_head: str = "",
+    hmac_key: bytes | None = None,
+    timestamp: int | None = None,
+) -> PassReceiptEmitter:
+    """Build the emitter the contour uses for its per-pass receipts.
+
+    Reuses the ``review-receipt`` machinery unchanged: each pass signs its own
+    canonical binding with the install's Ed25519 identity, anchors it in the
+    review lineage spine, and mirrors it into the HMAC-chained audit log, so
+    ``bernstein review-receipt verify --chain`` recomputes the whole sequence
+    offline.
+
+    Args:
+        workdir: Project root holding ``.sdd/``.
+        pr_url: The pull request the receipts cover.
+        repo: ``owner/repo`` slug.
+        issue_body: The ticket text every pass is reviewed against.
+        plan: Optional plan text bound into ``plan_hash``.
+        task_id: Task the review is attributed to.
+        journal_head: Run journal Merkle head, when the caller has one.
+        hmac_key: Audit-chain key; loaded from the install when omitted.
+        timestamp: Fixed timestamp, for reproducible fixtures.
+
+    Returns:
+        A :class:`PassReceiptEmitter` returning each receipt's spine anchor.
+    """
+    from bernstein.core.review.receipt import emit_review_receipt, load_or_create_review_identity
+    from bernstein.core.security.audit import load_or_create_audit_key
+    from bernstein.core.security.audit_chain import AuditChainStore, record_review_receipt
+
+    root = Path(workdir)
+    key = hmac_key if hmac_key is not None else load_or_create_audit_key()
+    private_pem, public_pem = load_or_create_review_identity(root / ".sdd" / "identity")
+
+    def _emit(request: PassReceiptRequest, /) -> str:
+        receipt = emit_review_receipt(
+            workdir=root,
+            lineage_root=root / ".sdd" / "lineage",
+            hmac_key=key,
+            private_key_pem=private_pem,
+            public_key_pem=public_pem,
+            pr_url=pr_url,
+            repo=repo,
+            issue_body=issue_body,
+            plan=plan,
+            journal_head=journal_head,
+            diff=request.diff,
+            findings=(),
+            verdict=request.verdict,
+            task_id=task_id,
+            timestamp=timestamp if timestamp is not None else int(time.time()),
+            pass_index=request.pass_index,
+            ruleset_digest=request.ruleset_digest,
+            prev_entry_hash=request.prev_entry_hash,
+        )
+        record_review_receipt(
+            chain=AuditChainStore(root / ".sdd" / "audit", key=key),
+            pr_url=receipt.pr_url,
+            issue_hash=receipt.issue_hash,
+            plan_hash=receipt.plan_hash,
+            journal_head=receipt.journal_head,
+            diff_hash=receipt.diff_hash,
+            verdict=receipt.verdict,
+            journal_entry_hash=receipt.journal_entry_hash,
+        )
+        return receipt.journal_entry_hash
+
+    return _emit
+
+
+# ---------------------------------------------------------------------------
+# The loop
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PassRecord:
+    """What one pass of the contour did.
+
+    Attributes:
+        index: 1-based pass index.
+        verdict: The pipeline verdict this pass produced.
+        checks_state: The rollup state this pass reviewed against.
+        diff_hash: Content hash of the diff this pass reviewed.
+        ruleset_digest: Digest of the ruleset the verdict was produced under.
+        receipt_entry_hash: The pass receipt's spine anchor; empty when no
+            emitter was wired.
+        failing_checks: Names of the checks that were red.
+        fix_pushed: Whether the fix pass after this review landed a commit.
+    """
+
+    index: int
+    verdict: FinalVerdict
+    checks_state: CheckState
+    diff_hash: str
+    ruleset_digest: str
+    receipt_entry_hash: str = ""
+    failing_checks: tuple[str, ...] = ()
+    fix_pushed: bool = False
+
+
+@dataclass(frozen=True)
+class ContourResult:
+    """The contour's single outcome.
+
+    Attributes:
+        outcome: ``approved`` or ``needs-operator``.
+        reason: Why the loop stopped short; empty on approval.
+        passes: One record per review pass, in order.
+    """
+
+    outcome: ContourOutcome
+    reason: str
+    passes: tuple[PassRecord, ...]
+
+    @property
+    def exit_code(self) -> int:
+        """Process exit code: 0 on approval, 1 when an operator is needed."""
+        return 0 if self.outcome == "approved" else 1
+
+
+def _exhausted_reason(verdict: PipelineVerdict, rollup: CheckRollup, max_passes: int) -> str:
+    parts: list[str] = []
+    if verdict.verdict != "approve":
+        parts.append("the review still requests changes")
+    if rollup.state != "green":
+        parts.append(f"the checks are {rollup.state}")
+    detail = " and ".join(parts) or "the contour did not converge"
+    return f"budget spent (max_passes={max_passes}): {detail}"
+
+
+def run_review_contour(
+    pipeline: ReviewPipeline,
+    *,
+    fetch_diff: Callable[[], DiffSource],
+    read_rollup: Callable[[], CheckRollup],
+    review: Callable[[DiffSource], PipelineVerdict],
+    ruleset: ReviewRuleset = EMPTY_RULESET,
+    fetch_logs: Callable[[CheckRun], CheckLogExcerpt] | None = None,
+    fix_runner: FixRunner | None = None,
+    emit_receipt: PassReceiptEmitter | None = None,
+    max_passes: int = 3,
+    until_checks_green: bool = True,
+    settle_timeout_s: float = 900.0,
+    poll_interval_s: float = 15.0,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+    pr_number: int | None = None,
+) -> ContourResult:
+    """Run review -> fix -> re-check until it converges or the budget is spent.
+
+    Args:
+        pipeline: The validated review pipeline whose passes are being run.
+        fetch_diff: Reads the PR's current diff.
+        read_rollup: Reads the PR's current check rollup.
+        review: Runs the pipeline against a diff.
+        ruleset: The ruleset the verdicts are produced under.
+        fetch_logs: Fetches one failing check's log excerpt.  Without it the
+            fix pass is told which checks failed but not why.
+        fix_runner: Runs one fix pass.  Without it the contour reviews once
+            and, unless that single pass already approves with green checks,
+            hands back to the operator rather than approving anyway.
+        emit_receipt: Emits one receipt per pass.
+        max_passes: Review budget; at least 1.
+        until_checks_green: When true, an approval also requires green checks.
+        settle_timeout_s: Bound on each wait for the rollup to settle.
+        poll_interval_s: Delay between rollup reads.
+        sleep: Injected for tests.
+        monotonic: Injected for tests.
+        pr_number: PR number, for prompts and logs.
+
+    Returns:
+        A :class:`ContourResult` whose ``exit_code`` is non-zero unless the
+        contour approved.
+
+    Raises:
+        ValueError: If ``max_passes`` is below 1.
+    """
+    from bernstein.core.review.receipt import compute_diff_hash
+
+    if max_passes < 1:
+        raise ValueError(f"max_passes must be at least 1, got {max_passes}")
+
+    records: list[PassRecord] = []
+    previous_anchor = ""
+    reason = ""
+
+    for index in range(1, max_passes + 1):
+        rollup = wait_for_checks(
+            read_rollup,
+            timeout_s=settle_timeout_s,
+            poll_interval_s=poll_interval_s,
+            sleep=sleep,
+            monotonic=monotonic,
+        )
+        diff_src = fetch_diff()
+        verdict = review(diff_src)
+        diff_bytes = diff_src.diff.encode("utf-8")
+
+        anchor = ""
+        if emit_receipt is not None:
+            anchor = emit_receipt(
+                PassReceiptRequest(
+                    pass_index=index,
+                    diff=diff_bytes,
+                    verdict=verdict.verdict,
+                    ruleset_digest=ruleset.digest,
+                    prev_entry_hash=previous_anchor,
+                )
+            )
+            previous_anchor = anchor
+
+        record = PassRecord(
+            index=index,
+            verdict=verdict.verdict,
+            checks_state=rollup.state,
+            diff_hash=compute_diff_hash(diff_bytes),
+            ruleset_digest=ruleset.digest,
+            receipt_entry_hash=anchor,
+            failing_checks=tuple(c.name for c in rollup.failing),
+        )
+        logger.info(
+            "review contour: %s pass %d/%d verdict=%s checks=%s",
+            pipeline.name or "<unnamed>",
+            index,
+            max_passes,
+            verdict.verdict,
+            rollup.state,
+        )
+
+        if verdict.verdict == "approve" and (rollup.state == "green" or not until_checks_green):
+            records.append(record)
+            return ContourResult(outcome="approved", reason="", passes=tuple(records))
+
+        if index == max_passes:
+            records.append(record)
+            reason = _exhausted_reason(verdict, rollup, max_passes)
+            break
+
+        if fix_runner is None:
+            records.append(record)
+            reason = "no fix runner configured; pass --fix with a fix command to let the contour continue"
+            break
+
+        request = FixRequest(
+            pass_index=index,
+            pr_number=pr_number if pr_number is not None else diff_src.pr_number,
+            feedback=verdict.feedback,
+            issues=tuple(verdict.issues),
+            failing_checks=rollup.failing,
+            logs=_collect_logs(rollup.failing, fetch_logs),
+            ruleset=ruleset,
+        )
+        outcome = fix_runner(request)
+        records.append(replace(record, fix_pushed=outcome.pushed))
+        if not outcome.pushed:
+            reason = f"fix pass {index} landed no commit: {outcome.summary or 'no detail reported'}"
+            break
+
+    return ContourResult(outcome="needs-operator", reason=reason, passes=tuple(records))
+
+
+def _collect_logs(
+    checks: Sequence[CheckRun],
+    fetch_logs: Callable[[CheckRun], CheckLogExcerpt] | None,
+) -> tuple[CheckLogExcerpt, ...]:
+    """Fetch one log excerpt per failing check, tolerating fetch failures."""
+    if fetch_logs is None:
+        return ()
+    out: list[CheckLogExcerpt] = []
+    for check in checks:
+        try:
+            out.append(fetch_logs(check))
+        except (OSError, RuntimeError) as exc:
+            logger.warning("review contour: could not fetch log for %s: %s", check.name, exc)
+            out.append(CheckLogExcerpt(check=check.name, error=str(exc)))
+    return tuple(out)
+
+
+# ---------------------------------------------------------------------------
+# Default collaborators (the CLI wires these; the loop above stays pure)
+# ---------------------------------------------------------------------------
+
+
+def check_log_fetcher(
+    *,
+    repo: str | None = None,
+    byte_budget: int = DEFAULT_LOG_BYTE_BUDGET,
+) -> Callable[[CheckRun], CheckLogExcerpt]:
+    """Return a log fetcher backed by the existing ``gh run view`` wrapper.
+
+    Args:
+        repo: ``owner/name`` override passed to ``gh``.
+        byte_budget: Hard cap on one check's excerpt.
+
+    Returns:
+        A callable mapping a failing :class:`CheckRun` to its log excerpt.
+    """
+    from bernstein.core.autofix.gh_logs import extract_failed_log
+
+    def _fetch(check: CheckRun) -> CheckLogExcerpt:
+        if not check.run_id:
+            return CheckLogExcerpt(check=check.name, error="check has no workflow run id")
+        extraction = extract_failed_log(check.run_id, byte_budget=byte_budget, repo=repo)
+        return CheckLogExcerpt(
+            check=check.name,
+            body=extraction.body,
+            truncated=extraction.truncated,
+            error=extraction.error,
+        )
+
+    return _fetch
+
+
+def command_fix_runner(
+    command: str,
+    *,
+    repo_root: Path,
+    timeout_s: float = 3600.0,
+) -> FixRunner:
+    """Run an operator-supplied command as the fix pass.
+
+    The command is invoked with the rendered fix prompt appended as its last
+    argument (via a file path, so a multi-kilobyte prompt survives the argv
+    limit).  The pass counts as pushed only when the command exits 0 *and*
+    ``HEAD`` moved -- a command that changed nothing cannot change the next
+    check rollup, and the contour stops rather than looping over it.
+
+    Args:
+        command: Shell-quoted command; split with :func:`shlex.split`.
+        repo_root: Repository the command runs in.
+        timeout_s: Per-pass timeout.
+
+    Returns:
+        A :class:`FixRunner`.
+    """
+    argv_prefix = shlex.split(command)
+
+    def _head() -> str:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        return proc.stdout.strip()
+
+    def _run(request: FixRequest, /) -> FixOutcome:
+        prompt_path = repo_root / ".sdd" / "runtime" / f"review-fix-pass-{request.pass_index}.md"
+        prompt_path.parent.mkdir(parents=True, exist_ok=True)
+        prompt_path.write_text(request.to_prompt(), encoding="utf-8")
+        before = _head()
+        try:
+            proc = subprocess.run(
+                [*argv_prefix, str(prompt_path)],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return FixOutcome(pushed=False, summary=f"fix command timed out after {timeout_s:.0f}s")
+        except OSError as exc:
+            return FixOutcome(pushed=False, summary=f"could not run the fix command: {exc}")
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+            return FixOutcome(
+                pushed=False,
+                summary=f"fix command exited {proc.returncode}: {detail[-1] if detail else 'no output'}",
+            )
+        after = _head()
+        if after == before:
+            return FixOutcome(pushed=False, summary="fix command produced no commit")
+        return FixOutcome(pushed=True, summary=f"landed {after[:12]}")
+
+    return _run

--- a/src/bernstein/core/quality/review_pipeline/ruleset.py
+++ b/src/bernstein/core/quality/review_pipeline/ruleset.py
@@ -1,0 +1,229 @@
+"""Repo-level review ruleset: the standard a verdict was produced under.
+
+A review drifts when its standard lives only in a prompt.  This module makes
+the standard a loadable, hashable input:
+
+* **raise rules** -- a defect class the reviewer must flag;
+* **guard rules** -- a finding the reviewer must *not* raise, because an
+  operator already rejected it as a false positive.
+
+Guard rules are what makes an unattended reviewer tolerable: without them
+every pass re-reports the same rejected finding and the fix pass chases it.
+
+The rules live in ``.bernstein/review-rules.md`` by default, or wherever a
+pipeline's ``rules:`` key points.  :attr:`ReviewRuleset.digest` is a sha256
+over the *canonical* rule set -- sorted and de-duplicated -- so reordering the
+file leaves the digest alone while editing a rule moves it.  That digest is
+what a per-pass review receipt binds, so a verdict names its standard.
+
+With no rules file the ruleset is empty, :meth:`to_prompt_section` returns the
+empty string (the reviewer prompt is byte-identical to what shipped before
+rulesets existed), and the digest is the digest of the empty set.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+#: Where a repository keeps its review rules unless a pipeline says otherwise.
+DEFAULT_RULES_RELPATH = Path(".bernstein") / "review-rules.md"
+
+#: Version stamped into the digest preimage. Bump only on a format change.
+RULESET_DIGEST_VERSION = 1
+
+RuleKind = Literal["raise", "guard"]
+
+# A markdown heading whose text starts with "raise" / "guard" opens a section;
+# any other heading closes the current one.
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(?P<title>.+?)\s*$")
+_BULLET_RE = re.compile(r"^\s{0,3}[-*+]\s+(?P<text>.+?)\s*$")
+
+
+class ReviewRulesetError(ValueError):
+    """Raised when a ruleset explicitly named by a pipeline cannot be read."""
+
+
+class RulesSpec(BaseModel):
+    """The ``rules:`` mapping form in a pipeline YAML.
+
+    Attributes:
+        path: Rules file to load instead of the repository default.
+        raise_rules: Extra raise rules declared inline (YAML key ``raise``).
+        guard_rules: Extra guard rules declared inline (YAML key ``guard``).
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True, populate_by_name=True)
+
+    path: str | None = None
+    raise_rules: list[str] = Field(default_factory=list[str], alias="raise")
+    guard_rules: list[str] = Field(default_factory=list[str], alias="guard")
+
+
+@dataclass(frozen=True)
+class ReviewRule:
+    """One rule the reviewer is held to.
+
+    Attributes:
+        kind: ``raise`` (must be flagged) or ``guard`` (must not be raised).
+        text: The rule body, whitespace-stripped.
+    """
+
+    kind: RuleKind
+    text: str
+
+
+@dataclass(frozen=True)
+class ReviewRuleset:
+    """An ordered rule set plus the digest that names it.
+
+    Attributes:
+        rules: Rules in declaration order.
+        source: Human-readable origin (a path, or ``""`` when none was found).
+    """
+
+    rules: tuple[ReviewRule, ...] = ()
+    source: str = ""
+
+    @property
+    def raise_rules(self) -> tuple[ReviewRule, ...]:
+        """Rules the reviewer must flag."""
+        return tuple(r for r in self.rules if r.kind == "raise")
+
+    @property
+    def guard_rules(self) -> tuple[ReviewRule, ...]:
+        """Rules the reviewer must not raise."""
+        return tuple(r for r in self.rules if r.kind == "guard")
+
+    @property
+    def is_empty(self) -> bool:
+        """True when no rule was declared anywhere."""
+        return not self.rules
+
+    @property
+    def digest(self) -> str:
+        """Content digest over the canonical (sorted, de-duplicated) rule set.
+
+        Reordering the rules leaves this alone; editing one moves it.
+        """
+        payload = {
+            "v": RULESET_DIGEST_VERSION,
+            "guard": sorted({r.text for r in self.guard_rules}),
+            "raise": sorted({r.text for r in self.raise_rules}),
+        }
+        canonical = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    def to_prompt_section(self) -> str:
+        """Render the ruleset for a reviewer or fixer prompt.
+
+        Returns the empty string for an empty ruleset so the prompt is
+        unchanged when a repository ships no rules.
+        """
+        if self.is_empty:
+            return ""
+        lines: list[str] = ["", "## Review ruleset", "", f"Ruleset digest: {self.digest}", ""]
+        if self.raise_rules:
+            lines.append("### Raise - a review must flag these")
+            lines.extend(f"- {r.text}" for r in self.raise_rules)
+            lines.append("")
+        if self.guard_rules:
+            lines.append("### Guard - a review must not raise these (already rejected as false positives)")
+            lines.extend(f"- {r.text}" for r in self.guard_rules)
+            lines.append("")
+        return "\n".join(lines)
+
+
+#: The ruleset a repository with no rules file gets.
+EMPTY_RULESET = ReviewRuleset()
+
+
+def _section_kind(title: str) -> RuleKind | None:
+    lowered = title.strip().lower()
+    if lowered.startswith("raise"):
+        return "raise"
+    if lowered.startswith("guard"):
+        return "guard"
+    return None
+
+
+def parse_ruleset(text: str, *, source: str = "") -> ReviewRuleset:
+    """Parse a review-rules markdown document.
+
+    Bullets under a heading whose text starts with ``raise`` / ``guard``
+    become rules of that kind; everything else (prose, other headings) is
+    ignored so the file stays readable as documentation.
+
+    Args:
+        text: Markdown source.
+        source: Origin recorded on the ruleset for display.
+
+    Returns:
+        The parsed :class:`ReviewRuleset`.
+    """
+    rules: list[ReviewRule] = []
+    kind: RuleKind | None = None
+    for line in text.splitlines():
+        heading = _HEADING_RE.match(line)
+        if heading is not None:
+            kind = _section_kind(heading.group("title"))
+            continue
+        if kind is None:
+            continue
+        bullet = _BULLET_RE.match(line)
+        if bullet is not None:
+            rules.append(ReviewRule(kind=kind, text=bullet.group("text").strip()))
+    return ReviewRuleset(rules=tuple(rules), source=source)
+
+
+def load_ruleset(
+    *,
+    repo_root: Path,
+    rules: str | RulesSpec | None = None,
+    base_dir: Path | None = None,
+) -> ReviewRuleset:
+    """Load the ruleset a review runs under.
+
+    Args:
+        repo_root: Repository root; the default rules path resolves against it.
+        rules: A pipeline's ``rules:`` value -- a path string, a
+            :class:`RulesSpec`, or ``None`` for the repository default.
+        base_dir: Directory a relative ``rules:`` path resolves against
+            (normally the pipeline YAML's directory); defaults to
+            ``repo_root``.
+
+    Returns:
+        The loaded :class:`ReviewRuleset`; :data:`EMPTY_RULESET` when the
+        repository ships no rules file.
+
+    Raises:
+        ReviewRulesetError: When a pipeline names a rules file that is absent
+            or unreadable -- a typo there must not silently review against no
+            standard.
+    """
+    spec = RulesSpec(path=rules) if isinstance(rules, str) else rules
+    named = spec.path if spec is not None else None
+    root = base_dir if base_dir is not None else repo_root
+    path = (root / named) if named is not None else (repo_root / DEFAULT_RULES_RELPATH)
+
+    if not path.is_file():
+        if named is not None:
+            raise ReviewRulesetError(f"rules file not found: {path}")
+        loaded = EMPTY_RULESET
+    else:
+        try:
+            loaded = parse_ruleset(path.read_text(encoding="utf-8"), source=str(path))
+        except OSError as exc:
+            raise ReviewRulesetError(f"cannot read rules file {path}: {exc}") from exc
+
+    if spec is None or not (spec.raise_rules or spec.guard_rules):
+        return loaded
+    extra = tuple(ReviewRule(kind="raise", text=t.strip()) for t in spec.raise_rules)
+    extra += tuple(ReviewRule(kind="guard", text=t.strip()) for t in spec.guard_rules)
+    return ReviewRuleset(rules=loaded.rules + extra, source=loaded.source or "<pipeline rules>")

--- a/src/bernstein/core/quality/review_pipeline/runner.py
+++ b/src/bernstein/core/quality/review_pipeline/runner.py
@@ -40,6 +40,7 @@ from bernstein.core.quality.cross_model_verifier import (
     _parse_response,
     select_reviewer_model,
 )
+from bernstein.core.quality.review_pipeline.ruleset import EMPTY_RULESET, ReviewRuleset
 from bernstein.core.quality.review_pipeline.verdict import (
     AgentVerdict,
     PipelineVerdict,
@@ -50,6 +51,7 @@ from bernstein.core.quality.review_pipeline.verdict import (
 
 if TYPE_CHECKING:
     from bernstein.core.models import Task
+    from bernstein.core.quality.review_pipeline.contour import CheckRollup
     from bernstein.core.quality.review_pipeline.schema import (
         AgentSpec,
         ReviewPipeline,
@@ -80,6 +82,7 @@ class DiffSource:
         diff: Unified diff text.  Already truncated by the caller.
         pr_number: Optional PR number for audit / display.
         owned_files: Files in scope (used by the prompt builder).
+        pr_url: Optional PR url; the review receipt is keyed on it.
     """
 
     title: str
@@ -87,6 +90,7 @@ class DiffSource:
     diff: str
     pr_number: int | None = None
     owned_files: list[str] = field(default_factory=list[str])
+    pr_url: str = ""
 
 
 def diff_from_task(task: Task, worktree: Path, max_chars: int = _MAX_DIFF_CHARS) -> DiffSource:
@@ -106,6 +110,72 @@ def diff_from_task(task: Task, worktree: Path, max_chars: int = _MAX_DIFF_CHARS)
     )
 
 
+def gh_pr_view_json(
+    pr_number: int,
+    fields: str,
+    *,
+    repo_root: Path | None = None,
+    timeout: float = 30.0,
+) -> dict[str, object]:
+    """Read selected PR fields via ``gh pr view <N> --json <fields>``.
+
+    The single place the review surface talks to GitHub about a pull request:
+    the diff fetch, the receipt's PR url, and the check rollup all go through
+    it, so there is one auth story and no second HTTP layer.
+
+    Args:
+        pr_number: GitHub PR number.
+        fields: Comma-separated ``gh`` JSON field list.
+        repo_root: Repository working directory; defaults to ``cwd``.
+        timeout: Subprocess timeout in seconds.
+
+    Returns:
+        The decoded JSON object.
+
+    Raises:
+        RuntimeError: If ``gh`` is unavailable, errors, or returns non-JSON.
+    """
+    import subprocess
+
+    cwd = repo_root if repo_root is not None else Path.cwd()
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", fields],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError(f"gh pr view failed: {exc}") from exc
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh pr view failed: {proc.stderr.strip()}")
+    try:
+        payload: object = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh pr view returned invalid JSON: {exc}") from exc
+    return cast("dict[str, object]", payload if isinstance(payload, dict) else {})
+
+
+def check_rollup_from_pr(pr_number: int, *, repo_root: Path | None = None) -> CheckRollup:
+    """Read a PR's aggregate check rollup through the same ``gh`` path.
+
+    Args:
+        pr_number: GitHub PR number.
+        repo_root: Repository working directory; defaults to ``cwd``.
+
+    Returns:
+        The parsed :class:`~bernstein.core.quality.review_pipeline.contour.CheckRollup`.
+
+    Raises:
+        RuntimeError: If ``gh`` is unavailable or the rollup cannot be read.
+    """
+    from bernstein.core.quality.review_pipeline.contour import rollup_from_payload
+
+    return rollup_from_payload(gh_pr_view_json(pr_number, "statusCheckRollup", repo_root=repo_root))
+
+
 def diff_from_pr(pr_number: int, *, repo_root: Path | None = None, max_chars: int = _MAX_DIFF_CHARS) -> DiffSource:
     """Fetch a PR's diff via ``gh pr diff <N>`` and wrap it as a :class:`DiffSource`.
 
@@ -123,24 +193,7 @@ def diff_from_pr(pr_number: int, *, repo_root: Path | None = None, max_chars: in
     import subprocess
 
     cwd = repo_root if repo_root is not None else Path.cwd()
-    try:
-        proc = subprocess.run(
-            ["gh", "pr", "view", str(pr_number), "--json", "title,body"],
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError) as exc:
-        raise RuntimeError(f"gh pr view failed: {exc}") from exc
-    if proc.returncode != 0:
-        raise RuntimeError(f"gh pr view failed: {proc.stderr.strip()}")
-    try:
-        meta_obj: object = json.loads(proc.stdout or "{}")
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"gh pr view returned invalid JSON: {exc}") from exc
-    meta = cast("dict[str, object]", meta_obj if isinstance(meta_obj, dict) else {})
+    meta = gh_pr_view_json(pr_number, "title,body,url", repo_root=repo_root)
 
     try:
         proc = subprocess.run(
@@ -164,6 +217,7 @@ def diff_from_pr(pr_number: int, *, repo_root: Path | None = None, max_chars: in
         description=str(meta.get("body", "")),
         diff=diff,
         pr_number=pr_number,
+        pr_url=str(meta.get("url", "")),
     )
 
 
@@ -264,6 +318,7 @@ async def _run_one_agent(
     llm_caller: LLMCaller,
     provider: str,
     max_tokens: int,
+    ruleset: ReviewRuleset = EMPTY_RULESET,
 ) -> AgentVerdict:
     """Run a single agent and return its verdict.
 
@@ -273,7 +328,9 @@ async def _run_one_agent(
     # Cost-aware routing - if the spec pinned a model use it; otherwise let
     # the cascade pick one based on writer style ("low" effort → cheap).
     model = agent.model or select_reviewer_model("any", override=None)
-    prompt = _build_agent_prompt(diff_src, prior_stages)
+    # An empty ruleset renders to "", so a repository without a rules file
+    # sends exactly the prompt it sent before rulesets existed.
+    prompt = _build_agent_prompt(diff_src, prior_stages, extra=ruleset.to_prompt_section())
 
     started = time.monotonic()
     try:
@@ -329,6 +386,7 @@ async def _run_stage(
     max_tokens: int,
     bulletin: BulletinBoard | None,
     pipeline: ReviewPipeline,
+    ruleset: ReviewRuleset = EMPTY_RULESET,
 ) -> StageVerdict:
     """Run a single stage's agents (parallel, capped by ``parallelism``)."""
     sem = asyncio.Semaphore(stage.parallelism)
@@ -342,6 +400,7 @@ async def _run_stage(
                 llm_caller=llm_caller,
                 provider=provider,
                 max_tokens=max_tokens,
+                ruleset=ruleset,
             )
 
     started = time.monotonic()
@@ -401,6 +460,7 @@ async def run_pipeline(
     bulletin: BulletinBoard | None = None,
     audit_log: AuditLog | None = None,
     actor: str = "review_pipeline",
+    ruleset: ReviewRuleset | None = None,
 ) -> PipelineVerdict:
     """Execute *pipeline* against *diff_src* and return the final verdict.
 
@@ -418,11 +478,14 @@ async def run_pipeline(
         audit_log: When supplied, each stage and the final verdict are
             written as HMAC-chained events.
         actor: Audit ``actor`` field - defaults to ``review_pipeline``.
+        ruleset: The raise / guard rules every reviewer is held to.  ``None``
+            (or an empty ruleset) leaves the prompt untouched.
 
     Returns:
         :class:`PipelineVerdict`.
     """
     caller = llm_caller or _default_llm_caller
+    rules = ruleset if ruleset is not None else EMPTY_RULESET
     board = bulletin if bulletin is not None else BulletinBoard()
     pipeline_started = time.monotonic()
     pr_resource = f"pr-{diff_src.pr_number}" if diff_src.pr_number is not None else f"task:{diff_src.title[:60]}"
@@ -438,6 +501,7 @@ async def run_pipeline(
                     "pipeline_name": pipeline.name,
                     "stages": [s.name for s in pipeline.stages],
                     "block_on_fail": pipeline.block_on_fail,
+                    "ruleset_digest": rules.digest,
                 },
             )
 
@@ -452,6 +516,7 @@ async def run_pipeline(
             max_tokens=max_tokens,
             bulletin=board,
             pipeline=pipeline,
+            ruleset=rules,
         )
         stage_verdicts.append(sv)
         if audit_log is not None:
@@ -495,6 +560,7 @@ async def run_pipeline(
                     "stages_total": len(stage_verdicts),
                     "elapsed_sec": round(time.monotonic() - pipeline_started, 3),
                     "block_on_fail": final.block_on_fail,
+                    "ruleset_digest": rules.digest,
                 },
             )
     logger.info(

--- a/src/bernstein/core/quality/review_pipeline/schema.py
+++ b/src/bernstein/core/quality/review_pipeline/schema.py
@@ -10,6 +10,7 @@ Schema:
 
     version: 1
     pass_threshold: 0.66
+    rules: .bernstein/review-rules.md
     stages:
       - name: cheap-verifiers
         parallelism: 5
@@ -43,6 +44,8 @@ from typing import Any, Literal, cast
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from bernstein.core.quality.review_pipeline.ruleset import RulesSpec  # noqa: TC001 - Pydantic needs it at runtime
 
 # Aggregator strategy literals.  Mirrors the ticket spec:
 # any | all | majority | weighted.
@@ -155,6 +158,10 @@ class ReviewPipeline(BaseModel):
         block_on_fail: When True, a failing pipeline blocks the janitor /
             merge gate the same way the cross-model verifier does today.
         name: Optional pipeline name (audit / docs only).
+        rules: Where the review ruleset lives - a path to a rules file, or a
+            mapping with ``path`` / ``raise`` / ``guard``.  ``None`` falls back
+            to ``.bernstein/review-rules.md``, and a repository with no rules
+            file reviews exactly as it did before rulesets existed.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
@@ -164,6 +171,7 @@ class ReviewPipeline(BaseModel):
     stages: list[StageSpec] = Field(min_length=1)
     block_on_fail: bool = True
     name: str | None = None
+    rules: str | RulesSpec | None = None
 
     @field_validator("stages")
     @classmethod

--- a/src/bernstein/core/review/receipt.py
+++ b/src/bernstein/core/review/receipt.py
@@ -18,6 +18,13 @@ Shapes
   over the receipt's canonical binding bytes.
 * :class:`AutofixReceipt` -- links a reviewer finding to the fix commit and the
   gate result (AC3), produced only after the fix ran in an isolated worktree.
+* A *chain* of :class:`ReviewReceipt` -- one per pass of a fix-until-green
+  review contour (#4481). Each pass additionally binds its ``pass_index``, the
+  ``ruleset_digest`` its verdict was produced under, and the previous pass's
+  anchor, so :func:`verify_review_chain` recomputes the whole sequence offline.
+  Those three fields are omitted from the signed binding while unset, so a
+  single-pass receipt is byte-identical to one emitted before the contour
+  existed.
 
 Determinism
 -----------
@@ -235,6 +242,12 @@ class ReviewReceipt:
             checks the signature against it offline.
         signature: Ed25519 detached signature over the canonical binding.
         journal_entry_hash: The review-spine entry hash anchoring the receipt.
+        pass_index: 1-based pass of a multi-pass review contour; ``0`` for a
+            single-pass review.
+        ruleset_digest: Digest of the ruleset the verdict was produced under;
+            empty when the review ran without one.
+        prev_entry_hash: The preceding pass's ``journal_entry_hash``, which is
+            what links one pass's receipt to the next.
     """
 
     pr_url: str
@@ -250,10 +263,18 @@ class ReviewReceipt:
     signer_public_key_pem: str = ""
     signature: str = ""
     journal_entry_hash: str = ""
+    pass_index: int = 0
+    ruleset_digest: str = ""
+    prev_entry_hash: str = ""
 
     def _binding(self) -> dict[str, Any]:
-        """Return the signed + anchored binding (no signature / anchor)."""
-        return {
+        """Return the signed + anchored binding (no signature / anchor).
+
+        The contour fields are omitted while unset so a single-pass receipt
+        binds -- and therefore recomputes -- byte-identically to one emitted
+        before multi-pass reviews existed.
+        """
+        binding: dict[str, Any] = {
             "v": REVIEW_SCHEMA_VERSION,
             "pr_url": self.pr_url,
             "repo": self.repo,
@@ -266,6 +287,13 @@ class ReviewReceipt:
             "task_id": self.task_id,
             "timestamp": self.timestamp,
         }
+        if self.pass_index:
+            binding["pass_index"] = self.pass_index
+        if self.ruleset_digest:
+            binding["ruleset_digest"] = self.ruleset_digest
+        if self.prev_entry_hash:
+            binding["prev_entry_hash"] = self.prev_entry_hash
+        return binding
 
     def to_canonical_bytes(self) -> bytes:
         """Serialise the binding to canonical JSON bytes (signed + spine-hashed)."""
@@ -295,17 +323,30 @@ class ReviewReceipt:
             signer_public_key_pem=str(row.get("signer_public_key_pem", "")),
             signature=str(row.get("signature", "")),
             journal_entry_hash=str(row.get("journal_entry_hash", "")),
+            pass_index=int(row.get("pass_index", 0)),
+            ruleset_digest=str(row.get("ruleset_digest", "")),
+            prev_entry_hash=str(row.get("prev_entry_hash", "")),
         )
 
 
-def receipt_path(workdir: Path, pr_url: str) -> Path:
-    """Return the on-disk review-receipt path for ``pr_url``."""
-    return workdir.joinpath(*_RECEIPT_SUBPATH, f"{_safe_pr_name(pr_url)}.json")
+def receipt_path(workdir: Path, pr_url: str, pass_index: int = 0) -> Path:
+    """Return the on-disk review-receipt path for ``pr_url``.
+
+    Args:
+        workdir: Project root.
+        pr_url: The pull request the receipt covers.
+        pass_index: 1-based contour pass; ``0`` is the single-pass receipt and
+            keeps the path it has always had.
+    """
+    name = _safe_pr_name(pr_url)
+    if pass_index > 0:
+        name = f"{name}-p{pass_index}"
+    return workdir.joinpath(*_RECEIPT_SUBPATH, f"{name}.json")
 
 
-def read_review_receipt(workdir: Path, pr_url: str) -> ReviewReceipt | None:
+def read_review_receipt(workdir: Path, pr_url: str, pass_index: int = 0) -> ReviewReceipt | None:
     """Return the review receipt for ``pr_url`` or ``None`` if absent."""
-    path = receipt_path(workdir, pr_url)
+    path = receipt_path(workdir, pr_url, pass_index)
     if not path.is_file():
         return None
     try:
@@ -313,6 +354,22 @@ def read_review_receipt(workdir: Path, pr_url: str) -> ReviewReceipt | None:
     except (json.JSONDecodeError, KeyError, TypeError, ValueError):
         logger.warning("review: malformed receipt at %s", path)
         return None
+
+
+def read_review_chain(workdir: Path, pr_url: str) -> tuple[ReviewReceipt, ...]:
+    """Return the contour's per-pass receipts for ``pr_url``, in pass order.
+
+    The walk stops at the first missing pass, so a truncated chain is returned
+    as what is actually on disk rather than silently skipping a gap.
+    """
+    chain: list[ReviewReceipt] = []
+    index = 1
+    while True:
+        receipt = read_review_receipt(workdir, pr_url, pass_index=index)
+        if receipt is None:
+            return tuple(chain)
+        chain.append(receipt)
+        index += 1
 
 
 # ---------------------------------------------------------------------------
@@ -337,6 +394,9 @@ def emit_review_receipt(
     verdict: str,
     task_id: str,
     timestamp: int,
+    pass_index: int = 0,
+    ruleset_digest: str = "",
+    prev_entry_hash: str = "",
 ) -> ReviewReceipt:
     """Bind issue, plan, tool calls, and diff into a signed, anchored receipt.
 
@@ -363,6 +423,10 @@ def emit_review_receipt(
         verdict: The review verdict.
         task_id: The task the review is attributed to.
         timestamp: Integer timestamp for the receipt.
+        pass_index: 1-based pass of a multi-pass review contour; ``0`` emits
+            the single-pass receipt at its historical path and binding.
+        ruleset_digest: Digest of the ruleset the verdict was produced under.
+        prev_entry_hash: The preceding pass's ``journal_entry_hash``.
 
     Returns:
         The signed, anchored :class:`ReviewReceipt`.
@@ -378,17 +442,24 @@ def emit_review_receipt(
         verdict=verdict,
         task_id=task_id,
         timestamp=timestamp,
+        pass_index=pass_index,
+        ruleset_digest=ruleset_digest,
+        prev_entry_hash=prev_entry_hash,
     )
     payload = unsigned.to_canonical_bytes()
     signature = sign_payload(payload, private_key_pem)
 
     spine = LineageSpine(lineage_root, run_id=REVIEW_RUN_ID, hmac_key=hmac_key)
-    artifact_path = "/".join((*_RECEIPT_SUBPATH, f"{_safe_pr_name(pr_url)}.json"))
+    path = receipt_path(workdir, pr_url, pass_index)
+    artifact_path = "/".join((*_RECEIPT_SUBPATH, path.name))
+    # Two passes over an unchanged diff must still anchor distinctly, so the
+    # pass index rides along in the step id.
+    step_id = f"{unsigned.diff_hash}#p{pass_index}" if pass_index > 0 else unsigned.diff_hash
     anchor = spine.record(
         artifact_path=artifact_path,
         content=payload,
         actor=_REVIEW_ACTOR,
-        step_id=unsigned.diff_hash,
+        step_id=step_id,
         model=_REVIEW_MODEL,
         timestamp=timestamp,
     )
@@ -406,8 +477,10 @@ def emit_review_receipt(
         signer_public_key_pem=public_key_pem,
         signature=signature,
         journal_entry_hash=anchor,
+        pass_index=pass_index,
+        ruleset_digest=ruleset_digest,
+        prev_entry_hash=prev_entry_hash,
     )
-    path = receipt_path(workdir, pr_url)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(anchored.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True),
@@ -514,6 +587,150 @@ def verify_review_receipt(
         )
 
     return ReviewVerifyResult(ok=True, reason="", receipt=receipt, verdict=receipt.verdict)
+
+
+# ---------------------------------------------------------------------------
+# Chain verify -- one receipt per pass of a fix-until-green contour (#4481)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReviewChainVerifyResult:
+    """Outcome of :func:`verify_review_chain`.
+
+    Attributes:
+        ok: True only when every pass recomputed and every link held.
+        reason: Why the chain was rejected; empty when ``ok``.
+        passes: Number of per-pass receipts walked.
+        verdict: The last pass's verdict.
+        ruleset_digest: The ruleset digest every pass was produced under.
+    """
+
+    ok: bool
+    reason: str
+    passes: int = 0
+    verdict: str = ""
+    ruleset_digest: str = ""
+
+
+def _verify_one(
+    receipt: ReviewReceipt,
+    *,
+    spine: LineageSpine,
+    issue_body: str,
+) -> str:
+    """Return the rejection reason for one receipt, or ``""`` when it holds."""
+    if compute_issue_hash(issue_body) != receipt.issue_hash:
+        return "issue_hash mismatch: presented issue body differs from the reviewed ticket"
+    if not receipt.signature or not receipt.signer_public_key_pem:
+        return "receipt is unsigned"
+    outcome = verify_payload(
+        receipt.to_canonical_bytes(),
+        receipt.signature,
+        receipt.signer_public_key_pem,
+        allow_unverified=True,
+    )
+    if not outcome.verified:
+        return f"signature does not verify ({outcome.reason})"
+    recomputed = _recompute_anchor(spine, receipt.to_canonical_bytes())
+    if recomputed is None:
+        return "receipt is not anchored in the review spine"
+    if recomputed != receipt.journal_entry_hash:
+        return "recorded journal_entry_hash does not match the spine anchor over the receipt bytes"
+    return ""
+
+
+def verify_review_chain(
+    *,
+    workdir: Path,
+    lineage_root: Path,
+    hmac_key: bytes,
+    pr_url: str,
+    issue_body: str,
+    diff: bytes | None = None,
+    ruleset_digest: str | None = None,
+) -> ReviewChainVerifyResult:
+    """Prove offline that every pass of a review contour holds.
+
+    Walks the per-pass receipts in order and, for each, recomputes the issue
+    hash, checks the Ed25519 signature over the canonical binding, re-anchors
+    the receipt against the review spine, and checks that its recorded
+    ``prev_entry_hash`` is the previous pass's anchor. Because the binding
+    carries the reviewed diff hash and the ruleset digest, editing either one
+    on disk breaks that pass's signature; presenting a different diff or a
+    different ruleset breaks the comparison below.
+
+    Args:
+        workdir: Project root holding ``.sdd/reviews/receipts/``.
+        lineage_root: Spine root (``.sdd/lineage``).
+        hmac_key: The audit-chain HMAC key that tags spine entries.
+        pr_url: The pull request the chain covers.
+        issue_body: The issue body every pass was reviewed against.
+        diff: When supplied, checked against the *last* pass's ``diff_hash``.
+        ruleset_digest: When supplied, checked against every pass.
+
+    Returns:
+        A :class:`ReviewChainVerifyResult`.
+    """
+    chain = read_review_chain(workdir, pr_url)
+    if not chain:
+        return ReviewChainVerifyResult(ok=False, reason="no review chain found")
+
+    spine = LineageSpine(lineage_root, run_id=REVIEW_RUN_ID, hmac_key=hmac_key)
+    spine_result = spine.verify()
+    if not spine_result.ok:
+        return ReviewChainVerifyResult(
+            ok=False,
+            reason=f"review spine failed verification ({spine_result.status.value})",
+            passes=len(chain),
+        )
+
+    declared = chain[0].ruleset_digest
+    previous = ""
+    for expected, receipt in enumerate(chain, start=1):
+        if receipt.pass_index != expected:
+            return ReviewChainVerifyResult(
+                ok=False,
+                reason=f"pass {expected}: recorded pass_index {receipt.pass_index} breaks the chain order",
+                passes=len(chain),
+            )
+        if receipt.prev_entry_hash != previous:
+            return ReviewChainVerifyResult(
+                ok=False,
+                reason=f"pass {expected}: chain link does not match the previous pass's anchor",
+                passes=len(chain),
+            )
+        if receipt.ruleset_digest != declared:
+            return ReviewChainVerifyResult(
+                ok=False,
+                reason=f"pass {expected}: ruleset digest differs from the ruleset pass 1 was reviewed under",
+                passes=len(chain),
+            )
+        if ruleset_digest is not None and receipt.ruleset_digest != ruleset_digest:
+            return ReviewChainVerifyResult(
+                ok=False,
+                reason=f"pass {expected}: ruleset digest mismatch: presented ruleset differs from the reviewed one",
+                passes=len(chain),
+            )
+        reason = _verify_one(receipt, spine=spine, issue_body=issue_body)
+        if reason:
+            return ReviewChainVerifyResult(ok=False, reason=f"pass {expected}: {reason}", passes=len(chain))
+        previous = receipt.journal_entry_hash
+
+    if diff is not None and compute_diff_hash(diff) != chain[-1].diff_hash:
+        return ReviewChainVerifyResult(
+            ok=False,
+            reason="diff_hash mismatch: presented diff differs from the last reviewed diff",
+            passes=len(chain),
+        )
+
+    return ReviewChainVerifyResult(
+        ok=True,
+        reason="",
+        passes=len(chain),
+        verdict=chain[-1].verdict,
+        ruleset_digest=declared,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -823,6 +1040,7 @@ __all__ = [
     "AutofixReceipt",
     "AutofixVerifyResult",
     "Finding",
+    "ReviewChainVerifyResult",
     "ReviewReceipt",
     "ReviewVerifyResult",
     "autofix_receipt_path",
@@ -832,9 +1050,11 @@ __all__ = [
     "emit_review_receipt",
     "load_or_create_review_identity",
     "read_autofix_receipt",
+    "read_review_chain",
     "read_review_receipt",
     "receipt_path",
     "run_autofix_in_worktree",
     "verify_autofix_receipt",
+    "verify_review_chain",
     "verify_review_receipt",
 ]

--- a/templates/review/review-rules.example.md
+++ b/templates/review/review-rules.example.md
@@ -1,0 +1,29 @@
+# Review rules (example)
+
+Copy this file to `.bernstein/review-rules.md`, or point a pipeline at it with
+a `rules:` key, to hold every reviewer to one written standard.  Bullets under
+a heading that starts with `Raise` or `Guard` become rules; everything else on
+the page is prose the parser ignores, so the file stays readable.
+
+The digest of the parsed rule set is bound into every review receipt, so a
+verdict names the standard it was produced under.  Reordering the bullets
+leaves the digest alone; editing one moves it.
+
+## Raise
+
+Defect classes a review must flag.
+
+- A bare `except:` that swallows the traceback.
+- A `subprocess` call with no timeout.
+- A new public function without a docstring stating its arguments and returns.
+- A test that asserts on a mock's call count and nothing else.
+
+## Guard
+
+Findings a review must not raise, because an operator already rejected them.
+Without this half, every unattended pass re-reports the same false positive
+and the fix pass chases it.
+
+- `assert` inside `tests/` is not a security finding.
+- The vendored parser under `third_party/` is exempt from the style rules.
+- A missing type annotation on a pytest fixture is not a defect.

--- a/tests/unit/quality/review_pipeline/test_contour.py
+++ b/tests/unit/quality/review_pipeline/test_contour.py
@@ -1,0 +1,364 @@
+"""Fix-until-green contour tests (issue #4481).
+
+The contour is the loop an operator used to write in shell around
+``bernstein review --pipeline``: settle the checks, review, feed the verdict
+and the failing checks' logs to a fix pass, push, re-check.  These tests pin
+its stop condition, its budget, and what reaches the fix prompt.
+
+* AC1 -- the loop runs to ``--max-passes`` and exits non-zero with a
+  ``needs-operator`` outcome rather than an approval.
+* AC2 -- the fix prompt carries the failing checks' log excerpts.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.quality.review_pipeline.contour import (
+    CheckLogExcerpt,
+    CheckRollup,
+    CheckRun,
+    FixOutcome,
+    FixRequest,
+    rollup_from_payload,
+    run_review_contour,
+    wait_for_checks,
+)
+from bernstein.core.quality.review_pipeline.ruleset import parse_ruleset
+from bernstein.core.quality.review_pipeline.runner import DiffSource
+from bernstein.core.quality.review_pipeline.schema import (
+    AgentSpec,
+    ReviewPipeline,
+    StageSpec,
+)
+from bernstein.core.quality.review_pipeline.verdict import (
+    AgentVerdict,
+    PipelineVerdict,
+    StageVerdict,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+_PIPELINE = ReviewPipeline(stages=[StageSpec(name="s", agents=[AgentSpec(role="r")])])
+
+_GREEN = CheckRollup(state="green", checks=(CheckRun(name="ci", status="COMPLETED", conclusion="SUCCESS"),))
+_RED = CheckRollup(
+    state="red",
+    checks=(CheckRun(name="ci", status="COMPLETED", conclusion="FAILURE", run_id="991"),),
+)
+
+
+def _verdict(kind: str, *, issues: Sequence[str] = ()) -> PipelineVerdict:
+    agent = AgentVerdict(role="r", model="m", verdict=kind, feedback="f", issues=list(issues))  # type: ignore[arg-type]
+    stage = StageVerdict(
+        stage="s",
+        verdict=kind,  # type: ignore[arg-type]
+        approve_count=1 if kind == "approve" else 0,
+        total_count=1,
+        pass_score=1.0 if kind == "approve" else 0.0,
+        agents=[agent],
+    )
+    return PipelineVerdict(
+        verdict=kind,  # type: ignore[arg-type]
+        feedback="pipeline feedback",
+        pass_score=stage.pass_score,
+        stages=[stage],
+    )
+
+
+def _diff(text: str = "+ one line") -> DiffSource:
+    return DiffSource(title="t", description="d", diff=text, pr_number=7)
+
+
+def _scripted(values: Sequence[object]) -> tuple[object, list[int]]:
+    """Return a zero-arg callable replaying ``values``, plus a call counter."""
+    calls: list[int] = []
+
+    def _next(*_args: object, **_kwargs: object) -> object:
+        index = min(len(calls), len(values) - 1)
+        calls.append(index)
+        return values[index]
+
+    return _next, calls
+
+
+# ---------------------------------------------------------------------------
+# Check rollup
+# ---------------------------------------------------------------------------
+
+
+def test_failing_conclusions_make_the_rollup_red() -> None:
+    rollup = rollup_from_payload(
+        {
+            "statusCheckRollup": [
+                {"name": "unit", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {
+                    "name": "lint",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                    "detailsUrl": "https://x/runs/42/job/9",
+                },
+            ]
+        }
+    )
+
+    assert rollup.state == "red"
+    assert [c.name for c in rollup.failing] == ["lint"]
+    assert rollup.failing[0].run_id == "42"
+
+
+def test_queued_checks_make_the_rollup_pending() -> None:
+    rollup = rollup_from_payload({"statusCheckRollup": [{"name": "unit", "status": "QUEUED", "conclusion": ""}]})
+
+    assert rollup.state == "pending"
+
+
+def test_rollup_wait_stops_polling_once_the_checks_settle() -> None:
+    pending = CheckRollup(state="pending", checks=())
+    read, calls = _scripted([pending, pending, _GREEN])
+    slept: list[float] = []
+
+    result = wait_for_checks(
+        read,  # type: ignore[arg-type]
+        timeout_s=100.0,
+        poll_interval_s=5.0,
+        sleep=slept.append,
+        monotonic=lambda: 0.0,
+    )
+
+    assert result.state == "green"
+    assert len(calls) == 3
+    assert slept == [5.0, 5.0]
+
+
+def test_rollup_wait_is_bounded_and_reports_pending_on_timeout() -> None:
+    pending = CheckRollup(state="pending", checks=())
+    read, calls = _scripted([pending])
+    clock = iter([0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0])
+
+    result = wait_for_checks(
+        read,  # type: ignore[arg-type]
+        timeout_s=10.0,
+        poll_interval_s=5.0,
+        sleep=lambda _s: None,
+        monotonic=lambda: next(clock),
+    )
+
+    assert result.state == "pending"
+    assert len(calls) <= 3
+
+
+# ---------------------------------------------------------------------------
+# AC1 -- the loop, its stop condition and its budget
+# ---------------------------------------------------------------------------
+
+
+def test_approved_and_green_stops_after_a_single_pass() -> None:
+    review, calls = _scripted([_verdict("approve")])
+
+    result = run_review_contour(
+        _PIPELINE,
+        fetch_diff=_diff,
+        read_rollup=lambda: _GREEN,
+        review=review,  # type: ignore[arg-type]
+        fix_runner=lambda _r: FixOutcome(pushed=True),
+        max_passes=3,
+    )
+
+    assert result.outcome == "approved"
+    assert result.exit_code == 0
+    assert len(result.passes) == 1
+    assert len(calls) == 1
+
+
+def test_red_checks_withhold_approval_when_until_checks_green() -> None:
+    review, _ = _scripted([_verdict("approve")])
+
+    result = run_review_contour(
+        _PIPELINE,
+        fetch_diff=_diff,
+        read_rollup=lambda: _RED,
+        review=review,  # type: ignore[arg-type]
+        max_passes=1,
+        until_checks_green=True,
+    )
+
+    assert result.outcome == "needs-operator"
+    assert result.passes[-1].checks_state == "red"
+
+
+def test_red_checks_do_not_withhold_approval_without_until_checks_green() -> None:
+    review, _ = _scripted([_verdict("approve")])
+
+    result = run_review_contour(
+        _PIPELINE,
+        fetch_diff=_diff,
+        read_rollup=lambda: _RED,
+        review=review,  # type: ignore[arg-type]
+        max_passes=1,
+        until_checks_green=False,
+    )
+
+    assert result.outcome == "approved"
+
+
+def test_fix_pass_runs_between_review_passes_until_checks_go_green() -> None:
+    review, review_calls = _scripted([_verdict("request_changes", issues=["boom"]), _verdict("approve")])
+    read_rollup, _ = _scripted([_RED, _GREEN])
+    seen: list[FixRequest] = []
+
+    def _fix(request: FixRequest) -> FixOutcome:
+        seen.append(request)
+        return FixOutcome(pushed=True, summary="pushed abc123")
+
+    result = run_review_contour(
+        _PIPELINE,
+        fetch_diff=_diff,
+        read_rollup=read_rollup,  # type: ignore[arg-type]
+        review=review,  # type: ignore[arg-type]
+        fix_runner=_fix,
+        max_passes=3,
+    )
+
+    assert result.outcome == "approved"
+    assert len(review_calls) == 2
+    assert [r.pass_index for r in seen] == [1]
+    assert result.passes[0].fix_pushed is True
+
+
+def test_budget_exhausted_exits_needs_operator_nonzero() -> None:
+    review, review_calls = _scripted([_verdict("request_changes", issues=["still broken"])])
+    fixes: list[FixRequest] = []
+
+    result = run_review_contour(
+        _PIPELINE,
+        fetch_diff=_diff,
+        read_rollup=lambda: _RED,
+        review=review,  # type: ignore[arg-type]
+        fix_runner=lambda r: (fixes.append(r), FixOutcome(pushed=True))[1],
+        max_passes=3,
+    )
+
+    assert result.outcome == "needs-operator"
+    assert result.exit_code != 0
+    assert len(result.passes) == 3
+    assert len(review_calls) == 3
+    # The budget buys three reviews and the two fixes that sit between them -
+    # no fix runs after the last review, that is what "exhausted" means.
+    assert [f.pass_index for f in fixes] == [1, 2]
+    assert "max_passes" in result.reason
+
+
+def test_contour_without_a_fix_runner_stops_needs_operator_never_approved() -> None:
+    review, review_calls = _scripted([_verdict("request_changes")])
+
+    result = run_review_contour(
+        _PIPELINE,
+        fetch_diff=_diff,
+        read_rollup=lambda: _RED,
+        review=review,  # type: ignore[arg-type]
+        max_passes=3,
+    )
+
+    assert result.outcome == "needs-operator"
+    assert result.exit_code != 0
+    assert len(review_calls) == 1
+    assert "no fix runner" in result.reason
+
+
+def test_fix_runner_that_did_not_push_stops_the_loop() -> None:
+    review, review_calls = _scripted([_verdict("request_changes")])
+
+    result = run_review_contour(
+        _PIPELINE,
+        fetch_diff=_diff,
+        read_rollup=lambda: _RED,
+        review=review,  # type: ignore[arg-type]
+        fix_runner=lambda _r: FixOutcome(pushed=False, summary="adapter exited 1"),
+        max_passes=3,
+    )
+
+    assert result.outcome == "needs-operator"
+    assert len(review_calls) == 1
+    assert "adapter exited 1" in result.reason
+
+
+def test_max_passes_below_one_is_rejected() -> None:
+    with pytest.raises(ValueError, match="max_passes"):
+        run_review_contour(
+            _PIPELINE,
+            fetch_diff=_diff,
+            read_rollup=lambda: _GREEN,
+            review=lambda _d: _verdict("approve"),
+            max_passes=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC2 -- what reaches the fix prompt
+# ---------------------------------------------------------------------------
+
+
+def test_fix_prompt_contains_the_failing_check_log_excerpts() -> None:
+    seen: list[str] = []
+
+    def _fix(request: FixRequest) -> FixOutcome:
+        seen.append(request.to_prompt())
+        return FixOutcome(pushed=False)
+
+    run_review_contour(
+        _PIPELINE,
+        fetch_diff=_diff,
+        read_rollup=lambda: _RED,
+        review=lambda _d: _verdict("request_changes"),
+        fetch_logs=lambda check: CheckLogExcerpt(check=check.name, body="E   assert 1 == 2\nFAILED tests/test_x.py"),
+        fix_runner=_fix,
+        max_passes=2,
+    )
+
+    assert seen, "the fix pass never ran"
+    assert "E   assert 1 == 2" in seen[0]
+    assert "FAILED tests/test_x.py" in seen[0]
+    assert "ci" in seen[0]
+
+
+def test_fix_prompt_contains_the_review_verdict_issues() -> None:
+    seen: list[str] = []
+
+    def _fix(request: FixRequest) -> FixOutcome:
+        seen.append(request.to_prompt())
+        return FixOutcome(pushed=False)
+
+    run_review_contour(
+        _PIPELINE,
+        fetch_diff=_diff,
+        read_rollup=lambda: _RED,
+        review=lambda _d: _verdict("request_changes", issues=["drop the bare except"]),
+        fix_runner=_fix,
+        max_passes=2,
+    )
+
+    assert "drop the bare except" in seen[0]
+
+
+def test_fix_prompt_lists_guard_rules_so_rejected_findings_are_not_refixed() -> None:
+    seen: list[str] = []
+
+    def _fix(request: FixRequest) -> FixOutcome:
+        seen.append(request.to_prompt())
+        return FixOutcome(pushed=False)
+
+    run_review_contour(
+        _PIPELINE,
+        fetch_diff=_diff,
+        read_rollup=lambda: _RED,
+        review=lambda _d: _verdict("request_changes"),
+        ruleset=parse_ruleset("## Guard\n\n- Never touch the vendored parser.\n"),
+        fix_runner=_fix,
+        max_passes=2,
+    )
+
+    assert "Never touch the vendored parser." in seen[0]

--- a/tests/unit/quality/review_pipeline/test_ruleset.py
+++ b/tests/unit/quality/review_pipeline/test_ruleset.py
@@ -1,0 +1,138 @@
+"""Review-ruleset tests (issue #4481).
+
+The ruleset is the standard a verdict was produced under.  These tests pin
+the two properties that make it usable as provenance:
+
+* AC4 -- raise and guard rules are loaded, the digest is stable under
+  reordering but not under an edit, and guard rules reach the reviewer.
+* AC5 -- with no rules file the pipeline is unchanged and the digest is the
+  digest of the empty set.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.quality.review_pipeline.ruleset import (
+    EMPTY_RULESET,
+    ReviewRulesetError,
+    RulesSpec,
+    load_ruleset,
+    parse_ruleset,
+)
+
+_RULES = """# Review rules
+
+## Raise
+
+- Bare `except:` that swallows the traceback.
+- A subprocess call without a timeout.
+
+## Guard
+
+- Do not re-report `assert` in tests as a security finding.
+"""
+
+_REORDERED = """# Review rules
+
+## Guard
+
+- Do not re-report `assert` in tests as a security finding.
+
+## Raise
+
+- A subprocess call without a timeout.
+- Bare `except:` that swallows the traceback.
+"""
+
+
+def _write(root: Path, text: str, relpath: str = ".bernstein/review-rules.md") -> Path:
+    path = root / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# AC4 -- loading, digest stability, guard visibility
+# ---------------------------------------------------------------------------
+
+
+def test_raise_and_guard_rules_are_parsed_from_the_rules_file(tmp_path: Path) -> None:
+    _write(tmp_path, _RULES)
+    ruleset = load_ruleset(repo_root=tmp_path)
+
+    assert [r.text for r in ruleset.raise_rules] == [
+        "Bare `except:` that swallows the traceback.",
+        "A subprocess call without a timeout.",
+    ]
+    assert [r.text for r in ruleset.guard_rules] == [
+        "Do not re-report `assert` in tests as a security finding.",
+    ]
+    assert not ruleset.is_empty
+
+
+def test_ruleset_digest_is_stable_under_rule_reordering() -> None:
+    assert parse_ruleset(_RULES).digest == parse_ruleset(_REORDERED).digest
+
+
+def test_ruleset_digest_changes_when_a_rule_body_changes() -> None:
+    edited = _RULES.replace("without a timeout", "without an explicit timeout")
+
+    assert parse_ruleset(edited).digest != parse_ruleset(_RULES).digest
+
+
+def test_pipeline_rules_key_points_at_another_rules_file(tmp_path: Path) -> None:
+    _write(tmp_path, _RULES)
+    _write(tmp_path, "## Raise\n\n- Only this one.\n", relpath="review/house-rules.md")
+
+    ruleset = load_ruleset(repo_root=tmp_path, rules="review/house-rules.md")
+
+    assert [r.text for r in ruleset.raise_rules] == ["Only this one."]
+    assert ruleset.guard_rules == ()
+    assert ruleset.digest != parse_ruleset(_RULES).digest
+
+
+def test_inline_pipeline_rules_extend_the_rules_file(tmp_path: Path) -> None:
+    _write(tmp_path, _RULES)
+    spec = RulesSpec.model_validate({"guard": ["Do not flag the vendored parser."]})
+
+    ruleset = load_ruleset(repo_root=tmp_path, rules=spec)
+
+    assert [r.text for r in ruleset.guard_rules] == [
+        "Do not re-report `assert` in tests as a security finding.",
+        "Do not flag the vendored parser.",
+    ]
+    assert ruleset.digest != parse_ruleset(_RULES).digest
+
+
+def test_explicitly_named_missing_rules_file_is_an_error(tmp_path: Path) -> None:
+    with pytest.raises(ReviewRulesetError, match="review/house-rules.md"):
+        load_ruleset(repo_root=tmp_path, rules="review/house-rules.md")
+
+
+def test_guard_rules_are_labelled_as_findings_not_to_raise(tmp_path: Path) -> None:
+    _write(tmp_path, _RULES)
+    section = load_ruleset(repo_root=tmp_path).to_prompt_section()
+
+    assert "Do not re-report `assert` in tests as a security finding." in section
+    assert "must not" in section.lower()
+
+
+# ---------------------------------------------------------------------------
+# AC5 -- no rules file
+# ---------------------------------------------------------------------------
+
+
+def test_missing_rules_file_yields_the_empty_set_digest(tmp_path: Path) -> None:
+    ruleset = load_ruleset(repo_root=tmp_path)
+
+    assert ruleset.is_empty
+    assert ruleset.digest == EMPTY_RULESET.digest
+    assert ruleset.digest.startswith("sha256:")
+
+
+def test_empty_ruleset_contributes_no_prompt_section() -> None:
+    assert EMPTY_RULESET.to_prompt_section() == ""

--- a/tests/unit/quality/review_pipeline/test_runner_ruleset.py
+++ b/tests/unit/quality/review_pipeline/test_runner_ruleset.py
@@ -1,0 +1,65 @@
+"""Reviewer-prompt ruleset tests (issue #4481).
+
+AC4 -- guard rules are visible to the reviewer prompt, so an unattended pass
+stops re-reporting a finding the operator already rejected.
+AC5 -- with no ruleset the prompt is byte-identical to what the pipeline sent
+before the ruleset existed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from bernstein.core.quality.review_pipeline import (
+    AgentSpec,
+    DiffSource,
+    ReviewPipeline,
+    StageSpec,
+    run_pipeline_sync,
+)
+from bernstein.core.quality.review_pipeline.ruleset import EMPTY_RULESET, parse_ruleset
+
+_RULES = """## Raise
+
+- Bare `except:` that swallows the traceback.
+
+## Guard
+
+- Do not re-report `assert` in tests as a security finding.
+"""
+
+_PIPELINE = ReviewPipeline(stages=[StageSpec(name="s", agents=[AgentSpec(role="r", model="m")])])
+
+
+def _capturing_caller() -> Any:
+    prompts: list[str] = []
+
+    async def caller(*, prompt: str, model: str, **_: object) -> str:
+        prompts.append(prompt)
+        return json.dumps({"verdict": "approve", "feedback": "ok", "issues": []})
+
+    caller.prompts = prompts  # type: ignore[attr-defined]
+    return caller
+
+
+def _run(ruleset: object) -> str:
+    caller = _capturing_caller()
+    run_pipeline_sync(
+        _PIPELINE,
+        DiffSource(title="t", description="d", diff="+ x"),
+        llm_caller=caller,
+        ruleset=ruleset,
+    )
+    return str(caller.prompts[0])
+
+
+def test_reviewer_prompt_carries_the_guard_rules() -> None:
+    prompt = _run(parse_ruleset(_RULES))
+
+    assert "Do not re-report `assert` in tests as a security finding." in prompt
+    assert "Bare `except:` that swallows the traceback." in prompt
+
+
+def test_reviewer_prompt_is_unchanged_when_the_ruleset_is_empty() -> None:
+    assert _run(EMPTY_RULESET) == _run(None)

--- a/tests/unit/review/test_review_receipt_chain.py
+++ b/tests/unit/review/test_review_receipt_chain.py
@@ -1,0 +1,220 @@
+"""Per-pass review-receipt chain tests (issue #4481).
+
+AC3 -- each pass of the fix-until-green contour emits a receipt binding the
+reviewed diff hash, the ruleset digest, the pass index and the verdict; the
+chain verifies offline and rejects a receipt whose diff or ruleset moved.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.core.quality.review_pipeline.contour import PassReceiptRequest, receipt_emitter
+from bernstein.core.review.receipt import (
+    emit_review_receipt,
+    load_or_create_review_identity,
+    read_review_chain,
+    read_review_receipt,
+    receipt_path,
+    verify_review_chain,
+    verify_review_receipt,
+)
+
+_KEY = b"0" * 32
+_PR_URL = "https://github.com/acme/widget/pull/42"
+_ISSUE = "## Problem\nthe fix loop lives outside the product\n"
+_RULES_DIGEST = "sha256:" + "a" * 64
+_DIFFS = (b"--- a/x\n+++ b/x\n@@\n-a\n+b\n", b"--- a/x\n+++ b/x\n@@\n-a\n+c\n")
+
+
+def _emit_chain(tmp_path: Path, *, verdicts: tuple[str, ...] = ("request_changes", "approve")) -> tuple[str, ...]:
+    """Emit one receipt per pass through the contour's emitter; return anchors."""
+    emit = receipt_emitter(
+        workdir=tmp_path,
+        pr_url=_PR_URL,
+        repo="acme/widget",
+        issue_body=_ISSUE,
+        hmac_key=_KEY,
+        timestamp=1000,
+    )
+    anchors: list[str] = []
+    prev = ""
+    for index, verdict in enumerate(verdicts, start=1):
+        prev = emit(
+            PassReceiptRequest(
+                pass_index=index,
+                diff=_DIFFS[index - 1],
+                verdict=verdict,
+                ruleset_digest=_RULES_DIGEST,
+                prev_entry_hash=prev,
+            )
+        )
+        anchors.append(prev)
+    return tuple(anchors)
+
+
+def _rewrite(path: Path, **fields: object) -> None:
+    row = json.loads(path.read_text(encoding="utf-8"))
+    row.update(fields)
+    path.write_text(json.dumps(row, ensure_ascii=False, separators=(",", ":"), sort_keys=True), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# AC3 -- one receipt per pass, chained
+# ---------------------------------------------------------------------------
+
+
+def test_each_pass_emits_a_receipt_binding_diff_ruleset_index_and_verdict(tmp_path: Path) -> None:
+    _emit_chain(tmp_path)
+
+    chain = read_review_chain(tmp_path, _PR_URL)
+
+    assert [r.pass_index for r in chain] == [1, 2]
+    assert [r.verdict for r in chain] == ["request_changes", "approve"]
+    assert {r.ruleset_digest for r in chain} == {_RULES_DIGEST}
+    assert chain[0].diff_hash != chain[1].diff_hash
+    for receipt in chain:
+        binding = json.loads(receipt.to_canonical_bytes())
+        assert binding["pass_index"] == receipt.pass_index
+        assert binding["ruleset_digest"] == _RULES_DIGEST
+
+
+def test_receipt_chain_links_each_pass_to_the_previous_anchor(tmp_path: Path) -> None:
+    anchors = _emit_chain(tmp_path)
+
+    chain = read_review_chain(tmp_path, _PR_URL)
+
+    assert chain[0].prev_entry_hash == ""
+    assert chain[1].prev_entry_hash == anchors[0]
+    assert chain[1].journal_entry_hash == anchors[1]
+
+
+def test_verify_chain_accepts_an_untampered_chain(tmp_path: Path) -> None:
+    _emit_chain(tmp_path)
+
+    result = verify_review_chain(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        pr_url=_PR_URL,
+        issue_body=_ISSUE,
+        diff=_DIFFS[-1],
+        ruleset_digest=_RULES_DIGEST,
+    )
+
+    assert result.ok, result.reason
+    assert result.passes == 2
+    assert result.verdict == "approve"
+
+
+def test_verify_chain_rejects_a_tampered_pass_diff(tmp_path: Path) -> None:
+    _emit_chain(tmp_path)
+
+    result = verify_review_chain(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        pr_url=_PR_URL,
+        issue_body=_ISSUE,
+        diff=b"--- a/x\n+++ b/x\n@@\n-a\n+something else\n",
+        ruleset_digest=_RULES_DIGEST,
+    )
+
+    assert not result.ok
+    assert "diff_hash" in result.reason
+
+
+def test_verify_chain_rejects_an_altered_ruleset_digest(tmp_path: Path) -> None:
+    _emit_chain(tmp_path)
+
+    result = verify_review_chain(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        pr_url=_PR_URL,
+        issue_body=_ISSUE,
+        diff=_DIFFS[-1],
+        ruleset_digest="sha256:" + "b" * 64,
+    )
+
+    assert not result.ok
+    assert "ruleset" in result.reason
+
+
+def test_verify_chain_rejects_a_receipt_whose_stored_ruleset_was_rewritten(tmp_path: Path) -> None:
+    _emit_chain(tmp_path)
+    _rewrite(receipt_path(tmp_path, _PR_URL, pass_index=1), ruleset_digest="sha256:" + "c" * 64)
+
+    result = verify_review_chain(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        pr_url=_PR_URL,
+        issue_body=_ISSUE,
+    )
+
+    assert not result.ok
+    assert "pass 1" in result.reason
+
+
+def test_verify_chain_rejects_a_broken_chain_link(tmp_path: Path) -> None:
+    _emit_chain(tmp_path)
+    path = receipt_path(tmp_path, _PR_URL, pass_index=2)
+    receipt = read_review_receipt(tmp_path, _PR_URL, pass_index=2)
+    assert receipt is not None
+    # Re-sign nothing: only the recorded link moves, which the chain walk sees
+    # before the signature check can absolve it.
+    _rewrite(path, prev_entry_hash="sha256:" + "d" * 64)
+
+    result = verify_review_chain(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        pr_url=_PR_URL,
+        issue_body=_ISSUE,
+    )
+
+    assert not result.ok
+    assert "chain" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Back-compat -- a single-pass receipt is byte-identical to what shipped before
+# ---------------------------------------------------------------------------
+
+
+def test_single_pass_receipt_binding_is_unchanged_by_the_contour_fields(tmp_path: Path) -> None:
+    private_pem, public_pem = load_or_create_review_identity(tmp_path / ".sdd" / "identity")
+    receipt = emit_review_receipt(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        private_key_pem=private_pem,
+        public_key_pem=public_pem,
+        pr_url=_PR_URL,
+        repo="acme/widget",
+        issue_body=_ISSUE,
+        plan="plan",
+        journal_head="deadbeef",
+        diff=_DIFFS[0],
+        findings=(),
+        verdict="approve",
+        task_id="task-1",
+        timestamp=1000,
+    )
+
+    binding = json.loads(receipt.to_canonical_bytes())
+
+    assert "pass_index" not in binding
+    assert "ruleset_digest" not in binding
+    assert "prev_entry_hash" not in binding
+    assert receipt_path(tmp_path, _PR_URL) == receipt_path(tmp_path, _PR_URL, pass_index=0)
+    assert verify_review_receipt(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        pr_url=_PR_URL,
+        issue_body=_ISSUE,
+        diff=_DIFFS[0],
+    ).ok

--- a/tests/unit/test_review_pipeline_contour_cmd.py
+++ b/tests/unit/test_review_pipeline_contour_cmd.py
@@ -1,0 +1,120 @@
+"""CLI wiring for the fix-until-green contour (issue #4481).
+
+The loop lives in :mod:`bernstein.core.quality.review_pipeline.contour`; these
+tests pin that the CLI only assembles its inputs and forwards the outcome's
+exit code (AC1).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.cli.commands import review_pipeline_cmd
+from bernstein.core.quality.review_pipeline.contour import ContourResult, PassRecord
+
+_PIPELINE_YAML = """version: 1
+name: contour
+stages:
+  - name: s
+    agents:
+      - role: r
+"""
+
+_RULES = "## Guard\n\n- Do not flag the vendored parser.\n"
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    (tmp_path / "review.yaml").write_text(_PIPELINE_YAML, encoding="utf-8")
+    rules = tmp_path / ".bernstein" / "review-rules.md"
+    rules.parent.mkdir(parents=True, exist_ok=True)
+    rules.write_text(_RULES, encoding="utf-8")
+    return tmp_path
+
+
+def _stub_contour(monkeypatch: pytest.MonkeyPatch, result: ContourResult) -> dict[str, Any]:
+    """Stub every collaborator that would touch GitHub or the install identity."""
+    seen: dict[str, Any] = {}
+
+    def _fake(pipeline: Any, **kwargs: Any) -> ContourResult:
+        seen["pipeline"] = pipeline
+        seen.update(kwargs)
+        return result
+
+    monkeypatch.setattr(review_pipeline_cmd, "run_review_contour", _fake)
+    monkeypatch.setattr(
+        review_pipeline_cmd,
+        "gh_pr_view_json",
+        lambda *_a, **_k: {"url": "https://github.com/acme/widget/pull/7", "body": "ticket"},
+    )
+    monkeypatch.setattr(review_pipeline_cmd, "receipt_emitter", lambda **_k: "emitter")
+    return seen
+
+
+def test_cli_returns_nonzero_when_the_contour_needs_an_operator(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    record = PassRecord(
+        index=1,
+        verdict="request_changes",
+        checks_state="red",
+        diff_hash="sha256:x",
+        ruleset_digest="sha256:y",
+    )
+    seen = _stub_contour(
+        monkeypatch,
+        ContourResult(outcome="needs-operator", reason="max_passes=1 spent", passes=(record,)),
+    )
+
+    code = review_pipeline_cmd.run_review_pipeline_cli(
+        pipeline_path=str(project / "review.yaml"),
+        pr_number=7,
+        validate_only=False,
+        dry_run=False,
+        workdir=str(project),
+        until_checks_green=True,
+        max_passes=1,
+    )
+
+    assert code == 1
+    assert seen["max_passes"] == 1
+
+
+def test_cli_hands_the_loaded_ruleset_to_the_contour(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _stub_contour(monkeypatch, ContourResult(outcome="approved", reason="", passes=()))
+
+    code = review_pipeline_cmd.run_review_pipeline_cli(
+        pipeline_path=str(project / "review.yaml"),
+        pr_number=7,
+        validate_only=False,
+        dry_run=False,
+        workdir=str(project),
+        until_checks_green=True,
+        max_passes=3,
+    )
+
+    assert code == 0
+    assert [r.text for r in seen["ruleset"].guard_rules] == ["Do not flag the vendored parser."]
+
+
+def test_cli_without_a_fix_command_supplies_no_fix_runner(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _stub_contour(monkeypatch, ContourResult(outcome="approved", reason="", passes=()))
+
+    review_pipeline_cmd.run_review_pipeline_cli(
+        pipeline_path=str(project / "review.yaml"),
+        pr_number=7,
+        validate_only=False,
+        dry_run=False,
+        workdir=str(project),
+        fix=True,
+        until_checks_green=True,
+    )
+
+    assert seen["fix_runner"] is None
+
+
+def test_repo_slug_is_derived_from_the_pr_url_offline() -> None:
+    assert review_pipeline_cmd._repo_slug("https://github.com/acme/widget/pull/42") == "acme/widget"
+    assert review_pipeline_cmd._repo_slug("https://ghe.example.com/team/tool/pull/7") == "team/tool"
+    assert review_pipeline_cmd._repo_slug("not-a-pr-url") == ""

--- a/tests/unit/test_review_receipt_cmd.py
+++ b/tests/unit/test_review_receipt_cmd.py
@@ -121,3 +121,73 @@ def test_verify_no_receipt_exit_1(project: Path) -> None:
         ],
     )
     assert result.exit_code == 1, result.output
+
+
+# ---------------------------------------------------------------------------
+# ``verify --chain`` -- the fix-until-green contour's per-pass receipts (#4481)
+# ---------------------------------------------------------------------------
+
+_RULES = "## Guard\n\n- Do not flag the vendored parser.\n"
+_PASS_DIFFS = ("--- a/x\n+++ b/x\n-leak\n+redact\n", "--- a/x\n+++ b/x\n-leak\n+scrub\n")
+
+
+def _emit_chain(project: Path) -> str:
+    """Emit two contour passes and return the ruleset digest they used."""
+    from bernstein.core.quality.review_pipeline.contour import PassReceiptRequest, receipt_emitter
+    from bernstein.core.quality.review_pipeline.ruleset import parse_ruleset
+
+    (project / "issue.md").write_text(_ISSUE, encoding="utf-8")
+    (project / "rules.md").write_text(_RULES, encoding="utf-8")
+    digest = parse_ruleset(_RULES).digest
+    emit = receipt_emitter(workdir=project, pr_url=_PR_URL, repo="acme/widget", issue_body=_ISSUE, timestamp=1000)
+    previous = ""
+    for index, (diff, verdict) in enumerate(zip(_PASS_DIFFS, ("request_changes", "approve"), strict=True), start=1):
+        (project / "pr.diff").write_text(diff, encoding="utf-8")
+        previous = emit(
+            PassReceiptRequest(
+                pass_index=index,
+                diff=diff.encode("utf-8"),
+                verdict=verdict,
+                ruleset_digest=digest,
+                prev_entry_hash=previous,
+            )
+        )
+    return digest
+
+
+def _verify_chain(project: Path, *, rules: Path | None) -> object:
+    argv = [
+        "verify",
+        "--chain",
+        "--pr",
+        _PR_URL,
+        "--issue",
+        str(project / "issue.md"),
+        "--diff",
+        str(project / "pr.diff"),
+        "-w",
+        str(project),
+    ]
+    if rules is not None:
+        argv.extend(["--rules", str(rules)])
+    return CliRunner().invoke(review_receipt_group, argv)
+
+
+def test_verify_chain_accepts_every_pass_of_the_contour(project: Path) -> None:
+    _emit_chain(project)
+
+    result = _verify_chain(project, rules=project / "rules.md")
+
+    assert result.exit_code == 0, result.output
+    assert "passes  2" in result.output
+
+
+def test_verify_chain_rejects_a_ruleset_the_passes_were_not_reviewed_under(project: Path) -> None:
+    _emit_chain(project)
+    moved = project / "moved-rules.md"
+    moved.write_text("## Guard\n\n- Something else entirely.\n", encoding="utf-8")
+
+    result = _verify_chain(project, rules=moved)
+
+    assert result.exit_code == 2, result.output
+    assert "ruleset" in result.output


### PR DESCRIPTION
## Problem

`bernstein review --pipeline` reviewed a PR and printed a verdict table, and everything that turns that verdict into an outcome on the pull request lived outside the product: deciding that a verdict needs a fix pass, collecting the failing checks' log tails so the fixer is told why CI is red, re-reading the check rollup after each push, and emitting the receipt that binds the verdict to the diff it was made against. Operators running unattended review wrote that loop in shell around the CLI, each with its own stop condition, its own idea of "red", and usually no provenance at all, so two operators reviewing the same PR could not compare results.

## What this changes

- `bernstein.core.quality.review_pipeline.contour` owns the loop: wait (bounded) for the check rollup to settle, review the current diff, stop on approve-plus-green, otherwise run a fix pass and start the next pass. At `--max-passes` it stops with an explicit `needs-operator` outcome and a non-zero exit code, never an approval. A missing fix runner and a fix pass that landed no commit both end the same way.
- `bernstein review --pipeline` gains `--fix`, `--until-checks-green`, `--max-passes N` and `--fix-command`. The CLI module only assembles the contour's inputs and forwards its exit code.
- The fix pass is given the verdict, its issues, the failing check names, and those checks' log excerpts, fetched through the existing `gh run view --log-failed` wrapper (`core/autofix/gh_logs.py`). The check rollup is read through the same `gh pr view` helper the diff fetch already used, factored out as `runner.gh_pr_view_json` - no second HTTP layer.
- `.bernstein/review-rules.md` (or a pipeline's `rules:` key, as a path or an inline `raise`/`guard` mapping) declares the standard a review is held to. Guard rules - the findings not to raise - are what stops an unattended pass re-reporting a rejected finding. The digest is a SHA-256 over the canonical rule set, so reordering the file leaves it alone and editing a rule moves it. With no rules file the ruleset is empty, the reviewer prompt is byte-identical to before, and the digest is the digest of the empty set.
- Every pass emits a review receipt through the existing `review-receipt` machinery, additionally binding `pass_index`, `ruleset_digest` and the previous pass's anchor. `review-receipt verify --chain` walks the whole sequence offline and rejects a pass whose diff or ruleset moved. The three new fields are omitted from the signed binding while unset, so a single-pass receipt keeps the path and the byte-identical binding it always had.

## Test evidence

New: 40 tests - `tests/unit/quality/review_pipeline/test_contour.py` (15), `test_ruleset.py` (9), `test_runner_ruleset.py` (2), `tests/unit/review/test_review_receipt_chain.py` (8), `tests/unit/test_review_pipeline_contour_cmd.py` (4), and 2 added to `tests/unit/test_review_receipt_cmd.py`.

- `uv run --frozen pytest tests/unit -k "review" -q`: 677 passed before, 717 passed after.
- `uv run --frozen pytest tests/integration/review_pipeline tests/unit/test_capability_surfaces.py tests/unit/test_cli_decomposition.py tests/unit/test_operator_surface_imports.py tests/unit/cli/test_task_cmd_mode.py tests/unit/test_bernstein_pr_review_workflow_yaml.py -q`: 45 passed.
- `uv run ruff format` / `uv run ruff check` clean on every touched file; `uv run pyright` clean on the new modules.

Mutation-checked the three load-bearing conditions: dropping the green-checks clause from the stop condition fails `test_red_checks_withhold_approval_when_until_checks_green`; making the budget check unreachable fails `test_budget_exhausted_exits_needs_operator_nonzero`; removing the chain-link check fails `test_verify_chain_rejects_a_broken_chain_link`. All restored.

## Acceptance criteria

| Criterion | Covered by |
|---|---|
| `--until-checks-green` + `--fix` loop to `--max-passes`, non-zero `needs-operator` when spent | `test_budget_exhausted_exits_needs_operator_nonzero`, `test_fix_pass_runs_between_review_passes_until_checks_go_green`, `test_red_checks_withhold_approval_when_until_checks_green`, `test_contour_without_a_fix_runner_stops_needs_operator_never_approved`, `test_fix_runner_that_did_not_push_stops_the_loop`, `test_rollup_wait_is_bounded_and_reports_pending_on_timeout`, `test_cli_returns_nonzero_when_the_contour_needs_an_operator` |
| Fix prompt contains the failing checks' log excerpts | `test_fix_prompt_contains_the_failing_check_log_excerpts`, `test_fix_prompt_contains_the_review_verdict_issues` |
| Per-pass receipt binds diff hash, ruleset digest, pass index, verdict; verify accepts the chain, rejects altered diff/ruleset | `test_each_pass_emits_a_receipt_binding_diff_ruleset_index_and_verdict`, `test_receipt_chain_links_each_pass_to_the_previous_anchor`, `test_verify_chain_accepts_an_untampered_chain`, `test_verify_chain_rejects_a_tampered_pass_diff`, `test_verify_chain_rejects_an_altered_ruleset_digest`, `test_verify_chain_rejects_a_broken_chain_link`, `test_verify_chain_accepts_every_pass_of_the_contour` |
| Rules file loaded, digest stable under reordering only if content is unchanged, guard rules visible to the reviewer prompt | `test_raise_and_guard_rules_are_parsed_from_the_rules_file`, `test_ruleset_digest_is_stable_under_rule_reordering`, `test_ruleset_digest_changes_when_a_rule_body_changes`, `test_reviewer_prompt_carries_the_guard_rules` |
| Missing rules file: pipeline unchanged, digest of the empty set, documented | `test_missing_rules_file_yields_the_empty_set_digest`, `test_empty_ruleset_contributes_no_prompt_section`, `test_reviewer_prompt_is_unchanged_when_the_ruleset_is_empty`, plus `docs/operations/review-pipeline.md` |

## Notes

- The fix pass is an operator-supplied command rather than a bundled fixer: `--fix-command` (or `$BERNSTEIN_REVIEW_FIX_COMMAND`) is invoked with the rendered prompt's path as its last argument and counts only when it exits 0 and `HEAD` moved. Wiring a specific adapter as the default belongs in its own change.
- Merging and auth stay out of scope, as the ticket says: the caller supplies an authenticated `gh` and landing the PR remains a separate decision.
- `--pr` keeps taking a number rather than a url, so the existing flag's contract does not change; the receipt's PR url is read from `gh pr view --json url`.

Docs: `docs/operations/review-pipeline.md` (ruleset, contour, per-pass receipts), `src/bernstein/core/quality/AGENTS.md`, `templates/review/review-rules.example.md`, release-notes fragment.

Closes #4481
