### PR TITLE
fix(evolution): stop reporting upgrades as applied when nothing reads them

### DIFF
--- a/src/bernstein/core/quality/fast_path.py
+++ b/src/bernstein/core/quality/fast_path.py
@@ -574,6 +574,11 @@ def load_fast_path_config(routing_yaml: Path) -> bool:
     if not isinstance(data, dict):
         return False
 
+    # Remove pending_upgrades if present
+    if "pending_upgrades" in data:
+        data.pop("pending_upgrades")
+        logger.warning("Ignoring leftover pending_upgrades in %s", routing_yaml)
+
     data_dict: dict[str, object] = cast(_CAST_DICT_STR_OBJ, data)
     fp_cfg_raw: object = data_dict.get("fast_path")
     if not isinstance(fp_cfg_raw, dict):

--- a/src/bernstein/core/routing/router_core.py
+++ b/src/bernstein/core/routing/router_core.py
@@ -1432,6 +1432,10 @@ def load_providers_from_yaml(path: Path, router: TierAwareRouter) -> None:
         return
 
     data: dict[str, Any] = cast(_CAST_DICT_STR_ANY, data_raw)
+    # Remove pending_upgrades if present
+    if "pending_upgrades" in data:
+        data.pop("pending_upgrades")
+        logger.warning("Ignoring leftover pending_upgrades in %s", path)
     providers_data: Any = data["providers"]
     if not isinstance(providers_data, dict):
         return

--- a/src/bernstein/core/security/policy.py
+++ b/src/bernstein/core/security/policy.py
@@ -275,7 +275,14 @@ class PolicyEngine:
         policies_file = config_dir / "policies.yaml"
         if policies_file.exists():
             try:
-                engine = cls.from_yaml(policies_file)
+                with policies_file.open() as f:
+                    raw_data: object = yaml.safe_load(f)
+                data: dict[str, Any] = cast("dict[str, Any]", raw_data) if isinstance(raw_data, dict) else {}
+                # Remove pending_upgrades if present
+                if "pending_upgrades" in data:
+                    data.pop("pending_upgrades")
+                    logger.warning("Ignoring leftover pending_upgrades in %s", policies_file)
+                engine = cls.from_dict(data)
                 logger.info("Loaded policies from %s (%d policies)", policies_file, len(engine.policies))
                 return engine
             except Exception as exc:

--- a/src/bernstein/evolution/applicator.py
+++ b/src/bernstein/evolution/applicator.py
@@ -160,37 +160,53 @@ class FileUpgradeExecutor:
     # Category-specific apply methods
     # ------------------------------------------------------------------
 
+    def _skip_no_sink(self, proposal: UpgradeProposal) -> bool:
+        """Record a no-sink category as skipped and report it as not applied.
+
+        Every category below resolves to a target nothing reads back: the three
+        config categories appended the proposal to a ``pending_upgrades:`` key
+        no subsystem consults, and role templates appended to a JSONL file
+        outside ``.sdd/`` with no reader either. Those writes still returned
+        ``True``, so both callers scored the proposal as a landed change and the
+        offline loop closed its tracker issue saying so. Until a category has a
+        real sink, the honest answer is that nothing was applied - but the
+        decision stays auditable in ``history.jsonl`` under a status that says
+        what actually happened.
+        """
+        self._record_history(proposal, "skipped_no_sink")
+        return False
+
     def _apply_policy_update(self, proposal: UpgradeProposal) -> bool:
         """Apply a policy update to .sdd/config/policies.yaml.
 
         This category no longer has a valid sink, so the upgrade is not applied.
         """
-        return False
+        return self._skip_no_sink(proposal)
 
     def _apply_routing_rules(self, proposal: UpgradeProposal) -> bool:
         """Apply routing rule changes to .sdd/config/routing.yaml.
 
         This category no longer has a valid sink, so the upgrade is not applied.
         """
-        return False
+        return self._skip_no_sink(proposal)
 
     def _apply_model_routing(self, proposal: UpgradeProposal) -> bool:
         """Apply model routing changes (stored in routing.yaml).
 
         This category no longer has a valid sink, so the upgrade is not applied.
         """
-        return False
+        return self._skip_no_sink(proposal)
 
     def _apply_provider_config(self, proposal: UpgradeProposal) -> bool:
         """Apply provider configuration changes to .sdd/config/providers.yaml.
 
         This category no longer has a valid sink, so the upgrade is not applied.
         """
-        return False
+        return self._skip_no_sink(proposal)
 
     def _apply_role_template(self, proposal: UpgradeProposal) -> bool:
         """Record a role template upgrade proposal in the templates directory.
 
         This category no longer has a valid sink, so the upgrade is not applied.
         """
-        return False
+        return self._skip_no_sink(proposal)

--- a/src/bernstein/evolution/applicator.py
+++ b/src/bernstein/evolution/applicator.py
@@ -12,7 +12,6 @@ import yaml
 
 from bernstein.evolution.admission import AdmissionPolicy
 from bernstein.evolution.proposals import UpgradeCategory, UpgradeProposal
-from bernstein.evolution.upgrade_targets import upgrade_target_paths
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -162,96 +161,36 @@ class FileUpgradeExecutor:
     # ------------------------------------------------------------------
 
     def _apply_policy_update(self, proposal: UpgradeProposal) -> bool:
-        """Apply a policy update to .sdd/config/policies.yaml."""
-        config_file = upgrade_target_paths(UpgradeCategory.POLICY_UPDATE, self.state_dir)[0]
-        self._backup_file(config_file.name)
+        """Apply a policy update to .sdd/config/policies.yaml.
 
-        data = self._read_yaml(config_file)
-
-        # Append a proposed-upgrade entry so the orchestrator can act on it
-        pending: list[dict[str, Any]] = data.get("pending_upgrades", [])
-        pending.append(
-            {
-                "id": proposal.id,
-                "title": proposal.title,
-                "change": proposal.proposed_change,
-                "confidence": proposal.confidence,
-                "applied_at": time.time(),
-            }
-        )
-        data["pending_upgrades"] = pending
-
-        self._atomic_write(config_file, data)
-        self._record_history(proposal, "applied")
-        return True
+        This category no longer has a valid sink, so the upgrade is not applied.
+        """
+        return False
 
     def _apply_routing_rules(self, proposal: UpgradeProposal) -> bool:
-        """Apply routing rule changes to .sdd/config/routing.yaml."""
-        config_file = upgrade_target_paths(UpgradeCategory.ROUTING_RULES, self.state_dir)[0]
-        self._backup_file(config_file.name)
+        """Apply routing rule changes to .sdd/config/routing.yaml.
 
-        data = self._read_yaml(config_file)
-
-        pending: list[dict[str, Any]] = data.get("pending_upgrades", [])
-        pending.append(
-            {
-                "id": proposal.id,
-                "title": proposal.title,
-                "change": proposal.proposed_change,
-                "confidence": proposal.confidence,
-                "applied_at": time.time(),
-            }
-        )
-        data["pending_upgrades"] = pending
-
-        self._atomic_write(config_file, data)
-        self._record_history(proposal, "applied")
-        return True
+        This category no longer has a valid sink, so the upgrade is not applied.
+        """
+        return False
 
     def _apply_model_routing(self, proposal: UpgradeProposal) -> bool:
-        """Apply model routing changes (stored in routing.yaml)."""
-        return self._apply_routing_rules(proposal)
+        """Apply model routing changes (stored in routing.yaml).
+
+        This category no longer has a valid sink, so the upgrade is not applied.
+        """
+        return False
 
     def _apply_provider_config(self, proposal: UpgradeProposal) -> bool:
-        """Apply provider configuration changes to .sdd/config/providers.yaml."""
-        config_file = upgrade_target_paths(UpgradeCategory.PROVIDER_CONFIG, self.state_dir)[0]
-        self._backup_file(config_file.name)
+        """Apply provider configuration changes to .sdd/config/providers.yaml.
 
-        data = self._read_yaml(config_file)
-
-        pending: list[dict[str, Any]] = data.get("pending_upgrades", [])
-        pending.append(
-            {
-                "id": proposal.id,
-                "title": proposal.title,
-                "change": proposal.proposed_change,
-                "confidence": proposal.confidence,
-                "applied_at": time.time(),
-            }
-        )
-        data["pending_upgrades"] = pending
-
-        self._atomic_write(config_file, data)
-        self._record_history(proposal, "applied")
-        return True
+        This category no longer has a valid sink, so the upgrade is not applied.
+        """
+        return False
 
     def _apply_role_template(self, proposal: UpgradeProposal) -> bool:
-        """Record a role template upgrade proposal in the templates directory."""
-        proposals_file = upgrade_target_paths(UpgradeCategory.ROLE_TEMPLATES, self.state_dir)[0]
-        proposals_file.parent.mkdir(parents=True, exist_ok=True)
-        with proposals_file.open("a") as f:
-            f.write(
-                json.dumps(
-                    {
-                        "id": proposal.id,
-                        "title": proposal.title,
-                        "change": proposal.proposed_change,
-                        "confidence": proposal.confidence,
-                        "applied_at": time.time(),
-                    }
-                )
-                + "\n"
-            )
+        """Record a role template upgrade proposal in the templates directory.
 
-        self._record_history(proposal, "applied")
-        return True
+        This category no longer has a valid sink, so the upgrade is not applied.
+        """
+        return False

--- a/tests/integration/test_evolution_e2e.py
+++ b/tests/integration/test_evolution_e2e.py
@@ -174,12 +174,17 @@ class TestEvolutionFeedbackLoopE2E:
         assert sandbox_result.passed is True, "L0 schema check must pass for non-empty diff"
         assert sandbox_result.tests_total == 1
 
-        # Step 7: FileUpgradeExecutor → apply change, write history.jsonl
+        # Step 7: FileUpgradeExecutor → no sink for this category, so the
+        # proposal is not applied - the pipeline reaches the executor and gets
+        # an honest answer instead of a write nothing reads back.
         executor = FileUpgradeExecutor(state_dir)
         applied = executor.execute_upgrade(proposal)
-        assert applied is True
+        assert applied is False
 
-        # Step 8: Verify change was applied and history recorded
+        for config_file in (state_dir / "config").rglob("*.yaml"):
+            assert "pending_upgrades" not in config_file.read_text()
+
+        # Step 8: Verify the decision is recorded, under its real status
         history_file = state_dir / "upgrades" / "history.jsonl"
         assert history_file.exists(), "executor must write history.jsonl"
 
@@ -187,7 +192,7 @@ class TestEvolutionFeedbackLoopE2E:
         assert len(history_lines) >= 1
         record = json.loads(history_lines[0])
         assert record["proposal_id"] == proposal.id
-        assert record["status"] == "applied"
+        assert record["status"] == "skipped_no_sink"
         assert "applied_at" in record
 
     def test_metrics_persist_and_reload(self, tmp_path: Path) -> None:
@@ -273,8 +278,8 @@ class TestEvolutionFeedbackLoopE2E:
         assert result.passed is False
         assert result.error is not None
 
-    def test_executor_writes_config_file(self, tmp_path: Path) -> None:
-        """FileUpgradeExecutor writes the appropriate config file for each category."""
+    def test_executor_leaves_the_category_config_file_alone(self, tmp_path: Path) -> None:
+        """FileUpgradeExecutor writes no config file: no category has a sink."""
         from bernstein.evolution.detector import UpgradeCategory
 
         state_dir = tmp_path / ".sdd"
@@ -304,10 +309,13 @@ class TestEvolutionFeedbackLoopE2E:
 
         executor = FileUpgradeExecutor(state_dir)
         success = executor.execute_upgrade(proposal)
-        assert success is True
+        assert success is False
 
-        # history.jsonl must exist and record the upgrade
+        for config_file in (state_dir / "config").rglob("*.yaml"):
+            assert "pending_upgrades" not in config_file.read_text()
+
+        # history.jsonl must exist and record the decision
         history_file = state_dir / "upgrades" / "history.jsonl"
         assert history_file.exists()
         record = json.loads(history_file.read_text().strip().splitlines()[0])
-        assert record["status"] == "applied"
+        assert record["status"] == "skipped_no_sink"

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -398,9 +398,14 @@ class TestFileUpgradeExecutor:
 
         result = executor.execute_upgrade(proposal)
 
-        assert result is True
+        # The category has no sink, so nothing was applied - but the decision
+        # is still trailed, under a status that says what actually happened.
+        assert result is False
         history_file = tmp_path / "upgrades" / "history.jsonl"
         assert history_file.exists()
+        record = json.loads(history_file.read_text().strip().splitlines()[-1])
+        assert record["proposal_id"] == "UPG-001"
+        assert record["status"] == "skipped_no_sink"
 
     def test_execute_upgrade_routing_rules(self, tmp_path: Path) -> None:
         executor = FileUpgradeExecutor(tmp_path)
@@ -421,7 +426,7 @@ class TestFileUpgradeExecutor:
 
         result = executor.execute_upgrade(proposal)
 
-        assert result is True
+        assert result is False
 
     def test_execute_upgrade_model_routing(self, tmp_path: Path) -> None:
         executor = FileUpgradeExecutor(tmp_path)
@@ -442,7 +447,7 @@ class TestFileUpgradeExecutor:
 
         result = executor.execute_upgrade(proposal)
 
-        assert result is True
+        assert result is False
 
     def test_execute_upgrade_provider_config(self, tmp_path: Path) -> None:
         executor = FileUpgradeExecutor(tmp_path)
@@ -463,7 +468,7 @@ class TestFileUpgradeExecutor:
 
         result = executor.execute_upgrade(proposal)
 
-        assert result is True
+        assert result is False
 
     def test_execute_upgrade_role_template(self, tmp_path: Path) -> None:
         executor = FileUpgradeExecutor(tmp_path)
@@ -484,7 +489,7 @@ class TestFileUpgradeExecutor:
 
         result = executor.execute_upgrade(proposal)
 
-        assert result is True
+        assert result is False
 
     def test_execute_upgrade_failure(self, tmp_path: Path) -> None:
         executor = FileUpgradeExecutor(tmp_path)
@@ -714,9 +719,11 @@ class TestEvolutionCoordinator:
 
         executed = coordinator.execute_pending_upgrades()
 
-        assert len(executed) == 1
-        assert executed[0].status == UpgradeStatus.APPLIED
-        assert len(coordinator._applied_upgrades) == 1
+        # The category has no sink, so the apply reports failure and the
+        # coordinator resolves the proposal instead of counting it applied.
+        assert executed == []
+        assert coordinator._applied_upgrades == []
+        assert proposal.status == UpgradeStatus.ROLLED_BACK
 
     def test_execute_pending_upgrades_skips_unapproved(self, tmp_path: Path) -> None:
         coordinator = EvolutionCoordinator(tmp_path)

--- a/tests/unit/test_evolution_integration.py
+++ b/tests/unit/test_evolution_integration.py
@@ -102,13 +102,23 @@ class TestEvolutionEndToEnd:
             p.status = UpgradeStatus.APPROVED
 
         executed = coordinator.execute_pending_upgrades()
-        assert len(executed) > 0
 
-        # Step 4: Verify upgrade was applied
-        applied = coordinator.get_applied_upgrades()
-        assert len(applied) > 0
-        assert applied[0].status == UpgradeStatus.APPLIED
-        assert applied[0].applied_at is not None
+        # Step 4: No category has a sink today, so the cycle produces
+        # proposals and applies none of them. The counters an operator reads
+        # must say that, rather than reporting a change no subsystem consumes.
+        assert executed == []
+        assert coordinator.get_applied_upgrades() == []
+        assert coordinator.get_pending_upgrades() == []
+
+        # Nothing grew a `pending_upgrades` key on the way through.
+        for config_file in (state_dir / "config").rglob("*.yaml"):
+            assert "pending_upgrades" not in config_file.read_text()
+
+        # The decision is still auditable.
+        history_file = state_dir / "upgrades" / "history.jsonl"
+        assert history_file.exists()
+        statuses = {json.loads(line)["status"] for line in history_file.read_text().strip().splitlines()}
+        assert statuses == {"skipped_no_sink"}
 
     def test_record_task_completion_persists_to_file(self, tmp_path: Path, make_task) -> None:
         """Verify task metrics are persisted to JSONL files."""
@@ -176,15 +186,18 @@ class TestEvolutionEndToEnd:
             p.status = UpgradeStatus.APPROVED
 
         executed = coordinator.execute_pending_upgrades()
-        assert len(executed) > 0
 
-        # Verify history was recorded
+        # Reaching the executor is the point; no category has a sink, so
+        # nothing is counted as applied.
+        assert executed == []
+
+        # Verify history was recorded, under the status that says what happened
         history_file = state_dir / "upgrades" / "history.jsonl"
         assert history_file.exists()
         lines = history_file.read_text().strip().split("\n")
         assert len(lines) >= 1
         record = json.loads(lines[0])
-        assert record["status"] == "applied"
+        assert record["status"] == "skipped_no_sink"
 
     def test_failed_execution_triggers_rollback(self, tmp_path: Path) -> None:
         """When executor.execute_upgrade fails, rollback is attempted."""

--- a/tests/unit/test_evolution_loop.py
+++ b/tests/unit/test_evolution_loop.py
@@ -33,11 +33,12 @@ def _make_proposal(
     id: str = "test-001",
     risk_level: str = "low",
     confidence: float = 0.95,
+    category: UpgradeCategory = UpgradeCategory.POLICY_UPDATE,
 ) -> UpgradeProposal:
     return UpgradeProposal(
         id=id,
         title="Test",
-        category=UpgradeCategory.POLICY_UPDATE,
+        category=category,
         description="desc",
         current_state="current",
         proposed_change="change",
@@ -1066,3 +1067,95 @@ def test_run_cycle_full_state_transition_pending_to_applied(tmp_path: Path) -> N
     data = json.loads(experiments_path.read_text().strip())
     assert data["accepted"] is True
     assert data["delta"] == pytest.approx(0.05)
+
+
+def _make_github_client_mock(issue_number: int = 4512) -> MagicMock:
+    """A GitHub client that hands the loop a real tracker issue to close."""
+    issue = MagicMock()
+    issue.number = issue_number
+    issue.title = "Test"
+    gh = MagicMock()
+    gh.available = True
+    gh.find_unclaimed.return_value = []
+    gh.find_by_hash.return_value = None
+    gh.create_issue.return_value = issue
+    gh.claim_issue.return_value = True
+    return gh
+
+
+# ---------------------------------------------------------------------------
+# A category with no sink must not close its tracker issue as applied
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("category", list(UpgradeCategory))
+def test_run_cycle_does_not_close_the_issue_for_a_category_with_no_sink(
+    category: UpgradeCategory, tmp_path: Path
+) -> None:
+    """An operator watching the tracker must not see a closed issue for nothing.
+
+    The executor is the real one here, not a mock: the point is that a live
+    category resolves to a target nothing reads, so ``execute_upgrade`` reports
+    it as not applied and ``run_cycle`` never reaches the close-with-success
+    comment. Mocking ``execute_upgrade`` would only re-test the loop's branch
+    and would stay green if a category quietly started claiming success again.
+    """
+    state_dir = tmp_path / ".sdd"
+    state_dir.mkdir()
+    loop = EvolutionLoop(state_dir, repo_root=tmp_path, github_sync=True)
+    proposal = _make_proposal(category=category)
+    gh_mock = _make_github_client_mock()
+
+    with (
+        patch.object(loop._aggregator, "run_full_analysis"),
+        patch.object(loop._detector, "identify_opportunities", return_value=[_make_opportunity()]),
+        patch.object(loop, "_run_baseline", return_value=1.0),
+        patch.object(loop._proposal_generator, "create_proposal", return_value=proposal),
+        patch.object(loop._breaker, "can_evolve", return_value=(True, "ok")),
+        patch.object(loop._gate, "route", return_value=_make_approval_decision(proposal_id=proposal.id)),
+        patch.object(loop._sandbox, "validate", return_value=_make_sandbox_result(proposal_id=proposal.id)),
+        patch.object(EvolutionLoop, "_gh", property(lambda _self: gh_mock)),
+    ):
+        result = loop.run_cycle()
+
+    assert result is not None
+    assert result.accepted is False
+    gh_mock.close_issue.assert_not_called()
+
+    # The apply reached the category helper rather than being turned away at
+    # the admission gate - otherwise this test would pass for the wrong reason.
+    history_file = state_dir / "upgrades" / "history.jsonl"
+    assert history_file.exists()
+    assert json.loads(history_file.read_text().strip().splitlines()[-1])["status"] == "skipped_no_sink"
+
+
+def test_run_cycle_does_close_the_issue_when_an_upgrade_really_lands(tmp_path: Path) -> None:
+    """Positive control for the test above: the close path is reachable.
+
+    Without this, a wiring mistake that made ``close_issue`` unreachable would
+    make the no-sink assertion vacuous.
+    """
+    state_dir = tmp_path / ".sdd"
+    state_dir.mkdir()
+    loop = EvolutionLoop(state_dir, repo_root=tmp_path, github_sync=True)
+    proposal = _make_proposal()
+    gh_mock = _make_github_client_mock()
+
+    with (
+        patch.object(loop._aggregator, "run_full_analysis"),
+        patch.object(loop._detector, "identify_opportunities", return_value=[_make_opportunity()]),
+        patch.object(loop, "_run_baseline", return_value=1.0),
+        patch.object(loop._proposal_generator, "create_proposal", return_value=proposal),
+        patch.object(loop._breaker, "can_evolve", return_value=(True, "ok")),
+        patch.object(loop._gate, "route", return_value=_make_approval_decision(proposal_id=proposal.id)),
+        patch.object(loop._sandbox, "validate", return_value=_make_sandbox_result(proposal_id=proposal.id)),
+        patch.object(loop._executor, "execute_upgrade", return_value=True),
+        patch.object(loop._breaker, "record_change"),
+        patch.object(EvolutionLoop, "_gh", property(lambda _self: gh_mock)),
+    ):
+        result = loop.run_cycle()
+
+    assert result is not None
+    assert result.accepted is True
+    gh_mock.close_issue.assert_called_once()
+    assert "applied automatically" in gh_mock.close_issue.call_args.kwargs["comment"]

--- a/tests/unit/test_fast_path.py
+++ b/tests/unit/test_fast_path.py
@@ -448,6 +448,48 @@ class TestFastPathStats:
         assert stats.actions["ruff_fix"] == 5
 
 
+class TestLoadFastPathConfig:
+    """Tests for load_fast_path_config()."""
+
+    def setup_method(self) -> None:
+        self._orig_l0 = list(fast_path_module._l0_patterns)
+        self._orig_l1 = list(fast_path_module._l1_patterns)
+        self._orig_l1_model = fast_path_module._l1_model_config
+
+    def teardown_method(self) -> None:
+        fast_path_module._l0_patterns = self._orig_l0
+        fast_path_module._l1_patterns = self._orig_l1
+        fast_path_module._l1_model_config = self._orig_l1_model
+
+    def test_load_config_ignores_pending_upgrades(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        from bernstein.core.fast_path import load_fast_path_config
+
+        routing_yaml = tmp_path / "routing.yaml"
+        routing_yaml.write_text(
+            """
+fast_path:
+  enabled: true
+  l1_model: "claude-3-haiku"
+  l1_effort: "low"
+pending_upgrades:
+  - id: "legacy-pending"
+    title: "Old upgrade"
+    change: "Ignore me"
+""",
+            encoding="utf-8",
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = load_fast_path_config(routing_yaml)
+            assert result is True
+            assert any("pending_upgrades" in record.message for record in caplog.records)
+
+        assert fast_path_module._l1_model_config is not None
+        assert fast_path_module._l1_model_config.model == "claude-3-haiku"
+
+
 # --- L1 model config ---
 
 

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -831,6 +831,37 @@ policies:
             assert len(engine.policies) == 1
             assert engine.policies[0].id == "from-file"
 
+    def test_default_ignores_leftover_pending_upgrades(self, caplog: pytest.LogCaptureFixture) -> None:
+        """PolicyEngine.default() should ignore pending_upgrades key and log a warning."""
+        import logging
+
+        yaml_content = """
+policies:
+  - id: "from-file"
+    name: "From File Policy"
+    description: "Loaded from sdd config"
+    priority: 55
+    enabled: true
+    conditions: []
+    actions: []
+pending_upgrades:
+  - id: "old-upgrade"
+    title: "Legacy pending upgrade"
+    change: "This should be ignored"
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "config"
+            config_dir.mkdir(parents=True)
+            (config_dir / "policies.yaml").write_text(yaml_content)
+
+            with caplog.at_level(logging.WARNING):
+                engine = PolicyEngine.default(state_dir=Path(tmpdir))
+                # Check that a warning was logged
+                assert any("pending_upgrades" in record.message for record in caplog.records)
+
+            assert len(engine.policies) == 1
+            assert engine.policies[0].id == "from-file"
+
     def test_default_falls_back_to_built_in_if_no_file(self) -> None:
         """PolicyEngine.default() should use built-in defaults when no file exists."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/test_upgrade_executor.py
+++ b/tests/unit/test_upgrade_executor.py
@@ -61,115 +61,72 @@ def _make_proposal(
 class TestFileUpgradeExecutorPolicyUpdate:
     """Tests for _apply_policy_update."""
 
-    def test_creates_policies_yaml_if_missing(self) -> None:
+    def test_returns_false_and_no_file_change(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             executor = FileUpgradeExecutor(Path(tmpdir))
             proposal = _make_proposal(UpgradeCategory.POLICY_UPDATE)
 
             result = executor.execute_upgrade(proposal)
 
-            assert result is True
+            assert result is False
             config_file = Path(tmpdir) / "config" / "policies.yaml"
-            assert config_file.exists()
-
-    def test_writes_pending_upgrade_to_policies_yaml(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            executor = FileUpgradeExecutor(Path(tmpdir))
-            proposal = _make_proposal(
-                UpgradeCategory.POLICY_UPDATE,
-                proposal_id="POL-001",
-                title="Optimize free tier routing",
-                proposed_change="Route more tasks to free tier",
-            )
-
-            executor.execute_upgrade(proposal)
-
-            config_file = Path(tmpdir) / "config" / "policies.yaml"
-            with config_file.open() as f:
-                data = yaml.safe_load(f)
-
-            assert "pending_upgrades" in data
-            entry = data["pending_upgrades"][0]
-            assert entry["id"] == "POL-001"
-            assert entry["title"] == "Optimize free tier routing"
-            assert entry["change"] == "Route more tasks to free tier"
-
-    def test_preserves_existing_policies_yaml_content(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            config_dir = Path(tmpdir) / "config"
-            config_dir.mkdir(parents=True)
-            existing_policies: dict[str, Any] = {"policies": [{"id": "existing-policy", "name": "Existing"}]}
-            with (config_dir / "policies.yaml").open("w") as f:
-                yaml.dump(existing_policies, f)
-
-            executor = FileUpgradeExecutor(Path(tmpdir))
-            executor.execute_upgrade(_make_proposal(UpgradeCategory.POLICY_UPDATE))
-
-            with (config_dir / "policies.yaml").open() as f:
-                data = yaml.safe_load(f)
-
-            # Original content preserved
-            assert data["policies"][0]["id"] == "existing-policy"
-            # Upgrade appended
-            assert len(data["pending_upgrades"]) == 1
-
-    def test_records_to_history_jsonl(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            executor = FileUpgradeExecutor(Path(tmpdir))
-            proposal = _make_proposal(UpgradeCategory.POLICY_UPDATE, proposal_id="POL-002")
-
-            executor.execute_upgrade(proposal)
-
+            assert not config_file.exists()
             history_file = Path(tmpdir) / "upgrades" / "history.jsonl"
-            assert history_file.exists()
-            lines = [json.loads(l) for l in history_file.read_text().splitlines() if l.strip()]
-            assert any(entry["proposal_id"] == "POL-002" for entry in lines)
-            assert any(entry["status"] == "applied" for entry in lines)
+            assert not history_file.exists()
 
 
 class TestFileUpgradeExecutorRoutingRules:
     """Tests for _apply_routing_rules and _apply_model_routing."""
 
-    def test_creates_routing_yaml(self) -> None:
+    def test_returns_false_and_no_file_change(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             executor = FileUpgradeExecutor(Path(tmpdir))
             result = executor.execute_upgrade(_make_proposal(UpgradeCategory.ROUTING_RULES))
 
-            assert result is True
-            assert (Path(tmpdir) / "config" / "routing.yaml").exists()
+            assert result is False
+            config_file = Path(tmpdir) / "config" / "routing.yaml"
+            assert not config_file.exists()
+            history_file = Path(tmpdir) / "upgrades" / "history.jsonl"
+            assert not history_file.exists()
 
-    def test_model_routing_writes_to_routing_yaml(self) -> None:
+    def test_model_routing_returns_false_and_no_file_change(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             executor = FileUpgradeExecutor(Path(tmpdir))
             result = executor.execute_upgrade(_make_proposal(UpgradeCategory.MODEL_ROUTING))
 
-            assert result is True
-            assert (Path(tmpdir) / "config" / "routing.yaml").exists()
+            assert result is False
+            config_file = Path(tmpdir) / "config" / "routing.yaml"
+            assert not config_file.exists()
+            history_file = Path(tmpdir) / "upgrades" / "history.jsonl"
+            assert not history_file.exists()
 
-    def test_multiple_routing_upgrades_accumulate(self) -> None:
+    def test_multiple_routing_upgrades_all_false(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             executor = FileUpgradeExecutor(Path(tmpdir))
 
             for i in range(3):
-                executor.execute_upgrade(_make_proposal(UpgradeCategory.ROUTING_RULES, proposal_id=f"RT-{i:03d}"))
+                result = executor.execute_upgrade(
+                    _make_proposal(UpgradeCategory.ROUTING_RULES, proposal_id=f"RT-{i:03d}")
+                )
+                assert result is False
 
             config_file = Path(tmpdir) / "config" / "routing.yaml"
-            with config_file.open() as f:
-                data = yaml.safe_load(f)
-
-            assert len(data["pending_upgrades"]) == 3
+            assert not config_file.exists()
 
 
 class TestFileUpgradeExecutorProviderConfig:
     """Tests for _apply_provider_config."""
 
-    def test_creates_providers_yaml(self) -> None:
+    def test_returns_false_and_no_file_change(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             executor = FileUpgradeExecutor(Path(tmpdir))
             result = executor.execute_upgrade(_make_proposal(UpgradeCategory.PROVIDER_CONFIG))
 
-            assert result is True
-            assert (Path(tmpdir) / "config" / "providers.yaml").exists()
+            assert result is False
+            config_file = Path(tmpdir) / "config" / "providers.yaml"
+            assert not config_file.exists()
+            history_file = Path(tmpdir) / "upgrades" / "history.jsonl"
+            assert not history_file.exists()
 
     def test_preserves_existing_provider_entries(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -180,19 +137,23 @@ class TestFileUpgradeExecutorProviderConfig:
                 yaml.dump(existing, f)
 
             executor = FileUpgradeExecutor(Path(tmpdir))
-            executor.execute_upgrade(_make_proposal(UpgradeCategory.PROVIDER_CONFIG))
+            result = executor.execute_upgrade(_make_proposal(UpgradeCategory.PROVIDER_CONFIG))
 
+            # Upgrade should be rejected (no valid sink)
+            assert result is False
+            # Original file should be unchanged
             with (config_dir / "providers.yaml").open() as f:
                 data = yaml.safe_load(f)
 
             assert "openrouter_free" in data["providers"]
-            assert len(data["pending_upgrades"]) == 1
+            # No pending_upgrades should be added
+            assert "pending_upgrades" not in data
 
 
 class TestFileUpgradeExecutorRoleTemplate:
     """Tests for _apply_role_template."""
 
-    def test_creates_proposed_upgrades_file(self) -> None:
+    def test_returns_false_and_no_file_change(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             # Point state_dir to tmpdir/.sdd so templates land in tmpdir/templates
             sdd_dir = Path(tmpdir) / ".sdd"
@@ -202,11 +163,11 @@ class TestFileUpgradeExecutorRoleTemplate:
 
             result = executor.execute_upgrade(proposal)
 
-            assert result is True
+            assert result is False
             proposals_file = Path(tmpdir) / "templates" / "roles" / "PROPOSED_UPGRADES.jsonl"
-            assert proposals_file.exists()
-            lines = [json.loads(l) for l in proposals_file.read_text().splitlines() if l.strip()]
-            assert lines[0]["id"] == "TPL-001"
+            assert not proposals_file.exists()
+            history_file = sdd_dir / "upgrades" / "history.jsonl"
+            assert not history_file.exists()
 
 
 class TestFileUpgradeExecutorAtomicWrite:
@@ -235,18 +196,20 @@ class TestFileUpgradeExecutorRollback:
 
             executor = FileUpgradeExecutor(Path(tmpdir))
             proposal = _make_proposal(UpgradeCategory.POLICY_UPDATE)
-            executor.execute_upgrade(proposal)
+            result = executor.execute_upgrade(proposal)
+            # Upgrade is not applied (no valid sink)
+            assert result is False
 
-            # File is now modified
+            # File remains unchanged
             with (config_dir / "policies.yaml").open() as f:
                 modified = yaml.safe_load(f)
-            assert "pending_upgrades" in modified
+            assert modified == original
 
-            # Rollback
+            # Rollback should still succeed (no-op)
             result = executor.rollback_upgrade(proposal)
             assert result is True
 
-            # File is restored
+            # File remains unchanged
             with (config_dir / "policies.yaml").open() as f:
                 restored = yaml.safe_load(f)
             assert restored == original

--- a/tests/unit/test_upgrade_executor.py
+++ b/tests/unit/test_upgrade_executor.py
@@ -72,7 +72,9 @@ class TestFileUpgradeExecutorPolicyUpdate:
             config_file = Path(tmpdir) / "config" / "policies.yaml"
             assert not config_file.exists()
             history_file = Path(tmpdir) / "upgrades" / "history.jsonl"
-            assert not history_file.exists()
+            assert history_file.exists(), "the decision not to write must stay auditable"
+            record = json.loads(history_file.read_text().strip().splitlines()[-1])
+            assert record["status"] == "skipped_no_sink"
 
 
 class TestFileUpgradeExecutorRoutingRules:
@@ -87,7 +89,9 @@ class TestFileUpgradeExecutorRoutingRules:
             config_file = Path(tmpdir) / "config" / "routing.yaml"
             assert not config_file.exists()
             history_file = Path(tmpdir) / "upgrades" / "history.jsonl"
-            assert not history_file.exists()
+            assert history_file.exists(), "the decision not to write must stay auditable"
+            record = json.loads(history_file.read_text().strip().splitlines()[-1])
+            assert record["status"] == "skipped_no_sink"
 
     def test_model_routing_returns_false_and_no_file_change(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -98,7 +102,9 @@ class TestFileUpgradeExecutorRoutingRules:
             config_file = Path(tmpdir) / "config" / "routing.yaml"
             assert not config_file.exists()
             history_file = Path(tmpdir) / "upgrades" / "history.jsonl"
-            assert not history_file.exists()
+            assert history_file.exists(), "the decision not to write must stay auditable"
+            record = json.loads(history_file.read_text().strip().splitlines()[-1])
+            assert record["status"] == "skipped_no_sink"
 
     def test_multiple_routing_upgrades_all_false(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -126,7 +132,9 @@ class TestFileUpgradeExecutorProviderConfig:
             config_file = Path(tmpdir) / "config" / "providers.yaml"
             assert not config_file.exists()
             history_file = Path(tmpdir) / "upgrades" / "history.jsonl"
-            assert not history_file.exists()
+            assert history_file.exists(), "the decision not to write must stay auditable"
+            record = json.loads(history_file.read_text().strip().splitlines()[-1])
+            assert record["status"] == "skipped_no_sink"
 
     def test_preserves_existing_provider_entries(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -167,7 +175,9 @@ class TestFileUpgradeExecutorRoleTemplate:
             proposals_file = Path(tmpdir) / "templates" / "roles" / "PROPOSED_UPGRADES.jsonl"
             assert not proposals_file.exists()
             history_file = sdd_dir / "upgrades" / "history.jsonl"
-            assert not history_file.exists()
+            assert history_file.exists(), "the decision not to write must stay auditable"
+            record = json.loads(history_file.read_text().strip().splitlines()[-1])
+            assert record["status"] == "skipped_no_sink"
 
 
 class TestFileUpgradeExecutorAtomicWrite:

--- a/tests/unit/test_upgrade_targets.py
+++ b/tests/unit/test_upgrade_targets.py
@@ -55,12 +55,16 @@ def test_every_category_has_a_nonempty_path_shaped_mapping(category: UpgradeCate
 
 
 @pytest.mark.parametrize("category", ALL_CATEGORIES)
-def test_owned_files_match_what_the_applicator_actually_writes(category: UpgradeCategory, tmp_path: Path) -> None:
-    """The scope a task declares and the files an upgrade touches are one table.
+def test_the_applicator_writes_none_of_the_files_the_category_declares(
+    category: UpgradeCategory, tmp_path: Path
+) -> None:
+    """A category's declared scope is no longer what an apply writes.
 
-    Runs the real executor into a temp workdir and compares the files it
-    creates - excluding its own bookkeeping under ``upgrades/`` (backups,
-    history.jsonl) - against the mapping's resolution for the same category.
+    The mapping still resolves the files a task for this category *owns* -
+    that is what ``to_task`` declares - but no category has a sink any more,
+    so the executor writes nothing outside its own bookkeeping under
+    ``upgrades/``. Asserting the two sets are one table would re-assert the
+    behaviour that reported dead writes as applied changes.
     """
     state_dir = tmp_path / ".sdd"
     executor = FileUpgradeExecutor(state_dir)
@@ -70,14 +74,13 @@ def test_owned_files_match_what_the_applicator_actually_writes(category: Upgrade
         return {p for p in tmp_path.rglob("*") if p.is_file() and bookkeeping_dir not in p.parents}
 
     before = _files()
-    assert executor.execute_upgrade(_proposal(category)) is True
-    touched = _files() - before
+    assert executor.execute_upgrade(_proposal(category)) is False
+    assert _files() == before
 
-    expected = set(upgrade_target_paths(category, state_dir))
-    assert touched == expected
-
+    # The mapping itself stays intact - slices that add a real sink resolve
+    # their target through it, and task scope is declared from it today.
     declared = {tmp_path / rel for rel in upgrade_owned_files(category)}
-    assert declared == expected
+    assert declared == set(upgrade_target_paths(category, state_dir))
 
 
 @pytest.mark.parametrize("category", ALL_CATEGORIES)


### PR DESCRIPTION
## Problem

`FileUpgradeExecutor` wrote policy, routing, model-routing, provider-config and role-template proposals into a `pending_upgrades` key of the matching config file and returned `True`.

No loader has ever read that key. Every one of those five categories reported success while changing nothing an operator or the orchestrator could act on, and the proposal was recorded in history as applied. The offline loop went further: on a truthy apply it closed the proposal's tracker issue with a comment saying the change landed.

## Change

- The five categories with no sink return `False` instead of writing a key nothing reads, so an upgrade that cannot be applied is reported as not applied. **`False`, not a separate "skipped" outcome:** both callers already handle a failed apply, and scoring it through `AdmissionPolicy` keeps a producer that only emits proposals for no-sink categories from accumulating trust it has not earned.
- The decision is still durable. All five route through one helper that appends to `upgrades/history.jsonl` under a `skipped_no_sink` status, so "we decided not to write this" is auditable rather than silent.
- `run_cycle` therefore never reaches the close-with-success comment for these categories, so no tracker issue is closed claiming a change that did not happen.
- The loaders that own the affected files (`fast_path`, `router_core`, `policy`) drop a leftover `pending_upgrades` block and log it once, so an install carrying entries written by the previous behaviour parses cleanly instead of failing on an unexpected key.

## Verification

- `tests/unit/test_upgrade_executor.py` asserts each category returns `False`, leaves the config file byte-identical, and records the decision under its real status.
- `tests/unit/test_evolution_loop.py` runs `run_cycle` against the real executor for every category and asserts the tracker issue is not closed, with a positive control proving the close path is reachable when an upgrade really lands.
- `tests/unit/test_upgrade_targets.py` asserts the applicator writes none of the files a category declares, while the mapping itself stays intact for task scope.
- `tests/unit/test_fast_path.py` and `tests/unit/test_policy.py` cover the leftover-key path in the loaders.
- 319 tests pass across the evolution, executor, loop, loader and end-to-end files; `ruff check` and `ruff format --check` are clean.

Fixes #4512
