### PR TITLE
docs(release-notes): credit the contributors whose work shipped in v3.18.0

### DIFF
--- a/docs/release-notes/v3.18.0.md
+++ b/docs/release-notes/v3.18.0.md
@@ -32,3 +32,19 @@ Every HMAC-chained store signed with the same raw key. New audit entries carry s
 ## Also
 
 A board carrying a dependency cycle drains instead of wedging (#4287). The legacy `/dashboard` route is gone; `bernstein dashboard` points at `bernstein gui serve` (#4395). The watchdog no longer restarts a run that already finished (#4445). The nightly dependency audit is green again on `pip` 26.2.1. A release-notes entry can ship as its own fragment file instead of a line in the shared page, so parallel PRs stop colliding in the merge queue (#4474).
+
+## Contributors
+
+- **Chirag Honnyal** — the gate-name fix that lets a seed naming
+  `agent_test_mutation` parse (#4493), the cycle-forming dependency rejected
+  before persistence rather than after (#4431), the legacy `/dashboard` route
+  removal (#4430), quality gates running in reap-and-merge before an agent
+  branch lands (#4429), and the staleness-clock reset for the curated context
+  files (#4477).
+- **Louis20060723** — Agent Plugins directory layout in `skills install`,
+  including the containment walk that refuses a skill escaping its pack
+  (#4448).
+- **Aditya Pathak** — the mypy configuration and its preview follow-up
+  (#4434, #4432).
+- **Vaibhav Srivastava** — the CI canary proposal branch now builds on the
+  fetched default branch, not on whatever the runner had checked out (#4497).


### PR DESCRIPTION
The v3.18.0 page describes the changes but names nobody. Four people outside the maintainer authored work in that window; this adds the section the earlier release pages carry, one line each naming what they built.

The GitHub Release body is untouched — its generated changelog already lists the authors.

No source changes.