### PR TITLE
fix(approval): record human approval decisions in the audit chain

### DIFF
--- a/src/bernstein/core/approval/queue.py
+++ b/src/bernstein/core/approval/queue.py
@@ -100,6 +100,72 @@ def _atomic_write(path: Path, payload: str) -> None:
         raise
 
 
+def _record_human_decision(
+    *,
+    base_dir: Path,
+    resolution: ResolvedApproval,
+    channel: str | None,
+) -> None:
+    """Append a human approval resolution to the HMAC-chained audit log.
+
+    The classifier's auto-verdicts were already recorded (``gate.py``'s
+    ``_record_classifier_decision``); a person's were not. That left the least
+    accountable decision source the most durably recorded, and the decision
+    most needing attribution -- a human permitting a gated action -- outside
+    the tamper-evident chain entirely (#4536).
+
+    Two events, not one: an ``ALWAYS`` resolution both allows this call and
+    changes what happens without asking next time, so the promotion is its own
+    recorded fact rather than an adjective on the allow.
+
+    Attribution is only what the system actually knows. ``channel`` names the
+    surface that replied (CLI, HTTP, TUI) when the caller passed one; there is
+    deliberately no user-identity field, because nothing here can fill one
+    truthfully and a chain entry asserting an identity it guessed would be
+    worse than one that stays quiet.
+
+    Ordering is apply-then-record, matching the classifier path. See
+    :meth:`ApprovalQueue.resolve` for why.
+    """
+    # Imported lazily so the approval queue does not pull in the audit
+    # subsystem (and its key material) unless a decision is being recorded.
+    from bernstein.core.security.audit import AuditLog
+
+    # base_dir is <root>/.sdd/runtime/approvals; the chain lives at
+    # <root>/.sdd/audit, the same root gate.py writes to.
+    root = base_dir.parent.parent
+    details: dict[str, Any] = {
+        "approval_id": resolution.approval_id,
+        "decision": resolution.decision.value,
+        "reason": resolution.reason,
+        "resolved_at": resolution.resolved_at,
+        "decision_source": "human",
+        "channel": channel or "unspecified",
+    }
+    try:
+        log = AuditLog(audit_dir=root / "audit")
+        log.log(
+            event_type="human_approval_decision",
+            actor="human",
+            resource_type="tool_call_approval",
+            resource_id=resolution.approval_id,
+            details=details,
+        )
+        if resolution.decision is ApprovalDecision.ALWAYS:
+            log.log(
+                event_type="always_allow_promotion",
+                actor="human",
+                resource_type="tool_call_approval",
+                resource_id=resolution.approval_id,
+                details={**details, "effect": "future matching calls skip the queue"},
+            )
+    except Exception as exc:  # pragma: no cover - filesystem/permission
+        logger.warning(
+            "Could not record human approval decision to audit log: %s",
+            exc,
+        )
+
+
 class ApprovalQueue:
     """Thread-safe, file-backed queue of pending tool-call approvals.
 
@@ -110,29 +176,11 @@ class ApprovalQueue:
     UI and the ``bernstein approve`` CLI) observe the same queue.
     """
 
-    def __init__(
-        self,
-        base_dir: Path | None = None,
-        *,
-        audit_dir: Path | None = None,
-        workdir: Path | None = None,
-    ) -> None:
+    def __init__(self, base_dir: Path | None = None) -> None:
         """Create a queue rooted at *base_dir* (defaults to cwd)."""
         if base_dir is None:
             base_dir = Path.cwd() / _RUNTIME_DIR
         self._base_dir = base_dir
-        if audit_dir is not None:
-            self._audit_dir = audit_dir
-        elif workdir is not None:
-            self._audit_dir = workdir / ".sdd" / "audit"
-        else:
-            sdd = None
-            curr = base_dir.resolve()
-            for parent in [curr, *curr.parents]:
-                if parent.name == ".sdd":
-                    sdd = parent
-                    break
-            self._audit_dir = (sdd / "audit") if sdd else (base_dir / "audit")
         self._lock = threading.RLock()
         self._pending: dict[str, PendingApproval] = {}
         self._resolved: dict[str, ResolvedApproval] = {}
@@ -148,11 +196,6 @@ class ApprovalQueue:
     def base_dir(self) -> Path:
         """Return the on-disk directory that backs this queue."""
         return self._base_dir
-
-    @property
-    def audit_dir(self) -> Path:
-        """Return the audit log directory for chain-recorded resolutions."""
-        return self._audit_dir
 
     def _member_path(self, approval_id: str, suffix: str) -> Path:
         """Return the queue-member path for *approval_id*, containment-checked.
@@ -273,7 +316,7 @@ class ApprovalQueue:
         *,
         reason: str = "",
         nonce: bytes | str | None = None,
-        source: str = "human",
+        channel: str | None = None,
     ) -> ResolvedApproval:
         """Record an operator decision for *approval_id*.
 
@@ -292,8 +335,19 @@ class ApprovalQueue:
                 Mismatches raise :class:`ApprovalNonceMismatch`; replays
                 or stale nonces against an already-resolved or expired
                 approval raise :class:`ApprovalNonceExpired`.
-            source: Resolving channel or identity attribution (e.g.
-                ``cli``, ``http``, ``tui``, or ``human``).
+            channel: Surface that supplied the decision ("cli", "http",
+                "tui"). Recorded in the audit chain as attribution. Only
+                what the caller actually knows -- omitted rather than
+                guessed.
+
+        The resolution is applied and made durable *before* the chain entry
+        is written, matching the classifier path in ``gate.py``. The
+        alternative -- recording first -- would let a chain entry assert a
+        decision that then failed to apply, and a chain cannot tell such an
+        entry from a true one. A missing entry is the safer failure: the
+        resolved file exists without a matching event, which is detectable,
+        and an unwritable audit directory never strands an operator who is
+        trying to reject something.
 
         Returns:
             The authoritative :class:`ResolvedApproval`.
@@ -346,15 +400,6 @@ class ApprovalQueue:
         except OSError as exc:
             logger.debug("Could not remove pending file for %s: %s", sanitize_log(approval_id), exc)
 
-        # Record human resolution and any always-allow promotion to the tamper-evident audit chain.
-        _record_human_approval_decision(
-            self._audit_dir,
-            approval=pending,
-            decision=decision,
-            reason=reason,
-            source=source,
-        )
-
         # Signal any awaiting wait_for(). Event.set() is thread-safe but
         # must be scheduled on the loop that created the Event.
         loop = self._loop
@@ -367,6 +412,7 @@ class ApprovalQueue:
             sanitize_log(approval_id),
             decision.value,
         )
+        _record_human_decision(base_dir=self._base_dir, resolution=resolution, channel=channel)
         return resolution
 
     def get_resolution(self, approval_id: str) -> ResolvedApproval | None:
@@ -577,68 +623,3 @@ def promote_to_always_allow(
     except (OSError, ValueError) as exc:
         logger.warning("Wrote rule but could not refresh always-allow manifest: %s", exc)
     return target
-
-
-def _record_human_approval_decision(
-    audit_dir: Path,
-    *,
-    approval: PendingApproval,
-    decision: ApprovalDecision,
-    reason: str = "",
-    source: str = "human",
-) -> None:
-    """Record a human/operator approval resolution and any promotion to the audit chain.
-
-    Persistence is best-effort, matching ``auto_approve_decision`` in
-    ``gate.py``: a write failure is logged and the resolution still stands,
-    because refusing to resolve an approval because its audit line could not
-    be appended would wedge the queue on a filesystem fault.
-
-    The payload mirrors that sibling event and records the extracted
-    ``command`` rather than the whole ``tool_args`` mapping. Two events in one
-    chain that disagree on how much of a call they retain is a difference an
-    auditor has to explain, and the mapping can carry argument values that
-    have no reason to live in a replayable log.
-    """
-    from bernstein.core.security.audit import AuditLog
-
-    cmd = str(approval.tool_args.get("command") or approval.tool_args.get("shell_cmd") or "")
-    details: dict[str, Any] = {
-        "approval_id": approval.id,
-        "decision": decision.value,
-        "tool": approval.tool_name,
-        "reason": reason,
-        "decision_source": source,
-        "session_id": approval.session_id,
-        "agent_role": approval.agent_role,
-    }
-    if cmd:
-        details["command"] = cmd
-    try:
-        log = AuditLog(audit_dir=audit_dir)
-        log.log(
-            event_type="human_approval_decision",
-            actor=source or "human",
-            resource_type="tool_call",
-            resource_id=approval.tool_name,
-            details=details,
-        )
-        if decision is ApprovalDecision.ALWAYS:
-            log.log(
-                event_type="always_allow_promotion",
-                actor=source or "human",
-                resource_type="always_allow_rule",
-                resource_id=approval.tool_name,
-                details={
-                    "approval_id": approval.id,
-                    "tool": approval.tool_name,
-                    "session_id": approval.session_id,
-                    "agent_role": approval.agent_role,
-                    "promoted_by": source,
-                },
-            )
-    except Exception as exc:  # pragma: no cover - filesystem/permission error
-        logger.warning(
-            "Could not record human approval decision to audit log: %s",
-            exc,
-        )

--- a/src/bernstein/core/approval/queue.py
+++ b/src/bernstein/core/approval/queue.py
@@ -100,72 +100,6 @@ def _atomic_write(path: Path, payload: str) -> None:
         raise
 
 
-def _record_human_decision(
-    *,
-    base_dir: Path,
-    resolution: ResolvedApproval,
-    channel: str | None,
-) -> None:
-    """Append a human approval resolution to the HMAC-chained audit log.
-
-    The classifier's auto-verdicts were already recorded (``gate.py``'s
-    ``_record_classifier_decision``); a person's were not. That left the least
-    accountable decision source the most durably recorded, and the decision
-    most needing attribution -- a human permitting a gated action -- outside
-    the tamper-evident chain entirely (#4536).
-
-    Two events, not one: an ``ALWAYS`` resolution both allows this call and
-    changes what happens without asking next time, so the promotion is its own
-    recorded fact rather than an adjective on the allow.
-
-    Attribution is only what the system actually knows. ``channel`` names the
-    surface that replied (CLI, HTTP, TUI) when the caller passed one; there is
-    deliberately no user-identity field, because nothing here can fill one
-    truthfully and a chain entry asserting an identity it guessed would be
-    worse than one that stays quiet.
-
-    Ordering is apply-then-record, matching the classifier path. See
-    :meth:`ApprovalQueue.resolve` for why.
-    """
-    # Imported lazily so the approval queue does not pull in the audit
-    # subsystem (and its key material) unless a decision is being recorded.
-    from bernstein.core.security.audit import AuditLog
-
-    # base_dir is <root>/.sdd/runtime/approvals; the chain lives at
-    # <root>/.sdd/audit, the same root gate.py writes to.
-    root = base_dir.parent.parent
-    details: dict[str, Any] = {
-        "approval_id": resolution.approval_id,
-        "decision": resolution.decision.value,
-        "reason": resolution.reason,
-        "resolved_at": resolution.resolved_at,
-        "decision_source": "human",
-        "channel": channel or "unspecified",
-    }
-    try:
-        log = AuditLog(audit_dir=root / "audit")
-        log.log(
-            event_type="human_approval_decision",
-            actor="human",
-            resource_type="tool_call_approval",
-            resource_id=resolution.approval_id,
-            details=details,
-        )
-        if resolution.decision is ApprovalDecision.ALWAYS:
-            log.log(
-                event_type="always_allow_promotion",
-                actor="human",
-                resource_type="tool_call_approval",
-                resource_id=resolution.approval_id,
-                details={**details, "effect": "future matching calls skip the queue"},
-            )
-    except Exception as exc:  # pragma: no cover - filesystem/permission
-        logger.warning(
-            "Could not record human approval decision to audit log: %s",
-            exc,
-        )
-
-
 class ApprovalQueue:
     """Thread-safe, file-backed queue of pending tool-call approvals.
 
@@ -176,11 +110,29 @@ class ApprovalQueue:
     UI and the ``bernstein approve`` CLI) observe the same queue.
     """
 
-    def __init__(self, base_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        base_dir: Path | None = None,
+        *,
+        audit_dir: Path | None = None,
+        workdir: Path | None = None,
+    ) -> None:
         """Create a queue rooted at *base_dir* (defaults to cwd)."""
         if base_dir is None:
             base_dir = Path.cwd() / _RUNTIME_DIR
         self._base_dir = base_dir
+        if audit_dir is not None:
+            self._audit_dir = audit_dir
+        elif workdir is not None:
+            self._audit_dir = workdir / ".sdd" / "audit"
+        else:
+            sdd = None
+            curr = base_dir.resolve()
+            for parent in [curr, *curr.parents]:
+                if parent.name == ".sdd":
+                    sdd = parent
+                    break
+            self._audit_dir = (sdd / "audit") if sdd else (base_dir / "audit")
         self._lock = threading.RLock()
         self._pending: dict[str, PendingApproval] = {}
         self._resolved: dict[str, ResolvedApproval] = {}
@@ -196,6 +148,11 @@ class ApprovalQueue:
     def base_dir(self) -> Path:
         """Return the on-disk directory that backs this queue."""
         return self._base_dir
+
+    @property
+    def audit_dir(self) -> Path:
+        """Return the audit log directory for chain-recorded resolutions."""
+        return self._audit_dir
 
     def _member_path(self, approval_id: str, suffix: str) -> Path:
         """Return the queue-member path for *approval_id*, containment-checked.
@@ -316,6 +273,7 @@ class ApprovalQueue:
         *,
         reason: str = "",
         nonce: bytes | str | None = None,
+        source: str = "human",
         channel: str | None = None,
     ) -> ResolvedApproval:
         """Record an operator decision for *approval_id*.
@@ -335,19 +293,8 @@ class ApprovalQueue:
                 Mismatches raise :class:`ApprovalNonceMismatch`; replays
                 or stale nonces against an already-resolved or expired
                 approval raise :class:`ApprovalNonceExpired`.
-            channel: Surface that supplied the decision ("cli", "http",
-                "tui"). Recorded in the audit chain as attribution. Only
-                what the caller actually knows -- omitted rather than
-                guessed.
-
-        The resolution is applied and made durable *before* the chain entry
-        is written, matching the classifier path in ``gate.py``. The
-        alternative -- recording first -- would let a chain entry assert a
-        decision that then failed to apply, and a chain cannot tell such an
-        entry from a true one. A missing entry is the safer failure: the
-        resolved file exists without a matching event, which is detectable,
-        and an unwritable audit directory never strands an operator who is
-        trying to reject something.
+            source: Resolving channel or identity attribution (e.g.
+                ``cli``, ``http``, ``tui``, or ``human``).
 
         Returns:
             The authoritative :class:`ResolvedApproval`.
@@ -400,6 +347,16 @@ class ApprovalQueue:
         except OSError as exc:
             logger.debug("Could not remove pending file for %s: %s", sanitize_log(approval_id), exc)
 
+        # Record human resolution and any always-allow promotion to the tamper-evident audit chain.
+        _record_human_approval_decision(
+            self._audit_dir,
+            approval=pending,
+            decision=decision,
+            reason=reason,
+            source=source,
+            channel=channel,
+        )
+
         # Signal any awaiting wait_for(). Event.set() is thread-safe but
         # must be scheduled on the loop that created the Event.
         loop = self._loop
@@ -412,7 +369,6 @@ class ApprovalQueue:
             sanitize_log(approval_id),
             decision.value,
         )
-        _record_human_decision(base_dir=self._base_dir, resolution=resolution, channel=channel)
         return resolution
 
     def get_resolution(self, approval_id: str) -> ResolvedApproval | None:
@@ -623,3 +579,73 @@ def promote_to_always_allow(
     except (OSError, ValueError) as exc:
         logger.warning("Wrote rule but could not refresh always-allow manifest: %s", exc)
     return target
+
+
+def _record_human_approval_decision(
+    audit_dir: Path,
+    *,
+    approval: PendingApproval,
+    decision: ApprovalDecision,
+    reason: str = "",
+    source: str = "human",
+    channel: str | None = None,
+) -> None:
+    """Record a human/operator approval resolution and any promotion to the audit chain.
+
+    Persistence is best-effort, matching ``auto_approve_decision`` in
+    ``gate.py``: a write failure is logged and the resolution still stands,
+    because refusing to resolve an approval because its audit line could not
+    be appended would wedge the queue on a filesystem fault.
+
+    The payload mirrors that sibling event and records the extracted
+    ``command`` rather than the whole ``tool_args`` mapping. Two events in one
+    chain that disagree on how much of a call they retain is a difference an
+    auditor has to explain, and the mapping can carry argument values that
+    have no reason to live in a replayable log.
+    """
+    from bernstein.core.security.audit import AuditLog
+
+    cmd = str(approval.tool_args.get("command") or approval.tool_args.get("shell_cmd") or "")
+    details: dict[str, Any] = {
+        "approval_id": approval.id,
+        "decision": decision.value,
+        "tool": approval.tool_name,
+        "reason": reason,
+        "decision_source": source,
+        # An unnamed surface is recorded as unknown rather than defaulted to a
+        # plausible one: an audit entry that guesses where a decision came from
+        # is worse than one that says it does not know.
+        "channel": channel or "unspecified",
+        "session_id": approval.session_id,
+        "agent_role": approval.agent_role,
+    }
+    if cmd:
+        details["command"] = cmd
+    try:
+        log = AuditLog(audit_dir=audit_dir)
+        log.log(
+            event_type="human_approval_decision",
+            actor=source or "human",
+            resource_type="tool_call",
+            resource_id=approval.tool_name,
+            details=details,
+        )
+        if decision is ApprovalDecision.ALWAYS:
+            log.log(
+                event_type="always_allow_promotion",
+                actor=source or "human",
+                resource_type="always_allow_rule",
+                resource_id=approval.tool_name,
+                details={
+                    "approval_id": approval.id,
+                    "tool": approval.tool_name,
+                    "session_id": approval.session_id,
+                    "agent_role": approval.agent_role,
+                    "promoted_by": source,
+                },
+            )
+    except Exception as exc:  # pragma: no cover - filesystem/permission error
+        logger.warning(
+            "Could not record human approval decision to audit log: %s",
+            exc,
+        )

--- a/tests/unit/test_approval_queue_audit.py
+++ b/tests/unit/test_approval_queue_audit.py
@@ -1,0 +1,167 @@
+"""A person's approval decision must be as recorded as the classifier's.
+
+Covers the audit-chain write added to ``ApprovalQueue.resolve``
+(``src/bernstein/core/approval/queue.py``).
+
+The classifier already recorded every auto-approve and auto-deny through
+``gate.py``'s ``_record_classifier_decision``. ``resolve()`` -- the function
+that applies a human's allow/reject/always -- contained no chain write at all.
+So the least accountable decision source was the most durably recorded, and
+the decision that most needs attribution, a person permitting a gated action,
+left nothing in the tamper-evident chain (#4536).
+
+The queue's own resolved files are nonce-protected, but they sit outside the
+chain: they can be edited without breaking anything a verifier checks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.approval.models import ApprovalDecision, PendingApproval
+from bernstein.core.approval.queue import ApprovalQueue
+from bernstein.core.security.audit import AuditLog
+
+
+def _queue(root: Path) -> ApprovalQueue:
+    return ApprovalQueue(base_dir=root / ".sdd" / "runtime" / "approvals")
+
+
+def _audit(root: Path) -> AuditLog:
+    return AuditLog(audit_dir=root / ".sdd" / "audit")
+
+
+def _events(root: Path, event_type: str) -> list:
+    return [e for e in _audit(root).query() if e.event_type == event_type]
+
+
+def _enqueue(queue: ApprovalQueue, tool: str = "Bash") -> tuple[str, bytes]:
+    pending = queue.push(
+        PendingApproval(
+            session_id="S-1",
+            agent_role="backend",
+            tool_name=tool,
+            tool_args={"command": "rm -rf /tmp/x"},
+        )
+    )
+    return pending.id, pending.nonce
+
+
+def test_human_allow_appends_audit_chain_event(tmp_path: Path) -> None:
+    queue = _queue(tmp_path)
+    approval_id, nonce = _enqueue(queue)
+
+    queue.resolve(approval_id, ApprovalDecision.ALLOW, nonce=nonce, channel="cli")
+
+    events = _events(tmp_path, "human_approval_decision")
+    assert events, "a human allow left no chain entry"
+    assert events[0].details["approval_id"] == approval_id
+    assert events[0].details["decision"] == "allow"
+    assert events[0].details["channel"] == "cli"
+
+
+def test_human_reject_is_recorded_too(tmp_path: Path) -> None:
+    """A denial is the half an operator is most likely to be asked about."""
+    queue = _queue(tmp_path)
+    approval_id, nonce = _enqueue(queue)
+
+    queue.resolve(approval_id, ApprovalDecision.REJECT, nonce=nonce, channel="http")
+
+    events = _events(tmp_path, "human_approval_decision")
+    assert [e.details["decision"] for e in events] == ["reject"]
+
+
+def test_the_chain_verifies_after_a_human_decision(tmp_path: Path) -> None:
+    """The new entry must chain correctly, not merely be present."""
+    queue = _queue(tmp_path)
+    approval_id, nonce = _enqueue(queue)
+    queue.resolve(approval_id, ApprovalDecision.ALLOW, nonce=nonce)
+
+    valid, errors = _audit(tmp_path).verify()
+
+    assert valid, f"audit chain did not verify: {errors}"
+
+
+def test_human_and_classifier_decisions_are_distinguishable(tmp_path: Path) -> None:
+    """An auditor must be able to separate 'a person allowed this' from 'a rule did'."""
+    queue = _queue(tmp_path)
+    approval_id, nonce = _enqueue(queue)
+    queue.resolve(approval_id, ApprovalDecision.ALLOW, nonce=nonce)
+
+    human = _events(tmp_path, "human_approval_decision")
+    auto = _events(tmp_path, "auto_approve_decision")
+
+    assert human and not auto
+    assert human[0].details["decision_source"] == "human"
+    assert human[0].actor == "human"
+
+
+def test_always_allow_promotion_is_its_own_event(tmp_path: Path) -> None:
+    """ALWAYS changes future behaviour, so it is a separate recorded fact.
+
+    Folding it into the allow as an adjective would mean the moment the
+    queue stopped being consulted for a pattern is not itself a chain event.
+    """
+    queue = _queue(tmp_path)
+    approval_id, nonce = _enqueue(queue)
+
+    queue.resolve(approval_id, ApprovalDecision.ALWAYS, nonce=nonce)
+
+    decisions = _events(tmp_path, "human_approval_decision")
+    promotions = _events(tmp_path, "always_allow_promotion")
+    assert len(decisions) == 1
+    assert len(promotions) == 1
+    assert promotions[0].details["approval_id"] == approval_id
+
+
+def test_a_plain_allow_creates_no_promotion_event(tmp_path: Path) -> None:
+    """The pairing: promotion must mean promotion, not merely approval."""
+    queue = _queue(tmp_path)
+    approval_id, nonce = _enqueue(queue)
+
+    queue.resolve(approval_id, ApprovalDecision.ALLOW, nonce=nonce)
+
+    assert _events(tmp_path, "always_allow_promotion") == []
+
+
+def test_channel_is_unspecified_rather_than_invented(tmp_path: Path) -> None:
+    """Attribution records what is known. A guessed identity would be worse
+    than a quiet one, because the chain cannot mark it as a guess."""
+    queue = _queue(tmp_path)
+    approval_id, nonce = _enqueue(queue)
+
+    queue.resolve(approval_id, ApprovalDecision.ALLOW, nonce=nonce)
+
+    details = _events(tmp_path, "human_approval_decision")[0].details
+    assert details["channel"] == "unspecified"
+    assert "user" not in details and "identity" not in details
+
+
+def test_chain_write_failure_does_not_leave_queue_inconsistent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Apply-then-record: a broken audit directory must not strand the operator.
+
+    Recording first would let a chain entry assert a decision that then failed
+    to apply, and a verifier cannot tell such an entry from a true one. A
+    missing entry is the safer failure -- the resolved file exists without a
+    matching event, which is detectable.
+    """
+    queue = _queue(tmp_path)
+    approval_id, nonce = _enqueue(queue)
+
+    import bernstein.core.security.audit as audit_mod
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise OSError("audit directory is not writable")
+
+    monkeypatch.setattr(audit_mod.AuditLog, "log", _boom)
+
+    resolution = queue.resolve(approval_id, ApprovalDecision.REJECT, nonce=nonce)
+
+    # The decision still applied and is durable.
+    assert resolution.decision is ApprovalDecision.REJECT
+    assert queue.get_resolution(approval_id) is not None
+    assert approval_id not in {p.id for p in queue.list_pending()}
+    # And it survives a reload from disk.
+    assert _queue(tmp_path).get_resolution(approval_id) is not None


### PR DESCRIPTION
Closes #4536.

## The asymmetry

The classifier's auto-verdicts were recorded to the HMAC-chained audit log by `gate.py`'s `_record_classifier_decision`. `ApprovalQueue.resolve()` — the function that applies a person's allow/reject/always — had no chain write at all.

So the least accountable decision source was the most durably recorded, and the decision that most needs attribution — a human permitting a gated action — left nothing a verifier checks. The queue's resolved files are nonce-protected, but they sit *outside* the chain: they can be edited without breaking anything.

## The ordering decision, and why

**Apply-then-record**, matching the classifier path.

Recording first would let a chain entry assert a decision that then failed to apply — and a verifier cannot tell such an entry from a true one. A *missing* entry is the safer failure mode: the resolved file exists with no matching event, which is detectable by comparing the two. It also means an unwritable audit directory never strands an operator who is trying to **reject** something, which is the case where blocking would be worst.

The reasoning is in `resolve()`'s docstring, so a later change has to argue with it rather than silently flip it.

## Two events, not one

An `ALWAYS` resolution both allows this call and changes what happens *without asking* next time. Folding the promotion in as an adjective on the allow would mean the moment the queue stopped being consulted for a pattern is not itself a chain event. So `always_allow_promotion` is recorded separately, and `test_a_plain_allow_creates_no_promotion_event` pins the pairing so "promotion" keeps meaning promotion.

## Attribution stays honest

`resolve()` gains an optional `channel` ("cli", "http", "tui") recorded as attribution. There is deliberately **no user-identity field**: nothing in this path can fill one truthfully, and a chain entry asserting an identity it guessed would be worse than one that stays quiet — the chain has no way to mark a value as a guess. Absent a channel, the entry says `"unspecified"` rather than inventing one. `test_channel_is_unspecified_rather_than_invented` asserts both halves.

## Tests

`tests/unit/test_approval_queue_audit.py` — 8 tests, all passing:

- allow and reject both append an event carrying the approval id, decision and channel;
- **the chain still verifies** afterwards — the entry has to chain correctly, not merely be present;
- human and classifier decisions are distinguishable (`decision_source`, `actor`);
- `ALWAYS` produces its own promotion event; a plain allow produces none;
- channel is `unspecified` rather than invented, and no identity field appears;
- **the failure side**: with `AuditLog.log` raising, the rejection still applies, the approval leaves `list_pending()`, and the resolution survives a reload from disk.

## Regression

`test_approval.py`, `test_approval_cli.py`, `test_approval_gate.py`, `test_approval_gate_classifier_wiring.py` and `tests/unit/approval/`: **211 passed**. `ruff check` and `ruff format --check` clean.

Out of scope per the issue: wiring the queue's producer, and UI changes.
