### PR TITLE
fix(approval): record human resolutions and promotions to the audit chain (#4536)

### DIFF
--- a/docs/release-notes/fragments/4536-human-approval-audit-chain.md
+++ b/docs/release-notes/fragments/4536-human-approval-audit-chain.md
@@ -1,1 +1,1 @@
-﻿Record operator approval decisions and always-allow promotions to the HMAC audit chain in ApprovalQueue.resolve (#4536).
+Record operator approval decisions and always-allow promotions to the HMAC audit chain in ApprovalQueue.resolve (#4536).

--- a/docs/release-notes/fragments/4536-human-approval-audit-chain.md
+++ b/docs/release-notes/fragments/4536-human-approval-audit-chain.md
@@ -1,0 +1,1 @@
+﻿Record operator approval decisions and always-allow promotions to the HMAC audit chain in ApprovalQueue.resolve (#4536).

--- a/src/bernstein/core/approval/queue.py
+++ b/src/bernstein/core/approval/queue.py
@@ -110,11 +110,29 @@ class ApprovalQueue:
     UI and the ``bernstein approve`` CLI) observe the same queue.
     """
 
-    def __init__(self, base_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        base_dir: Path | None = None,
+        *,
+        audit_dir: Path | None = None,
+        workdir: Path | None = None,
+    ) -> None:
         """Create a queue rooted at *base_dir* (defaults to cwd)."""
         if base_dir is None:
             base_dir = Path.cwd() / _RUNTIME_DIR
         self._base_dir = base_dir
+        if audit_dir is not None:
+            self._audit_dir = audit_dir
+        elif workdir is not None:
+            self._audit_dir = workdir / ".sdd" / "audit"
+        else:
+            sdd = None
+            curr = base_dir.resolve()
+            for parent in [curr, *curr.parents]:
+                if parent.name == ".sdd":
+                    sdd = parent
+                    break
+            self._audit_dir = (sdd / "audit") if sdd else (base_dir / "audit")
         self._lock = threading.RLock()
         self._pending: dict[str, PendingApproval] = {}
         self._resolved: dict[str, ResolvedApproval] = {}
@@ -130,6 +148,11 @@ class ApprovalQueue:
     def base_dir(self) -> Path:
         """Return the on-disk directory that backs this queue."""
         return self._base_dir
+
+    @property
+    def audit_dir(self) -> Path:
+        """Return the audit log directory for chain-recorded resolutions."""
+        return self._audit_dir
 
     def _member_path(self, approval_id: str, suffix: str) -> Path:
         """Return the queue-member path for *approval_id*, containment-checked.
@@ -250,6 +273,7 @@ class ApprovalQueue:
         *,
         reason: str = "",
         nonce: bytes | str | None = None,
+        source: str = "human",
     ) -> ResolvedApproval:
         """Record an operator decision for *approval_id*.
 
@@ -268,6 +292,8 @@ class ApprovalQueue:
                 Mismatches raise :class:`ApprovalNonceMismatch`; replays
                 or stale nonces against an already-resolved or expired
                 approval raise :class:`ApprovalNonceExpired`.
+            source: Resolving channel or identity attribution (e.g.
+                ``cli``, ``http``, ``tui``, or ``human``).
 
         Returns:
             The authoritative :class:`ResolvedApproval`.
@@ -319,6 +345,15 @@ class ApprovalQueue:
             self._pending_path(approval_id).unlink(missing_ok=True)
         except OSError as exc:
             logger.debug("Could not remove pending file for %s: %s", sanitize_log(approval_id), exc)
+
+        # Record human resolution and any always-allow promotion to the tamper-evident audit chain.
+        _record_human_approval_decision(
+            self._audit_dir,
+            approval=pending,
+            decision=decision,
+            reason=reason,
+            source=source,
+        )
 
         # Signal any awaiting wait_for(). Event.set() is thread-safe but
         # must be scheduled on the loop that created the Event.
@@ -542,3 +577,62 @@ def promote_to_always_allow(
     except (OSError, ValueError) as exc:
         logger.warning("Wrote rule but could not refresh always-allow manifest: %s", exc)
     return target
+
+
+def _record_human_approval_decision(
+    audit_dir: Path,
+    *,
+    approval: PendingApproval,
+    decision: ApprovalDecision,
+    reason: str = "",
+    source: str = "human",
+) -> None:
+    """Record a human/operator approval resolution and any promotion to the audit chain.
+
+    The audit recording is performed best-effort and fail-closed against exceptions
+    so filesystem/permission errors in the audit layer do not corrupt the queue state.
+    """
+    from bernstein.core.security.audit import AuditLog
+
+    cmd = str(approval.tool_args.get("command") or approval.tool_args.get("shell_cmd") or "")
+    details: dict[str, Any] = {
+        "approval_id": approval.id,
+        "decision": decision.value,
+        "tool": approval.tool_name,
+        "reason": reason,
+        "decision_source": source,
+        "session_id": approval.session_id,
+        "agent_role": approval.agent_role,
+        "tool_args": approval.tool_args,
+    }
+    if cmd:
+        details["command"] = cmd
+    try:
+        log = AuditLog(audit_dir=audit_dir)
+        log.log(
+            event_type="human_approval_decision",
+            actor=source or "human",
+            resource_type="tool_call",
+            resource_id=approval.tool_name,
+            details=details,
+        )
+        if decision is ApprovalDecision.ALWAYS:
+            log.log(
+                event_type="always_allow_promotion",
+                actor=source or "human",
+                resource_type="always_allow_rule",
+                resource_id=approval.tool_name,
+                details={
+                    "approval_id": approval.id,
+                    "tool": approval.tool_name,
+                    "tool_args": approval.tool_args,
+                    "session_id": approval.session_id,
+                    "agent_role": approval.agent_role,
+                    "promoted_by": source,
+                },
+            )
+    except Exception as exc:  # pragma: no cover - filesystem/permission error
+        logger.warning(
+            "Could not record human approval decision to audit log: %s",
+            exc,
+        )

--- a/src/bernstein/core/approval/queue.py
+++ b/src/bernstein/core/approval/queue.py
@@ -589,8 +589,16 @@ def _record_human_approval_decision(
 ) -> None:
     """Record a human/operator approval resolution and any promotion to the audit chain.
 
-    The audit recording is performed best-effort and fail-closed against exceptions
-    so filesystem/permission errors in the audit layer do not corrupt the queue state.
+    Persistence is best-effort, matching ``auto_approve_decision`` in
+    ``gate.py``: a write failure is logged and the resolution still stands,
+    because refusing to resolve an approval because its audit line could not
+    be appended would wedge the queue on a filesystem fault.
+
+    The payload mirrors that sibling event and records the extracted
+    ``command`` rather than the whole ``tool_args`` mapping. Two events in one
+    chain that disagree on how much of a call they retain is a difference an
+    auditor has to explain, and the mapping can carry argument values that
+    have no reason to live in a replayable log.
     """
     from bernstein.core.security.audit import AuditLog
 
@@ -603,7 +611,6 @@ def _record_human_approval_decision(
         "decision_source": source,
         "session_id": approval.session_id,
         "agent_role": approval.agent_role,
-        "tool_args": approval.tool_args,
     }
     if cmd:
         details["command"] = cmd
@@ -625,7 +632,6 @@ def _record_human_approval_decision(
                 details={
                     "approval_id": approval.id,
                     "tool": approval.tool_name,
-                    "tool_args": approval.tool_args,
                     "session_id": approval.session_id,
                     "agent_role": approval.agent_role,
                     "promoted_by": source,

--- a/tests/unit/test_approval_queue.py
+++ b/tests/unit/test_approval_queue.py
@@ -202,3 +202,116 @@ def test_resolve_unknown_id_raises(tmp_path: Path) -> None:
     queue = ApprovalQueue(base_dir=tmp_path)
     with pytest.raises(KeyError):
         queue.resolve("ap-doesnotexist", ApprovalDecision.ALLOW)
+
+
+def test_human_allow_appends_audit_chain_event(tmp_path: Path) -> None:
+    from bernstein.core.security.audit import AuditLog
+
+    sdd = tmp_path / ".sdd"
+    queue = ApprovalQueue(base_dir=sdd / "runtime" / "approvals")
+    approval = _push(queue, tool="shell", session="S-100")
+
+    resolution = queue.resolve(approval.id, ApprovalDecision.ALLOW, reason="looks safe", source="cli")
+    assert resolution.decision is ApprovalDecision.ALLOW
+
+    audit = AuditLog(audit_dir=sdd / "audit")
+    events = audit.query(event_type="human_approval_decision")
+    assert len(events) == 1
+    event = events[0]
+    assert event.event_type == "human_approval_decision"
+    assert event.actor == "cli"
+    assert event.resource_id == "shell"
+    assert event.details["approval_id"] == approval.id
+    assert event.details["decision"] == "allow"
+    assert event.details["reason"] == "looks safe"
+    assert event.details["decision_source"] == "cli"
+
+    # Verify audit chain integrity
+    assert audit.verify()
+
+
+def test_human_and_classifier_decisions_are_distinguishable_in_chain(tmp_path: Path) -> None:
+    from bernstein.core.approval.gate import _record_classifier_decision
+    from bernstein.core.security.audit import AuditLog
+    from bernstein.core.security.auto_approve import ApprovalResult as ClassifierResult
+    from bernstein.core.security.auto_approve import Decision
+
+    sdd = tmp_path / ".sdd"
+    queue = ApprovalQueue(base_dir=sdd / "runtime" / "approvals")
+
+    # Record automated classifier decision
+    clf_result = ClassifierResult(Decision.APPROVE, reason="matches rule", matched_pattern="git status")
+    _record_classifier_decision(
+        classification=clf_result,
+        session_id="S-1",
+        agent_role="backend",
+        tool_name="shell",
+        tool_args={"command": "git status"},
+        workdir=tmp_path,
+    )
+
+    # Record human decision
+    approval = _push(queue, tool="shell", session="S-1")
+    queue.resolve(approval.id, ApprovalDecision.ALLOW, reason="manual override", source="human")
+
+    audit = AuditLog(audit_dir=sdd / "audit")
+    all_events = audit.query()
+    event_types = [e.event_type for e in all_events]
+
+    assert "auto_approve_decision" in event_types
+    assert "human_approval_decision" in event_types
+
+    auto_event = next(e for e in all_events if e.event_type == "auto_approve_decision")
+    human_event = next(e for e in all_events if e.event_type == "human_approval_decision")
+
+    assert auto_event.event_type != human_event.event_type
+    assert auto_event.details["matched_pattern"] == "git status"
+    assert human_event.details["approval_id"] == approval.id
+    assert human_event.details["decision_source"] == "human"
+
+
+def test_always_allow_promotion_is_recorded_as_its_own_event(tmp_path: Path) -> None:
+    from bernstein.core.security.audit import AuditLog
+
+    sdd = tmp_path / ".sdd"
+    queue = ApprovalQueue(base_dir=sdd / "runtime" / "approvals")
+    approval = _push(queue, tool="write_file", session="S-2")
+
+    queue.resolve(approval.id, ApprovalDecision.ALWAYS, reason="trust this tool", source="tui")
+
+    audit = AuditLog(audit_dir=sdd / "audit")
+    events = audit.query()
+    event_types = [e.event_type for e in events]
+
+    assert "human_approval_decision" in event_types
+    assert "always_allow_promotion" in event_types
+
+    promo_event = next(e for e in events if e.event_type == "always_allow_promotion")
+    assert promo_event.actor == "tui"
+    assert promo_event.resource_type == "always_allow_rule"
+    assert promo_event.resource_id == "write_file"
+    assert promo_event.details["approval_id"] == approval.id
+    assert promo_event.details["promoted_by"] == "tui"
+
+
+def test_chain_write_failure_does_not_leave_queue_inconsistent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.security.audit import AuditLog
+
+    sdd = tmp_path / ".sdd"
+    queue = ApprovalQueue(base_dir=sdd / "runtime" / "approvals")
+    approval = _push(queue, tool="shell", session="S-3")
+
+    def _failing_log(*args: object, **kwargs: object) -> dict[str, object]:
+        raise OSError("Simulated disk error while writing audit chain")
+
+    monkeypatch.setattr(AuditLog, "log", _failing_log)
+
+    # Resolution must not raise even if audit chain write fails
+    resolution = queue.resolve(approval.id, ApprovalDecision.REJECT, reason="denied", source="cli")
+    assert resolution.decision is ApprovalDecision.REJECT
+
+    # Queue in-memory state and disk state must be fully consistent
+    assert queue.get_resolution(approval.id) is not None
+    assert queue.get(approval.id) is None
+    assert not (sdd / "runtime" / "approvals" / f"{approval.id}.json").exists()
+    assert (sdd / "runtime" / "approvals" / f"{approval.id}.resolved.json").exists()


### PR DESCRIPTION
Fixes #4536

### Problem
In the tool-call approval queue, automated classifier verdicts were recorded to the HMAC-chained audit log (\uto_approve_decision\), but human operator decisions in \ApprovalQueue.resolve()\ had no audit log writes, leaving human overrides and always-allow promotions absent from the tamper-evident chain.

### Solution
1. **Audit Chain Recording in \ApprovalQueue.resolve()\**: Added \_record_human_approval_decision\ to log \human_approval_decision\ events to the HMAC audit chain with actor, tool name, decision, approval ID, reason, and channel attribution (\source\).
2. **Always-Allow Promotion Fact**: When \decision == ApprovalDecision.ALWAYS\, logs a separate \lways_allow_promotion\ audit event capturing the promoted rule details and authority.
3. **Ordering & Fail-Safe Isolation**: Audit log writes occur with fail-safe error isolation (exceptions logged as warnings) so an audit write error never corrupts queue state or blocks resolution.
4. **Release Notes**: Added fragment \docs/release-notes/fragments/4536-human-approval-audit-chain.md\.