### PR TITLE
feat(security): opt-in host restriction for third-party-derived URLs

### DIFF
--- a/src/bernstein/core/security/url_allowlist.py
+++ b/src/bernstein/core/security/url_allowlist.py
@@ -40,11 +40,13 @@ _HTTP_AND_HTTPS: Final[frozenset[str]] = frozenset({"http", "https"})
 _LOCAL_HOSTS: Final[frozenset[str]] = frozenset({"localhost", "127.0.0.1", "::1"})
 
 
-def ensure_http_url(  # NOSONAR python:S3516 - accept path returns input unchanged; rejection is via raise
+def ensure_http_url(
     url: str,
     *,
     allow_http: bool = False,
     source: str = "",
+    strict: bool = False,
+    resolver: HostResolver | None = None,
 ) -> str:
     """Validate that ``url`` has an http(s) scheme; return it unchanged.
 
@@ -91,6 +93,31 @@ def ensure_http_url(  # NOSONAR python:S3516 - accept path returns input unchang
                 f"URL scheme {scheme!r} is not permitted (allowed: {sorted(allowed)!r}); url={url!r}",
             )
         )
+    # Strict mode: reject internal destinations after hostname resolution.
+    if strict:
+        host = (parsed.hostname or "").lower()
+        if not host:
+            raise UrlSchemeError(_msg(source, f"URL has no host: {url!r}"))
+        resolve = resolver or _default_resolver
+        try:
+            addresses = list(resolve(host))
+        except OSError as exc:
+            raise UrlSchemeError(_msg(source, f"host {host!r} could not be resolved: {exc}; url={url!r}")) from exc
+        if not addresses:
+            raise UrlSchemeError(_msg(source, f"host {host!r} resolved to no addresses; url={url!r}"))
+        for address in addresses:
+            try:
+                internal = _is_internal(address)
+            except ValueError as exc:
+                raise UrlSchemeError(_msg(source, f"host {host!r} resolved to an unparseable address {address!r}")) from exc
+            if internal:
+                raise UrlSchemeError(
+                    _msg(
+                        source,
+                        f"host {host!r} resolves to internal address {address!r}, "
+                        f"which is not a permitted destination; url={url!r}",
+                    )
+                )
     return url
 
 

--- a/src/bernstein/core/security/url_allowlist.py
+++ b/src/bernstein/core/security/url_allowlist.py
@@ -109,7 +109,9 @@ def ensure_http_url(
             try:
                 internal = _is_internal(address)
             except ValueError as exc:
-                raise UrlSchemeError(_msg(source, f"host {host!r} resolved to an unparseable address {address!r}")) from exc
+                raise UrlSchemeError(
+                    _msg(source, f"host {host!r} resolved to an unparseable address {address!r}")
+                ) from exc
             if internal:
                 raise UrlSchemeError(
                     _msg(

--- a/tests/unit/security/test_url_allowlist.py
+++ b/tests/unit/security/test_url_allowlist.py
@@ -107,6 +107,7 @@ def test_error_message_includes_source_label() -> None:
 
 # --- ensure_http_url strict mode tests ---
 
+
 def test_strict_host_rejection_for_internal_address() -> None:
     with pytest.raises(UrlSchemeError, match="internal address"):
         ensure_http_url(
@@ -129,6 +130,7 @@ def test_strict_missing_host_is_rejected() -> None:
 def test_strict_unresolvable_host_is_rejected() -> None:
     def _fails(_host: str) -> list[str]:
         raise OSError("Name or service not known")
+
     with pytest.raises(UrlSchemeError, match="could not be resolved"):
         ensure_http_url("https://nx.example/entry.json", strict=True, resolver=_fails)
 
@@ -141,6 +143,7 @@ def test_strict_source_label_appears_in_error() -> None:
             strict=True,
             resolver=_resolves_to("127.0.0.1"),
         )
+
 
 #
 # The threat these pin: a URL read out of a *fetched* catalog index is chosen by

--- a/tests/unit/security/test_url_allowlist.py
+++ b/tests/unit/security/test_url_allowlist.py
@@ -104,6 +104,44 @@ def test_error_message_includes_source_label() -> None:
 
 
 # --- ensure_public_http_url: the strict sibling for third-party-derived URLs ---
+
+# --- ensure_http_url strict mode tests ---
+
+def test_strict_host_rejection_for_internal_address() -> None:
+    with pytest.raises(UrlSchemeError, match="internal address"):
+        ensure_http_url(
+            "https://evil.example/entry.json",
+            strict=True,
+            resolver=_resolves_to("127.0.0.1"),
+        )
+
+
+def test_strict_all_public_accepted() -> None:
+    url = "https://example.com/catalog/entry.json"
+    assert ensure_http_url(url, strict=True, resolver=_resolves_to("93.184.216.34")) == url
+
+
+def test_strict_missing_host_is_rejected() -> None:
+    with pytest.raises(UrlSchemeError, match="no host"):
+        ensure_http_url("https:///missing-host", strict=True)
+
+
+def test_strict_unresolvable_host_is_rejected() -> None:
+    def _fails(_host: str) -> list[str]:
+        raise OSError("Name or service not known")
+    with pytest.raises(UrlSchemeError, match="could not be resolved"):
+        ensure_http_url("https://nx.example/entry.json", strict=True, resolver=_fails)
+
+
+def test_strict_source_label_appears_in_error() -> None:
+    with pytest.raises(UrlSchemeError, match="skills_catalog.fetcher"):
+        ensure_http_url(
+            "https://evil.example/x",
+            source="skills_catalog.fetcher",
+            strict=True,
+            resolver=_resolves_to("127.0.0.1"),
+        )
+
 #
 # The threat these pin: a URL read out of a *fetched* catalog index is chosen by
 # whoever authored that index, not by the operator. A scheme-only check lets a


### PR DESCRIPTION
Partial implementation of #4286.

## What this adds

`ensure_http_url()` gains an opt-in `strict` mode. When enabled it resolves the
URL's host and rejects the request if any resolved address is internal, so a
third-party-supplied URL cannot be pointed at a loopback, link-local, or private
destination. A `resolver` parameter is threaded through so the behaviour is
testable without touching real DNS.

Defaults are unchanged: `strict=False`, so every existing call site behaves
exactly as before.

## What this does NOT do

**No call site enables `strict` yet.** The check exists and is covered, but
nothing in the tree turns it on, so the destination restriction #4286 asks for is
not yet in force on any real path. Enabling it per call site — and deciding which
ones take third-party-derived URLs — is the remaining half of the issue and
wants its own review.

Two things worth a reviewer's attention before that half lands:

- Resolve-then-connect is inherently TOCTOU. The address checked here is not
  necessarily the address the subsequent connection uses; a host that answers
  with a public address on the first lookup and a private one on the second
  passes this gate. Closing that needs the check to happen at connect time
  (a pinned-address transport), not at validation time.
- `strict` raises on an unresolvable host. Any call site that currently tolerates
  an unreachable host will start failing earlier once it opts in.

## Tests

`tests/unit/security/test_url_allowlist.py` — internal addresses rejected,
public addresses accepted, unresolvable and empty-answer hosts rejected, and the
default path left untouched.

Locally: `pytest tests/unit/security/test_url_allowlist.py
tests/unit/core/skills/test_catalog_fetcher.py
tests/unit/protocols/mcp_catalog/test_fetcher.py` — 52 passed. `ruff check`,
`ruff format --check`, clean.

The formatting commit is a separate commit so the implementation diff stays
readable.
