### PR TITLE
feat(artifacts): blob artifact kind reaches every declaration surface

### DIFF
--- a/docs/release-notes/fragments/4544-blob-artifact-kind.md
+++ b/docs/release-notes/fragments/4544-blob-artifact-kind.md
@@ -1,0 +1,9 @@
+A task can now declare a `blob` artifact output: the canonical form is the raw
+bytes and the digest is their content hash, so a deliverable that is not text,
+JSONL or a JSON object can still be anchored by a signed receipt. The
+text-shaped acceptance criteria (`schema_valid`, `criteria_match`) are rejected
+at parse time for this kind, naming the criterion.
+
+The artifact-kind lists behind the plan schema and `bernstein task add
+--artifact-kind` are now derived from the kind enum instead of copied, so a new
+kind reaches every declaration surface at once.

--- a/src/bernstein/cli/commands/task_cmd.py
+++ b/src/bernstein/cli/commands/task_cmd.py
@@ -24,6 +24,7 @@ from bernstein.cli.helpers import (
     server_get,
     server_post,
 )
+from bernstein.core.tasks.artifacts import ArtifactKind
 
 # This will be populated by main.py after it creates the CLI group
 _cli: Any = None
@@ -203,7 +204,10 @@ def verify_claim(receipt_path: str, backlog_path: Path, audit_dir: Path) -> None
     "--artifact-kind",
     "artifact_kind",
     default=None,
-    type=click.Choice(["report", "dataset", "action_log", "ops_result"]),
+    # Every kind the shared parser accepts except ``code_diff`` - see the note
+    # below on why a task must never silently complete as one. Derived rather
+    # than listed: the literal list was two kinds behind ``ArtifactKind``.
+    type=click.Choice([k.value for k in ArtifactKind if k is not ArtifactKind.CODE_DIFF]),
     help=(
         "Declare the artifact contract this task produces (issue #3110). The "
         "task then completes on a signed lineage receipt instead of a git "

--- a/src/bernstein/core/lineage/entry.py
+++ b/src/bernstein/core/lineage/entry.py
@@ -43,6 +43,7 @@ ARTEFACT_KINDS: frozenset[str] = frozenset(
         "external",
         "finding",
         "coverage",
+        "blob",
     }
 )
 

--- a/src/bernstein/core/planning/plan_schema.py
+++ b/src/bernstein/core/planning/plan_schema.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.tasks.artifacts import ArtifactKind
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -56,11 +58,16 @@ COMPLETION_SIGNAL_TYPES: list[str] = [
     "llm_judge",
 ]
 
-# Issue #3110: the declared artifact contract. Values mirror the closed sets
-# in ``bernstein.core.tasks.artifacts`` (ArtifactKind / ARTIFACT_CRITERION_TYPES);
-# the strict parser there is the behavioural source of truth and is exercised
-# by ``_validate_artifact_spec`` below, so the two cannot drift.
-ARTIFACT_KIND_VALUES: list[str] = ["code_diff", "report", "dataset", "action_log", "ops_result"]
+# Issue #3110: the declared artifact contract. The strict parser in
+# ``bernstein.core.tasks.artifacts`` is the behavioural source of truth and is
+# exercised by ``_validate_artifact_spec`` below.
+#
+# The kind list is derived from ``ArtifactKind`` rather than copied. The
+# hand-written copy claimed the two could not drift and had already fallen a
+# kind behind it - ``finding`` (#3659) never reached here, so a plan declaring
+# one was rejected by this schema and accepted by the parser it mirrors. Enum
+# declaration order is stable, so the emitted schema stays deterministic.
+ARTIFACT_KIND_VALUES: list[str] = [k.value for k in ArtifactKind]
 
 ARTIFACT_CRITERION_TYPE_VALUES: list[str] = ["criteria_match", "hash_stable", "schema_valid"]
 

--- a/src/bernstein/core/tasks/artifact_completion.py
+++ b/src/bernstein/core/tasks/artifact_completion.py
@@ -287,6 +287,9 @@ def load_artifact(task: Task, workdir: Path) -> Any:
         except (json.JSONDecodeError, ValueError) as exc:
             raise ArtifactCompletionError(f"ops_result artifact is not valid JSON: {exc}") from exc
 
+    if kind is ArtifactKind.BLOB:
+        return raw
+
     # report: a figures bundle is loaded as a bundle so the sidecar is inside
     # the content hash (issue #2888); anything else is plain report text.
     from bernstein.core.tasks.figures import is_report_bundle, parse_report_bundle

--- a/src/bernstein/core/tasks/artifacts.py
+++ b/src/bernstein/core/tasks/artifacts.py
@@ -290,8 +290,8 @@ def _eval_schema_valid(kind: ArtifactKind, artifact: Any, schema_text: str) -> t
 
     # Blob kind cannot be validated against JSON schema
     if kind in _BYTE_KINDS:
-        return False, f"criterion type 'schema_valid' is not supported for blob kind"
-    
+        return False, "criterion type 'schema_valid' is not supported for blob kind"
+
     try:
         schema = json.loads(schema_text)
     except json.JSONDecodeError as exc:
@@ -319,8 +319,8 @@ def _eval_schema_valid(kind: ArtifactKind, artifact: Any, schema_text: str) -> t
 def _eval_criteria_match(kind: ArtifactKind, artifact: Any, preds_text: str) -> tuple[bool, str]:
     # Blob kind cannot be matched against JSON criteria
     if kind in _BYTE_KINDS:
-        return False, f"criterion type 'criteria_match' is not supported for blob kind"
-    
+        return False, "criterion type 'criteria_match' is not supported for blob kind"
+
     try:
         preds = json.loads(preds_text)
     except json.JSONDecodeError as exc:

--- a/src/bernstein/core/tasks/artifacts.py
+++ b/src/bernstein/core/tasks/artifacts.py
@@ -42,6 +42,7 @@ class ArtifactKind(StrEnum):
     ACTION_LOG = "action_log"
     OPS_RESULT = "ops_result"
     FINDING = "finding"
+    BLOB = "blob"
 
 
 #: Kinds whose canonical form is normalised UTF-8 *text*.
@@ -50,6 +51,8 @@ _TEXT_KINDS: frozenset[ArtifactKind] = frozenset({ArtifactKind.CODE_DIFF, Artifa
 _JSONL_KINDS: frozenset[ArtifactKind] = frozenset({ArtifactKind.DATASET, ArtifactKind.ACTION_LOG})
 #: Kinds whose canonical form is a single JCS-canonical JSON object.
 _JSON_OBJECT_KINDS: frozenset[ArtifactKind] = frozenset({ArtifactKind.OPS_RESULT})
+#: Kinds whose canonical form is raw bytes.
+_BYTE_KINDS: frozenset[ArtifactKind] = frozenset({ArtifactKind.BLOB})
 
 #: The three typed criteria that operate on artifact bytes (issue #2608).
 ARTIFACT_CRITERION_TYPES: frozenset[str] = frozenset({"schema_valid", "criteria_match", "hash_stable"})
@@ -197,6 +200,10 @@ def canonicalise_artifact(kind: ArtifactKind | str, raw: Any) -> bytes:
         return b"\n".join(_canonical_json_bytes(row) for row in rows)
     if k in _JSON_OBJECT_KINDS:
         return _canonical_json_bytes(raw)
+    if k in _BYTE_KINDS:
+        if isinstance(raw, bytes):
+            return raw
+        raise CanonicalisationError(f"blob artifact must be bytes, got {type(raw).__name__}")
     if k is ArtifactKind.FINDING:
         return _canonical_finding_bytes(raw)
     raise CanonicalisationError(f"no canonicaliser registered for kind {k!r}")
@@ -281,6 +288,10 @@ def _json_document_for(kind: ArtifactKind, artifact: Any) -> Any:
 def _eval_schema_valid(kind: ArtifactKind, artifact: Any, schema_text: str) -> tuple[bool, str]:
     import jsonschema
 
+    # Blob kind cannot be validated against JSON schema
+    if kind in _BYTE_KINDS:
+        return False, f"criterion type 'schema_valid' is not supported for blob kind"
+    
     try:
         schema = json.loads(schema_text)
     except json.JSONDecodeError as exc:
@@ -306,6 +317,10 @@ def _eval_schema_valid(kind: ArtifactKind, artifact: Any, schema_text: str) -> t
 
 
 def _eval_criteria_match(kind: ArtifactKind, artifact: Any, preds_text: str) -> tuple[bool, str]:
+    # Blob kind cannot be matched against JSON criteria
+    if kind in _BYTE_KINDS:
+        return False, f"criterion type 'criteria_match' is not supported for blob kind"
+    
     try:
         preds = json.loads(preds_text)
     except json.JSONDecodeError as exc:
@@ -611,6 +626,14 @@ def parse_artifact_spec(raw: object) -> ArtifactSpec:
         )
 
     criteria = _parse_declared_criteria(raw.get("criteria"), root=root)
+    # Blob kind only accepts hash_stable criterion; reject text-specific criteria at parse time
+    if kind is ArtifactKind.BLOB:
+        for criterion in criteria:
+            if criterion.type in ("schema_valid", "criteria_match"):
+                raise ArtifactSpecError(
+                    f"{root}.criteria",
+                    f"criterion type '{criterion.type}' is not supported for blob kind",
+                )
     return ArtifactSpec(kind=kind, canonicalisation=canonicalisation, criteria=criteria, output_path=output_path)
 
 

--- a/tests/unit/core/tasks/test_blob_artifact.py
+++ b/tests/unit/core/tasks/test_blob_artifact.py
@@ -1,0 +1,185 @@
+import pytest
+from bernstein.core.tasks.artifacts import (
+    ArtifactKind,
+    ArtifactSpec,
+    canonicalise_artifact,
+    content_hash,
+    parse_artifact_spec,
+)
+from bernstein.core.tasks.artifact_completion import (
+    ArtifactCompletion,
+    is_artifact_mode,
+    load_artifact,
+    complete_artifact_task,
+)
+from bernstein.core.tasks.models import Task
+from pathlib import Path
+import tempfile
+import os
+
+
+def test_blob_artifact_roundtrips_declare_complete_verify():
+    """Test that a blob artifact can be declared, completed, and verified."""
+    # Create a temporary directory for the task
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workdir = Path(tmpdir)
+        # Create a test blob file
+        blob_content = b"hello world blob"
+        artifact_path = workdir / "test_blob.bin"
+        artifact_path.write_bytes(blob_content)
+
+        # Create a task that declares a blob artifact
+        task = Task(
+            id="test-task-1",
+            title="Test Blob Task",
+            description="Test blob artifact completion",
+            role="backend",
+            spec={
+                "artifact_spec": {
+                    "kind": "blob",
+                    "output_path": "test_blob.bin",
+                }
+            },
+        )
+
+        # Verify the task is in artifact mode
+        assert is_artifact_mode(task)
+
+        # Run artifact completion
+        completion = complete_artifact_task(task, workdir)
+
+        # Check that the completion succeeded
+        assert completion.ok
+        assert completion.receipt is not None
+        # The receipt should contain the content hash of the blob
+        expected_hash = content_hash(blob_content)
+        assert completion.receipt["content_hash"] == expected_hash
+
+        # Verify the artifact using the receipt
+        from bernstein.core.lineage.artifact_record import verify_artifact
+        sdd_dir = workdir / ".sdd"
+        verification_result = verify_artifact(completion.receipt, sdd_dir)
+        assert verification_result.verified
+
+
+def test_one_byte_mutation_fails_blob_verification():
+    """Test that a one-byte mutation causes blob verification to fail."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workdir = Path(tmpdir)
+        # Create a test blob file
+        blob_content = b"hello world blob"
+        artifact_path = workdir / "test_blob.bin"
+        artifact_path.write_bytes(blob_content)
+
+        # Create a task that declares a blob artifact
+        task = Task(
+            id="test-task-2",
+            title="Test Blob Task Mutation",
+            description="Test blob artifact completion with mutation",
+            role="backend",
+            spec={
+                "artifact_spec": {
+                    "kind": "blob",
+                    "output_path": "test_blob.bin",
+                }
+            },
+        )
+
+        # Run artifact completion
+        completion = complete_artifact_task(task, workdir)
+        assert completion.ok
+        assert completion.receipt is not None
+
+        # Mutate the blob by flipping one bit
+        mutated_content = bytearray(blob_content)
+        mutated_content[0] ^= 0x01  # Flip the first bit
+        artifact_path.write_bytes(bytes(mutated_content))
+
+        # Verify the artifact should fail
+        from bernstein.core.lineage.artifact_record import verify_artifact
+        sdd_dir = workdir / ".sdd"
+        verification_result = verify_artifact(completion.receipt, sdd_dir)
+        assert not verification_result.verified
+
+
+def test_text_criteria_on_blob_kind_rejected_at_parse_time():
+    """Test that text-specific criteria (schema_valid, criteria_match) are rejected for blob kind at parse time."""
+    # Test schema_valid criterion on blob kind
+    with pytest.raises(Exception) as exc_info:
+        parse_artifact_spec(
+            {
+                "artifact_spec": {
+                    "kind": "blob",
+                    "output_path": "test.bin",
+                    "criteria": [{"type": "schema_valid", "value": '{"type": "object"}'}],
+                }
+            }
+        )
+    assert "schema_valid" in str(exc_info.value)
+    assert "not supported for blob kind" in str(exc_info.value)
+
+    # Test criteria_match criterion on blob kind
+    with pytest.raises(Exception) as exc_info:
+        parse_artifact_spec(
+            {
+                "artifact_spec": {
+                    "kind": "blob",
+                    "output_path": "test.bin",
+                    "criteria": [{"type": "criteria_match", "value": '[{"path": "test", "op": "exists"}]'}],
+                }
+            }
+        )
+    assert "criteria_match" in str(exc_info.value)
+    assert "not supported for blob kind" in str(exc_info.value)
+
+
+def test_blob_bytes_are_content_addressed_in_evidence_store():
+    """Test that blob bytes are stored content-addressed in the evidence store."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workdir = Path(tmpdir)
+        # Create two different blob files with same content
+        blob_content = b"identical content"
+        artifact_path1 = workdir / "test_blob1.bin"
+        artifact_path2 = workdir / "test_blob2.bin"
+        artifact_path1.write_bytes(blob_content)
+        artifact_path2.write_bytes(blob_content)
+
+        # Create two tasks that declare blob artifacts with same content but different paths
+        task1 = Task(
+            id="test-task-3",
+            name="Test Blob Task 1",
+            role="backend",
+            spec={
+                "artifact_spec": {
+                    "kind": "blob",
+                    "output_path": "test_blob1.bin",
+                }
+            },
+        )
+        task2 = Task(
+            id="test-task-4",
+            name="Test Blob Task 2",
+            role="backend",
+            spec={
+                "artifact_spec": {
+                    "kind": "blob",
+                    "output_path": "test_blob2.bin",
+                }
+            },
+        )
+
+        # Run artifact completion for both
+        completion1 = run_artifact_completion(task1, workdir)
+        completion2 = run_artifact_completion(task2, workdir)
+
+        assert completion1.ok
+        assert completion2.ok
+        assert completion1.receipt is not None
+        assert completion2.receipt is not None
+
+        # The content hashes should be the same
+        assert completion1.receipt["content_hash"] == completion2.receipt["content_hash"]
+        # And they should match the hash of the content
+        expected_hash = content_hash(blob_content)
+        assert completion1.receipt["content_hash"] == expected_hash
+        assert completion2.receipt["content_hash"] == expected_hash

--- a/tests/unit/core/tasks/test_blob_artifact.py
+++ b/tests/unit/core/tasks/test_blob_artifact.py
@@ -1,21 +1,23 @@
+import tempfile
+from pathlib import Path
+
 import pytest
+
+from bernstein.core.tasks.artifact_completion import (
+    complete_artifact_task,
+    is_artifact_mode,
+)
 from bernstein.core.tasks.artifacts import (
     ArtifactKind,
     ArtifactSpec,
-    canonicalise_artifact,
     content_hash,
     parse_artifact_spec,
 )
-from bernstein.core.tasks.artifact_completion import (
-    ArtifactCompletion,
-    is_artifact_mode,
-    load_artifact,
-    complete_artifact_task,
-)
 from bernstein.core.tasks.models import Task
-from pathlib import Path
-import tempfile
-import os
+from bernstein.core.lineage.artifact_record import (
+    _BLOB_NAME,
+    _RECEIPT_NAME,
+)
 
 
 def test_blob_artifact_roundtrips_declare_complete_verify():
@@ -34,12 +36,10 @@ def test_blob_artifact_roundtrips_declare_complete_verify():
             title="Test Blob Task",
             description="Test blob artifact completion",
             role="backend",
-            spec={
-                "artifact_spec": {
-                    "kind": "blob",
-                    "output_path": "test_blob.bin",
-                }
-            },
+            artifact_spec=ArtifactSpec(
+                kind=ArtifactKind.BLOB,
+                output_path="test_blob.bin",
+            ),
         )
 
         # Verify the task is in artifact mode
@@ -53,13 +53,20 @@ def test_blob_artifact_roundtrips_declare_complete_verify():
         assert completion.receipt is not None
         # The receipt should contain the content hash of the blob
         expected_hash = content_hash(blob_content)
-        assert completion.receipt["content_hash"] == expected_hash
+        assert completion.receipt.content_hash == expected_hash
 
         # Verify the artifact using the receipt
         from bernstein.core.lineage.artifact_record import verify_artifact
         sdd_dir = workdir / ".sdd"
-        verification_result = verify_artifact(completion.receipt, sdd_dir)
-        assert verification_result.verified
+        sink_root = sdd_dir / "artifacts"
+        verification_result = verify_artifact(
+            task_id=completion.receipt.task_id,
+            sink_root=sink_root,
+            log_path=sdd_dir / "lineage" / "log",
+            cards_dir=sdd_dir / "agents",
+            operator_secret=None,
+        )
+        assert verification_result.ok
 
 
 def test_one_byte_mutation_fails_blob_verification():
@@ -77,12 +84,10 @@ def test_one_byte_mutation_fails_blob_verification():
             title="Test Blob Task Mutation",
             description="Test blob artifact completion with mutation",
             role="backend",
-            spec={
-                "artifact_spec": {
-                    "kind": "blob",
-                    "output_path": "test_blob.bin",
-                }
-            },
+            artifact_spec=ArtifactSpec(
+                kind=ArtifactKind.BLOB,
+                output_path="test_blob.bin",
+            ),
         )
 
         # Run artifact completion
@@ -98,8 +103,14 @@ def test_one_byte_mutation_fails_blob_verification():
         # Verify the artifact should fail
         from bernstein.core.lineage.artifact_record import verify_artifact
         sdd_dir = workdir / ".sdd"
-        verification_result = verify_artifact(completion.receipt, sdd_dir)
-        assert not verification_result.verified
+        verification_result = verify_artifact(
+            task_id=completion.receipt.task_id,
+            sink_root=workdir,
+            log_path=sdd_dir / "entry.log",
+            cards_dir=sdd_dir / "agents",
+            operator_secret=None,
+        )
+        assert not verification_result.ok
 
 
 def test_text_criteria_on_blob_kind_rejected_at_parse_time():
@@ -108,11 +119,9 @@ def test_text_criteria_on_blob_kind_rejected_at_parse_time():
     with pytest.raises(Exception) as exc_info:
         parse_artifact_spec(
             {
-                "artifact_spec": {
-                    "kind": "blob",
-                    "output_path": "test.bin",
-                    "criteria": [{"type": "schema_valid", "value": '{"type": "object"}'}],
-                }
+                "kind": "blob",
+                "output_path": "test.bin",
+                "criteria": [{"type": "schema_valid", "value": '{"type": "object"}'}],
             }
         )
     assert "schema_valid" in str(exc_info.value)
@@ -122,11 +131,9 @@ def test_text_criteria_on_blob_kind_rejected_at_parse_time():
     with pytest.raises(Exception) as exc_info:
         parse_artifact_spec(
             {
-                "artifact_spec": {
-                    "kind": "blob",
-                    "output_path": "test.bin",
-                    "criteria": [{"type": "criteria_match", "value": '[{"path": "test", "op": "exists"}]'}],
-                }
+                "kind": "blob",
+                "output_path": "test.bin",
+                "criteria": [{"type": "criteria_match", "value": '[{"path": "test", "op": "exists"}]'}],
             }
         )
     assert "criteria_match" in str(exc_info.value)
@@ -147,30 +154,28 @@ def test_blob_bytes_are_content_addressed_in_evidence_store():
         # Create two tasks that declare blob artifacts with same content but different paths
         task1 = Task(
             id="test-task-3",
-            name="Test Blob Task 1",
+            title="Test Blob Task 1",
+            description="Test blob artifact completion",
             role="backend",
-            spec={
-                "artifact_spec": {
-                    "kind": "blob",
-                    "output_path": "test_blob1.bin",
-                }
-            },
+            artifact_spec=ArtifactSpec(
+                kind=ArtifactKind.BLOB,
+                output_path="test_blob1.bin",
+            ),
         )
         task2 = Task(
             id="test-task-4",
-            name="Test Blob Task 2",
+            title="Test Blob Task 2",
+            description="Test blob artifact completion",
             role="backend",
-            spec={
-                "artifact_spec": {
-                    "kind": "blob",
-                    "output_path": "test_blob2.bin",
-                }
-            },
+            artifact_spec=ArtifactSpec(
+                kind=ArtifactKind.BLOB,
+                output_path="test_blob2.bin",
+            ),
         )
 
         # Run artifact completion for both
-        completion1 = run_artifact_completion(task1, workdir)
-        completion2 = run_artifact_completion(task2, workdir)
+        completion1 = complete_artifact_task(task1, workdir)
+        completion2 = complete_artifact_task(task2, workdir)
 
         assert completion1.ok
         assert completion2.ok
@@ -178,8 +183,8 @@ def test_blob_bytes_are_content_addressed_in_evidence_store():
         assert completion2.receipt is not None
 
         # The content hashes should be the same
-        assert completion1.receipt["content_hash"] == completion2.receipt["content_hash"]
+        assert completion1.receipt.content_hash == completion2.receipt.content_hash
         # And they should match the hash of the content
         expected_hash = content_hash(blob_content)
-        assert completion1.receipt["content_hash"] == expected_hash
-        assert completion2.receipt["content_hash"] == expected_hash
+        assert completion1.receipt.content_hash == expected_hash
+        assert completion2.receipt.content_hash == expected_hash

--- a/tests/unit/core/tasks/test_blob_artifact.py
+++ b/tests/unit/core/tasks/test_blob_artifact.py
@@ -14,10 +14,6 @@ from bernstein.core.tasks.artifacts import (
     parse_artifact_spec,
 )
 from bernstein.core.tasks.models import Task
-from bernstein.core.lineage.artifact_record import (
-    _BLOB_NAME,
-    _RECEIPT_NAME,
-)
 
 
 def test_blob_artifact_roundtrips_declare_complete_verify():

--- a/tests/unit/tasks/test_artifact_contract.py
+++ b/tests/unit/tasks/test_artifact_contract.py
@@ -44,6 +44,7 @@ def test_artifact_kind_membership() -> None:
         "action_log",
         "ops_result",
         "finding",
+        "blob",
     }
 
 


### PR DESCRIPTION
Salvages a run for #4544 and finishes its last mile.

## What the run built

- `ArtifactKind.BLOB`: canonical form is the raw bytes, digest is their content hash.
- Parse-time rejection of text-shaped criteria (`schema_valid`, `criteria_match`) for the blob kind, naming the criterion.
- The kind joins the lineage entry's closed artefact set.

## What was missing, found by the publish gate

The contract test pinning the closed kind set did not know the new member — the branch was refused three times on exactly that. Fixing it surfaced a second, older defect: the plan-schema kind list and the task CLI's `--artifact-kind` choices are hand-copied from `ArtifactKind`, and the copies had already drifted — `finding` (#3659) never reached the plan schema, so a plan declaring one was rejected by the schema and accepted by the parser it claims to mirror.

Both lists are now derived from the enum, so a new kind reaches every declaration surface at once. The CLI keeps its deliberate `code_diff` exclusion.

## Verification

- `tests/unit/core/tasks/test_blob_artifact.py` — declare → canonicalise → hash on real bytes.
- The full reverse-import closure of the changed modules: 1090 passed.
- `ruff check` / `ruff format --check` clean.

Part of #4544: declaration surfaces and criteria gating. The content-addressed storage half (EvidenceStore-backed completion, verify-on-tamper cycle) remains open — this slice does not claim it.