### PR TITLE
fix(approvals): surface pre-spawn approval-spec pendings in GET /approvals (#4535)

### DIFF
--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -6062,7 +6062,7 @@
           "approvals"
         ],
         "summary": "List Approvals",
-        "description": "List all pending approval requests.",
+        "description": "List all pending approval requests across task-review and pre-spawn gates.",
         "operationId": "list_approvals_approvals_get",
         "responses": {
           "200": {
@@ -14821,7 +14821,7 @@
           "approvals"
         ],
         "summary": "List Approvals",
-        "description": "List all pending approval requests.",
+        "description": "List all pending approval requests across task-review and pre-spawn gates.",
         "operationId": "list_approvals_api_v1_approvals_get",
         "responses": {
           "200": {
@@ -20006,6 +20006,52 @@
             "type": "string",
             "title": "Test Summary",
             "default": ""
+          },
+          "mechanism": {
+            "type": "string",
+            "title": "Mechanism",
+            "default": "task_review"
+          },
+          "prompt": {
+            "type": "string",
+            "title": "Prompt",
+            "default": ""
+          },
+          "default_action": {
+            "type": "string",
+            "title": "Default Action",
+            "default": ""
+          },
+          "timeout_at_iso": {
+            "type": "string",
+            "title": "Timeout At Iso",
+            "default": ""
+          },
+          "created_iso": {
+            "type": "string",
+            "title": "Created Iso",
+            "default": ""
+          },
+          "timeout_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timeout Seconds"
+          },
+          "unblocks": {
+            "type": "string",
+            "title": "Unblocks",
+            "default": "task completion and merge"
+          },
+          "resolution_endpoint": {
+            "type": "string",
+            "title": "Resolution Endpoint",
+            "default": ""
           }
         },
         "type": "object",
@@ -20015,7 +20061,7 @@
           "session_id"
         ],
         "title": "PendingApproval",
-        "description": "A single pending approval request."
+        "description": "A single pending approval request (task-level or pre-spawn)."
       },
       "PlanDecisionRequest": {
         "properties": {

--- a/docs/release-notes/fragments/4535-approvals-route-pre-spawn-pending.md
+++ b/docs/release-notes/fragments/4535-approvals-route-pre-spawn-pending.md
@@ -1,0 +1,1 @@
+Expose pre-spawn approval-spec pending entries alongside task-review pending entries in GET /approvals with mechanism and resolution tagging (#4535).

--- a/docs/release-notes/fragments/4535-approvals-route-pre-spawn-pendings.md
+++ b/docs/release-notes/fragments/4535-approvals-route-pre-spawn-pendings.md
@@ -1,1 +1,0 @@
-Expose pre-spawn approval-spec pendings alongside task-review pendings in GET /approvals with mechanism and resolution tagging (#4535).

--- a/docs/release-notes/fragments/4535-approvals-route-pre-spawn-pendings.md
+++ b/docs/release-notes/fragments/4535-approvals-route-pre-spawn-pendings.md
@@ -1,0 +1,1 @@
+﻿Expose pre-spawn approval-spec pendings alongside task-review pendings in GET /approvals with mechanism and resolution tagging (#4535).

--- a/docs/release-notes/fragments/4535-approvals-route-pre-spawn-pendings.md
+++ b/docs/release-notes/fragments/4535-approvals-route-pre-spawn-pendings.md
@@ -1,1 +1,1 @@
-﻿Expose pre-spawn approval-spec pendings alongside task-review pendings in GET /approvals with mechanism and resolution tagging (#4535).
+Expose pre-spawn approval-spec pendings alongside task-review pendings in GET /approvals with mechanism and resolution tagging (#4535).

--- a/src/bernstein/core/routes/approvals.py
+++ b/src/bernstein/core/routes/approvals.py
@@ -50,13 +50,21 @@ router = APIRouter(prefix="/approvals", tags=["approvals"])
 
 
 class PendingApproval(BaseModel):
-    """A single pending approval request."""
+    """A single pending approval request (task-level or pre-spawn)."""
 
     task_id: str
     task_title: str
     session_id: str
     diff: str = ""
     test_summary: str = ""
+    mechanism: str = "task_review"
+    prompt: str = ""
+    default_action: str = ""
+    timeout_at_iso: str = ""
+    created_iso: str = ""
+    timeout_seconds: int | None = None
+    unblocks: str = "task completion and merge"
+    resolution_endpoint: str = ""
 
 
 class ListApprovalsResponse(BaseModel):
@@ -139,16 +147,51 @@ def _load_pending(filepath: Path) -> PendingApproval | None:
 
 @router.get("")
 def list_approvals() -> ListApprovalsResponse:
-    """List all pending approval requests."""
-    pending_dir = _pending_dir()
-    if not pending_dir.exists():
-        return ListApprovalsResponse(pending=[])
-
+    """List all pending approval requests across task-review and pre-spawn gates."""
     results: list[PendingApproval] = []
-    for fpath in sorted(pending_dir.glob("*.json")):
-        approval = _load_pending(fpath)
-        if approval is not None:
-            results.append(approval)
+
+    # 1. Task-level review pendings (.sdd/runtime/pending_approvals/*.json)
+    pending_dir = _pending_dir()
+    if pending_dir.exists():
+        for fpath in sorted(pending_dir.glob("*.json")):
+            approval = _load_pending(fpath)
+            if approval is not None:
+                approval.mechanism = "task_review"
+                approval.unblocks = "task completion and merge"
+                approval.resolution_endpoint = f"/approvals/{approval.task_id}/approve"
+                results.append(approval)
+
+    # 2. Pre-spawn gate pendings (.sdd/runtime/approvals/*.pending)
+    approvals_dir = _approvals_dir()
+    if approvals_dir.exists():
+        for sentinel in sorted(approvals_dir.glob("*.pending")):
+            try:
+                data = json.loads(sentinel.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.debug("approval routes: skipping unreadable sentinel %s: %s", sentinel.name, exc)
+                continue
+            if not isinstance(data, dict):
+                continue
+            task_id = str(data.get("task_id") or sentinel.stem)
+            prompt = str(data.get("prompt", ""))
+            timeout_seconds_raw = data.get("timeout_seconds")
+            timeout_seconds = int(timeout_seconds_raw) if isinstance(timeout_seconds_raw, (int, float)) else None
+            pre_spawn_approval = PendingApproval(
+                task_id=task_id,
+                task_title=prompt or task_id,
+                session_id=str(data.get("session_id", "")),
+                diff="",
+                test_summary="",
+                mechanism="pre_spawn",
+                prompt=prompt,
+                default_action=str(data.get("default_action", "reject")),
+                timeout_at_iso=str(data.get("timeout_at_iso", "")),
+                created_iso=str(data.get("created_iso", "")),
+                timeout_seconds=timeout_seconds,
+                unblocks="agent spawn and task execution",
+                resolution_endpoint=f"/approvals/{task_id}/approve",
+            )
+            results.append(pre_spawn_approval)
 
     return ListApprovalsResponse(pending=results)
 
@@ -176,16 +219,18 @@ def approve_task(task_id: str, body: ApprovalDecisionRequest) -> dict[str, str]:
     safe_id = Path(task_id).name  # Strip any directory components
     approvals_dir = _approvals_dir()
     pending_path = _safe_child(_pending_dir(), f"{safe_id}.json")
+    pre_spawn_pending = _safe_child(approvals_dir, f"{safe_id}.pending")
     approved_path = _safe_child(approvals_dir, f"{safe_id}.approved")
 
-    if not pending_path.exists():
+    if not pending_path.exists() and not pre_spawn_pending.exists():
         raise HTTPException(status_code=404, detail=f"No pending approval for task {task_id}")
 
     # Write decision
     approved_path.write_text(json.dumps({"reason": body.reason}, indent=2))
 
-    # Remove pending file
+    # Remove pending files
     pending_path.unlink(missing_ok=True)
+    pre_spawn_pending.unlink(missing_ok=True)
 
     logger.info("Approval routes: task %r approved via TUI/API", task_id.replace("\n", "\\n").replace("\r", "\\r"))
     return {"status": "approved", "task_id": task_id}
@@ -214,16 +259,18 @@ def reject_task(task_id: str, body: ApprovalDecisionRequest) -> dict[str, str]:
     safe_id = Path(task_id).name  # Strip any directory components
     approvals_dir = _approvals_dir()
     pending_path = _safe_child(_pending_dir(), f"{safe_id}.json")
+    pre_spawn_pending = _safe_child(approvals_dir, f"{safe_id}.pending")
     rejected_path = _safe_child(approvals_dir, f"{safe_id}.rejected")
 
-    if not pending_path.exists():
+    if not pending_path.exists() and not pre_spawn_pending.exists():
         raise HTTPException(status_code=404, detail=f"No pending approval for task {task_id}")
 
     # Write decision
     rejected_path.write_text(json.dumps({"reason": body.reason}, indent=2))
 
-    # Remove pending file
+    # Remove pending files
     pending_path.unlink(missing_ok=True)
+    pre_spawn_pending.unlink(missing_ok=True)
 
     logger.info("Approval routes: task %r rejected via TUI/API", task_id.replace("\n", "\\n").replace("\r", "\\r"))
     return {"status": "rejected", "task_id": task_id}

--- a/src/bernstein/core/routes/approvals.py
+++ b/src/bernstein/core/routes/approvals.py
@@ -150,7 +150,7 @@ def list_approvals() -> ListApprovalsResponse:
     """List all pending approval requests across task-review and pre-spawn gates."""
     results: list[PendingApproval] = []
 
-    # 1. Task-level review pendings (.sdd/runtime/pending_approvals/*.json)
+    # 1. Task-level review pending entries (.sdd/runtime/pending_approvals/*.json)
     pending_dir = _pending_dir()
     if pending_dir.exists():
         for fpath in sorted(pending_dir.glob("*.json")):
@@ -161,7 +161,7 @@ def list_approvals() -> ListApprovalsResponse:
                 approval.resolution_endpoint = f"/approvals/{approval.task_id}/approve"
                 results.append(approval)
 
-    # 2. Pre-spawn gate pendings (.sdd/runtime/approvals/*.pending)
+    # 2. Pre-spawn gate pending entries (.sdd/runtime/approvals/*.pending)
     approvals_dir = _approvals_dir()
     if approvals_dir.exists():
         for sentinel in sorted(approvals_dir.glob("*.pending")):

--- a/tests/unit/test_routes_approvals.py
+++ b/tests/unit/test_routes_approvals.py
@@ -1,7 +1,7 @@
 """Unit tests for approvals route (issue #4535).
 
-Verifies that GET /approvals returns both task-review pendings and
-pre-spawn approval-spec pendings, tagged with mechanism and resolution details.
+Verifies that GET /approvals returns both task-review pending entries and
+pre-spawn approval-spec pending entries, tagged with mechanism and resolution details.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ def _create_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     return TestClient(app)
 
 
-def test_task_level_pendings_keep_their_existing_shape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_task_level_pending_entries_keep_their_existing_shape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     client = _create_app(tmp_path, monkeypatch)
 
     pending_dir = tmp_path / ".sdd" / "runtime" / "pending_approvals"

--- a/tests/unit/test_routes_approvals.py
+++ b/tests/unit/test_routes_approvals.py
@@ -1,0 +1,137 @@
+"""Unit tests for approvals route (issue #4535).
+
+Verifies that GET /approvals returns both task-review pendings and
+pre-spawn approval-spec pendings, tagged with mechanism and resolution details.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from bernstein.core.models import ApprovalSpec
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bernstein.core.orchestration.approval_gate import write_pending_sentinel
+from bernstein.core.routes import approvals
+
+
+def _create_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    app = FastAPI()
+    app.include_router(approvals.router)
+
+    # Re-anchor directories under tmp_path
+    monkeypatch.setattr(approvals, "_PENDING_DIR", tmp_path / ".sdd" / "runtime" / "pending_approvals")
+    monkeypatch.setattr(approvals, "_APPROVALS_DIR", tmp_path / ".sdd" / "runtime" / "approvals")
+
+    return TestClient(app)
+
+
+def test_task_level_pendings_keep_their_existing_shape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _create_app(tmp_path, monkeypatch)
+
+    pending_dir = tmp_path / ".sdd" / "runtime" / "pending_approvals"
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    (pending_dir / "T-1.json").write_text(
+        json.dumps(
+            {
+                "task_id": "T-1",
+                "task_title": "Fix auth",
+                "session_id": "S-1",
+                "diff": "+line",
+                "test_summary": "1 passed",
+            }
+        )
+    )
+
+    resp = client.get("/approvals")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "pending" in data
+    assert len(data["pending"]) == 1
+    item = data["pending"][0]
+
+    # Existing shape preserved
+    assert item["task_id"] == "T-1"
+    assert item["task_title"] == "Fix auth"
+    assert item["session_id"] == "S-1"
+    assert item["diff"] == "+line"
+    assert item["test_summary"] == "1 passed"
+
+    # Additive metadata present
+    assert item["mechanism"] == "task_review"
+    assert item["unblocks"] == "task completion and merge"
+    assert item["resolution_endpoint"] == "/approvals/T-1/approve"
+
+
+def test_pre_spawn_pending_is_listed_while_task_is_blocked(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _create_app(tmp_path, monkeypatch)
+
+    spec = ApprovalSpec(prompt="Deploy to staging?", timeout_seconds=300, default_action="reject")
+    write_pending_sentinel(tmp_path, "T-2", spec)
+
+    resp = client.get("/approvals")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["pending"]) == 1
+    item = data["pending"][0]
+
+    assert item["task_id"] == "T-2"
+    assert item["task_title"] == "Deploy to staging?"
+    assert item["mechanism"] == "pre_spawn"
+    assert item["prompt"] == "Deploy to staging?"
+    assert item["default_action"] == "reject"
+    assert item["timeout_seconds"] == 300
+    assert item["unblocks"] == "agent spawn and task execution"
+    assert item["resolution_endpoint"] == "/approvals/T-2/approve"
+
+
+def test_resolved_pre_spawn_pending_leaves_the_listing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _create_app(tmp_path, monkeypatch)
+
+    spec = ApprovalSpec(prompt="Deploy to staging?", timeout_seconds=300, default_action="reject")
+    write_pending_sentinel(tmp_path, "T-3", spec)
+
+    resp1 = client.get("/approvals")
+    assert len(resp1.json()["pending"]) == 1
+
+    # Approve via endpoint
+    approve_resp = client.post("/approvals/T-3/approve", json={"reason": "operator verified"})
+    assert approve_resp.status_code == 200
+    assert approve_resp.json()["status"] == "approved"
+
+    # Must be gone from listing
+    resp2 = client.get("/approvals")
+    assert len(resp2.json()["pending"]) == 0
+
+
+def test_both_mechanisms_coexist_in_listing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _create_app(tmp_path, monkeypatch)
+
+    # 1. Task-level review pending
+    pending_dir = tmp_path / ".sdd" / "runtime" / "pending_approvals"
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    (pending_dir / "T-review.json").write_text(
+        json.dumps(
+            {
+                "task_id": "T-review",
+                "task_title": "Review diff",
+                "session_id": "S-rev",
+            }
+        )
+    )
+
+    # 2. Pre-spawn pending
+    spec = ApprovalSpec(prompt="Allow spawn?", timeout_seconds=120)
+    write_pending_sentinel(tmp_path, "T-prespawn", spec)
+
+    resp = client.get("/approvals")
+    assert resp.status_code == 200
+    items = resp.json()["pending"]
+    assert len(items) == 2
+
+    mechanisms = {item["task_id"]: item["mechanism"] for item in items}
+    assert mechanisms["T-review"] == "task_review"
+    assert mechanisms["T-prespawn"] == "pre_spawn"


### PR DESCRIPTION
Fixes #4535

### Problem
The approvals route (`GET /approvals`) only read task-level post-completion review pendings from `.sdd/runtime/pending_approvals/`, completely missing pre-spawn approval-spec pendings (`.sdd/runtime/approvals/*.pending`). As a result, when an orchestrator run paused on an `approval_spec`, the web dashboard showed an empty approvals queue while the run remained blocked.

### Solution
1. **Unified Approvals Listing in `GET /approvals`**: Updated `list_approvals` in `src/bernstein/core/routes/approvals.py` to enumerate both task-review pendings (`.sdd/runtime/pending_approvals/*.json`) and pre-spawn gate sentinels (`.sdd/runtime/approvals/*.pending`).
2. **Design Decision (Single list with `mechanism` tag)**: Merged both sources into a unified `pending` list with a `mechanism` field (`"pre_spawn"` vs `"task_review"`) and resolution metadata (`unblocks`, `resolution_endpoint`). This preserves full backward compatibility for existing clients expecting a list of items with `task_id`, `task_title`, etc., while cleanly differentiating the two gates.
3. **Resolution Parity**: Updated `POST /approvals/{task_id}/approve` and `POST /approvals/{task_id}/reject` to locate and clear either `.pending` or `.json` files upon resolution.
4. **Release Notes**: Added fragment `docs/release-notes/fragments/4535-approvals-route-pre-spawn-pendings.md`.
