### PR TITLE
fix(tickets): handle 429 rate limits and wire provider circuit breaker (#4534)

### DIFF
--- a/docs/release-notes/fragments/4534-ticket-rate-limit-circuit-breaker.md
+++ b/docs/release-notes/fragments/4534-ticket-rate-limit-circuit-breaker.md
@@ -1,1 +1,1 @@
-﻿Honor Retry-After headers on 429/503 responses and wire ProviderCircuitBreaker in ticket integration HTTP layer (#4534).
+Honor Retry-After headers on 429/503 responses and wire ProviderCircuitBreaker in ticket integration HTTP layer (#4534).

--- a/docs/release-notes/fragments/4534-ticket-rate-limit-circuit-breaker.md
+++ b/docs/release-notes/fragments/4534-ticket-rate-limit-circuit-breaker.md
@@ -1,0 +1,1 @@
+﻿Honor Retry-After headers on 429/503 responses and wire ProviderCircuitBreaker in ticket integration HTTP layer (#4534).

--- a/src/bernstein/core/integrations/tickets/__init__.py
+++ b/src/bernstein/core/integrations/tickets/__init__.py
@@ -16,8 +16,10 @@ from urllib.parse import urlparse
 
 __all__ = [
     "TicketAuthError",
+    "TicketCircuitOpenError",
     "TicketParseError",
     "TicketPayload",
+    "TicketRateLimitError",
     "fetch_ticket",
 ]
 
@@ -44,6 +46,23 @@ class TicketAuthError(RuntimeError):
 
 class TicketParseError(RuntimeError):
     """Raised when a ticket URL cannot be parsed or the response is malformed."""
+
+
+class TicketRateLimitError(RuntimeError):
+    """Raised when a ticket provider rate-limits requests and retries are exhausted."""
+
+    def __init__(self, message: str, *, provider: str = "", retry_after_s: float | None = None) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.retry_after_s = retry_after_s
+
+
+class TicketCircuitOpenError(RuntimeError):
+    """Raised when requests to a ticket provider are fast-failed because its circuit is OPEN."""
+
+    def __init__(self, message: str, *, provider: str = "") -> None:
+        super().__init__(message)
+        self.provider = provider
 
 
 _LINEAR_WEB = re.compile(

--- a/src/bernstein/core/integrations/tickets/_http.py
+++ b/src/bernstein/core/integrations/tickets/_http.py
@@ -1,21 +1,209 @@
 """Tiny HTTP helper shared by ticket providers.
 
 Each provider module (Linear GraphQL, GitHub Issues REST, Jira REST)
-needs the same two-layer fetch: prefer ``httpx`` when available, fall
-back to ``urllib.request`` otherwise, and translate 401/403 into
-:class:`TicketAuthError` and any other 4xx/5xx into :class:`TicketParseError`.
-Centralising the shape removes the copy-paste between providers.
+needs the same fetch capabilities:
+- Prefer ``httpx`` when available, fall back to ``urllib.request``.
+- URL scheme validation via ``ensure_http_url``.
+- Honor ``Retry-After`` on 429 (rate limits) and 503 (service unavailable)
+  with jittered exponential backoff.
+- Circuit breaker integration via ``ProviderCircuitBreakerRegistry`` to fast-fail
+  providers experiencing extended outages.
+- Typed exception mapping:
+  - 401/403 -> :class:`TicketAuthError`
+  - 429 (exhausted) -> :class:`TicketRateLimitError`
+  - OPEN circuit -> :class:`TicketCircuitOpenError`
+  - other 4xx/5xx -> :class:`TicketParseError`
 """
 
 from __future__ import annotations
 
 import json
+import logging
+import random
+import time
+from email.utils import parsedate_to_datetime
 from typing import Any, cast
 
-from bernstein.core.integrations.tickets import TicketAuthError, TicketParseError
+from bernstein.core.integrations.tickets import (
+    TicketAuthError,
+    TicketCircuitOpenError,
+    TicketParseError,
+    TicketRateLimitError,
+)
+from bernstein.core.observability.provider_circuit_breaker import (
+    ProviderCircuitBreaker,
+    ProviderCircuitBreakerRegistry,
+)
 from bernstein.core.security.url_allowlist import UrlSchemeError, ensure_http_url
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_TIMEOUT_SECONDS = 10.0
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_BACKOFF_BASE_S = 0.5
+DEFAULT_MAX_BACKOFF_S = 30.0
+
+# Process-wide circuit breaker registry for ticket providers
+_DEFAULT_REGISTRY = ProviderCircuitBreakerRegistry()
+
+
+def _parse_retry_after(header_val: str | None) -> float | None:
+    """Parse a Retry-After header into delay seconds, or return None."""
+    if not header_val:
+        return None
+    val = header_val.strip()
+    try:
+        seconds = float(val)
+        return max(0.0, seconds)
+    except ValueError:
+        pass
+    try:
+        dt = parsedate_to_datetime(val)
+        delay = dt.timestamp() - time.time()
+        return max(0.0, delay)
+    except Exception:
+        return None
+
+
+def http_request_json(
+    *,
+    method: str = "GET",
+    url: str,
+    headers: dict[str, str],
+    json_data: dict[str, Any] | None = None,
+    provider_label: str,
+    auth_env_var: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    backoff_base_s: float = DEFAULT_BACKOFF_BASE_S,
+    max_backoff_s: float = DEFAULT_MAX_BACKOFF_S,
+    circuit_breaker: ProviderCircuitBreaker | None = None,
+    sleep_fn: Any = time.sleep,
+) -> dict[str, Any]:
+    """Execute an HTTP request and decode the JSON response with retries and circuit breaker."""
+    try:
+        ensure_http_url(url, allow_http=True, source=f"tickets.{provider_label}")
+    except UrlSchemeError as exc:
+        raise TicketParseError(str(exc)) from exc
+
+    breaker = circuit_breaker if circuit_breaker is not None else _DEFAULT_REGISTRY.get_breaker(provider_label.lower())
+    if not breaker.should_allow():
+        raise TicketCircuitOpenError(
+            f"{provider_label} circuit breaker is OPEN; fast-failing request",
+            provider=provider_label,
+        )
+
+    attempt = 0
+    total_waited_s = 0.0
+
+    while True:
+        try:
+            import httpx
+
+            if method.upper() == "POST":
+                resp = httpx.post(url, headers=headers, json=json_data, timeout=timeout)
+            else:
+                resp = httpx.get(url, headers=headers, timeout=timeout)
+
+            # 1. Auth errors fail immediately
+            if resp.status_code in (401, 403):
+                raise TicketAuthError(
+                    f"{provider_label} rejected the request (HTTP {resp.status_code}). "
+                    f"Check the {auth_env_var} environment variable."
+                )
+
+            # 2. Rate limit (429) or Service Unavailable (503) -> Retry
+            if resp.status_code in (429, 503):
+                retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+                if attempt < max_retries:
+                    attempt += 1
+                    if retry_after is not None:
+                        wait_s = min(retry_after, max_backoff_s)
+                    else:
+                        jitter = random.uniform(0, 0.1 * backoff_base_s)
+                        wait_s = min(max_backoff_s, (backoff_base_s * (2 ** (attempt - 1))) + jitter)
+                    logger.warning(
+                        "%s returned HTTP %d (attempt %d/%d), retrying in %.2fs...",
+                        provider_label,
+                        resp.status_code,
+                        attempt,
+                        max_retries,
+                        wait_s,
+                    )
+                    sleep_fn(wait_s)
+                    total_waited_s += wait_s
+                    continue
+                else:
+                    if resp.status_code == 429:
+                        breaker.record_failure()
+                        raise TicketRateLimitError(
+                            f"{provider_label} rate limit exceeded (HTTP 429); "
+                            f"retries exhausted after {total_waited_s:.1f}s (last Retry-After: {retry_after})",
+                            provider=provider_label,
+                            retry_after_s=retry_after,
+                        )
+                    breaker.record_failure()
+                    raise TicketParseError(
+                        f"{provider_label} API returned HTTP {resp.status_code} "
+                        f"after {max_retries} retries: {resp.text[:200]}"
+                    )
+
+            # 3. Other 4xx client errors (e.g. 404) fail immediately
+            if 400 <= resp.status_code < 500:
+                raise TicketParseError(f"{provider_label} API returned HTTP {resp.status_code}: {resp.text[:200]}")
+
+            # 4. Server errors (5xx)
+            if resp.status_code >= 500:
+                breaker.record_failure()
+                raise TicketParseError(f"{provider_label} API returned HTTP {resp.status_code}: {resp.text[:200]}")
+
+            # Success
+            breaker.record_success()
+            return cast(dict[str, Any], resp.json())
+
+        except ImportError:  # pragma: no cover - fallback when httpx is not imported
+            import urllib.error
+            import urllib.request
+
+            req_data = json.dumps(json_data).encode("utf-8") if json_data is not None else None
+            req = urllib.request.Request(url, data=req_data, headers=headers, method=method.upper())
+            try:
+                # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+                with urllib.request.urlopen(req, timeout=timeout) as handle:
+                    raw = handle.read().decode("utf-8")
+                    breaker.record_success()
+                    return cast(dict[str, Any], json.loads(raw))
+            except urllib.error.HTTPError as exc:
+                if exc.code in (401, 403):
+                    raise TicketAuthError(
+                        f"{provider_label} rejected the request (HTTP {exc.code}). "
+                        f"Check the {auth_env_var} environment variable."
+                    ) from exc
+                if exc.code in (429, 503) and attempt < max_retries:
+                    retry_after = _parse_retry_after(exc.headers.get("Retry-After"))
+                    attempt += 1
+                    wait_s = (
+                        retry_after
+                        if retry_after is not None
+                        else min(max_backoff_s, backoff_base_s * (2 ** (attempt - 1)))
+                    )
+                    sleep_fn(wait_s)
+                    total_waited_s += wait_s
+                    continue
+                if exc.code == 429:
+                    breaker.record_failure()
+                    raise TicketRateLimitError(
+                        f"{provider_label} rate limit exceeded (HTTP 429); retries exhausted",
+                        provider=provider_label,
+                    ) from exc
+                if exc.code >= 500:
+                    breaker.record_failure()
+                raise TicketParseError(f"{provider_label} API returned HTTP {exc.code}") from exc
+        except (TicketAuthError, TicketParseError, TicketRateLimitError, TicketCircuitOpenError):
+            raise
+        except Exception as exc:
+            breaker.record_failure()
+            raise TicketParseError(f"{provider_label} request failed: {exc}") from exc
 
 
 def http_get_json(
@@ -25,58 +213,54 @@ def http_get_json(
     provider_label: str,
     auth_env_var: str,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    backoff_base_s: float = DEFAULT_BACKOFF_BASE_S,
+    max_backoff_s: float = DEFAULT_MAX_BACKOFF_S,
+    circuit_breaker: ProviderCircuitBreaker | None = None,
+    sleep_fn: Any = time.sleep,
 ) -> dict[str, Any]:
-    """GET ``url`` and decode the JSON body.
+    """GET ``url`` and decode the JSON body with rate limit retries and circuit breaker."""
+    return http_request_json(
+        method="GET",
+        url=url,
+        headers=headers,
+        provider_label=provider_label,
+        auth_env_var=auth_env_var,
+        timeout=timeout,
+        max_retries=max_retries,
+        backoff_base_s=backoff_base_s,
+        max_backoff_s=max_backoff_s,
+        circuit_breaker=circuit_breaker,
+        sleep_fn=sleep_fn,
+    )
 
-    Args:
-        url: Full endpoint URL.
-        headers: HTTP request headers.
-        provider_label: Human-readable provider name used in error messages
-            (e.g. ``"GitHub"``, ``"Jira"``).
-        auth_env_var: Name of the environment variable users should check
-            when they hit a 401/403.
-        timeout: Per-call timeout in seconds.
 
-    Returns:
-        The decoded JSON object.
-
-    Raises:
-        TicketAuthError: The provider replied 401 or 403.
-        TicketParseError: Any other 4xx / 5xx response.
-    """
-    try:
-        # ``url`` is operator-supplied (Jira/GitHub/Linear base + path);
-        # reject non-HTTP(S) schemes regardless of transport implementation.
-        ensure_http_url(url, allow_http=True, source=f"tickets.{provider_label}")
-    except UrlSchemeError as exc:
-        raise TicketParseError(str(exc)) from exc
-
-    try:
-        import httpx
-
-        resp = httpx.get(url, headers=headers, timeout=timeout)
-        if resp.status_code in (401, 403):
-            raise TicketAuthError(
-                f"{provider_label} rejected the request (HTTP {resp.status_code}). "
-                f"Check the {auth_env_var} environment variable."
-            )
-        if resp.status_code >= 400:
-            raise TicketParseError(f"{provider_label} API returned HTTP {resp.status_code}: {resp.text[:200]}")
-        return cast(dict[str, Any], resp.json())
-    except ImportError:  # pragma: no cover - httpx is a declared dependency
-        import urllib.error
-        import urllib.request
-
-        req = urllib.request.Request(url, headers=headers)
-        try:
-            # ``url`` was scheme-validated by :func:`ensure_http_url` above.
-            # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
-            with urllib.request.urlopen(req, timeout=timeout) as handle:
-                return cast(dict[str, Any], json.loads(handle.read().decode("utf-8")))
-        except urllib.error.HTTPError as exc:
-            if exc.code in (401, 403):
-                raise TicketAuthError(
-                    f"{provider_label} rejected the request (HTTP {exc.code}). "
-                    f"Check the {auth_env_var} environment variable."
-                ) from exc
-            raise TicketParseError(f"{provider_label} API returned HTTP {exc.code}") from exc
+def http_post_json(
+    *,
+    url: str,
+    headers: dict[str, str],
+    json_data: dict[str, Any],
+    provider_label: str,
+    auth_env_var: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    backoff_base_s: float = DEFAULT_BACKOFF_BASE_S,
+    max_backoff_s: float = DEFAULT_MAX_BACKOFF_S,
+    circuit_breaker: ProviderCircuitBreaker | None = None,
+    sleep_fn: Any = time.sleep,
+) -> dict[str, Any]:
+    """POST ``url`` with JSON data and decode the response with rate limit retries and circuit breaker."""
+    return http_request_json(
+        method="POST",
+        url=url,
+        headers=headers,
+        json_data=json_data,
+        provider_label=provider_label,
+        auth_env_var=auth_env_var,
+        timeout=timeout,
+        max_retries=max_retries,
+        backoff_base_s=backoff_base_s,
+        max_backoff_s=max_backoff_s,
+        circuit_breaker=circuit_breaker,
+        sleep_fn=sleep_fn,
+    )

--- a/src/bernstein/core/integrations/tickets/_http.py
+++ b/src/bernstein/core/integrations/tickets/_http.py
@@ -182,11 +182,16 @@ def http_request_json(
                 if exc.code in (429, 503) and attempt < max_retries:
                     retry_after = _parse_retry_after(exc.headers.get("Retry-After"))
                     attempt += 1
-                    wait_s = (
-                        retry_after
-                        if retry_after is not None
-                        else min(max_backoff_s, backoff_base_s * (2 ** (attempt - 1)))
-                    )
+                    # Mirrors the httpx branch exactly: a server-supplied
+                    # Retry-After is honoured but still capped, so a provider
+                    # answering `Retry-After: 3600` cannot park the calling
+                    # thread for an hour, and the un-hinted backoff carries the
+                    # same jitter so two clients retrying together spread out.
+                    if retry_after is not None:
+                        wait_s = min(retry_after, max_backoff_s)
+                    else:
+                        jitter = random.uniform(0, 0.1 * backoff_base_s)
+                        wait_s = min(max_backoff_s, (backoff_base_s * (2 ** (attempt - 1))) + jitter)
                     sleep_fn(wait_s)
                     total_waited_s += wait_s
                     continue

--- a/src/bernstein/core/integrations/tickets/linear.py
+++ b/src/bernstein/core/integrations/tickets/linear.py
@@ -7,15 +7,15 @@ import time), so this module is safe to import without credentials.
 
 from __future__ import annotations
 
-import json
 import re
-from typing import Any, cast
+from typing import Any
 
 from bernstein.core.integrations.tickets import (
     TicketAuthError,
     TicketParseError,
     TicketPayload,
 )
+from bernstein.core.integrations.tickets._http import http_post_json
 
 __all__ = ["fetch_linear"]
 
@@ -52,41 +52,15 @@ def _extract_key(url: str) -> str:
 def _post_graphql(api_key: str, query: str, variables: dict[str, Any]) -> dict[str, Any]:
     """POST a GraphQL request, returning the decoded JSON body."""
     body = {"query": query, "variables": variables}
-    try:
-        import httpx
-
-        headers = {"Authorization": api_key, "Content-Type": "application/json"}
-        resp = httpx.post(_LINEAR_ENDPOINT, json=body, headers=headers, timeout=_TIMEOUT_S)
-        if resp.status_code in (401, 403):
-            raise TicketAuthError(
-                f"Linear rejected the request (HTTP {resp.status_code}). Check the {_LINEAR_ENV} environment variable."
-            )
-        if resp.status_code >= 400:
-            raise TicketParseError(f"Linear API returned HTTP {resp.status_code}: {resp.text[:200]}")
-        return cast(dict[str, Any], resp.json())
-    except ImportError:  # pragma: no cover - httpx is a declared dependency
-        import urllib.error
-        import urllib.request
-
-        req = urllib.request.Request(
-            _LINEAR_ENDPOINT,
-            data=json.dumps(body).encode("utf-8"),
-            headers={"Authorization": api_key, "Content-Type": "application/json"},
-            method="POST",
-        )
-        try:
-            # Internal-only: ``_LINEAR_ENDPOINT`` is a hard-coded module
-            # constant pointing at the Linear GraphQL API.
-            # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
-            with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as handle:
-                raw = handle.read().decode("utf-8")
-            return cast(dict[str, Any], json.loads(raw))
-        except urllib.error.HTTPError as exc:
-            if exc.code in (401, 403):
-                raise TicketAuthError(
-                    f"Linear rejected the request (HTTP {exc.code}). Check the {_LINEAR_ENV} environment variable."
-                ) from exc
-            raise TicketParseError(f"Linear API returned HTTP {exc.code}") from exc
+    headers = {"Authorization": api_key, "Content-Type": "application/json"}
+    return http_post_json(
+        url=_LINEAR_ENDPOINT,
+        headers=headers,
+        json_data=body,
+        provider_label="Linear",
+        auth_env_var=_LINEAR_ENV,
+        timeout=_TIMEOUT_S,
+    )
 
 
 def _extract_labels(issue: dict[str, Any]) -> tuple[str, ...]:

--- a/tests/unit/test_ticket_import.py
+++ b/tests/unit/test_ticket_import.py
@@ -409,6 +409,110 @@ def test_429_with_retry_after_is_retried_and_succeeds() -> None:
     assert breaker.state.value == "closed"
 
 
+def test_a_huge_retry_after_is_capped_not_obeyed() -> None:
+    """A provider must not be able to park the calling thread.
+
+    ``Retry-After`` is a server-controlled number and this helper sleeps on it
+    synchronously, so honouring it unbounded hands any tracker the ability to
+    block a ticket sync for as long as it likes. The existing coverage uses
+    2.5s, which is under the cap and so passes either way; this pins the cap.
+    """
+    from bernstein.core.integrations.tickets._http import http_get_json
+    from bernstein.core.observability.provider_circuit_breaker import ProviderCircuitBreaker
+
+    slept: list[float] = []
+    calls = 0
+
+    class FakeResponse:
+        def __init__(self, status_code: int, headers: dict[str, str], json_data: dict[str, Any] | None = None):
+            self.status_code = status_code
+            self.headers = headers
+            self._json = json_data or {}
+            self.text = "rate limited"
+
+        def json(self) -> dict[str, Any]:
+            return self._json
+
+    def mock_get(url: str, headers: dict[str, str], timeout: float) -> FakeResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return FakeResponse(429, {"Retry-After": "3600"})
+        return FakeResponse(200, {}, {"title": "ok"})
+
+    breaker = ProviderCircuitBreaker("cap-httpx")
+    with patch("httpx.get", side_effect=mock_get):
+        http_get_json(
+            url="https://api.github.com/repos/acme/repo/issues/1",
+            headers={"Authorization": "Bearer tok"},
+            provider_label="GitHub",
+            auth_env_var="GITHUB_TOKEN",
+            circuit_breaker=breaker,
+            max_backoff_s=30.0,
+            sleep_fn=slept.append,
+        )
+
+    assert slept == [30.0], f"Retry-After must be capped at max_backoff_s; slept {slept}"
+
+
+def test_the_urllib_fallback_caps_retry_after_the_same_way() -> None:
+    """The two transports must not disagree about how long they will wait.
+
+    ``http_request_json`` falls back to ``urllib`` when ``httpx`` is absent, and
+    that branch is otherwise uncovered. A response that costs 30s through one
+    transport must not cost an hour through the other.
+    """
+    import sys
+    import urllib.error
+
+    from bernstein.core.integrations.tickets._http import http_get_json
+    from bernstein.core.observability.provider_circuit_breaker import ProviderCircuitBreaker
+
+    slept: list[float] = []
+    calls = 0
+
+    class _Headers(dict[str, str]):
+        pass
+
+    def mock_urlopen(req: Any, timeout: float | None = None) -> Any:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise urllib.error.HTTPError(
+                "https://api.github.com/x", 429, "Too Many Requests", _Headers({"Retry-After": "3600"}), None
+            )
+
+        class _Handle:
+            def __enter__(self) -> Any:
+                return self
+
+            def __exit__(self, *a: object) -> bool:
+                return False
+
+            def read(self) -> bytes:
+                return b'{"title": "ok"}'
+
+        return _Handle()
+
+    breaker = ProviderCircuitBreaker("cap-urllib")
+    with (
+        patch.dict(sys.modules, {"httpx": None}),
+        patch("urllib.request.urlopen", side_effect=mock_urlopen),
+    ):
+        http_get_json(
+            url="https://api.github.com/repos/acme/repo/issues/1",
+            headers={"Authorization": "Bearer tok"},
+            provider_label="GitHub",
+            auth_env_var="GITHUB_TOKEN",
+            circuit_breaker=breaker,
+            max_backoff_s=30.0,
+            sleep_fn=slept.append,
+        )
+
+    assert calls == 2
+    assert slept == [30.0], f"urllib fallback must cap Retry-After too; slept {slept}"
+
+
 def test_404_fails_immediately_without_retry() -> None:
     from bernstein.core.integrations.tickets._http import http_get_json
     from bernstein.core.observability.provider_circuit_breaker import ProviderCircuitBreaker

--- a/tests/unit/test_ticket_import.py
+++ b/tests/unit/test_ticket_import.py
@@ -360,3 +360,173 @@ def test_explicit_role_flag_overrides_inference() -> None:
     payload = build_task_payload(ticket, role="backend", priority="low")
     assert payload["role"] == "backend"
     assert payload["priority"] == 3
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper: retries, rate limits, and circuit breaker (Issue #4534)
+# ---------------------------------------------------------------------------
+
+
+def test_429_with_retry_after_is_retried_and_succeeds() -> None:
+    from bernstein.core.integrations.tickets._http import http_get_json
+    from bernstein.core.observability.provider_circuit_breaker import ProviderCircuitBreaker
+
+    calls = 0
+    slept: list[float] = []
+
+    class FakeResponse:
+        def __init__(self, status_code: int, headers: dict[str, str], json_data: dict[str, Any] | None = None):
+            self.status_code = status_code
+            self.headers = headers
+            self._json = json_data or {}
+            self.text = "rate limited"
+
+        def json(self) -> dict[str, Any]:
+            return self._json
+
+    def mock_get(url: str, headers: dict[str, str], timeout: float) -> FakeResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return FakeResponse(429, {"Retry-After": "2.5"})
+        return FakeResponse(200, {}, {"title": "Issue title"})
+
+    breaker = ProviderCircuitBreaker("test-provider")
+
+    with patch("httpx.get", side_effect=mock_get):
+        data = http_get_json(
+            url="https://api.github.com/repos/acme/repo/issues/1",
+            headers={"Authorization": "Bearer tok"},
+            provider_label="GitHub",
+            auth_env_var="GITHUB_TOKEN",
+            circuit_breaker=breaker,
+            sleep_fn=slept.append,
+        )
+
+    assert calls == 2
+    assert slept == [2.5]
+    assert data["title"] == "Issue title"
+    assert breaker.state.value == "closed"
+
+
+def test_404_fails_immediately_without_retry() -> None:
+    from bernstein.core.integrations.tickets._http import http_get_json
+    from bernstein.core.observability.provider_circuit_breaker import ProviderCircuitBreaker
+
+    slept: list[float] = []
+
+    class FakeResponse:
+        status_code = 404
+        headers: dict[str, str] = {}
+        text = "Not Found"
+
+        def json(self) -> dict[str, Any]:
+            return {}
+
+    breaker = ProviderCircuitBreaker("test-provider")
+
+    with patch("httpx.get", return_value=FakeResponse()):
+        with pytest.raises(TicketParseError) as exc_info:
+            http_get_json(
+                url="https://api.github.com/repos/acme/repo/issues/999",
+                headers={},
+                provider_label="GitHub",
+                auth_env_var="GITHUB_TOKEN",
+                circuit_breaker=breaker,
+                sleep_fn=slept.append,
+            )
+
+    assert "404" in str(exc_info.value)
+    assert len(slept) == 0
+
+
+def test_retry_exhaustion_raises_rate_limited_error_not_parse_error() -> None:
+    from bernstein.core.integrations.tickets import TicketRateLimitError
+    from bernstein.core.integrations.tickets._http import http_get_json
+    from bernstein.core.observability.provider_circuit_breaker import ProviderCircuitBreaker
+
+    calls = 0
+    slept: list[float] = []
+
+    class FakeResponse:
+        status_code = 429
+        headers = {"Retry-After": "1"}
+        text = "Too Many Requests"
+
+        def json(self) -> dict[str, Any]:
+            return {}
+
+    def mock_get(url: str, headers: dict[str, str], timeout: float) -> FakeResponse:
+        nonlocal calls
+        calls += 1
+        return FakeResponse()
+
+    breaker = ProviderCircuitBreaker("test-provider")
+
+    with patch("httpx.get", side_effect=mock_get):
+        with pytest.raises(TicketRateLimitError) as exc_info:
+            http_get_json(
+                url="https://api.github.com/repos/acme/repo/issues/1",
+                headers={},
+                provider_label="GitHub",
+                auth_env_var="GITHUB_TOKEN",
+                max_retries=2,
+                circuit_breaker=breaker,
+                sleep_fn=slept.append,
+            )
+
+    assert calls == 3  # initial + 2 retries
+    assert len(slept) == 2
+    assert "rate limit exceeded" in str(exc_info.value)
+    assert exc_info.value.provider == "GitHub"
+
+
+def test_repeated_provider_failures_open_the_circuit() -> None:
+    from bernstein.core.integrations.tickets import TicketCircuitOpenError
+    from bernstein.core.integrations.tickets._http import http_get_json
+    from bernstein.core.observability.provider_circuit_breaker import CircuitBreakerConfig, ProviderCircuitBreaker
+
+    class FakeResponse:
+        status_code = 500
+        headers: dict[str, str] = {}
+        text = "Internal Server Error"
+
+        def json(self) -> dict[str, Any]:
+            return {}
+
+    config = CircuitBreakerConfig(failure_threshold=2, recovery_timeout_s=60.0)
+    breaker = ProviderCircuitBreaker("jira", config=config)
+
+    with patch("httpx.get", return_value=FakeResponse()):
+        # Attempt 1 -> Failure
+        with pytest.raises(TicketParseError):
+            http_get_json(
+                url="https://jira.example.com/rest/api/2/issue/1",
+                headers={},
+                provider_label="Jira",
+                auth_env_var="JIRA_API_TOKEN",
+                circuit_breaker=breaker,
+            )
+        assert breaker.state.value == "closed"
+
+        # Attempt 2 -> Failure (hits threshold 2) -> Transitions to OPEN
+        with pytest.raises(TicketParseError):
+            http_get_json(
+                url="https://jira.example.com/rest/api/2/issue/1",
+                headers={},
+                provider_label="Jira",
+                auth_env_var="JIRA_API_TOKEN",
+                circuit_breaker=breaker,
+            )
+        assert breaker.state.value == "open"
+
+        # Attempt 3 -> Immediately rejected by open circuit without HTTP call
+        with pytest.raises(TicketCircuitOpenError) as exc_info:
+            http_get_json(
+                url="https://jira.example.com/rest/api/2/issue/1",
+                headers={},
+                provider_label="Jira",
+                auth_env_var="JIRA_API_TOKEN",
+                circuit_breaker=breaker,
+            )
+        assert "circuit breaker is OPEN" in str(exc_info.value)


### PR DESCRIPTION
Fixes #4534

### Problem
The ticket integration HTTP layer (`src/bernstein/core/integrations/tickets/_http.py`) treated 429 rate limits and 503 service unavailable responses as immediate fatal parse errors (`if resp.status_code >= 400: raise TicketParseError`). Furthermore, the shipped `ProviderCircuitBreaker` (`src/bernstein/core/observability/provider_circuit_breaker.py`) had no callers in the ticket fetch path, causing repeated provider outages to continually hammer external APIs.

### Solution
1. **Rate Limit & Retry-After Handling**: Added retry loop in `http_request_json` honoring `Retry-After` header values (in seconds or HTTP-date formats) and applying jittered exponential backoff for 429 / 503 responses.
2. **Typed Error on Retry Exhaustion**: Introduced `TicketRateLimitError` carrying provider name and elapsed wait details when retries are exhausted on 429, keeping it distinct from authentication (`TicketAuthError`) or parse (`TicketParseError`) failures.
3. **Circuit Breaker Wiring**: Integrated `ProviderCircuitBreakerRegistry` into the HTTP fetch path:
   - Evaluates `breaker.should_allow()` before making network calls, fast-failing with typed `TicketCircuitOpenError` when the circuit is `OPEN`.
   - Records success on 2xx responses (`breaker.record_success()`) to reset or close the circuit.
   - Records failure on repeated 5xx errors and exhausted 429 rate limits (`breaker.record_failure()`).
4. **Design Decision (Module Registry with Caller Overrides)**: Used a module-level `_DEFAULT_REGISTRY = ProviderCircuitBreakerRegistry()` with optional `circuit_breaker` override. This provides process-wide failure tracking across all tracker invocations without plumbing breaker instances through `github_issues.py`, `jira.py`, or `linear.py`.
5. **Linear GraphQL Route**: Updated `linear.py` to route through `http_post_json`.
6. **Release Notes**: Added fragment `docs/release-notes/fragments/4534-ticket-rate-limit-circuit-breaker.md`.
