### PR TITLE
docs(release-notes): backfill fragments for two user-visible changes

### DIFF
--- a/docs/release-notes/fragments/4473-deterministic-plan-rendering.md
+++ b/docs/release-notes/fragments/4473-deterministic-plan-rendering.md
@@ -1,0 +1,1 @@
+Plans render deterministically and carry a SHA-256 hash of the rendered form, so two operators rendering the same plan get byte-identical output and a hash they can compare (#3839).

--- a/docs/release-notes/fragments/4581-artifact-verify-audit-key.md
+++ b/docs/release-notes/fragments/4581-artifact-verify-audit-key.md
@@ -1,0 +1,1 @@
+`bernstein artifact verify` no longer mints a fresh audit key on a host that has none. It previously did, which recomputed every HMAC against the wrong key and reported clean receipts as TAMPERED; verification now fails with a message naming the missing key instead.


### PR DESCRIPTION
Two changes merged without a release-notes fragment, so neither is discoverable from the release notes:

- **#4473** — plan rendering is deterministic and carries a SHA-256 of the rendered form.
- **#4581** — `bernstein artifact verify` no longer mints a fresh audit key on a host without one; it previously recomputed every HMAC against the wrong key and reported clean receipts as `TAMPERED`.

The review flagged the missing fragment on both at the time.