### PR TITLE
fix(ci): surface branch protection audit failure and drift via marker issues (#4558)

### DIFF
--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -49,30 +49,24 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-    env:
-      # Admin-scoped read is required to fetch repository rulesets; the
-      # default github.token cannot do it. See the workflow header for the
-      # secret's required fine-grained PAT scopes. No github.token fallback.
-      GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_AUDIT_TOKEN }}
+      issues: write
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
-      - name: Require branch-protection audit token
-        run: |
-          set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::BRANCH_PROTECTION_AUDIT_TOKEN secret not configured. Create a fine-grained PAT (Administration: read-only, Contents: read) for this repo and store it as the BRANCH_PROTECTION_AUDIT_TOKEN secret. See the workflow header comment."
-            exit 1
-          fi
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Audit live branch ruleset for main
+        id: run_audit
+        env:
+          # Admin-scoped read is required to fetch repository rulesets; the
+          # default github.token cannot do it. See the workflow header for the
+          # secret's required fine-grained PAT scopes. No github.token fallback.
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_AUDIT_TOKEN }}
         # scripts/check_branch_ruleset_audit.py reads rules/branches/main,
         # rulesets, and rulesets/{id} (stdlib-only, no `uv sync` needed for
         # this job) and asserts: merge_queue, non_fast_forward and deletion
@@ -80,4 +74,24 @@ jobs:
         # required-check canary; every referenced ruleset is 'active'; no
         # bypass actor. See the workflow header for why the classic
         # protection endpoint is not read here.
-        run: python3 scripts/check_branch_ruleset_audit.py
+        run: |
+          set +e
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::BRANCH_PROTECTION_AUDIT_TOKEN secret not configured. Create a fine-grained PAT (Administration: read-only, Contents: read) for this repo and store it as the BRANCH_PROTECTION_AUDIT_TOKEN secret. See the workflow header comment."
+            echo '{"exit_code": 2, "detail": "BRANCH_PROTECTION_AUDIT_TOKEN secret not configured"}' > .audit_result.json
+            exit 2
+          fi
+          python3 scripts/check_branch_ruleset_audit.py
+          CODE=$?
+          echo "{\"exit_code\": ${CODE}, \"detail\": \"check_branch_ruleset_audit exit code ${CODE}\"}" > .audit_result.json
+          exit ${CODE}
+
+      - name: Toggle branch protection audit marker issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 scripts/toggle_branch_protection_audit_marker.py \
+            --repo "${REPO}" \
+            --result-file .audit_result.json

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -160,7 +160,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/bernstein-issues-decompose.yml | workflow: {"contents": "read"}<br>decompose: {"contents": "write", "issues": "write", "pull-requests": "write"}<br>plan: {"contents": "read"}<br>reject-untrusted-issue: {"issues": "write"}<br>scope_gate: {"issues": "write"} | ANTHROPIC_API_KEY, BERNSTEIN_AUTOSYNC_TOKEN, GOOGLE_API_KEY, OPENAI_API_KEY |
 | .github/workflows/bernstein-pr-review.yml | workflow: {"contents": "read"}<br>review: {"contents": "read", "pull-requests": "write"} | ANTHROPIC_API_KEY |
 | .github/workflows/bisect-on-red.yml | bisect: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |
-| .github/workflows/branch-protection-audit.yml | audit: {"contents": "read"} | BRANCH_PROTECTION_AUDIT_TOKEN |
+| .github/workflows/branch-protection-audit.yml | audit: {"contents": "read", "issues": "write"} | BRANCH_PROTECTION_AUDIT_TOKEN |
 | .github/workflows/ci-gate-stub.yml | workflow: {"contents": "read"}<br>ci-gate: {"contents": "read"}<br>classify: {"contents": "read", "pull-requests": "read"} | - |
 | .github/workflows/ci-macos-nightly.yml | workflow: {"contents": "read"}<br>open-failure-issue: {"contents": "read", "issues": "write"}<br>test-macos-nightly: {"contents": "read"} | GITHUB_TOKEN |
 | .github/workflows/ci-topology-heal.yml | workflow: {"contents": "read"}<br>heal: {"contents": "write", "pull-requests": "write"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |

--- a/docs/release-notes/fragments/4558-branch-protection-audit-marker.md
+++ b/docs/release-notes/fragments/4558-branch-protection-audit-marker.md
@@ -1,0 +1,1 @@
+Surface branch protection audit failures and ruleset drift via automated marker issues (#4558).

--- a/scripts/toggle_branch_protection_audit_marker.py
+++ b/scripts/toggle_branch_protection_audit_marker.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Toggle marker issues for branch protection audit failures and recovery.
+
+Distinguishes two failure modes:
+1. "Unreachable / Auth failure" (exit code 2 or missing token):
+   Label `branch-protection-unreachable`
+   Title: `Branch protection audit cannot read live rulesets (auth/credential failure)`
+2. "Drift / Invariants violated" (exit code 1):
+   Label `branch-protection-drift`
+   Title: `Branch protection audit detected ruleset drift on main`
+
+When the audit succeeds (exit code 0):
+Closes any open marker issues labeled `branch-protection-unreachable` or
+`branch-protection-drift`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+LABEL_UNREACHABLE = "branch-protection-unreachable"
+LABEL_DRIFT = "branch-protection-drift"
+
+TITLE_UNREACHABLE = "Branch protection audit cannot read live rulesets (auth/credential failure)"
+TITLE_DRIFT = "Branch protection audit detected ruleset drift on main"
+
+DESC_UNREACHABLE = (
+    "Open while branch protection audit cannot read live rulesets (credential or network failure); "
+    "closed automatically on recovery"
+)
+DESC_DRIFT = "Open while live branch protection disagrees with in-tree invariants; closed automatically on recovery"
+
+
+def _gh(args: list[str]) -> str:
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args)} failed (exit {proc.returncode}): {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def ensure_label(repo: str, name: str, description: str, color: str) -> None:
+    try:
+        _gh(
+            [
+                "label",
+                "create",
+                name,
+                "--repo",
+                repo,
+                "--description",
+                description,
+                "--color",
+                color,
+                "--force",
+            ]
+        )
+    except Exception as exc:
+        print(f"Warning: could not ensure label {name}: {exc}", file=sys.stderr)
+
+
+def list_open_markers(repo: str, label: str) -> list[int]:
+    try:
+        raw = _gh(
+            [
+                "api",
+                f"repos/{repo}/issues?labels={label}&state=open&per_page=100",
+                "--jq",
+                "[.[] | select(.pull_request | not) | .number]",
+            ]
+        )
+        if not raw:
+            return []
+        data = json.loads(raw)
+        return [int(num) for num in data if isinstance(num, int)]
+    except Exception as exc:
+        print(f"Warning: could not list markers for label {label}: {exc}", file=sys.stderr)
+        return []
+
+
+def open_marker(repo: str, label: str, title: str, body: str) -> None:
+    open_issues = list_open_markers(repo, label)
+    if open_issues:
+        print(f"Marker issue with label '{label}' already open: #{open_issues[0]}")
+        return
+    try:
+        _gh(
+            [
+                "api",
+                "-X",
+                "POST",
+                f"repos/{repo}/issues",
+                "-f",
+                f"title={title}",
+                "-f",
+                f"body={body}",
+                "-f",
+                f"labels[]={label}",
+            ]
+        )
+        print(f"Opened new marker issue with label '{label}'.")
+    except Exception as exc:
+        print(f"Warning: failed to open marker issue: {exc}", file=sys.stderr)
+
+
+def close_markers(repo: str, label: str, close_comment: str) -> None:
+    open_issues = list_open_markers(repo, label)
+    for issue_num in open_issues:
+        try:
+            _gh(
+                [
+                    "api",
+                    "-X",
+                    "POST",
+                    f"repos/{repo}/issues/{issue_num}/comments",
+                    "-f",
+                    f"body={close_comment}",
+                ]
+            )
+            _gh(
+                [
+                    "api",
+                    "-X",
+                    "PATCH",
+                    f"repos/{repo}/issues/{issue_num}",
+                    "-f",
+                    "state=closed",
+                ]
+            )
+            print(f"Closed marker issue #{issue_num} ({label}).")
+        except Exception as exc:
+            print(f"Warning: failed to close marker issue #{issue_num}: {exc}", file=sys.stderr)
+
+
+def sync_markers(repo: str, exit_code: int, detail: str = "") -> None:
+    summary_lines: list[str] = [
+        "## Branch Protection Audit",
+        "",
+    ]
+
+    if exit_code == 0:
+        summary_lines.extend(
+            [
+                "Status: **PASS (Healthy)**",
+                "",
+                "All live ruleset invariants on `main` match in-tree expectations.",
+            ]
+        )
+        close_markers(
+            repo,
+            LABEL_UNREACHABLE,
+            "Branch protection audit successfully read live rulesets and all invariants passed. Closing marker.",
+        )
+        close_markers(
+            repo,
+            LABEL_DRIFT,
+            "Live branch protection now satisfies all in-tree invariants. Closing marker.",
+        )
+
+    elif exit_code == 1:
+        summary_lines.extend(
+            [
+                "Status: **FAIL (Ruleset Drift Detected)**",
+                "",
+                "The live ruleset on `main` violated one or more audited invariants.",
+            ]
+        )
+        if detail:
+            summary_lines.extend(["", "```", detail, "```"])
+        ensure_label(repo, LABEL_DRIFT, DESC_DRIFT, "B60205")
+        body = "\n".join(
+            [
+                "The scheduled branch protection audit detected drift between live rulesets and "
+                "in-tree invariants on `main`.",
+                "",
+                detail if detail else "One or more required rules or status checks were missing or misconfigured.",
+                "",
+                "This issue closes automatically when the next audit run confirms ruleset compliance.",
+            ]
+        )
+        open_marker(repo, LABEL_DRIFT, TITLE_DRIFT, body)
+        close_markers(
+            repo,
+            LABEL_UNREACHABLE,
+            "Audit was able to reach GitHub API (drift was detected). Closing unreachability marker.",
+        )
+
+    else:  # exit_code >= 2
+        summary_lines.extend(
+            [
+                "Status: **ERROR (Unreachable / Credential Failure)**",
+                "",
+                "The audit could not read live repository rulesets from GitHub API.",
+            ]
+        )
+        if detail:
+            summary_lines.extend(["", "```", detail, "```"])
+        ensure_label(repo, LABEL_UNREACHABLE, DESC_UNREACHABLE, "d73a4a")
+        body = "\n".join(
+            [
+                "The scheduled branch protection audit failed to read live rulesets from the GitHub API.",
+                "",
+                f"Details: {detail}"
+                if detail
+                else (
+                    "Check whether `BRANCH_PROTECTION_AUDIT_TOKEN` secret is set and has "
+                    "`Administration: read` permissions."
+                ),
+                "",
+                "This issue closes automatically when the next audit run successfully reads the live rulesets.",
+            ]
+        )
+        open_marker(repo, LABEL_UNREACHABLE, TITLE_UNREACHABLE, body)
+        close_markers(
+            repo,
+            LABEL_DRIFT,
+            "Audit could not read live rulesets; closing drift marker to avoid false state.",
+        )
+
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        try:
+            with open(summary_file, "a", encoding="utf-8") as f:
+                f.write("\n".join(summary_lines) + "\n")
+        except OSError:
+            pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", help="GitHub repo OWNER/REPO (defaults to GITHUB_REPOSITORY)")
+    parser.add_argument(
+        "--exit-code", type=int, default=0, help="Exit code from check_branch_ruleset_audit.py (0, 1, or 2)"
+    )
+    parser.add_argument("--result-file", help="Path to JSON file containing {exit_code: int, detail: str}")
+    parser.add_argument("--detail", default="", help="Error or violation details string")
+    args = parser.parse_args(argv)
+
+    repo = args.repo or os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        print("Error: repository not specified and GITHUB_REPOSITORY not set", file=sys.stderr)
+        return 1
+
+    exit_code = args.exit_code
+    detail = args.detail
+
+    if args.result_file and Path(args.result_file).is_file():
+        try:
+            data = json.loads(Path(args.result_file).read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                exit_code = int(data.get("exit_code", exit_code))
+                detail = str(data.get("detail", detail))
+        except (OSError, ValueError, TypeError) as exc:
+            print(f"Warning: could not parse result-file {args.result_file}: {exc}", file=sys.stderr)
+
+    sync_markers(repo, exit_code, detail)
+    return exit_code if exit_code != 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_toggle_branch_protection_audit_marker.py
+++ b/tests/unit/scripts/test_toggle_branch_protection_audit_marker.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import toggle_branch_protection_audit_marker as marker_mod
+from toggle_branch_protection_audit_marker import (
+    LABEL_DRIFT,
+    LABEL_UNREACHABLE,
+    TITLE_DRIFT,
+    TITLE_UNREACHABLE,
+    close_markers,
+    main,
+    open_marker,
+    sync_markers,
+)
+
+
+def test_open_marker_opens_issue_when_none_open() -> None:
+    with (
+        patch.object(marker_mod, "list_open_markers", return_value=[]),
+        patch.object(marker_mod, "_gh") as mock_gh,
+    ):
+        open_marker("acme/repo", LABEL_UNREACHABLE, TITLE_UNREACHABLE, "Auth error body")
+
+    mock_gh.assert_called_once()
+    args = mock_gh.call_args[0][0]
+    assert "repos/acme/repo/issues" in args[3]
+    assert f"title={TITLE_UNREACHABLE}" in args
+    assert f"labels[]={LABEL_UNREACHABLE}" in args
+
+
+def test_open_marker_leaves_existing_open_marker_in_place() -> None:
+    with (
+        patch.object(marker_mod, "list_open_markers", return_value=[42]),
+        patch.object(marker_mod, "_gh") as mock_gh,
+    ):
+        open_marker("acme/repo", LABEL_UNREACHABLE, TITLE_UNREACHABLE, "Auth error body")
+
+    mock_gh.assert_not_called()
+
+
+def test_close_markers_closes_all_matching_issues() -> None:
+    with (
+        patch.object(marker_mod, "list_open_markers", return_value=[42, 99]),
+        patch.object(marker_mod, "_gh") as mock_gh,
+    ):
+        close_markers("acme/repo", LABEL_UNREACHABLE, "Resolved")
+
+    # 2 API calls per issue (comment + patch state=closed)
+    assert mock_gh.call_count == 4
+
+
+def test_sync_markers_exit_code_0_closes_both_markers() -> None:
+    with (
+        patch.object(marker_mod, "close_markers") as mock_close,
+        patch.object(marker_mod, "open_marker") as mock_open,
+    ):
+        sync_markers("acme/repo", exit_code=0)
+
+    mock_open.assert_not_called()
+    assert mock_close.call_count == 2
+    closed_labels = [c[0][1] for c in mock_close.call_args_list]
+    assert LABEL_UNREACHABLE in closed_labels
+    assert LABEL_DRIFT in closed_labels
+
+
+def test_sync_markers_exit_code_1_opens_drift_and_closes_unreachable() -> None:
+    with (
+        patch.object(marker_mod, "ensure_label") as mock_ensure,
+        patch.object(marker_mod, "open_marker") as mock_open,
+        patch.object(marker_mod, "close_markers") as mock_close,
+    ):
+        sync_markers("acme/repo", exit_code=1, detail="missing deletion rule")
+
+    mock_ensure.assert_called_once()
+    mock_open.assert_called_once()
+    assert mock_open.call_args[0][1] == LABEL_DRIFT
+    assert mock_open.call_args[0][2] == TITLE_DRIFT
+
+    mock_close.assert_called_once()
+    assert mock_close.call_args[0][1] == LABEL_UNREACHABLE
+
+
+def test_sync_markers_exit_code_2_opens_unreachable_and_closes_drift() -> None:
+    with (
+        patch.object(marker_mod, "ensure_label") as mock_ensure,
+        patch.object(marker_mod, "open_marker") as mock_open,
+        patch.object(marker_mod, "close_markers") as mock_close,
+    ):
+        sync_markers("acme/repo", exit_code=2, detail="Bad credentials (HTTP 401)")
+
+    mock_ensure.assert_called_once()
+    mock_open.assert_called_once()
+    assert mock_open.call_args[0][1] == LABEL_UNREACHABLE
+    assert mock_open.call_args[0][2] == TITLE_UNREACHABLE
+
+    mock_close.assert_called_once()
+    assert mock_close.call_args[0][1] == LABEL_DRIFT
+
+
+def test_main_with_result_file(tmp_path: Path) -> None:
+    result_file = tmp_path / "result.json"
+    result_file.write_text(json.dumps({"exit_code": 2, "detail": "Token expired"}), encoding="utf-8")
+
+    with patch.object(marker_mod, "sync_markers") as mock_sync:
+        code = main(["--repo", "acme/repo", "--result-file", str(result_file)])
+
+    assert code == 2
+    mock_sync.assert_called_once_with("acme/repo", 2, "Token expired")

--- a/tests/unit/test_branch_protection_audit_workflow_yaml.py
+++ b/tests/unit/test_branch_protection_audit_workflow_yaml.py
@@ -97,10 +97,16 @@ def test_branch_protection_audit_is_scheduled_and_manual_only() -> None:
     assert schedule, "scheduled audit must include at least one cron entry"
 
 
-def test_branch_protection_audit_permissions_are_read_only() -> None:
+def test_branch_protection_audit_permissions() -> None:
     workflow = _workflow()
     assert workflow.get("permissions") in ({}, "{}"), "workflow-level permissions must be default-deny"
-    assert _audit_job(workflow).get("permissions") == {"contents": "read"}
+    assert _audit_job(workflow).get("permissions") == {"contents": "read", "issues": "write"}
+
+
+def test_branch_protection_audit_toggles_marker_issue_on_failure_and_recovery() -> None:
+    workflow_text = _workflow_text()
+    assert "scripts/toggle_branch_protection_audit_marker.py" in workflow_text
+    assert Path("scripts/toggle_branch_protection_audit_marker.py").exists()
 
 
 def test_branch_protection_audit_does_not_read_the_legacy_protection_endpoint() -> None:


### PR DESCRIPTION
Fixes #4558

### Problem
`branch-protection-audit.yml` runs on a weekly schedule (`37 8 * * 2`) to compare live repository rulesets against in-tree required status check canaries. When scheduled runs fail (such as from bad/expired credentials like `BRANCH_PROTECTION_AUDIT_TOKEN` or live ruleset violations), no pull request exists to report on, making failures invisible from outside the Actions tab.

### Solution
1. **Automated Marker Issue Toggling**: Modeled after `trunk-health-slo.yml`, added `scripts/toggle_branch_protection_audit_marker.py` to open and close actionable marker issues using `GITHUB_TOKEN` (`issues: write`).
2. **Failure Distinction Preserved**:
   - **Auth / Credential Failure (exit code 2 or missing token)**: Opens/maintains a marker labeled `branch-protection-unreachable` (`Branch protection audit cannot read live rulesets (auth/credential failure)`) alerting maintainers to check or rotate `BRANCH_PROTECTION_AUDIT_TOKEN`.
   - **Ruleset Drift (exit code 1)**: Opens/maintains a marker labeled `branch-protection-drift` (`Branch protection audit detected ruleset drift on main`) alerting maintainers that live rulesets disagree with in-tree invariants.
   - **Success (exit code 0)**: Automatically closes all open marker issues with both labels once the audit succeeds.
3. **Design Decision (Scoped script with dedicated labels)**: Scoped the surfacing script specifically to the branch protection audit rather than a generic multi-workflow hook. Each scheduled lane has unique failure semantics (e.g. trunk SLO vs ruleset drift vs auth expiration), and dedicated marker labels allow precise tracking and automated resolution.
4. **Tests & Release Notes**:
   - Added unit test suite in `tests/unit/scripts/test_toggle_branch_protection_audit_marker.py` covering all exit codes and transitions.
   - Updated workflow assertions in `tests/unit/test_branch_protection_audit_workflow_yaml.py`.
   - Added release notes fragment `docs/release-notes/fragments/4558-branch-protection-audit-marker.md`.
