### PR TITLE
fix(quality): run the repo seed's lint gate through uv

### DIFF
--- a/bernstein.yaml
+++ b/bernstein.yaml
@@ -33,7 +33,7 @@ constraints:
 quality_gates:
   enabled: true
   lint: true
-  lint_command: ruff check .
+  lint_command: uv run ruff check .
   type_check: false
   tests: false
 context_files:

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -10,3 +10,9 @@ holds the page to that — an entry naming an issue or PR a tagged release page
 already documents fails the build. An entry that cites released work as context
 rather than as its own attribution is exempted by hand there, with the reason.
 
+- The repo's own run seed ran the lint gate as a bare `ruff check .`. This
+  project is uv-managed and never activates its virtualenv, so the gate shell
+  could not find the binary and reported "ruff: not found" as a lint failure on
+  every run, blocking merges for a reason no code change could fix. The seed now
+  invokes ruff through `uv run`, and a test holds every gate command that names
+  a venv-resident tool to that form. (#4547)

--- a/tests/unit/test_repo_seed_gate_commands.py
+++ b/tests/unit/test_repo_seed_gate_commands.py
@@ -1,0 +1,46 @@
+"""The repo's own run seed must invoke Python tooling through uv.
+
+This project is uv-managed: the virtualenv lives at ``.venv`` and is never
+activated, so a bare ``ruff`` is not on PATH for the shell the quality gates
+spawn. A gate configured with a bare binary fails with "ruff: not found" on
+every run, which reads as a lint failure rather than a misconfiguration.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SEED = REPO_ROOT / "bernstein.yaml"
+
+# Tools that live in the project venv rather than on the system PATH.
+_VENV_TOOLS = ("ruff", "pytest", "mypy", "pyright")
+
+
+def _gate_commands() -> dict[str, str]:
+    config = yaml.safe_load(SEED.read_text(encoding="utf-8"))
+    gates = config.get("quality_gates") or {}
+    return {key: value for key, value in gates.items() if key.endswith("_command")}
+
+
+def test_seed_declares_gate_commands() -> None:
+    """Guard the guard: the assertions below are vacuous without commands."""
+    assert _gate_commands(), "bernstein.yaml declares no *_command gate entries"
+
+
+@pytest.mark.parametrize("tool", _VENV_TOOLS)
+def test_venv_tool_is_never_invoked_bare(tool: str) -> None:
+    for key, command in _gate_commands().items():
+        # Match the tool only as the command word, so "uv run ruff" passes
+        # while "ruff check ." fails.
+        if re.match(rf"^{re.escape(tool)}\b", command.strip()):
+            pytest.fail(
+                f"bernstein.yaml quality_gates.{key} runs {tool!r} directly "
+                f"({command!r}). The venv is not on PATH for the gate shell; "
+                f"use 'uv run {tool} ...' so the gate reports real violations "
+                f"instead of '{tool}: not found'."
+            )


### PR DESCRIPTION
The seed configured the lint gate as a bare `ruff check .`. This project is uv-managed: the virtualenv lives at `.venv` and is never activated, so the shell the gate spawns has no `ruff` on `PATH`.

Reproduced in a container running this seed:

```
$ sh -c "ruff check ."
sh: 1: ruff: not found

$ sh -c "uv run ruff check ."
Found 9 errors.
```

The first form fails the lint gate on every run. Because a missing binary is reported the same way as a lint violation, the gate blocks the merge and the failure reads as "this code does not lint" — so the follow-up work is aimed at the code, which can never fix it.

The seed's own guidance (line 2) already tells agents to run `uv run ruff check src/`, and its `test_command` already uses `uv run`. The lint command was the outlier.

This is narrow on purpose: the library defaults in `config_schema.py`, `seed_parser.py` and `quality_gates.py` keep the bare `ruff check .`, which is correct for projects that activate their environment. Only this repo's own seed changes.

The added test pins the invariant for this seed — any gate command naming a venv-resident tool (`ruff`, `pytest`, `mypy`, `pyright`) must go through `uv run`. It fails before this change and passes after, and it includes a guard so the parametrised assertions cannot pass vacuously if the gate block is ever restructured.

The deeper defect this exposed — a gate cannot distinguish "linter missing" (shell exit 127) from "linter found violations", because `_run_command` discards the exit code — is filed separately as #4548.
