### PR TITLE
feat(evidence): expose finding artifact type to MCP schema and HTTP route (#4533)

### DIFF
--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -159,6 +159,7 @@
               "application/json": {
                 "schema": {
                   "items": {
+                    "additionalProperties": true,
                     "type": "object"
                   },
                   "type": "array",
@@ -2177,6 +2178,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Get Task Graph Neighbors Tasks  Task Id  Graph Neighbors Get"
                 }
               }
@@ -2687,6 +2689,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Claim Receipt Tasks Claim Receipt Post"
                 }
@@ -3636,6 +3639,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response A2A V0 Accept Task A2A V0 Tasks Post"
                 }
@@ -5021,6 +5025,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Agents Observability Agents Get"
                 }
@@ -5041,6 +5046,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Effectiveness Observability Effectiveness Get"
                 }
@@ -5061,6 +5067,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Recommendations Observability Recommendations Get"
                 }
@@ -5081,6 +5088,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Budget Observability Budget Get"
                 }
@@ -5101,6 +5109,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Deps Observability Deps Get"
                 }
@@ -5121,6 +5130,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Recap Recap Get"
                 }
@@ -5141,6 +5151,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Token Histogram Observability Token Histogram Get"
                 }
@@ -5174,6 +5185,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Get Queue Depth Observability Queue Depth Get"
                 }
               }
@@ -5203,6 +5215,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Get Timeline Observability Timeline Get"
                 }
@@ -5236,6 +5249,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Get Changelog Changelog Get"
                 }
               }
@@ -5265,6 +5279,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response List Incidents Observability Incidents Get"
                 }
@@ -5317,6 +5332,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Get Incident Timeline Observability Incident Timeline  Incident Id  Get"
                 }
               }
@@ -5346,6 +5362,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Token Breakdown Observability Token Breakdown Get"
                 }
@@ -5509,6 +5526,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Fleet Projects Fleet Projects Get"
                 }
@@ -5556,6 +5574,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Fleet Search Fleet Search Get"
                 }
               }
@@ -6388,7 +6407,8 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": true
                   },
                   "title": "Response List Plans Plans Get"
                 }
@@ -6440,6 +6460,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Get Plan Plans  Plan Id  Get"
                 }
               }
@@ -6504,6 +6525,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Approve Plan Plans  Plan Id  Approve Post"
                 }
               }
@@ -6571,6 +6593,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Reject Plan Plans  Plan Id  Reject Post"
                 }
               }
@@ -7433,6 +7456,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Query Audit Log Audit Get"
                 }
               }
@@ -7465,6 +7489,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Audit Verify Audit Verify Get"
                 }
@@ -7503,6 +7528,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Audit Reverify Audit Verify Post"
                 }
@@ -7620,6 +7646,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Graphql Endpoint Graphql Post"
                 }
@@ -8891,6 +8918,7 @@
               "application/json": {
                 "schema": {
                   "items": {
+                    "additionalProperties": true,
                     "type": "object"
                   },
                   "type": "array",
@@ -10909,6 +10937,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Get Task Graph Neighbors Api V1 Tasks  Task Id  Graph Neighbors Get"
                 }
               }
@@ -11419,6 +11448,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Claim Receipt Api V1 Tasks Claim Receipt Post"
                 }
@@ -12368,6 +12398,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response A2A V0 Accept Task Api V1 A2A V0 Tasks Post"
                 }
@@ -13753,6 +13784,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Agents Api V1 Observability Agents Get"
                 }
@@ -13773,6 +13805,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Effectiveness Api V1 Observability Effectiveness Get"
                 }
@@ -13793,6 +13826,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Recommendations Api V1 Observability Recommendations Get"
                 }
@@ -13813,6 +13847,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Budget Api V1 Observability Budget Get"
                 }
@@ -13833,6 +13868,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Deps Api V1 Observability Deps Get"
                 }
@@ -13853,6 +13889,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Recap Api V1 Recap Get"
                 }
@@ -13873,6 +13910,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Token Histogram Api V1 Observability Token Histogram Get"
                 }
@@ -13906,6 +13944,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Get Queue Depth Api V1 Observability Queue Depth Get"
                 }
               }
@@ -13935,6 +13974,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Get Timeline Api V1 Observability Timeline Get"
                 }
@@ -13968,6 +14008,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Get Changelog Api V1 Changelog Get"
                 }
               }
@@ -13997,6 +14038,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response List Incidents Api V1 Observability Incidents Get"
                 }
@@ -14049,6 +14091,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Get Incident Timeline Api V1 Observability Incident Timeline  Incident Id  Get"
                 }
               }
@@ -14078,6 +14121,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Token Breakdown Api V1 Observability Token Breakdown Get"
                 }
@@ -14241,6 +14285,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Fleet Projects Api V1 Fleet Projects Get"
                 }
@@ -14288,6 +14333,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Fleet Search Api V1 Fleet Search Get"
                 }
               }
@@ -15120,7 +15166,8 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": true
                   },
                   "title": "Response List Plans Api V1 Plans Get"
                 }
@@ -15172,6 +15219,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Get Plan Api V1 Plans  Plan Id  Get"
                 }
               }
@@ -15236,6 +15284,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Approve Plan Api V1 Plans  Plan Id  Approve Post"
                 }
               }
@@ -15303,6 +15352,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Reject Plan Api V1 Plans  Plan Id  Reject Post"
                 }
               }
@@ -16165,6 +16215,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Query Audit Log Api V1 Audit Get"
                 }
               }
@@ -16197,6 +16248,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Audit Verify Api V1 Audit Verify Get"
                 }
@@ -16235,6 +16287,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Audit Reverify Api V1 Audit Verify Post"
                 }
@@ -16352,6 +16405,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Graphql Endpoint Api V1 Graphql Post"
                 }
@@ -17765,6 +17819,7 @@
           "receipt": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -17823,6 +17878,7 @@
             "title": "Description"
           },
           "input_schema": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Input Schema"
           }
@@ -18711,6 +18767,7 @@
         "properties": {
           "receipts": {
             "items": {
+              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -19247,6 +19304,7 @@
           "variables": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -19411,6 +19469,7 @@
           },
           "components": {
             "additionalProperties": {
+              "additionalProperties": true,
               "type": "object"
             },
             "type": "object",
@@ -20030,6 +20089,7 @@
             "title": "Tool Name"
           },
           "tool_args": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Tool Args"
           },
@@ -20459,6 +20519,7 @@
           "content": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -20539,6 +20600,7 @@
             "default": ""
           },
           "sarif_result": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Sarif Result"
           },
@@ -20616,6 +20678,7 @@
           "payload": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -20880,6 +20943,7 @@
           "upgrade_details": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -20940,6 +21004,7 @@
           "slack_context": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -20949,6 +21014,7 @@
             "title": "Slack Context"
           },
           "metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -21074,6 +21140,7 @@
           "artifact_spec": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21106,6 +21173,7 @@
           },
           "progress_entries": {
             "items": {
+              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -21118,6 +21186,7 @@
           },
           "artifacts": {
             "items": {
+              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -21126,6 +21195,7 @@
           "progress": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21716,6 +21786,7 @@
           "upgrade_details": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21775,6 +21846,7 @@
           "slack_context": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21784,6 +21856,7 @@
             "title": "Slack Context"
           },
           "metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -21916,6 +21989,7 @@
           "artifact_spec": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -22275,6 +22349,7 @@
             "default": ""
           },
           "payload": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           }
@@ -22426,6 +22501,13 @@
           "type": {
             "type": "string",
             "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
           }
         },
         "type": "object",
@@ -22607,6 +22689,7 @@
           "upgrade_details": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -22667,6 +22750,7 @@
           "slack_context": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -22676,6 +22760,7 @@
             "title": "Slack Context"
           },
           "metadata": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -22801,6 +22886,7 @@
           "artifact_spec": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -22826,6 +22912,7 @@
           "receipt": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -159,7 +159,6 @@
               "application/json": {
                 "schema": {
                   "items": {
-                    "additionalProperties": true,
                     "type": "object"
                   },
                   "type": "array",
@@ -2178,7 +2177,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Get Task Graph Neighbors Tasks  Task Id  Graph Neighbors Get"
                 }
               }
@@ -2689,7 +2687,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Claim Receipt Tasks Claim Receipt Post"
                 }
@@ -3639,7 +3636,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response A2A V0 Accept Task A2A V0 Tasks Post"
                 }
@@ -5025,7 +5021,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Agents Observability Agents Get"
                 }
@@ -5046,7 +5041,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Effectiveness Observability Effectiveness Get"
                 }
@@ -5067,7 +5061,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Recommendations Observability Recommendations Get"
                 }
@@ -5088,7 +5081,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Budget Observability Budget Get"
                 }
@@ -5109,7 +5101,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Deps Observability Deps Get"
                 }
@@ -5130,7 +5121,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Recap Recap Get"
                 }
@@ -5151,7 +5141,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Token Histogram Observability Token Histogram Get"
                 }
@@ -5185,7 +5174,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Get Queue Depth Observability Queue Depth Get"
                 }
               }
@@ -5215,7 +5203,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Get Timeline Observability Timeline Get"
                 }
@@ -5249,7 +5236,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Get Changelog Changelog Get"
                 }
               }
@@ -5279,7 +5265,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response List Incidents Observability Incidents Get"
                 }
@@ -5332,7 +5317,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Get Incident Timeline Observability Incident Timeline  Incident Id  Get"
                 }
               }
@@ -5362,7 +5346,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Token Breakdown Observability Token Breakdown Get"
                 }
@@ -5526,7 +5509,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Fleet Projects Fleet Projects Get"
                 }
@@ -5574,7 +5556,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Fleet Search Fleet Search Get"
                 }
               }
@@ -6407,8 +6388,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "additionalProperties": true
+                    "type": "object"
                   },
                   "title": "Response List Plans Plans Get"
                 }
@@ -6460,7 +6440,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Get Plan Plans  Plan Id  Get"
                 }
               }
@@ -6525,7 +6504,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Approve Plan Plans  Plan Id  Approve Post"
                 }
               }
@@ -6593,7 +6571,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Reject Plan Plans  Plan Id  Reject Post"
                 }
               }
@@ -7456,7 +7433,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Query Audit Log Audit Get"
                 }
               }
@@ -7489,7 +7465,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Audit Verify Audit Verify Get"
                 }
@@ -7528,7 +7503,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Audit Reverify Audit Verify Post"
                 }
@@ -7646,7 +7620,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Graphql Endpoint Graphql Post"
                 }
@@ -8918,7 +8891,6 @@
               "application/json": {
                 "schema": {
                   "items": {
-                    "additionalProperties": true,
                     "type": "object"
                   },
                   "type": "array",
@@ -10937,7 +10909,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Get Task Graph Neighbors Api V1 Tasks  Task Id  Graph Neighbors Get"
                 }
               }
@@ -11448,7 +11419,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Claim Receipt Api V1 Tasks Claim Receipt Post"
                 }
@@ -12398,7 +12368,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response A2A V0 Accept Task Api V1 A2A V0 Tasks Post"
                 }
@@ -13784,7 +13753,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Agents Api V1 Observability Agents Get"
                 }
@@ -13805,7 +13773,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Effectiveness Api V1 Observability Effectiveness Get"
                 }
@@ -13826,7 +13793,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Recommendations Api V1 Observability Recommendations Get"
                 }
@@ -13847,7 +13813,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Budget Api V1 Observability Budget Get"
                 }
@@ -13868,7 +13833,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Observability Deps Api V1 Observability Deps Get"
                 }
@@ -13889,7 +13853,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Recap Api V1 Recap Get"
                 }
@@ -13910,7 +13873,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Token Histogram Api V1 Observability Token Histogram Get"
                 }
@@ -13944,7 +13906,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Get Queue Depth Api V1 Observability Queue Depth Get"
                 }
               }
@@ -13974,7 +13935,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Get Timeline Api V1 Observability Timeline Get"
                 }
@@ -14008,7 +13968,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Get Changelog Api V1 Changelog Get"
                 }
               }
@@ -14038,7 +13997,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response List Incidents Api V1 Observability Incidents Get"
                 }
@@ -14091,7 +14049,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Get Incident Timeline Api V1 Observability Incident Timeline  Incident Id  Get"
                 }
               }
@@ -14121,7 +14078,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Token Breakdown Api V1 Observability Token Breakdown Get"
                 }
@@ -14285,7 +14241,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Fleet Projects Api V1 Fleet Projects Get"
                 }
@@ -14333,7 +14288,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Fleet Search Api V1 Fleet Search Get"
                 }
               }
@@ -15166,8 +15120,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "additionalProperties": true
+                    "type": "object"
                   },
                   "title": "Response List Plans Api V1 Plans Get"
                 }
@@ -15219,7 +15172,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Get Plan Api V1 Plans  Plan Id  Get"
                 }
               }
@@ -15284,7 +15236,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Approve Plan Api V1 Plans  Plan Id  Approve Post"
                 }
               }
@@ -15352,7 +15303,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Reject Plan Api V1 Plans  Plan Id  Reject Post"
                 }
               }
@@ -16215,7 +16165,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Query Audit Log Api V1 Audit Get"
                 }
               }
@@ -16248,7 +16197,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Audit Verify Api V1 Audit Verify Get"
                 }
@@ -16287,7 +16235,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Audit Reverify Api V1 Audit Verify Post"
                 }
@@ -16405,7 +16352,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Graphql Endpoint Api V1 Graphql Post"
                 }
@@ -17819,7 +17765,6 @@
           "receipt": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -17878,7 +17823,6 @@
             "title": "Description"
           },
           "input_schema": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Input Schema"
           }
@@ -18767,7 +18711,6 @@
         "properties": {
           "receipts": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -19304,7 +19247,6 @@
           "variables": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -19469,7 +19411,6 @@
           },
           "components": {
             "additionalProperties": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "object",
@@ -20089,7 +20030,6 @@
             "title": "Tool Name"
           },
           "tool_args": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Tool Args"
           },
@@ -20519,7 +20459,6 @@
           "content": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -20555,7 +20494,7 @@
           },
           "artifact_type": {
             "type": "string",
-            "pattern": "^(report|table|link)$",
+            "pattern": "^(report|table|link|finding)$",
             "title": "Artifact Type"
           },
           "poster": {
@@ -20597,6 +20536,40 @@
             "type": "string",
             "maxLength": 64,
             "title": "Link Kind",
+            "default": ""
+          },
+          "sarif_result": {
+            "type": "object",
+            "title": "Sarif Result"
+          },
+          "tool": {
+            "type": "string",
+            "maxLength": 1000,
+            "title": "Tool",
+            "default": ""
+          },
+          "tool_version": {
+            "type": "string",
+            "maxLength": 128,
+            "title": "Tool Version",
+            "default": ""
+          },
+          "pinned_ruleset_or_feed_digest": {
+            "type": "string",
+            "maxLength": 256,
+            "title": "Pinned Ruleset Or Feed Digest",
+            "default": ""
+          },
+          "invocation_argv_hash": {
+            "type": "string",
+            "maxLength": 256,
+            "title": "Invocation Argv Hash",
+            "default": ""
+          },
+          "target": {
+            "type": "string",
+            "maxLength": 4096,
+            "title": "Target",
             "default": ""
           }
         },
@@ -20643,7 +20616,6 @@
           "payload": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -20908,7 +20880,6 @@
           "upgrade_details": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -20969,7 +20940,6 @@
           "slack_context": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -20979,7 +20949,6 @@
             "title": "Slack Context"
           },
           "metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -21105,7 +21074,6 @@
           "artifact_spec": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21138,7 +21106,6 @@
           },
           "progress_entries": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -21151,7 +21118,6 @@
           },
           "artifacts": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -21160,7 +21126,6 @@
           "progress": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21751,7 +21716,6 @@
           "upgrade_details": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21811,7 +21775,6 @@
           "slack_context": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -21821,7 +21784,6 @@
             "title": "Slack Context"
           },
           "metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -21954,7 +21916,6 @@
           "artifact_spec": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -22314,7 +22275,6 @@
             "default": ""
           },
           "payload": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Payload"
           }
@@ -22466,13 +22426,6 @@
           "type": {
             "type": "string",
             "title": "Error Type"
-          },
-          "input": {
-            "title": "Input"
-          },
-          "ctx": {
-            "type": "object",
-            "title": "Context"
           }
         },
         "type": "object",
@@ -22654,7 +22607,6 @@
           "upgrade_details": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -22715,7 +22667,6 @@
           "slack_context": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -22725,7 +22676,6 @@
             "title": "Slack Context"
           },
           "metadata": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -22851,7 +22801,6 @@
           "artifact_spec": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -22877,7 +22826,6 @@
           "receipt": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {

--- a/docs/release-notes/fragments/4533-finding-artifact-reachability.md
+++ b/docs/release-notes/fragments/4533-finding-artifact-reachability.md
@@ -1,1 +1,1 @@
-﻿Expose SARIF finding artifact type through the MCP tool schema and HTTP post task artifacts route (#4533).
+Expose SARIF finding artifact type through the MCP tool schema and HTTP post task artifacts route (#4533).

--- a/docs/release-notes/fragments/4533-finding-artifact-reachability.md
+++ b/docs/release-notes/fragments/4533-finding-artifact-reachability.md
@@ -1,0 +1,1 @@
+﻿Expose SARIF finding artifact type through the MCP tool schema and HTTP post task artifacts route (#4533).

--- a/src/bernstein/core/routes/task_artifacts.py
+++ b/src/bernstein/core/routes/task_artifacts.py
@@ -144,6 +144,15 @@ def _build_payload(body: TaskArtifactPost) -> ArtifactPayload:
         return ArtifactPayload.report(body.body)
     if body.artifact_type == "table":
         return ArtifactPayload.table(body.columns, body.rows)
+    if body.artifact_type == "finding":
+        return ArtifactPayload.finding(
+            body.sarif_result,
+            tool=body.tool,
+            tool_version=body.tool_version,
+            pinned_ruleset_or_feed_digest=body.pinned_ruleset_or_feed_digest,
+            invocation_argv_hash=body.invocation_argv_hash,
+            target=body.target,
+        )
     return ArtifactPayload.link(body.url, body.link_kind)
 
 

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -569,13 +569,19 @@ class TaskArtifactPost(BaseModel):
     """
 
     key: str = Field(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9_.\-]{0,127}$")
-    artifact_type: str = Field(pattern="^(report|table|link)$")
+    artifact_type: str = Field(pattern="^(report|table|link|finding)$")
     poster: str = Field(min_length=1, max_length=_MAX_SHORT_STR_LEN)
     body: str = Field(default="", max_length=1_048_576)
     columns: list[str] = Field(default_factory=list[str])
     rows: list[list[str]] = Field(default_factory=list[list[str]])
     url: str = Field(default="", max_length=_MAX_PATH_LEN)
     link_kind: str = Field(default="", max_length=64)
+    sarif_result: dict[str, Any] = Field(default_factory=dict)
+    tool: str = Field(default="", max_length=_MAX_SHORT_STR_LEN)
+    tool_version: str = Field(default="", max_length=128)
+    pinned_ruleset_or_feed_digest: str = Field(default="", max_length=256)
+    invocation_argv_hash: str = Field(default="", max_length=256)
+    target: str = Field(default="", max_length=_MAX_PATH_LEN)
 
 
 class TaskArtifactResponse(BaseModel):

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -1180,6 +1180,12 @@ def _register_action_tools(mcp: FastMCP[None], server_url: str) -> None:
         rows: list[list[str]] | None = None,
         url: str = "",
         link_kind: str = "",
+        sarif_result: dict[str, Any] | None = None,
+        tool: str = "",
+        tool_version: str = "",
+        pinned_ruleset_or_feed_digest: str = "",
+        invocation_argv_hash: str = "",
+        target: str = "",
     ) -> str:
         """Attach a journal-anchored artifact to a task you hold the claim for.
 
@@ -1196,7 +1202,8 @@ def _register_action_tools(mcp: FastMCP[None], server_url: str) -> None:
             task_id: The task to attach the artifact to. You must hold its claim.
             key: The artifact slot; reposting a key appends a new version.
             artifact_type: One of ``report`` (markdown ``body``), ``table``
-                (``columns`` + ``rows``), or ``link`` (``url`` + ``link_kind``).
+                (``columns`` + ``rows``), ``link`` (``url`` + ``link_kind``),
+                or ``finding`` (``sarif_result`` + provenance).
             poster: Your claim identity; posting against a task you do not hold
                 is refused and the refusal is audit-recorded.
             body: Markdown body, for ``report`` artifacts.
@@ -1205,6 +1212,12 @@ def _register_action_tools(mcp: FastMCP[None], server_url: str) -> None:
             url: The URL, for ``link`` artifacts.
             link_kind: The declared link kind - ``preview`` / ``dashboard`` /
                 ``document`` - for ``link`` artifacts.
+            sarif_result: Normalized SARIF 2.1.0 result object, for ``finding`` artifacts.
+            tool: Scanner/linter name, for ``finding`` artifacts.
+            tool_version: Scanner version string, for ``finding`` artifacts.
+            pinned_ruleset_or_feed_digest: Ruleset/feed digest, for ``finding`` artifacts.
+            invocation_argv_hash: Hash of tool invocation arguments, for ``finding`` artifacts.
+            target: Target path or git ref, for ``finding`` artifacts.
 
         Returns:
             JSON of the chain-anchored artifact record (``key``, ``version``,
@@ -1232,6 +1245,18 @@ def _register_action_tools(mcp: FastMCP[None], server_url: str) -> None:
             args["url"] = url
         if link_kind:
             args["link_kind"] = link_kind
+        if sarif_result is not None:
+            args["sarif_result"] = sarif_result
+        if tool:
+            args["tool"] = tool
+        if tool_version:
+            args["tool_version"] = tool_version
+        if pinned_ruleset_or_feed_digest:
+            args["pinned_ruleset_or_feed_digest"] = pinned_ruleset_or_feed_digest
+        if invocation_argv_hash:
+            args["invocation_argv_hash"] = invocation_argv_hash
+        if target:
+            args["target"] = target
         err = _validate_or_error("bernstein_post_artifact", args)
         if err is not None:
             return _validation_error_response(err)

--- a/src/bernstein/mcp/tool_schemas/bernstein_post_artifact.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_post_artifact.json
@@ -9,7 +9,7 @@
   "properties": {
     "task_id": {"type": "string", "minLength": 1, "maxLength": 256, "pattern": "^[A-Za-z0-9_.:-]+$"},
     "key": {"type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$"},
-    "artifact_type": {"type": "string", "enum": ["report", "table", "link"]},
+    "artifact_type": {"type": "string", "enum": ["report", "table", "link", "finding"]},
     "poster": {"type": "string", "minLength": 1, "maxLength": 256},
     "body": {"type": "string", "minLength": 1, "maxLength": 60000},
     "columns": {
@@ -28,7 +28,13 @@
       }
     },
     "url": {"type": "string", "minLength": 1, "maxLength": 4096},
-    "link_kind": {"type": "string", "enum": ["preview", "dashboard", "document"]}
+    "link_kind": {"type": "string", "enum": ["preview", "dashboard", "document"]},
+    "sarif_result": {"type": "object"},
+    "tool": {"type": "string", "minLength": 1, "maxLength": 256},
+    "tool_version": {"type": "string", "maxLength": 128},
+    "pinned_ruleset_or_feed_digest": {"type": "string", "maxLength": 256},
+    "invocation_argv_hash": {"type": "string", "maxLength": 256},
+    "target": {"type": "string", "maxLength": 4096}
   },
   "allOf": [
     {
@@ -42,6 +48,10 @@
     {
       "if": {"properties": {"artifact_type": {"const": "link"}}, "required": ["artifact_type"]},
       "then": {"required": ["url", "link_kind"]}
+    },
+    {
+      "if": {"properties": {"artifact_type": {"const": "finding"}}, "required": ["artifact_type"]},
+      "then": {"required": ["sarif_result"]}
     }
   ]
 }

--- a/tests/unit/mcp/test_advertised_schema_parity.py
+++ b/tests/unit/mcp/test_advertised_schema_parity.py
@@ -140,6 +140,13 @@ _SEEDS: dict[str, list[dict[str, Any]]] = {
             "url": "https://example.invalid/x",
             "link_kind": "preview",
         },
+        {
+            "task_id": "t-1",
+            "key": "k1",
+            "artifact_type": "finding",
+            "poster": "w",
+            "sarif_result": {"ruleId": "R1", "level": "warning"},
+        },
     ],
     "load_skill": [{"name": "backend"}],
     "bernstein_scenario": [
@@ -234,15 +241,16 @@ def test_post_artifact_advertises_its_conditional_shape() -> None:
         "report": ["body"],
         "table": ["columns", "rows"],
         "link": ["link_kind", "url"],
+        "finding": ["sarif_result"],
     }
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("seed", _SEEDS["bernstein_post_artifact"], ids=["report", "table", "link"])
+@pytest.mark.parametrize("seed", _SEEDS["bernstein_post_artifact"], ids=["report", "table", "link", "finding"])
 async def test_a_call_matching_the_advertised_shape_reaches_the_task_server(seed: dict[str, Any]) -> None:
     """Filling the advertised conditional shape must not be refused up front.
 
-    The handler defaults the fields of the other two artifact types to the
+    The handler defaults the fields of the other artifact types to the
     empty string. Those defaults are absent from the advertised shape, so they
     must not be validated as if the caller had supplied them.
     """

--- a/tests/unit/test_post_artifact_tool_schema.py
+++ b/tests/unit/test_post_artifact_tool_schema.py
@@ -67,3 +67,20 @@ class TestTypeContract:
 
     def test_valid_link_passes(self) -> None:
         assert isinstance(_call(artifact_type="link", url="https://x", link_kind="preview"), ValidatedPayload)
+
+    def test_finding_requires_sarif_result(self) -> None:
+        assert isinstance(_call(artifact_type="finding"), ValidationError)
+
+    def test_valid_finding_passes(self) -> None:
+        sarif = {
+            "ruleId": "TEST-001",
+            "locations": [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": "src/a.py"},
+                        "region": {"startLine": 1, "snippet": {"text": "x"}},
+                    }
+                }
+            ],
+        }
+        assert isinstance(_call(artifact_type="finding", sarif_result=sarif, tool="semgrep"), ValidatedPayload)

--- a/tests/unit/test_task_artifacts_routes.py
+++ b/tests/unit/test_task_artifacts_routes.py
@@ -241,3 +241,74 @@ class TestProgress:
         # Posting five reports does not move the chain-computed progress vector.
         assert after["vector_hash"] == before["vector_hash"]
         assert after["earned_steps"] == 0
+
+
+class TestFindingArtifactRoute:
+    """Finding artifact reachability tests (#4533)."""
+
+    def _sample_sarif(self) -> dict[str, object]:
+        return {
+            "ruleId": "PY-SQLI-001",
+            "message": {"text": "SQL injection vulnerability"},
+            "locations": [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": "src/db.py"},
+                        "region": {
+                            "startLine": 42,
+                            "endLine": 42,
+                            "startColumn": 5,
+                            "endColumn": 30,
+                            "snippet": {"text": "cursor.execute(f'SELECT {query}')"},
+                        },
+                    }
+                }
+            ],
+        }
+
+    async def test_http_post_of_finding_artifact_succeeds_and_returns_content(self, app, client: AsyncClient) -> None:
+        task_id = await _create_claimed_task(client, app, "finding task", "worker-1")
+        sarif = self._sample_sarif()
+
+        resp = await _post_artifact(
+            client,
+            task_id,
+            "worker-1",
+            key="sec-finding",
+            artifact_type="finding",
+            sarif_result=sarif,
+            tool="bandit",
+            tool_version="1.7.5",
+            pinned_ruleset_or_feed_digest="sha256:" + "a" * 64,
+            invocation_argv_hash="sha256:" + "b" * 64,
+            target="git:head",
+        )
+
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["artifact_type"] == "finding"
+        assert data["key"] == "sec-finding"
+        assert data["version"] == 1
+        assert data["verified"] is True
+        assert data["content"] is not None
+        assert data["content"]["type"] == "finding"
+        assert "address" in data["content"]
+        assert data["content"]["identity"]["rule_id"] == "PY-SQLI-001"
+
+    async def test_http_post_of_malformed_finding_is_422_not_untyped_blob(self, app, client: AsyncClient) -> None:
+        task_id = await _create_claimed_task(client, app, "bad finding task", "worker-1")
+        # Missing required locations[0].physicalLocation
+        bad_sarif = {"ruleId": "BAD-001"}
+
+        resp = await _post_artifact(
+            client,
+            task_id,
+            "worker-1",
+            key="bad-finding",
+            artifact_type="finding",
+            sarif_result=bad_sarif,
+            tool="bandit",
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert "finding SARIF result is missing required field" in resp.json()["detail"]


### PR DESCRIPTION
Fixes #4533

### Problem
While SARIF \inding\ artifact normalization and storage was implemented in \src/bernstein/core/evidence/run_artifacts.py\, it was unreachable from both the MCP tool schema and the HTTP task artifacts route (\_build_payload\ in \src/bernstein/core/routes/task_artifacts.py\ only handled \eport\, \	able\, and \link\).

### Solution
1. **MCP Schema**: Added \inding\ to \rtifact_type\ enum and schema fields (\sarif_result\, \	ool\, \	ool_version\, \pinned_ruleset_or_feed_digest\, \invocation_argv_hash\, \	arget\) in \src/bernstein/mcp/tool_schemas/bernstein_post_artifact.json\ and mapped them in \src/bernstein/mcp/server.py:bernstein_post_artifact\.
2. **Server Route**: Updated \TaskArtifactPost\ in \src/bernstein/core/server/server_models.py\ and branched \_build_payload\ in \src/bernstein/core/routes/task_artifacts.py\ to construct \ArtifactPayload.finding\, raising typed HTTP 422 errors on malformed SARIF data.
3. **OpenAPI**: Regenerated \docs/reference/openapi.json\.
4. **Release Notes**: Added fragment \docs/release-notes/fragments/4533-finding-artifact-reachability.md\.