### PR TITLE
ci: finish making the SPA bundle gate required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2062,10 +2062,11 @@ jobs:
     # quarter of the suite per push instead of sharding, because its
     # `name:` was kept a literal, non-templated string on the assumption
     # that branch protection's required context depended on it. It does
-    # not: the repository ruleset requires exactly one status check,
-    # `CI gate` (confirmed via `gh api .../rules/branches/main` ->
-    # required_status_checks.contexts == ["CI gate"]; see the PR that
-    # unlocked this). Nothing reads a per-shard job's display name, so it
+    # not: the required contexts are `CI gate` and `shipped bundle matches
+    # the lockfile`, and no `test` cell is among them (the live list lives in
+    # required-check-canary.yml as BRANCH_PROTECTION_CONTEXTS_JSON, which the
+    # scheduled audit compares against `gh api .../rules/branches/main`).
+    # Nothing reads a per-shard job's display name, so it
     # can template like `test`'s does. required-check-canary.yml still
     # locks the name branch protection actually depends on
     # (`ci-gate.name == "CI gate"`). Per-push macOS coverage now shards

--- a/.github/workflows/required-check-canary.yml
+++ b/.github/workflows/required-check-canary.yml
@@ -1,9 +1,11 @@
 name: Required-check name canary
 
-# Branch protection on `main` requires a single context, `CI gate`.
-# This workflow verifies the in-tree `CI gate` emitters. The scheduled
-# branch-protection audit reads `BRANCH_PROTECTION_CONTEXTS_JSON` below
-# and compares it with live repository settings.
+# Branch protection on `main` requires two contexts: `CI gate` and
+# `shipped bundle matches the lockfile`. This workflow verifies the in-tree
+# `CI gate` emitters. The scheduled branch-protection audit reads
+# `BRANCH_PROTECTION_CONTEXTS_JSON` below and compares it with live
+# repository settings, so that line is the tree's record of what protection
+# demands - it has to be updated in the same change as the setting itself.
 #
 # This canary fails the PR (and the weekly scheduled run) if any of the
 # locked invariants drifts. It is intentionally narrow: it does not try
@@ -23,9 +25,9 @@ name: Required-check name canary
 #
 # This canary used to also lock the `test-macos` job's `name:` to a
 # literal (non-templated) string, on the assumption that branch
-# protection's required context depended on it. It does not - the
-# repository ruleset requires exactly the single `CI gate` context
-# checked above - so `test-macos` is free to template its name the same
+# protection's required context depended on it. It does not - the required
+# contexts are the ones listed above, and `test-macos` is not among them -
+# so `test-macos` is free to template its name the same
 # way the `test` matrix job already does (e.g. to carry a shard index).
 #
 # Run modes:
@@ -68,7 +70,7 @@ jobs:
       - name: Verify required-check invariants
         env:
           REQUIRED_CONTEXT: "CI gate"
-          BRANCH_PROTECTION_CONTEXTS_JSON: '["CI gate"]'
+          BRANCH_PROTECTION_CONTEXTS_JSON: '["CI gate", "shipped bundle matches the lockfile"]'
           REQUIRED_JOB_KEY: "ci-gate"
           STUB_WORKFLOW: ".github/workflows/ci-gate-stub.yml"
         run: |

--- a/.github/workflows/spa-bundle-freshness.yml
+++ b/.github/workflows/spa-bundle-freshness.yml
@@ -32,14 +32,21 @@ name: SPA bundle freshness
 #
 # Merge queue
 # -----------
-# This lane reports on a queued ref, so branch protection *can* require it.
-# It is not required yet: that is a repository-settings change, and the
-# ordering matters in one direction only. A required context that cannot
-# report on a queued ref wedges the queue - every entry waits forever for a
-# check that never arrives (docs/operations/merge-queue.md, troubleshooting
-# row 1). Trigger first, requirement second, never the reverse. Until the
-# switch is thrown this lane still only annotates; #4010 is the bill for
-# that state, and #4028 has the two flips that end it.
+# This lane reports on a queued ref, and branch protection now requires it.
+# That is why the ``pull_request`` trigger carries no ``paths`` filter.
+#
+# The two have to move together. A required context only ever reports for the
+# events its trigger accepts, so a filtered trigger plus a required context
+# means every pull request outside the filter waits for a check that will
+# never run. GitHub states it plainly on the enqueue attempt: ``Required
+# status check "shipped bundle matches the lockfile" is expected``. Nothing
+# retries, nothing times out, and no amount of re-running helps - the run does
+# not exist. On 2026-08-25 that wedged every pull request that did not touch
+# ``web/``.
+#
+# The cost of an unfiltered trigger is one runner slot for a median of 28s.
+# The cost of a filtered one, now that the context is required, is the whole
+# merge queue. See docs/operations/merge-queue.md, troubleshooting row 1.
 #
 # The ``merge_group`` trigger carries no ``paths`` filter, deliberately.
 # GitHub evaluates ``paths`` / ``paths-ignore`` for ``push``,
@@ -50,20 +57,17 @@ name: SPA bundle freshness
 #
 # #4020 took three lanes *out* of the queue on the rule that a lane which
 # cannot gate a merge should not compete for runners with the one that can.
-# That rule is not in tension with this trigger for long - this lane is on
-# its way to being required, which is the case #4020 excludes - and the
-# job is one slot for a median of 28s (14 recent executions: 23s min, 37s
+# That rule does not apply here: this lane *is* required, which is the case
+# #4020 excludes - and the job is one slot for a median of 28s (14 recent executions: 23s min, 37s
 # max; the multi-minute figures in the run list are queue wait, not
 # execution), against the 16-job matrices and multi-minute scanners #4020
 # removed.
 
 on:
   merge_group: {}
-  pull_request:
-    paths:
-      - "web/**"
-      - "src/bernstein/gui/static/**"
-      - ".github/workflows/spa-bundle-freshness.yml"
+  # No ``paths`` filter: this is a required context, so it must report on
+  # every pull request or the ones it skips can never merge.
+  pull_request: {}
   push:
     branches: [main]
     paths:

--- a/docs/operations/merge-queue-ruleset.json
+++ b/docs/operations/merge-queue-ruleset.json
@@ -22,7 +22,8 @@
         "strict_required_status_checks_policy": false,
         "do_not_enforce_on_create": true,
         "required_status_checks": [
-          { "context": "CI gate", "integration_id": 15368 }
+          { "context": "CI gate", "integration_id": 15368 },
+          { "context": "shipped bundle matches the lockfile", "integration_id": 15368 }
         ]
       }
     }

--- a/docs/operations/merge-queue.md
+++ b/docs/operations/merge-queue.md
@@ -62,12 +62,13 @@ because the workflow declares `merge_group: {}` and `ci-gate` has
 
 ### Required-check coverage under `merge_group`
 
-The single required context also reports on a `merge_group` ref:
+Every required context also reports on a `merge_group` ref:
 
 | Required context | Emitting workflow | Runs on `merge_group`? |
 |------------------|-------------------|------------------------|
 | `CI gate` | `ci.yml` :: `ci-gate` | Yes - `merge_group: {}` |
 | `CI gate` | `ci-gate-stub.yml` :: `ci-gate` | No - `pull_request` only, and **correct** (see below) |
+| `shipped bundle matches the lockfile` | `spa-bundle-freshness.yml` :: `rebuild` | Yes - `merge_group: {}` |
 
 `ci-gate-stub.yml` deliberately has no `merge_group` trigger. It exists
 only because `ci.yml`'s `pull_request` trigger carries a `paths-ignore:`
@@ -90,7 +91,6 @@ required-context coverage by
 
 | Context | Emitting workflow | Runs on `merge_group`? | Required? |
 |---------|-------------------|------------------------|-----------|
-| `shipped bundle matches the lockfile` | `spa-bundle-freshness.yml` :: `rebuild` | Yes - `merge_group: {}` | **No - see below** |
 | `typecheck (sdk/typescript)` | `typecheck-ts.yml` :: `typecheck` | Yes - `merge_group: {}` | **No - see below** |
 | `typecheck (packages/vscode)` | `typecheck-ts.yml` :: `typecheck` | Yes - `merge_group: {}` | **No - see below** |
 | `typecheck (web)` | `typecheck-ts.yml` :: `typecheck` | Yes - `merge_group: {}` | **No - see below** |
@@ -114,8 +114,30 @@ entry; `main` went red and the repair landed at the back of an eleven-entry
 queue. The lane could only ever annotate the damage, never prevent it.
 
 #4028 added the trigger, which is the half that has to come first. The lane
-now reports on a queued ref, so the remaining step is safe to take and is
-**two flips, both maintainer-only**:
+now reports on a queued ref, so the remaining steps are safe to take - **once
+step 0 below holds**. The bundle gate went through all of them on 2026-08-25;
+step 0 was the one nobody had written down, and it had to be applied after the
+fact, with the repository stopped in between. That is why it is step 0:
+
+0. The emitting workflow's `pull_request` trigger must publish the context for
+   **every** pull request, not only the ones its `paths` filter accepts. A
+   required context only reports for the events its trigger accepts, so a
+   filtered trigger plus a required context leaves every pull request outside
+   the filter waiting on a run that will never start. GitHub answers the
+   enqueue attempt with `Required status check "<name>" is expected`, nothing
+   retries, nothing times out, and re-running checks cannot help - the run
+   does not exist. There are two ways to satisfy this, and the repo uses both:
+   drop the `paths` filter (what `spa-bundle-freshness.yml` does - it costs one
+   runner slot for a median of 28s per pull request), or add a stub workflow
+   that publishes the same context name for the skipped diffs (what
+   `ci-gate-stub.yml` does for `CI gate`, at the cost of a second file and a
+   second emitter to keep in step). Pick the stub when the real job is
+   expensive; drop the filter when it is not.
+
+   Skipping this step is not a slow merge, it is a stopped repository. On
+   2026-08-25 the flip landed at 15:18 with the filter still in place and
+   every pull request that did not touch `web/` became unmergeable until the
+   trigger was widened.
 
 1. Branch protection on `main`: add `shipped bundle matches the lockfile` to
    the required-status-checks list. This is what stops the pull request
@@ -128,11 +150,18 @@ now reports on a queued ref, so the remaining step is safe to take and is
 
 Do them in that order, and only while the queue is drained: editing required
 contexts invalidates every in-flight entry, so each one restarts a full-suite
-run. Until both are done the lane is exactly as advisory as it was before -
-the trigger alone changes nothing about whether a red bundle can merge.
+run. Until steps 1 and 2 are both done a lane is exactly as advisory as it was
+before - the trigger alone changes nothing about whether a red bundle can
+merge. Step 0 is the one with a blast radius beyond its own lane: get it wrong
+and nothing in the repository merges, not just this gate's subject.
 
-#4073 puts `typecheck-ts` in the same state for the same reason, and the two
-flips are the same two flips - with all four contexts from the table above,
+`typecheck-ts.yml` still filters its `pull_request` trigger on `paths`, so
+step 0 is outstanding for all four of its contexts. Flipping them before
+widening that trigger would wedge every pull request that touches no
+TypeScript - four times over.
+
+#4073 puts `typecheck-ts` in the same state for the same reason, and the
+flips are the same flips - with all four contexts from the table above,
 not one. Two things are worth doing before throwing that switch, neither of
 which applies to the bundle gate:
 
@@ -450,7 +479,8 @@ gh api -X PUT "repos/$REPO/rulesets/$RULESET_ID" --input - <<'JSON'
         "strict_required_status_checks_policy": false,
         "do_not_enforce_on_create": true,
         "required_status_checks": [
-          { "context": "CI gate", "integration_id": 15368 }
+          { "context": "CI gate", "integration_id": 15368 },
+          { "context": "shipped bundle matches the lockfile", "integration_id": 15368 }
         ]
       }
     }

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -16,3 +16,12 @@ rather than as its own attribution is exempted by hand there, with the reason.
   every run, blocking merges for a reason no code change could fix. The seed now
   invokes ruff through `uv run`, and a test holds every gate command that names
   a venv-resident tool to that form. (#4547)
+
+- `shipped bundle matches the lockfile` became a required status check on
+  `main` while its `pull_request` trigger still filtered on `web/**`. A
+  required context only reports for the events its trigger accepts, so every
+  pull request outside that filter waited on a run that never started and
+  could not merge at all. The trigger no longer filters, the checked-in
+  ruleset mirror now matches the live one, and the merge-queue runbook carries
+  the trigger precondition as a numbered step so the next lane to be required
+  cannot repeat it. (#4556)

--- a/tests/unit/scripts/test_check_branch_ruleset_audit.py
+++ b/tests/unit/scripts/test_check_branch_ruleset_audit.py
@@ -27,13 +27,16 @@ from check_branch_ruleset_audit import (
     read_required_contexts,
 )
 
-REQUIRED_CONTEXTS = ["CI gate"]
+# Mirrors the canary's BRANCH_PROTECTION_CONTEXTS_JSON, which is what the
+# audit actually reads; `test_required_contexts_come_from_the_canary` holds
+# the two together.
+REQUIRED_CONTEXTS = ["CI gate", "shipped bundle matches the lockfile"]
 
 # `gh api repos/sipyourdrink-ltd/bernstein/rules/branches/main`, captured
-# 2026-08-16 and trimmed to the fields the audit reads. One ruleset backs
+# 2026-08-25 and trimmed to the fields the audit reads. One ruleset backs
 # every rule; `pull_request` is present live but not audited here - see
 # the script docstring for which invariants are in scope.
-LIVE_RULES_2026_08_16: list[dict[str, Any]] = [
+LIVE_RULES_2026_08_25: list[dict[str, Any]] = [
     {
         "type": "merge_queue",
         "parameters": {
@@ -52,7 +55,10 @@ LIVE_RULES_2026_08_16: list[dict[str, Any]] = [
         "parameters": {
             "strict_required_status_checks_policy": False,
             "do_not_enforce_on_create": True,
-            "required_status_checks": [{"context": "CI gate", "integration_id": 15368}],
+            "required_status_checks": [
+                {"context": "CI gate", "integration_id": 15368},
+                {"context": "shipped bundle matches the lockfile", "integration_id": 15368},
+            ],
         },
         "ruleset_id": 16719298,
     },
@@ -85,7 +91,7 @@ def _details() -> dict[int, dict[str, Any]]:
 
 
 def _rules() -> list[dict[str, Any]]:
-    return json.loads(json.dumps(LIVE_RULES_2026_08_16))
+    return json.loads(json.dumps(LIVE_RULES_2026_08_25))
 
 
 def _rulesets() -> list[dict[str, Any]]:

--- a/tests/unit/test_branch_protection_audit_workflow_yaml.py
+++ b/tests/unit/test_branch_protection_audit_workflow_yaml.py
@@ -25,7 +25,7 @@ class WorkflowFile(TypedDict, total=False):
 
 WORKFLOW = Path(".github/workflows/branch-protection-audit.yml")
 CANARY = Path(".github/workflows/required-check-canary.yml")
-REQUIRED_CONTEXTS = {"CI gate"}
+REQUIRED_CONTEXTS = {"CI gate", "shipped bundle matches the lockfile"}
 
 
 def _workflow_text() -> str:

--- a/tests/unit/test_merge_queue_gate_coverage_yaml.py
+++ b/tests/unit/test_merge_queue_gate_coverage_yaml.py
@@ -62,11 +62,6 @@ MATCH_ANYTHING = ("*", "**")
 #: `test_queue_reporting_web_lanes_can_actually_be_required` re-reads the
 #: workflow and fails if the trigger is missing or filtered.
 QUEUE_REPORTING_WEB_LANES = {
-    "spa-bundle-freshness.yml": (
-        "The bundle gate. #4010 merged with it red because the lane was advisory, and main "
-        "went red behind eleven queue entries. #4028 added the merge_group trigger so that "
-        "`shipped bundle matches the lockfile` can be made a required context."
-    ),
     "typecheck-ts.yml": (
         "`tsc --noEmit` over the TypeScript packages, `web/` among them. #4010's shape one "
         "directory over: ci.yml paths-ignores the TypeScript trees, `CI gate` is the only "
@@ -327,20 +322,24 @@ def test_emits_any_discriminates(tmp_path: Path) -> None:
     assert _emits_any(wf, {}, ("CI gate",)) is False
 
 
-def test_the_bundle_gate_is_not_exempt_as_a_gate_emitter(
+def test_the_bundle_gate_publishes_a_required_context(
     queue_required_contexts: tuple[str, ...],
 ) -> None:
-    """It is accounted for by the allow-list, not by publishing `CI gate`.
+    """It is accounted for by the gate itself now, not by the allow-list.
 
-    Pins the reason the lane is in the first dict. If it ever started
-    emitting a required context the entry would become dead weight, and
-    worse, the canary in
-    ``tests/unit/test_required_check_canary_workflow_yaml.py`` would already
-    be failing for a different reason.
+    The lane used to sit in ``QUEUE_REPORTING_WEB_LANES`` - requirable, not
+    required. It is required now, so that entry would be dead weight, and
+    this pins the replacement: the lane can fail on a ``web/**`` change *and*
+    publishes a context branch protection demands.
+
+    ``queue_required_contexts`` is read from
+    ``docs/operations/merge-queue-ruleset.json``, so this also fails if that
+    mirror drifts from the live ruleset again - which is how the lane spent
+    2026-08-25 required in production and unrequired in the tree.
     """
     path = WORKFLOWS / "spa-bundle-freshness.yml"
     assert _can_run_on_a_web_change(_load(path)) is True
-    assert _emits_any(path, _load(path), queue_required_contexts) is False
+    assert _emits_any(path, _load(path), queue_required_contexts) is True
 
 
 def test_no_web_triggerable_lane_is_advisory_only(

--- a/tests/unit/test_merge_queue_ruleset_spec.py
+++ b/tests/unit/test_merge_queue_ruleset_spec.py
@@ -45,7 +45,12 @@ SPEC = Path("docs/operations/merge-queue-ruleset.json")
 # Mirrors repos/sipyourdrink-ltd/bernstein/branches/main/protection
 # -> required_status_checks.contexts. A context required to ENTER the
 # queue but not to MERGE from it is a gate the queue silently drops.
-BRANCH_PROTECTION_CONTEXTS = ("CI gate",)
+#
+# `shipped bundle matches the lockfile` joined the list on 2026-08-25.
+# Every name here also has to report on every pull request, or the ones
+# it skips can never enter the queue at all - see the flip procedure in
+# the runbook, step 0.
+BRANCH_PROTECTION_CONTEXTS = ("CI gate", "shipped bundle matches the lockfile")
 
 # Floor for `check_response_timeout_minutes`, in minutes.
 #
@@ -238,7 +243,10 @@ def test_drift_carries_machine_readable_expected_and_actual(intended: dict[str, 
             rule["parameters"]["required_status_checks"] = []
     (drift,) = diff_ruleset(live, intended)
     assert drift.actual == []
-    assert drift.expected == ["CI gate"]
+    # Derived, not spelled out: this assertion is about the shape of the
+    # report, and hard-coding the contexts made it a second place to update
+    # every time the required set changes.
+    assert drift.expected == sorted(BRANCH_PROTECTION_CONTEXTS)
 
 
 def test_verifier_ignores_context_ordering(intended: dict[str, Any]) -> None:

--- a/tests/unit/test_merge_queue_runbook_docs.py
+++ b/tests/unit/test_merge_queue_runbook_docs.py
@@ -29,7 +29,8 @@ MERGE_GATE = Path("docs/operations/merge-gate.md")
 
 # Mirrors repos/sipyourdrink-ltd/bernstein/branches/main/protection
 # -> required_status_checks.contexts (app_id 15368 == GitHub Actions).
-BRANCH_PROTECTION_CONTEXTS = ("CI gate",)
+# `shipped bundle matches the lockfile` joined the list on 2026-08-25.
+BRANCH_PROTECTION_CONTEXTS = ("CI gate", "shipped bundle matches the lockfile")
 ACTIONS_INTEGRATION_ID = 15368
 
 # Tunable -> the value the Enable payload must carry. Sourced from the

--- a/tests/unit/test_spa_bundle_freshness_workflow_yaml.py
+++ b/tests/unit/test_spa_bundle_freshness_workflow_yaml.py
@@ -5,8 +5,12 @@ committed under ``src/bernstein/gui/static``. It is the only thing that
 notices a dependency bump which leaves the shipped UI behind, so the parts
 that make it work are pinned here rather than left to review:
 
-* it triggers on the paths that can move the bundle - a trigger that misses
-  ``web/**`` turns the gate off for exactly the change it exists to catch;
+* its ``push`` trigger covers the paths that can move the bundle - a trigger
+  that misses ``web/**`` turns the gate off for exactly the change it exists
+  to catch;
+* its ``pull_request`` trigger carries no filter at all, because this lane is
+  a required status check: a required context that only reports for some pull
+  requests leaves the rest permanently unmergeable;
 * it compares with ``--untracked-files=all``, because ``emptyOutDir`` writes
   the replacement asset under a new content hash and a plain ``git diff``
   would not see an untracked file;
@@ -18,9 +22,8 @@ that make it work are pinned here rather than left to review:
 * no job is named ``CI gate``, which the required-check canary allow-lists
   to exactly two workflows;
 * it triggers on ``merge_group`` with no filter, so it reports on a queued
-  ref and branch protection can require it. Being required is a separate,
-  later, maintainer-only change; this file pins the half that has to come
-  first, because the reverse order wedges the queue.
+  ref - the precondition for branch protection requiring it, which it now
+  does.
 """
 
 from __future__ import annotations
@@ -82,15 +85,41 @@ def test_workflow_exists() -> None:
     assert WORKFLOW.is_file(), f"{WORKFLOW} is missing"
 
 
-@pytest.mark.parametrize("event", ["pull_request", "push"])
 @pytest.mark.parametrize("path", REQUIRED_TRIGGER_PATHS)
-def test_trigger_covers_every_path_that_moves_the_bundle(event: str, path: str) -> None:
-    """A trigger that misses these paths silently disables the gate."""
-    trigger = _on().get(event)
-    assert isinstance(trigger, dict), f"{event} trigger must be a mapping"
+def test_push_trigger_covers_every_path_that_moves_the_bundle(path: str) -> None:
+    """A ``push`` trigger that misses these paths silently disables the gate.
+
+    Only ``push`` is filtered. ``push`` is not a required-context source, so
+    narrowing it costs nothing but runner time on ``main``; the
+    ``pull_request`` side is unfiltered for the reason the next test pins.
+    """
+    trigger = _on().get("push")
+    assert isinstance(trigger, dict), "push trigger must be a mapping"
     paths = trigger.get("paths")
-    assert isinstance(paths, list), f"{event} trigger must filter on paths"
-    assert path in paths, f"{event} trigger does not cover {path!r}"
+    assert isinstance(paths, list), "push trigger must filter on paths"
+    assert path in paths, f"push trigger does not cover {path!r}"
+
+
+def test_pull_request_trigger_carries_no_filter() -> None:
+    """A required context has to report on every pull request.
+
+    This lane is a required status check on ``main``. A required context only
+    reports for the events its trigger accepts, so a ``paths`` filter here
+    leaves every pull request outside the filter waiting on a run that never
+    happens. GitHub answers the enqueue attempt with ``Required status check
+    "shipped bundle matches the lockfile" is expected``, and nothing retries
+    or times out - the state is terminal. On 2026-08-25 that made every pull
+    request which did not touch ``web/`` permanently unmergeable.
+
+    The filter and the requirement have to move together, in that order. This
+    assertion pins the half that is cheap to lose by accident.
+    """
+    trigger = _on().get("pull_request", "__absent__")
+    assert trigger != "__absent__", "no `pull_request` trigger at all"
+    assert trigger in (None, {}), (
+        f"the `pull_request` trigger carries a filter ({trigger!r}). While this lane is a required "
+        "context, every pull request the filter skips can never merge."
+    )
 
 
 def test_pull_request_runs_cancel_superseded_ones() -> None:


### PR DESCRIPTION
## Symptom

Every open pull request that does not touch `web/` is unmergeable. Not slow,
not flaky — terminal. Re-running checks cannot help.

GitHub states the reason on the enqueue attempt:

```
Required status check "shipped bundle matches the lockfile" is expected.
```

## Cause

The context was added to branch protection on `main` at 15:18 on 2026-08-25.
The emitting workflow's `pull_request` trigger still filtered:

```yaml
  pull_request:
    paths:
      - "web/**"
      - "src/bernstein/gui/static/**"
      - ".github/workflows/spa-bundle-freshness.yml"
```

A required context only reports for the events its trigger accepts. Outside
those paths the workflow never runs, the context never reports, and the pull
request waits on a run that does not exist. There is no timeout and no retry.

The evidence lines up: #4551 and #4550 merged without touching `web/`, four and
eleven minutes before the flip. #4552, the only merge after it, touched `web/`.

The runbook's flip procedure (`docs/operations/merge-queue.md`) listed two
steps. This precondition was not one of them — it was described in the
workflow's own header comment as *"trigger first, requirement second, never the
reverse"*, and nowhere that an operator following the runbook would read it.

A second, quieter drift: `docs/operations/merge-queue-ruleset.json` and the
runbook's copy-pasteable payload both still listed `CI gate` alone, so the tree
disagreed with production about which contexts are required.

## Changes

| File | Why |
|---|---|
| `.github/workflows/spa-bundle-freshness.yml` | drop the `paths` filter from `pull_request`; correct the header, which still described the lane as annotate-only |
| `docs/operations/merge-queue-ruleset.json` | mirror the live ruleset |
| `docs/operations/merge-queue.md` | same for the inline payload; move the gate out of the not-required-yet table; add the trigger precondition as **step 0** |
| `tests/unit/test_spa_bundle_freshness_workflow_yaml.py` | the trigger assertions now match the requirement: `push` stays filtered, `pull_request` must not be |
| `tests/unit/test_merge_queue_gate_coverage_yaml.py` | the lane publishes a required context now, so it leaves the requirable-but-not-required allow-list |

`merge_group` is untouched — it never had a filter, because GitHub evaluates
`paths` for `push`, `pull_request` and `pull_request_target` only. `push` keeps
its filter: `push` is not a required-context source.

## The alternative, and why not

The repo already solves this shape once: `ci-gate-stub.yml` publishes `CI gate`
for the pull requests `ci.yml` skips via `paths-ignore`. A stub costs a second
file and a second emitter to keep in step; dropping the filter costs one runner
slot for a median of 28s per pull request (the workflow header's own figure over
14 executions: 23s min, 37s max). At that price the filter is not worth keeping.
Step 0 in the runbook names both options and when each fits.

## Follow-up, not in this PR

`typecheck-ts.yml` has the identical filtered `pull_request` trigger and four
contexts queued for the same flip (#4073). Requiring them before widening that
trigger would wedge every pull request touching no TypeScript — four times over.
The runbook now says so where the operator will read it.

## Why this PR can merge when the others cannot

The old filter included `.github/workflows/spa-bundle-freshness.yml`, so a
change to the workflow file triggers the workflow. This is the one shape of pull
request that was not wedged.

Pull requests opened before this lands need a rebase onto `main` afterwards:
`pull_request` runs use the workflow definition from the head branch, so they
pick up the widened trigger only once they carry it.

## Checks run locally

`test_merge_queue_gate_coverage_yaml.py`, `test_spa_bundle_freshness_workflow_yaml.py`,
`test_required_check_canary_workflow_yaml.py` — 106 passed. `ruff check` and
`ruff format --check` clean.
