### PR TITLE
test(ci): guard required status checks against path-filtered PR triggers (#4557)

### DIFF
--- a/docs/release-notes/fragments/4557-guard-required-check-pull-request-paths.md
+++ b/docs/release-notes/fragments/4557-guard-required-check-pull-request-paths.md
@@ -1,0 +1,1 @@
+Guard against requiring path-filtered workflows without all-paths emitters to prevent wedged PRs (#4557).

--- a/tests/unit/test_merge_queue_gate_coverage_yaml.py
+++ b/tests/unit/test_merge_queue_gate_coverage_yaml.py
@@ -889,3 +889,63 @@ def test_event_gated_required_jobs_declare_their_merge_group_tolerance(
         "by the roll-up and wedges the queue. Add the job to DOCS_ONLY_SKIPPABLE, MACOS_GATED or PUSH_ONLY with "
         "the reason its skip is safe, or drop the event condition."
     )
+
+
+def test_every_queue_required_context_emits_on_all_pull_requests_unconditionally(
+    queue_required_contexts: tuple[str, ...],
+) -> None:
+    """Every required check must emit on all PRs without being wedged by a paths filter (#4557).
+
+    If an emitting workflow has a `paths` or `paths-ignore` filter on `pull_request`, it
+    must have a companion stub (like `ci.yml` + `ci-gate-stub.yml`) covering non-matching paths,
+    or non-matching PRs will wait forever for `Required status check '<name>' is expected.`
+    """
+    for context in queue_required_contexts:
+        emitters: list[tuple[str, dict[str, Any]]] = []
+        for path in sorted(WORKFLOWS.glob("*.yml")):
+            try:
+                doc = _load(path)
+            except (AssertionError, yaml.YAMLError):
+                continue
+            text = path.read_text(encoding="utf-8")
+            jobs = doc.get("jobs")
+            if not isinstance(jobs, dict):
+                continue
+            for key, job in jobs.items():
+                if not isinstance(job, dict):
+                    continue
+                # Check if this job publishes `context`
+                name = job.get("name", key)
+                strategy = job.get("strategy")
+                is_emitter = False
+                if name == context or f"--name {context}" in text or (isinstance(name, str) and f"'{context}'" in name):
+                    is_emitter = True
+                elif isinstance(strategy, dict) and "${{" in str(name):
+                    matrix = strategy.get("matrix", {})
+                    includes = matrix.get("include", []) if isinstance(matrix, dict) else []
+                    for cell in includes:
+                        if isinstance(cell, dict):
+                            rendered = name
+                            for k, v in cell.items():
+                                rendered = rendered.replace(f"${{{{ matrix.{k} }}}}", str(v))
+                                rendered = rendered.replace(f"${{{{matrix.{k}}}}}", str(v))
+                            if rendered == context:
+                                is_emitter = True
+                                break
+                if is_emitter:
+                    pr_trigger = _triggers(doc).get("pull_request")
+                    emitters.append((path.name, pr_trigger if isinstance(pr_trigger, dict) else {}))
+
+        assert emitters, f"Required context {context!r} has no emitting workflow on pull_request"
+
+        # Check if at least one emitter is unfiltered, or if emitters have complementary stubs
+        unfiltered_emitters = [
+            wf for wf, trigger in emitters if not trigger.get("paths") and not trigger.get("paths-ignore")
+        ]
+        has_stub = any("stub" in wf for wf, _ in emitters)
+
+        assert unfiltered_emitters or has_stub, (
+            f"Required context {context!r} is only emitted by path-filtered workflows {[wf for wf, _ in emitters]} "
+            f"without an unfiltered trigger or companion stub workflow. Every PR outside the path filter will "
+            f"be permanently wedged waiting for {context!r}. See docs/operations/merge-queue.md step 0."
+        )

--- a/tests/unit/test_typecheck_ts_workflow_yaml.py
+++ b/tests/unit/test_typecheck_ts_workflow_yaml.py
@@ -255,3 +255,37 @@ def test_install_command_matches_lockfile_presence(
                 f"`{package}` has no package-lock.json, so `npm ci` aborts before `tsc` ever runs. Use "
                 "`npm install` for this cell, or commit a lockfile."
             )
+
+
+def test_typecheck_ts_cannot_be_required_while_pull_request_trigger_is_path_filtered(
+    doc: dict[str, Any],
+    matrix_entries: list[dict[str, Any]],
+) -> None:
+    """Requiring typecheck-ts contexts before widening pull_request trigger wedges non-TS PRs (#4557).
+
+    A required status check only reports for the events its trigger accepts. With a `paths`
+    filter in place, requiring the context means every PR outside the filter waits on a workflow
+    run that never starts, permanently wedging the PR.
+    """
+    pr_trigger = _on(doc).get("pull_request")
+    has_path_filter = isinstance(pr_trigger, dict) and bool(pr_trigger.get("paths") or pr_trigger.get("paths-ignore"))
+
+    if has_path_filter:
+        published = {f"typecheck ({entry.get('package')})" for entry in matrix_entries if entry.get("package")}
+        ruleset_path = REPO / "docs/operations/merge-queue-ruleset.json"
+        if ruleset_path.exists():
+            ruleset_data = json.loads(ruleset_path.read_text(encoding="utf-8"))
+            required_contexts: set[str] = set()
+            for rule in ruleset_data.get("rules", []):
+                if rule.get("type") == "required_status_checks":
+                    for c in rule.get("parameters", {}).get("required_status_checks", []):
+                        if isinstance(c, dict) and "context" in c:
+                            required_contexts.add(c["context"])
+
+            disallowed = published & required_contexts
+            assert not disallowed, (
+                f"typecheck-ts contexts {disallowed} are required in merge-queue-ruleset.json while "
+                f"typecheck-ts.yml's pull_request trigger still carries a `paths` filter. "
+                "Every non-TypeScript PR will be permanently wedged waiting for a run that never starts. "
+                "Widen the pull_request trigger or add an all-paths fallback stub before requiring."
+            )


### PR DESCRIPTION
Fixes #4557

### Problem
A required status check only reports for the events its trigger accepts. If a workflow publishing a required status check has a `paths` or `paths-ignore` filter on `pull_request`, pull requests outside the filter will never start a workflow run. GitHub will answer any enqueue attempt with:
```
Required status check "<name>" is expected.
```
This leaves non-matching pull requests permanently wedged and unmergeable (as happened previously with `shipped bundle matches the lockfile` before trigger widening in #4556).

### Solution
1. **Repository-Wide Required Context Guard (`tests/unit/test_merge_queue_gate_coverage_yaml.py`)**:
   - Added `test_every_queue_required_context_emits_on_all_pull_requests_unconditionally`.
   - Iterates through every context required by the merge queue ruleset and asserts that its emitting workflow(s) cover all pull request paths (i.e. either have an unfiltered `pull_request` trigger or a companion stub workflow like `ci.yml` + `ci-gate-stub.yml`).
2. **Lane-Specific TypeCheck Invariant (`tests/unit/test_typecheck_ts_workflow_yaml.py`)**:
   - Added `test_typecheck_ts_cannot_be_required_while_pull_request_trigger_is_path_filtered`.
   - Asserts that none of `typecheck-ts.yml`'s 4 published matrix contexts (`typecheck (sdk/typescript)`, `typecheck (packages/vscode)`, `typecheck (web)`, `typecheck (templates/cloudflare-mcp-server)`) can be added to `merge-queue-ruleset.json` or required checks while `typecheck-ts.yml`'s `pull_request` trigger still carries a `paths` filter.
3. **Design Decision (Why both general and lane-specific)**:
   - Applied the guard systematically across the repository in `test_merge_queue_gate_coverage_yaml.py` so any future lane promoted to required checks is automatically protected against the path-filter wedge trap, while preserving explicit local assertions in `test_typecheck_ts_workflow_yaml.py`.
4. **Validation & Hygiene**:
   - Verified 71/71 tests passing in `test_merge_queue_gate_coverage_yaml.py` and `test_typecheck_ts_workflow_yaml.py`.
   - Added release note fragment `docs/release-notes/fragments/4557-guard-required-check-pull-request-paths.md`.
