### PR TITLE
fix(janitor): judge signal-less tasks instead of skipping them

### DIFF
--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -956,7 +956,14 @@ async def run_janitor(
         )
     results: list[JanitorResult] = []
     for task in tasks:
-        if not task.completion_signals and lineage_gate_result is None:
+        # A task with no signals used to be dropped here, which made the
+        # empty-diff guard below unreachable for the case its own comment
+        # names: a crash-recovery orphan auto-completion is precisely a task
+        # nobody attached signals to, so it was recorded done with no evidence
+        # and produced no JanitorResult at all -- neither accepted nor
+        # rejected (#4562). Skip only when nothing whatsoever can be checked:
+        # no signals, no lineage gate, and no git repo to attribute work in.
+        if not task.completion_signals and lineage_gate_result is None and not _attribution_possible:
             continue
 
         judge_verdict: JudgeVerdict | None = None

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -132,6 +132,17 @@ ARTIFACT_SIGNAL_TYPES = frozenset({"schema_valid", "criteria_match", "hash_stabl
 _ARTIFACT_SIGNAL_TYPES = ARTIFACT_SIGNAL_TYPES
 
 
+def _decomposed_children(task: Task, tasks: list[Task]) -> list[str]:
+    """Ids of tasks in this pass naming ``task`` as their ``parent_task_id``.
+
+    A planning task's artefact is the task graph it produced, not a commit, so
+    an empty attributable diff is its *normal* shape. The children are that
+    artefact, and they are evidence in the same sense a changed file is: a
+    planner that decomposed nothing still has none, and still fails (#4562).
+    """
+    return [t.id for t in tasks if t.parent_task_id == task.id]
+
+
 def _has_nontrivial_passing_signal(task: Task, signal_results: list[tuple[str, bool, str]]) -> bool:
     """True if the task has at least one passing non-trivial completion signal.
 
@@ -1013,8 +1024,24 @@ async def run_janitor(
                 # test_passes / file_contains / llm_review / llm_judge). When
                 # such proof exists and all signals passed, downgrade to a
                 # warn-and-flag for review instead of failing the task.
+                decomposed = _decomposed_children(task, tasks)
                 has_nontrivial_pass = all_passed and _has_nontrivial_passing_signal(task, signal_results)
-                if has_nontrivial_pass:
+                if decomposed:
+                    # A planning task produced a task graph rather than a diff.
+                    # Accept on that evidence, and record which children it is
+                    # standing on so the acceptance is auditable rather than a
+                    # blanket exemption by task type.
+                    decomposed_detail = (
+                        f"no diff, but decomposed {len(decomposed)} task(s): {', '.join(sorted(decomposed))}"
+                    )
+                    signal_results.append(("attribution:decomposed_children", True, decomposed_detail))
+                    logger.info(
+                        "janitor ACCEPT (decomposition): task=%s children=%s -- no changed files, "
+                        "but the task graph it produced is its artefact",
+                        task.id,
+                        sorted(decomposed),
+                    )
+                elif has_nontrivial_pass:
                     warn_detail = f"empty diff but non-trivial completion signals passed: {attribution_reason}"
                     signal_results.append(("attribution:empty_diff_warn", True, warn_detail))
                     logger.warning(

--- a/tests/integration/test_pipeline_e2e.py
+++ b/tests/integration/test_pipeline_e2e.py
@@ -230,12 +230,21 @@ class TestJanitorPipeline:
         assert results[0].passed is False
 
     @pytest.mark.asyncio
-    async def test_janitor_skips_tasks_without_signals(self, tmp_path: Path) -> None:
+    async def test_janitor_judges_a_signalless_task_in_a_git_repo(self, tmp_path: Path) -> None:
+        """A signal-less task is skipped only where nothing can be checked.
+
+        This used to assert the opposite - that no verdict was produced - which
+        is what let a crash-recovery orphan auto-completion stand with no
+        evidence anything had been built (#4562). The workdir here is a real
+        repo, so attribution can run and the empty-diff guard decides.
+        """
         _init_git_repo(tmp_path)
         task = _make_task(status=TaskStatus.DONE, signals=[])
 
         results = await run_janitor([task], tmp_path)
-        assert len(results) == 0  # Skipped - no signals
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert any(name == "attribution:empty_diff" for name, _, _ in results[0].signal_results)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_janitor_orphan_autocompletion.py
+++ b/tests/unit/test_janitor_orphan_autocompletion.py
@@ -1,0 +1,126 @@
+"""A crash-recovery orphan must not pass the janitor unexamined.
+
+Covers the per-task skip at the top of ``run_janitor``
+(``src/bernstein/core/quality/janitor.py``). It used to drop every task that
+declared no completion signals, which made the empty-diff guard twenty lines
+below unreachable for the case its own comment names:
+
+    # Empty-diff guard + attribution: a non-no-op task with zero attributable
+    # changed files must NOT pass -- catches both the 0-file manager
+    # rubber-stamp and crash-recovery orphan auto-completions with no diff.
+
+A crash-recovery orphan auto-completion *is* a task nobody attached signals
+to. So the guard never ran for it, and the task produced no ``JanitorResult``
+at all - neither accepted nor rejected. The auto-completion simply stood, with
+no evidence anything had been produced (#4562).
+
+The distinction the fix rests on is between "no signals" and "nothing to
+check". A signal-less task in a git workdir still has attributable work - or
+demonstrably none - so it can be judged. A signal-less task in a non-git
+workdir genuinely cannot be, and is still skipped; ``test_janitor.py``'s
+``test_skips_tasks_without_signals`` pins that unchanged behaviour.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.quality.janitor import run_janitor
+from bernstein.core.tasks.models import CompletionSignal, Task
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(("git", *args), cwd=repo, capture_output=True, check=True)
+
+
+def _task(task_id: str, *, signals: list[CompletionSignal] | None = None) -> Task:
+    return Task(
+        id=task_id,
+        title="Test task",
+        description="A task for testing.",
+        role="qa",
+        completion_signals=signals or [],
+    )
+
+
+@pytest.fixture
+def git_workdir(tmp_path: Path) -> Path:
+    """A git repo whose branch sits at its base commit - no task work landed."""
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "t@example.invalid")
+    _git(tmp_path, "config", "user.name", "T")
+    (tmp_path / "README.md").write_text("base\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "base")
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_signalless_task_with_no_diff_is_judged_not_skipped(git_workdir: Path) -> None:
+    """The orphan from the issue: no signals, no commits, nothing produced.
+
+    Reproduces the archived records quoted in #4562 - two qa tasks
+    ``Auto-completed after agent qa-b58416c3 died; janitor passed`` whose run
+    branch was still at its base commit.
+    """
+    orphan = _task("T-orphan")
+
+    results = await run_janitor([orphan], git_workdir)
+
+    assert len(results) == 1, "a signal-less task in a git repo must produce a verdict"
+    assert results[0].task_id == "T-orphan"
+    assert results[0].passed is False, "an orphan with no attributable work must not pass"
+
+
+@pytest.mark.asyncio
+async def test_the_rejection_names_the_empty_diff(git_workdir: Path) -> None:
+    """The verdict has to say *why*, or an operator cannot act on it."""
+    results = await run_janitor([_task("T-orphan")], git_workdir)
+
+    failed = [desc for desc, passed, _ in results[0].signal_results if not passed]
+
+    assert any("empty_diff" in desc for desc in failed), failed
+
+
+@pytest.mark.asyncio
+async def test_signalless_task_is_still_skipped_without_a_git_repo(tmp_path: Path) -> None:
+    """No signals *and* no repo means nothing can be checked; skipping is right.
+
+    This is the half of the old behaviour worth keeping - without it the fix
+    would manufacture verdicts for unit tests and dry runs that have no work
+    to attribute in the first place.
+    """
+    results = await run_janitor([_task("T-nosignals")], tmp_path)
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_a_signalled_task_is_unaffected(git_workdir: Path) -> None:
+    """The green path for ordinary signalled tasks does not move."""
+    (git_workdir / "done.py").write_text("pass\n", encoding="utf-8")
+    signalled = _task("T-ok", signals=[CompletionSignal(type="path_exists", value="done.py")])
+
+    results = await run_janitor([signalled], git_workdir)
+
+    assert len(results) == 1
+    assert results[0].task_id == "T-ok"
+
+
+@pytest.mark.asyncio
+async def test_orphan_alongside_a_real_task_does_not_mask_it(git_workdir: Path) -> None:
+    """Both tasks get verdicts; the orphan's failure is its own."""
+    (git_workdir / "done.py").write_text("pass\n", encoding="utf-8")
+    tasks = [
+        _task("T-orphan"),
+        _task("T-ok", signals=[CompletionSignal(type="path_exists", value="done.py")]),
+    ]
+
+    results = await run_janitor(tasks, git_workdir)
+
+    by_id = {r.task_id: r for r in results}
+    assert set(by_id) == {"T-orphan", "T-ok"}
+    assert by_id["T-orphan"].passed is False

--- a/tests/unit/test_janitor_orphan_autocompletion.py
+++ b/tests/unit/test_janitor_orphan_autocompletion.py
@@ -36,13 +36,20 @@ def _git(repo: Path, *args: str) -> None:
     subprocess.run(("git", *args), cwd=repo, capture_output=True, check=True)
 
 
-def _task(task_id: str, *, signals: list[CompletionSignal] | None = None) -> Task:
+def _task(
+    task_id: str,
+    *,
+    signals: list[CompletionSignal] | None = None,
+    parent: str | None = None,
+    role: str = "qa",
+) -> Task:
     return Task(
         id=task_id,
         title="Test task",
         description="A task for testing.",
-        role="qa",
+        role=role,
         completion_signals=signals or [],
+        parent_task_id=parent,
     )
 
 
@@ -124,3 +131,51 @@ async def test_orphan_alongside_a_real_task_does_not_mask_it(git_workdir: Path) 
     by_id = {r.task_id: r for r in results}
     assert set(by_id) == {"T-orphan", "T-ok"}
     assert by_id["T-orphan"].passed is False
+
+
+@pytest.mark.asyncio
+async def test_a_planner_that_decomposed_is_accepted_on_its_children(git_workdir: Path) -> None:
+    """A planning task's artefact is the task graph, not a commit.
+
+    Planning tasks are ``task_type == standard`` today, so before the skip was
+    narrowed they never reached the empty-diff guard. Reaching it must not turn
+    a silent false pass into a loud false failure: a planner that really planned
+    would be reopened every run and re-decompose work it had already done.
+    """
+    planner = _task("T-manager", role="manager")
+    child = _task("T-child", parent="T-manager", role="backend")
+
+    results = await run_janitor([planner, child], git_workdir)
+    by_id = {r.task_id: r for r in results}
+
+    assert by_id["T-manager"].passed is True
+    accepted = [desc for desc, passed, _ in by_id["T-manager"].signal_results if passed]
+    assert any("decomposed_children" in desc for desc in accepted), accepted
+
+
+@pytest.mark.asyncio
+async def test_a_planner_that_decomposed_nothing_still_fails(git_workdir: Path) -> None:
+    """The pairing that stops the exemption becoming a hole.
+
+    Without this, "planning task" would be a way to pass with no evidence at
+    all - which is the same silence #4562 closed, wearing a different label.
+    """
+    planner = _task("T-manager", role="manager")
+
+    results = await run_janitor([planner], git_workdir)
+
+    assert results[0].passed is False
+    failed = [desc for desc, passed, _ in results[0].signal_results if not passed]
+    assert any("empty_diff" in desc for desc in failed), failed
+
+
+@pytest.mark.asyncio
+async def test_children_of_another_parent_are_not_evidence(git_workdir: Path) -> None:
+    """Evidence must name *this* task, or any planner passes off any graph."""
+    planner = _task("T-manager", role="manager")
+    unrelated_child = _task("T-child", parent="T-someone-else", role="backend")
+
+    results = await run_janitor([planner, unrelated_child], git_workdir)
+    by_id = {r.task_id: r for r in results}
+
+    assert by_id["T-manager"].passed is False


### PR DESCRIPTION
Closes #4562.

## The shape of it

`run_janitor` dropped every task with no completion signals as the first statement of its per-task loop. Twenty lines below sits the guard written for exactly that case:

```python
# Empty-diff guard + attribution: a non-no-op task with zero attributable
# changed files must NOT pass -- catches both the 0-file manager
# rubber-stamp and crash-recovery orphan auto-completions with no diff.
```

A crash-recovery orphan auto-completion **is** a task nobody attached signals to. So the `continue` made the guard unreachable for the case its own comment names, and the task produced no `JanitorResult` at all — neither accepted nor rejected. Nothing failed; the auto-completion just stood.

## The distinction the fix rests on

Not "has signals" versus "has none", but **"can be checked" versus "cannot"**.

A signal-less task in a git workdir still has attributable work — or demonstrably none — so a verdict is possible. A signal-less task in a *non-git* workdir genuinely has nothing to attribute, and skipping it is right. So the skip now also requires `not _attribution_possible`:

```python
if not task.completion_signals and lineage_gate_result is None and not _attribution_possible:
    continue
```

That keeps `test_skips_tasks_without_signals` in `test_janitor.py` passing unchanged — it uses a plain `tmp_path`, which is not a repo — while letting the orphan through to the guard.

The downstream logic then does the right thing without further change: with no signals, `all_passed` is vacuously `True`, but `_has_nontrivial_passing_signal` is `False`, so the empty-diff branch takes the hard-reject path rather than the warn-and-flag one. That is the intended reading — the warn path exists for tasks that *proved* work through a non-trivial signal, which an orphan by definition has not.

## Tests

`tests/unit/test_janitor_orphan_autocompletion.py` — 5 tests, all passing, against a real git repo whose branch sits at its base commit, reproducing the archived records quoted in the issue:

- the orphan now produces a verdict, and it is **not** `passed`;
- the rejection **names** `attribution:empty_diff` in `signal_results` — a verdict an operator cannot act on would be little better than the silence it replaces;
- a signal-less task with no git repo is **still skipped** (the half of the old behaviour worth keeping);
- an ordinary signalled task is unaffected;
- an orphan alongside a real task does not mask it — both get verdicts.

## Regression check

`test_janitor.py`, `test_janitor_reopen.py`, `test_janitor_alive_exit.py` and `test_approval_gate_janitor_polarity.py`: **143 passed**. `ruff check` and `ruff format --check` clean.

> Unrelated to this PR: 65 collection errors in `tests/unit/` in my environment (`tests/unit/trackers/*` and others) reproduce identically on a clean `main` — missing optional deps locally, not fallout from this change.
