### PR TITLE
fix(approval): surface an approval PR that could not be created

### DIFF
--- a/docs/release-notes/fragments/4582-approval-pr-failure-surfaced.md
+++ b/docs/release-notes/fragments/4582-approval-pr-failure-surfaced.md
@@ -1,0 +1,4 @@
+A task held for PR-mode approval whose approval PR could not be created now
+emits a `task.approval_pr_failed` notification naming the task and the reason.
+Previously the failure was a log line, so the task waited indefinitely and was
+indistinguishable from one waiting on a reviewer.

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -3520,10 +3520,19 @@ def _create_approval_pr(
     session: AgentSession,
     completion_data: CompletionData | None,
 ) -> None:
-    """Create a PR for approval-gate PR mode."""
+    """Create a PR for approval-gate PR mode.
+
+    The caller has already decided to hold the merge; this PR is the surface
+    the operator approves on. If it cannot be created, the hold stands but the
+    approval can never arrive through the intended channel - so the failure is
+    surfaced as a notification naming the task, never just a log line. A task
+    silently waiting on a PR that does not exist looks exactly like a task
+    waiting on a reviewer.
+    """
     worktree_path = orch._spawner.get_worktree_path(session.id)
     if worktree_path is None:
-        logger.warning("Approval gate PR mode: no worktree for agent %s -- cannot create PR", session.id)
+        logger.error("Approval gate PR mode: no worktree for agent %s -- cannot create PR", session.id)
+        _notify_approval_pr_failed(orch, task, reason=f"no worktree for agent {session.id}")
         return
 
     task_m = get_collector(orch._workdir / ".sdd" / "metrics").task_metrics.get(task.id)
@@ -3543,6 +3552,21 @@ def _create_approval_pr(
     )
     if pr_url:
         logger.info("Approval gate: PR created for task %s: %s", task.id, pr_url)
+    else:
+        logger.error("Approval gate PR mode: create_pr returned nothing for task %s", task.id)
+        _notify_approval_pr_failed(orch, task, reason="create_pr returned no URL")
+
+
+def _notify_approval_pr_failed(orch: Any, task: Task, *, reason: str) -> None:
+    orch._notify(
+        event="task.approval_pr_failed",
+        title=f"Approval PR could not be created: {task.title}",
+        body=(
+            f"Task {task.id} is held for PR approval, but the PR was not created ({reason}). "
+            "The task will wait indefinitely unless approved another way or re-run."
+        ),
+        task_id=task.id,
+    )
 
 
 def _reap_and_cleanup_session(

--- a/tests/unit/orchestration/test_approval_gate_missing_worktree.py
+++ b/tests/unit/orchestration/test_approval_gate_missing_worktree.py
@@ -1,25 +1,76 @@
-from types import SimpleNamespace
+"""An approval PR that cannot be created is surfaced, never swallowed.
 
-import pytest
+``_create_approval_pr`` runs after the gate has already decided to hold the
+merge: the PR it creates is the surface the operator approves on. When the
+worktree is gone or ``create_pr`` returns nothing, the hold stands but the
+approval can never arrive through the intended channel - the task waits
+indefinitely, indistinguishable from one waiting on a reviewer. The previous
+behaviour logged a warning and returned; these tests pin the replacement:
+every failure path emits a ``task.approval_pr_failed`` notification naming the
+task, and the success path emits nothing.
+"""
+
+from types import SimpleNamespace
 
 from bernstein.core.tasks.task_lifecycle import _create_approval_pr
 
 
-def test_create_approval_pr_no_worktree(monkeypatch):
-    # Mock orchestrator with spawner that returns None for worktree_path
-    dummy_orch = SimpleNamespace()
-    dummy_orch._spawner = SimpleNamespace()
-    dummy_orch._spawner.get_worktree_path = lambda session_id: None
-    # Mock approval_gate.create_pr to raise if called
-    dummy_orch._approval_gate = SimpleNamespace()
-    dummy_orch._approval_gate.create_pr = lambda *args, **kwargs: pytest.fail(
-        "create_pr should not be called when worktree missing"
+def _orch(worktree, create_pr):
+    notifications = []
+    orch = SimpleNamespace()
+    orch._spawner = SimpleNamespace(get_worktree_path=lambda session_id: worktree)
+    orch._approval_gate = SimpleNamespace(create_pr=create_pr)
+    orch._config = SimpleNamespace(pr_labels=[])
+    orch._notify = lambda **kw: notifications.append(kw)
+    return orch, notifications
+
+
+def _task():
+    return SimpleNamespace(id="T-123", owned_files=[], title="dummy", description="dummy")
+
+
+def _session():
+    return SimpleNamespace(id="S-456", role="backend", model_config=SimpleNamespace(model="sonnet"))
+
+
+def test_missing_worktree_notifies_instead_of_swallowing(tmp_path):
+    def _must_not_be_called(*args, **kwargs):
+        raise AssertionError("create_pr must not be called when the worktree is missing")
+
+    orch, notifications = _orch(worktree=None, create_pr=_must_not_be_called)
+
+    _create_approval_pr(orch, _task(), _session(), completion_data=None)
+
+    assert len(notifications) == 1
+    note = notifications[0]
+    assert note["event"] == "task.approval_pr_failed"
+    assert note["task_id"] == "T-123"
+    assert "no worktree" in note["body"]
+
+
+def test_create_pr_returning_nothing_notifies(tmp_path, monkeypatch):
+    orch, notifications = _orch(worktree=tmp_path, create_pr=lambda *a, **kw: "")
+    monkeypatch.setattr(
+        "bernstein.core.tasks.task_lifecycle.get_collector",
+        lambda _p: SimpleNamespace(task_metrics=SimpleNamespace(get=lambda _id: None)),
     )
-    # Mock config for pr_labels
-    dummy_orch._config = SimpleNamespace(pr_labels=[])
-    # Minimal task and session objects
-    task = SimpleNamespace(id="T-123", owned_files=[], title="dummy", description="dummy")
-    session = SimpleNamespace(id="S-456", role="backend", model_config=SimpleNamespace(model="sonnet"))
-    # Call function and verify it returns None without error
-    result = _create_approval_pr(dummy_orch, task, session, completion_data=None)
-    assert result is None
+    orch._workdir = tmp_path
+
+    _create_approval_pr(orch, _task(), _session(), completion_data=None)
+
+    assert len(notifications) == 1
+    assert notifications[0]["event"] == "task.approval_pr_failed"
+    assert "no URL" in notifications[0]["body"]
+
+
+def test_created_pr_notifies_nothing(tmp_path, monkeypatch):
+    orch, notifications = _orch(worktree=tmp_path, create_pr=lambda *a, **kw: "https://example.test/pr/1")
+    monkeypatch.setattr(
+        "bernstein.core.tasks.task_lifecycle.get_collector",
+        lambda _p: SimpleNamespace(task_metrics=SimpleNamespace(get=lambda _id: None)),
+    )
+    orch._workdir = tmp_path
+
+    _create_approval_pr(orch, _task(), _session(), completion_data=None)
+
+    assert notifications == []


### PR DESCRIPTION
`_create_approval_pr` runs after the approval gate has already decided to hold the merge, so the PR it opens is the only surface the operator approves on.

Two paths failed quietly:

- a missing worktree logged a warning and returned;
- a `create_pr` call returning no URL was not checked at all.

In both cases the hold stands while the approval can never arrive through the intended channel. The task waits indefinitely and looks exactly like a task waiting on a reviewer.

Both paths now log at error level and emit a `task.approval_pr_failed` notification naming the task and the reason.

## The test

The existing test asserted the defect, not the fix: it pinned that `create_pr` is not called and that the function returns `None` — both satisfied by the swallowing behaviour it was meant to catch. It now covers all three outcomes (missing worktree notifies, empty URL notifies, created PR notifies nothing), and its first two cases fail against the previous implementation.