### PR TITLE
fix(janitor): resolve test_passes paths against the tree before running them

### DIFF
--- a/docs/architecture/quality-pipeline.md
+++ b/docs/architecture/quality-pipeline.md
@@ -40,6 +40,18 @@ The janitor evaluates each `CompletionSignal` declared on the task
 | `llm_judge`      | Async LLM judge (`judge_task()`, `janitor.py:462`); used for ambiguous tasks. |
 | `schema_valid` / `criteria_match` / `hash_stable` / `figures_grounded` | Artifact-mode criteria over the produced artifact's canonical bytes. They fail closed on the filesystem path; only `evaluate_artifact_signals()`, called with the artifact in scope, can pass one. |
 
+A `test_passes` command is resolved against the tree before it runs. The path in
+the signal is written when the task is planned, not read off the suite, so the
+two drift: a plan mirroring `src/bernstein/core/security/` asks for
+`tests/unit/core/security/test_policy.py` while the file lives at
+`tests/unit/test_policy.py`. pytest then exits during collection without running
+anything, and the task is rejected over a path the agent never chose.
+`_resolve_test_path_command()` rewrites the command onto the file that exists,
+but only when exactly one file under the declared root carries that basename. A
+basename absent everywhere means the test was never written, and an ambiguous
+one means the janitor cannot tell which was meant; both keep the original path
+so the command fails honestly.
+
 Which evaluator runs is decided by the task's declared artifact kind.
 `verify_task_completion()` (`core/tasks/artifact_completion.py`) is the seam the
 completion paths call: a `code_diff` task falls through to `verify_task()`

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -25,3 +25,12 @@ rather than as its own attribution is exempted by hand there, with the reason.
   ruleset mirror now matches the live one, and the merge-queue runbook carries
   the trigger precondition as a numbered step so the next lane to be required
   cannot repeat it. (#4556)
+- A `test_passes` completion signal names its test by path, and that path is
+  written when the task is planned rather than read off the suite. A plan
+  mirroring `src/bernstein/core/security/` asked for
+  `tests/unit/core/security/test_policy.py` while the file lives at
+  `tests/unit/test_policy.py`, so pytest exited during collection and the
+  janitor rejected the task over a path the agent never chose. The command is
+  now resolved against the tree first, following only an unambiguous rename;
+  a basename that is absent everywhere or matches several files keeps the
+  original path so the command still fails honestly. (#4554)

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import subprocess
 import uuid
 from pathlib import Path
@@ -302,6 +303,7 @@ def evaluate_signal(
             )
         case "test_passes":
             command = _resolve_branch_check_command(signal.value, workdir)
+            command = _resolve_test_path_command(command, workdir)
             ok = _check_test_passes(command, workdir)
             return ok, "exit 0" if ok else "non-zero exit"
         case "file_contains":
@@ -2004,6 +2006,80 @@ def _resolve_branch_check_command(command: str, workdir: Path) -> str:
         branches,
     )
     return command
+
+
+def _resolve_test_path_command(command: str, workdir: Path) -> str:
+    """Rewrite a ``test_passes`` command onto the test files that actually exist.
+
+    A completion signal names its test by path, and that path is written by
+    whoever planned the task rather than read off the tree. When the two
+    disagree -- the plan mirrors the ``src`` layout
+    (``tests/unit/core/security/test_policy.py``) while the suite is flatter
+    (``tests/unit/test_policy.py``) -- pytest exits during collection without
+    running anything, and the janitor reads that exit as the agent's work
+    being wrong. The agent is then rejected over a path it never chose.
+
+    Only an unambiguous rename is followed: exactly one file with that
+    basename beneath the declared root. No match means the test genuinely is
+    not there -- the agent was asked to write it and did not -- and several
+    matches mean the janitor cannot tell which one was meant. Both keep the
+    original token, so the command still fails, honestly.
+
+    Args:
+        command: The ``test_passes`` shell command, after branch resolution.
+        workdir: Project root the command will run in.
+
+    Returns:
+        The original command, or the same command with every uniquely
+        resolvable missing test path replaced by the path that does exist.
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        # Unbalanced quotes: not the janitor's to repair. Run it verbatim.
+        return command
+
+    resolved_command = command
+    for token in tokens:
+        if token.startswith("-"):
+            continue
+        # ``path::node_id`` selects one test inside a file; only the path half
+        # is a filesystem claim, and the node id must survive the rewrite.
+        declared = token.split("::", 1)[0]
+        if not declared.endswith(".py") or (workdir / declared).exists():
+            continue
+        parts = Path(declared).parts
+        # Search only under the declared top-level directory (``tests``), never
+        # from the project root: a bare or dot-relative filename would walk the
+        # virtualenv and could match a file in an installed package.
+        if len(parts) < 2 or parts[0] in (".", "..") or Path(declared).is_absolute():
+            continue
+        root = workdir / parts[0]
+        if not root.is_dir():
+            continue
+        matches = sorted(p for p in root.rglob(Path(declared).name) if p.is_file())
+        if len(matches) != 1:
+            logger.info(
+                "janitor acceptance check: test path %r is absent from %s and "
+                "%d files share its name - verdict: will FAIL, running the "
+                "original command for an honest error",
+                declared,
+                workdir,
+                len(matches),
+            )
+            continue
+        actual = matches[0].relative_to(workdir).as_posix()
+        logger.info(
+            "janitor acceptance check: test path %r is absent from %s but %r "
+            "is the only file with that name - verdict: rewriting the command "
+            "onto it (the completion signal mirrors the src layout; the suite "
+            "does not)",
+            declared,
+            workdir,
+            actual,
+        )
+        resolved_command = resolved_command.replace(declared, actual)
+    return resolved_command
 
 
 def _check_test_passes(command: str, workdir: Path) -> bool:

--- a/tests/unit/test_janitor_test_path_resolution.py
+++ b/tests/unit/test_janitor_test_path_resolution.py
@@ -1,0 +1,117 @@
+"""Tests for ``test_passes`` signals whose test path mirrors the ``src`` layout.
+
+A completion signal names its test by path, and that path is written when the
+task is planned, not read off the tree. The two drift: a plan that mirrors
+``src/bernstein/core/security/`` asks for
+``tests/unit/core/security/test_policy.py`` while the suite keeps that file at
+``tests/unit/test_policy.py``. pytest then exits during collection without
+running a single test, and the janitor recorded that exit as the agent's work
+being wrong -- so the agent was rejected over a path it never chose.
+
+``_resolve_test_path_command`` rewrites such a command onto the file that
+exists, but only when the rename is unambiguous. The tests below pin both
+halves: the rewrite happens for a unique basename, and it deliberately does
+*not* happen when the file is absent everywhere (the agent really was asked to
+write it) or when several files share the name.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from bernstein.core.models import CompletionSignal
+
+from bernstein.core.quality.janitor import (
+    _resolve_test_path_command,
+    evaluate_signal,
+)
+
+
+def _touch(path: Path, body: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def test_unique_basename_is_rewritten_onto_the_file_that_exists(tmp_path: Path) -> None:
+    _touch(tmp_path / "tests/unit/test_policy.py")
+    command = "uv run pytest tests/unit/core/security/test_policy.py -x -q"
+
+    assert _resolve_test_path_command(command, tmp_path) == "uv run pytest tests/unit/test_policy.py -x -q"
+
+
+def test_every_missing_path_in_a_multi_file_command_is_rewritten(tmp_path: Path) -> None:
+    _touch(tmp_path / "tests/unit/routing/test_router_core.py")
+    _touch(tmp_path / "tests/unit/test_fast_path.py")
+    command = "uv run pytest tests/unit/core/routing/test_router_core.py tests/unit/core/quality/test_fast_path.py -q"
+
+    assert _resolve_test_path_command(command, tmp_path) == (
+        "uv run pytest tests/unit/routing/test_router_core.py tests/unit/test_fast_path.py -q"
+    )
+
+
+def test_node_id_survives_the_rewrite(tmp_path: Path) -> None:
+    _touch(tmp_path / "tests/unit/test_policy.py")
+    command = "pytest tests/unit/core/security/test_policy.py::test_denies -q"
+
+    assert _resolve_test_path_command(command, tmp_path) == "pytest tests/unit/test_policy.py::test_denies -q"
+
+
+def test_absent_everywhere_keeps_the_original_path(tmp_path: Path) -> None:
+    """The agent was asked to write this test and did not. That must still fail."""
+    (tmp_path / "tests/unit").mkdir(parents=True)
+    command = "uv run pytest tests/unit/evolution/test_applicator.py -x -q"
+
+    assert _resolve_test_path_command(command, tmp_path) == command
+
+
+def test_ambiguous_basename_keeps_the_original_path(tmp_path: Path) -> None:
+    _touch(tmp_path / "tests/unit/test_policy.py")
+    _touch(tmp_path / "tests/integration/test_policy.py")
+    command = "pytest tests/unit/core/security/test_policy.py -q"
+
+    assert _resolve_test_path_command(command, tmp_path) == command
+
+
+def test_existing_path_is_left_untouched(tmp_path: Path) -> None:
+    _touch(tmp_path / "tests/unit/test_policy.py")
+    _touch(tmp_path / "tests/integration/test_policy.py")
+    command = "pytest tests/unit/test_policy.py -q"
+
+    assert _resolve_test_path_command(command, tmp_path) == command
+
+
+def test_search_never_leaves_the_declared_root(tmp_path: Path) -> None:
+    """A match inside an installed package is not a match for the suite."""
+    _touch(tmp_path / ".venv/lib/site-packages/pkg/test_policy.py")
+    (tmp_path / "tests").mkdir()
+    command = "pytest tests/unit/core/security/test_policy.py -q"
+
+    assert _resolve_test_path_command(command, tmp_path) == command
+
+
+def test_signal_passes_once_the_moved_test_is_found(tmp_path: Path) -> None:
+    _touch(
+        tmp_path / "tests/unit/test_policy.py",
+        "def test_denies() -> None:\n    assert True\n",
+    )
+    signal = CompletionSignal(
+        type="test_passes",
+        value=f"{sys.executable} -m pytest tests/unit/core/security/test_policy.py -q -p no:cacheprovider",
+    )
+
+    passed, _ = evaluate_signal(signal, tmp_path)
+
+    assert passed
+
+
+def test_signal_still_fails_when_the_test_was_never_written(tmp_path: Path) -> None:
+    (tmp_path / "tests/unit").mkdir(parents=True)
+    signal = CompletionSignal(
+        type="test_passes",
+        value=f"{sys.executable} -m pytest tests/unit/evolution/test_applicator.py -q -p no:cacheprovider",
+    )
+
+    passed, _ = evaluate_signal(signal, tmp_path)
+
+    assert not passed


### PR DESCRIPTION
## Problem

A `test_passes` completion signal names its test by path, and that path is
written when the task is planned — not read off the suite. The two drift.

A plan that mirrors `src/bernstein/core/security/` asks for
`tests/unit/core/security/test_policy.py`; the file lives at
`tests/unit/test_policy.py`. pytest exits during collection without running a
single test, `_check_test_passes` sees a non-zero exit, and the janitor records
a failed completion signal. The agent is rejected over a path it never chose.

Observed on this repo's own runs — three distinct commands, none of whose paths
exist:

| Signal command | Real location |
|---|---|
| `pytest tests/unit/core/routing/test_router_core.py tests/unit/core/quality/test_fast_path.py -q` | `tests/unit/routing/test_router_core.py`, `tests/unit/test_fast_path.py` |
| `pytest tests/unit/core/security/test_policy.py -x -q` | `tests/unit/test_policy.py` |
| `pytest tests/unit/evolution/test_applicator.py -x -q` | nowhere — genuinely not written |

The first two are the harness rejecting correct work. The third is a real
failure, and it has to stay one.

## Fix

`_resolve_test_path_command()` rewrites the command onto the file that exists,
following only an unambiguous rename: exactly one file with that basename under
the declared top-level directory. A basename absent everywhere means the test
was never written; several matches mean the janitor cannot tell which was meant.
Both keep the original token, so the command still fails — honestly.

This mirrors `_resolve_branch_check_command()`, which already resolves the other
half of the same class (branch refs that drift between task generation and
agent-side naming).

Two details worth naming:

- `path::node_id` selects one test inside a file. Only the path half is a
  filesystem claim; the node id survives the rewrite.
- The search is anchored on the declared root, so a bare or dot-relative
  filename cannot walk the virtualenv and match a file inside an installed
  package.

## Tests

`tests/unit/test_janitor_test_path_resolution.py`, nine cases. Each is named for
the property it protects:

- unique basename is rewritten; every path in a multi-file command is rewritten
- node id survives the rewrite
- **absent everywhere keeps the original path** — an unwritten test still fails
- **ambiguous basename keeps the original path**
- an existing path is left untouched
- the search never leaves the declared root
- end to end through `evaluate_signal`: a signal naming the moved path passes,
  and a signal naming a test that was never written still fails

The two end-to-end cases spawn a real pytest, so they exercise the collection
exit code rather than a mock of it. `test_signal_passes_once_the_moved_test_is_found`
fails on `main` and passes here.

## Checks run locally

`pytest` over `test_janitor.py`, `test_janitor_reopen.py`,
`test_janitor_alive_exit.py`, `test_approval_gate_janitor_polarity.py` and the
new file — 152 passed. `ruff check`, `ruff format --check`, `mypy` clean.
