### PR TITLE
test(skills): pin DNS-rebinding rejection for the catalog index URL

### DIFF
--- a/tests/unit/core/skills/test_catalog_fetcher.py
+++ b/tests/unit/core/skills/test_catalog_fetcher.py
@@ -122,3 +122,27 @@ def test_link_local_metadata_url_is_rejected(tmp_path: Path) -> None:
     with pytest.raises(UrlSchemeError):
         fetcher.fetch()
     assert transport.calls == []
+
+
+def test_rebinding_hostname_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Simulate a hostname that resolves to a private address (rebinding attack)
+    def resolver(host: str) -> list[str]:
+        if host == "rebind.example":
+            # Return a private IP (loopback) and a public IP
+            return ["127.0.0.1", "93.184.216.34"]
+        return ["93.184.216.34"]  # default to public for any other host
+
+    monkeypatch.setattr(
+        "bernstein.core.security.url_allowlist._default_resolver",
+        resolver,
+    )
+
+    transport = _FakeTransport()
+    fetcher = _build_fetcher(
+        tmp_path,
+        transport,
+        primary_url="https://rebind.example/skills.json",
+    )
+    with pytest.raises(UrlSchemeError):
+        fetcher.fetch()
+    assert transport.calls == []


### PR DESCRIPTION
`test_catalog_fetcher.py` pins that the skills-catalog index URL is rejected for a bad scheme and for a link-local host, but nothing pinned the case where the host is ordinary and only its **resolution** is private. That is the DNS-rebinding shape, and it is the one a scheme check cannot catch.

The guard already handles it. This adds the test that says so, so a future refactor of the resolution path fails loudly instead of silently widening the fetcher's reach.

## The test

`test_rebinding_hostname_is_rejected` patches `url_allowlist._default_resolver` so `rebind.example` resolves to `127.0.0.1` alongside a public address, then asserts the fetch raises `UrlSchemeError` and that the transport was never called.

Verified it is not vacuous: with the resolver returning only public addresses the test fails on `unexpected request to https://rebind.example/skills.json` — the request goes through. The rejection in the passing case comes from the private address, not from some unrelated guard.

```
uv run pytest tests/unit/core/skills/test_catalog_fetcher.py -q   # 4 passed
```

## Scope

This covers the operator-supplied index URL. #4286 is about a different surface — URLs taken from *entries inside* a fetched index, which reach `ensure_http_url` without a host check. That gap is untouched here and #4286 stays open.
