### PR TITLE
fix(sla): attest an unresolved breach once, not once per tick

### DIFF
--- a/docs/release-notes/fragments/4579-sla-breach-attested-once.md
+++ b/docs/release-notes/fragments/4579-sla-breach-attested-once.md
@@ -1,0 +1,5 @@
+An unresolved SLA breach is now attested once, not once per supervisor tick: the
+monitor tracks the breach shape (contract hash plus breached axes) and emits a
+new signed receipt, chain event and trigger only when the shape changes or the
+breach resolves and recurs. A supervisor ticking at seconds no longer turns one
+open breach into thousands of identical attestations.

--- a/src/bernstein/core/orchestration/sla_monitor.py
+++ b/src/bernstein/core/orchestration/sla_monitor.py
@@ -29,7 +29,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
-from bernstein.core.observability.sla_eval import project_error_budget
+from bernstein.core.observability.sla_eval import any_breach, evaluate_all, project_error_budget
 from bernstein.core.orchestration.sla_receipt import (
     SLAViolationReceipt,
     build_receipt,
@@ -373,6 +373,13 @@ class SLAMonitor:
         self._trigger_sink = trigger_sink
         self._audit_window = audit_window
         self._evidence_provider = evidence_provider or default_evidence_provider(store.sdd_dir)
+        # Ongoing breaches, contract id -> breach shape. A contract stays here
+        # for as long as consecutive ticks judge the same axes breached, and
+        # leaves the moment a tick finds it clean - so a breach that resolves
+        # and recurs is attested again. Held in memory: the monitor lives for
+        # the supervisor process, and a restart re-attesting a still-open
+        # breach once is correct, not a duplicate.
+        self._active_breaches: dict[str, str] = {}
 
     def evaluate(self, now: int) -> list[SLAViolationReceipt]:
         """Evaluate every registered contract at ``now``; return emitted receipts.
@@ -402,6 +409,28 @@ class SLAMonitor:
         # head, so it stays outside the section that holds the chain.
         evidence = self._evidence_provider(contract, now)
 
+        # Deduplication runs before the chain section, on the same pure
+        # evaluation ``build_receipt`` performs. Without it, every tick of an
+        # unresolved breach signed a fresh receipt, appended a chain event and
+        # fired a trigger - a supervisor ticking at seconds turned one breach
+        # into thousands of attestations of the same fact (#4579 review, left
+        # unresolved at merge). The breach *shape* is the key: a new axis
+        # joining the breach is a new fact and is attested; the same axes still
+        # breached is the old fact and is not.
+        verdicts = evaluate_all(contract, evidence, now)
+        if not any_breach(verdicts):
+            self._active_breaches.pop(contract.id, None)
+            return None
+        shape = json.dumps(
+            {
+                "contract_hash": contract.contract_hash,
+                "breached_axes": sorted(str(v.axis) for v in verdicts if v.breached),
+            },
+            sort_keys=True,
+        )
+        if self._active_breaches.get(contract.id) == shape:
+            return None
+
         # The head is read per receipt, and inside the same section that appends
         # that receipt's chain event. A tick appends once per breach, so a head
         # captured once for the whole tick is already stale for the second
@@ -427,6 +456,7 @@ class SLAMonitor:
             if receipt is None:
                 return None
             signed = sign_receipt(receipt, signing_key=self._signing_key)
+            self._active_breaches[contract.id] = shape
             # ``write_receipt`` does not need the chain held, but it stays inside
             # and ahead of the append on purpose: the receipt file is the only
             # copy of the signed payload, while the chain event carries just its

--- a/tests/integration/test_sla_monitor_dedup.py
+++ b/tests/integration/test_sla_monitor_dedup.py
@@ -1,0 +1,127 @@
+"""An ongoing SLA breach is attested once, not once per tick (#4579 follow-up).
+
+The supervisor holds one ``SLAMonitor`` and calls ``evaluate`` on every tick.
+Before deduplication, a breach that stayed unresolved produced a fresh signed
+receipt, one ``sla.violation`` chain event and one trigger event on *every*
+tick - a supervisor ticking at seconds turned one fact into thousands of
+attestations. These tests drive the monitor exactly as the supervisor does,
+over a real ``.sdd`` tree, and pin the contract:
+
+* the first tick that finds a breach attests it (receipt + chain + trigger);
+* the next tick over unchanged state attests nothing new;
+* a breach that resolves and recurs is a new fact and is attested again.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bernstein.adapters.base import record_artifact_write
+from bernstein.core.orchestration.sla_monitor import SLAMonitor, build_monitor_from_sdd
+from bernstein.core.persistence.work_ledger import (
+    run_ledger_dir,  # noqa: F401 - fixture parity with test_sla_audit_chain
+)
+from bernstein.core.planning.sla_store import SLAStore, build_contract
+from bernstein.core.security.audit import load_or_create_audit_key
+from bernstein.core.security.audit_chain import AuditChainStore
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.tasks.models import TriggerEvent
+
+_NOW = 1_700_000_000
+_ARTIFACT = ".sdd/runs/nightly/report.md"
+
+
+def _seed_artifact(sdd: Path, *, rederived_at: int) -> None:
+    record_artifact_write(
+        artifact_path=_ARTIFACT,
+        content=b"report body",
+        actor="nightly",
+        step_id="s1",
+        model="",
+        lineage_root=sdd / "lineage",
+        run_id="nightly",
+        hmac_key=load_or_create_audit_key(),
+        timestamp=rederived_at,
+    )
+
+
+def _monitor(sdd: Path, fired: list[TriggerEvent]) -> tuple[SLAMonitor, AuditChainStore]:
+    chain = AuditChainStore(sdd / "audit", key=load_or_create_audit_key())
+    return build_monitor_from_sdd(sdd, chain=chain, trigger_sink=fired.append), chain
+
+
+def _breached_setup(tmp_path: Path) -> Path:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    SLAStore(sdd).add(
+        build_contract(
+            subject_type="schedule",
+            subject_id="sched_nightly",
+            artifact_freshness_s=90_000,
+            artifact_path=_ARTIFACT,
+        )
+    )
+    _seed_artifact(sdd, rederived_at=_NOW - 200_000)  # stale: breached at _NOW
+    return sdd
+
+
+def test_breached_contract_produces_signed_receipt_within_one_tick(tmp_path: Path) -> None:
+    sdd = _breached_setup(tmp_path)
+    fired: list[TriggerEvent] = []
+    monitor, chain = _monitor(sdd, fired)
+
+    receipts = monitor.evaluate(_NOW)
+
+    assert len(receipts) == 1
+    assert receipts[0].is_signed
+    assert len(fired) == 1
+    assert len(chain.query(event_type="sla.violation")) == 1
+
+
+def test_ongoing_breach_does_not_reemit_every_tick(tmp_path: Path) -> None:
+    sdd = _breached_setup(tmp_path)
+    fired: list[TriggerEvent] = []
+    monitor, chain = _monitor(sdd, fired)
+
+    assert len(monitor.evaluate(_NOW)) == 1
+    # Three more ticks over unchanged state: same contract, same breached axes.
+    for tick in range(1, 4):
+        assert monitor.evaluate(_NOW + tick * 60) == []
+
+    assert len(fired) == 1, "an unresolved breach is one fact, not one per tick"
+    assert len(chain.query(event_type="sla.violation")) == 1
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_resolved_then_recurring_breach_is_attested_again(tmp_path: Path) -> None:
+    sdd = _breached_setup(tmp_path)
+    fired: list[TriggerEvent] = []
+    monitor, chain = _monitor(sdd, fired)
+
+    assert len(monitor.evaluate(_NOW)) == 1
+
+    # The artifact is re-derived: the breach resolves.
+    _seed_artifact(sdd, rederived_at=_NOW + 100)
+    assert monitor.evaluate(_NOW + 200) == []
+
+    # Enough time passes that the fresh derivation is stale again: a new fact.
+    later = _NOW + 100 + 200_000
+    receipts = monitor.evaluate(later)
+    assert len(receipts) == 1, "a breach that resolved and recurred must be attested again"
+    assert len(fired) == 2
+    assert len(chain.query(event_type="sla.violation")) == 2
+
+
+def test_tick_without_contracts_attests_nothing(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    fired: list[TriggerEvent] = []
+    monitor, chain = _monitor(sdd, fired)
+
+    assert monitor.evaluate(_NOW) == []
+    assert fired == []
+    assert chain.query(event_type="sla.violation") == []


### PR DESCRIPTION
`SLAMonitor.evaluate` produced a signed receipt, an `sla.violation` chain event and a trigger event on every tick for as long as a breach stayed unresolved. The schedule supervisor ticks continuously, so one open breach became an unbounded stream of identical attestations.

The monitor now tracks the breach shape per contract — contract hash plus the sorted breached axes — and emits only when the shape changes. A breach that resolves clears its entry, so a recurrence is attested again. The dedup runs on the same pure verdict computation `build_receipt` performs, outside the chain section.

State is in-memory by design: the monitor lives for the supervisor process, and a restart re-attesting a still-open breach once is a correct re-statement.

## Verification

`tests/integration/test_sla_monitor_dedup.py` drives the monitor exactly as the supervisor does over a real `.sdd` tree: signed receipt within one tick, no re-emit across three ticks of unchanged state, re-attestation after resolve-and-recur, and a contract-free tick attesting nothing. The no-re-emit test fails against the previous behaviour. The existing chain-integrity suite (`test_sla_audit_chain.py`) stays green.