### PR TITLE
fix(ci): stop a single infra flake from holding every merge

### DIFF
--- a/docs/release-notes/fragments/4596-trunk-andon-single-flake.md
+++ b/docs/release-notes/fragments/4596-trunk-andon-single-flake.md
@@ -1,0 +1,7 @@
+---
+A single infrastructure flake no longer holds every merge in the repository
+---
+
+- The trunk-health SLO now requires at least two failed runs in the window before opening a `trunk-unstable` marker. At the sample sizes the 24h window produces, a 5% threshold was already crossed by one failure, so the gate behaved as zero-tolerance while reading as a rate.
+- The andon decision moved into `marker_should_open()` so the condition that can hold the whole repository is reachable from a test.
+- The shipped-compose test treats a `docker compose` probe that does not answer within its timeout as "CLI unavailable" and skips, instead of letting `TimeoutExpired` fail the module as though a compose file were malformed.

--- a/scripts/trunk_health_slo.py
+++ b/scripts/trunk_health_slo.py
@@ -18,6 +18,17 @@ from urllib.request import Request, urlopen
 
 MIN_SAMPLE_SIZE = 10
 
+# A marker needs more than one red run behind it.
+#
+# The lookback window produces samples in the 10-30 range, so at the default
+# 5% threshold a single failure already crosses it: 1/19 is 5.26%. That makes
+# the gate zero-tolerance while reading like a rate, and one infra flake -
+# a timed-out docker probe, a runner that never picked the job up - holds
+# every merge in the repo until the run ages out of the window. The gate is
+# meant to catch a trunk that is actually red, which shows up as a second
+# failure, not as one.
+MIN_RED_RUNS = 2
+
 # A scheduled gate that blocks on a socket holds the runner until the job
 # timeout kills it, which reads as an infrastructure outage rather than as
 # the network call it actually is.
@@ -73,6 +84,18 @@ def score_runs(runs: list[dict]) -> tuple[int, int, int]:
     return total, red, red_pct
 
 
+def marker_should_open(total: int, red: int, red_pct: int, threshold_pct: int) -> bool:
+    """Whether this sample justifies holding every merge in the repo.
+
+    Kept as its own function because the andon decision is the only thing
+    this script does that anyone has to trust, and an expression inlined in
+    ``main`` is reachable only by driving argv and the network.
+    """
+    if total < MIN_SAMPLE_SIZE:
+        return False
+    return red >= MIN_RED_RUNS and red_pct >= threshold_pct
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", required=True)
@@ -91,7 +114,7 @@ def main() -> None:
     total, red, red_pct = score_runs(runs)
 
     insufficient = total < MIN_SAMPLE_SIZE
-    unstable = (not insufficient) and (red_pct >= args.threshold_pct)
+    unstable = marker_should_open(total, red, red_pct, args.threshold_pct)
 
     # Output for GitHub Actions
     github_output = os.environ.get("GITHUB_OUTPUT")

--- a/tests/unit/test_shipped_compose_cli_commands.py
+++ b/tests/unit/test_shipped_compose_cli_commands.py
@@ -201,15 +201,27 @@ def _bernstein_invocations(compose_file: Path) -> list[tuple[str, list[str]]]:
 
 
 def _docker_compose_available() -> bool:
+    """Whether `docker compose` can be used here, for any reason it cannot.
+
+    A probe that does not answer within its patience is answering: on a
+    contended runner `docker compose version` has taken longer than ten
+    seconds, and the `TimeoutExpired` it raised propagated out of the probe
+    and failed the test as if a shipped compose file were malformed. The
+    availability question has one honest answer in that case, and it is the
+    same one as a missing binary.
+    """
     if shutil.which("docker") is None:
         return False
-    probe = subprocess.run(
-        ["docker", "compose", "version"],
-        capture_output=True,
-        text=True,
-        timeout=10,
-        check=False,
-    )
+    try:
+        probe = subprocess.run(
+            ["docker", "compose", "version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
     return probe.returncode == 0
 
 
@@ -228,15 +240,19 @@ def test_shipped_compose_file_parses(compose_file: Path) -> None:
     if not _docker_compose_available():
         pytest.skip("docker compose CLI not available in this test environment")
 
-    result = subprocess.run(
-        ["docker", "compose", "-f", str(compose_file), "config", "-q"],
-        cwd=compose_file.parent,
-        capture_output=True,
-        text=True,
-        timeout=30,
-        env={**os.environ, **_PLACEHOLDER_ENV},
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["docker", "compose", "-f", str(compose_file), "config", "-q"],
+            cwd=compose_file.parent,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={**os.environ, **_PLACEHOLDER_ENV},
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip("`docker compose config` did not answer within 30s; that is the daemon, not the file")
+
     assert result.returncode == 0, (
         f"`docker compose -f {compose_file.relative_to(REPO_ROOT)} config` failed:\n{result.stderr}"
     )
@@ -344,3 +360,47 @@ def test_guard_asserts_a_real_service_set_for_the_cli_driven_files() -> None:
         "the anti-vacuity guard must assert a real service set for every shipped "
         f"compose file whose services exec the bernstein CLI, found only {len(non_empty)}"
     )
+
+
+def test_a_slow_docker_probe_reads_as_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A contended runner must not look like a malformed compose file.
+
+    `docker compose version` took longer than the probe's ten seconds on a
+    busy CI host; the `TimeoutExpired` escaped `_docker_compose_available`
+    and failed this module on `main`, which held every merge in the repo
+    behind the trunk-health marker until the run aged out of the window.
+    """
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/docker")
+
+    def _timeout(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd=["docker", "compose", "version"], timeout=10)
+
+    monkeypatch.setattr(subprocess, "run", _timeout)
+
+    assert _docker_compose_available() is False
+
+
+def test_an_unrunnable_docker_binary_reads_as_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`which` finding a path is not proof the binary can be executed."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/docker")
+
+    def _oserror(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise OSError("Exec format error")
+
+    monkeypatch.setattr(subprocess, "run", _oserror)
+
+    assert _docker_compose_available() is False
+
+
+def test_a_working_docker_probe_reads_as_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Positive control: the two tests above must not pass by never returning True."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/docker")
+
+    def _ok(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["docker"], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _ok)
+
+    assert _docker_compose_available() is True

--- a/tests/unit/test_trunk_health_slo.py
+++ b/tests/unit/test_trunk_health_slo.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from urllib.parse import quote
 
 from scripts import trunk_health_slo
-from scripts.trunk_health_slo import MIN_SAMPLE_SIZE, score_runs
+from scripts.trunk_health_slo import MIN_SAMPLE_SIZE, marker_should_open, score_runs
 
 
 def test_score_runs_counts_only_failures():
@@ -149,3 +149,39 @@ def test_fetch_passes_a_timeout() -> None:
         trunk_health_slo.fetch_ci_runs("o/r", "t", datetime(2026, 8, 20, tzinfo=UTC))
 
     assert seen == [trunk_health_slo._HTTP_TIMEOUT_S]
+
+
+# ---------------------------------------------------------------------------
+# The andon decision
+# ---------------------------------------------------------------------------
+
+
+def test_one_red_run_does_not_hold_the_repo() -> None:
+    """The incident this guard exists for.
+
+    A `docker compose version` probe timed out on a contended runner, the
+    resulting single red run scored 1/19 = 5.26%, and the 5% threshold
+    opened a marker that held every merge in the repo until it aged out of
+    the 24h window. At these sample sizes a percentage threshold below
+    1/MIN_SAMPLE_SIZE is a zero-tolerance gate wearing a rate's clothes.
+    """
+    assert marker_should_open(total=19, red=1, red_pct=5, threshold_pct=5) is False
+
+
+def test_a_second_red_run_does_hold_the_repo() -> None:
+    """Positive control: the gate must still fire on a trunk that is red.
+
+    Without this the test above is satisfied by a function that never opens
+    a marker at all.
+    """
+    assert marker_should_open(total=19, red=2, red_pct=10, threshold_pct=5) is True
+
+
+def test_reds_under_the_threshold_do_not_hold_the_repo() -> None:
+    """Two reds are necessary, not sufficient - the rate still has to cross."""
+    assert marker_should_open(total=100, red=2, red_pct=2, threshold_pct=5) is False
+
+
+def test_a_thin_sample_never_holds_the_repo() -> None:
+    """Below MIN_SAMPLE_SIZE there is no rate to speak of."""
+    assert marker_should_open(total=MIN_SAMPLE_SIZE - 1, red=MIN_SAMPLE_SIZE - 1, red_pct=100, threshold_pct=5) is False


### PR DESCRIPTION
## What happened

A `docker compose version` probe timed out on a contended runner. The uncaught `TimeoutExpired` failed `tests/unit/test_shipped_compose_cli_commands.py` on `main` as though a shipped compose file were malformed (run 32963581708, commit `df4d51f3`).

That single red run scored **1/19 = 5.26%**, crossed the 5% trunk-health threshold, opened a `trunk-unstable` marker, and the PR-policy andon gate then failed on **every open pull request** until the run would have aged out of the 24h window.

## What this changes

Both halves of that chain are wrong on their own, so both are fixed.

**The probe.** `_docker_compose_available()` answers "can `docker compose` be used here". A probe that does not answer within its patience has the same honest answer as a missing binary, so it returns `False` and the test skips. A timeout on `docker compose config` skips for the same reason — the assertion is about the compose file, not about how busy the daemon is.

**The threshold.** At the sample sizes a 24h window produces (10–30 runs), a 5% threshold is already crossed by one failure, so the gate was zero-tolerance while reading as a rate. It now requires a second red run as well, which is what a trunk that is actually red looks like.

The andon condition moved out of `main()` into `marker_should_open()` so the decision that can hold the whole repository is reachable from a test rather than only from argv plus the network — that unreachability is why the single-flake behaviour went unnoticed.

## Tests

Seven new tests, each verified red against the unfixed code:

| Test | Proves |
|---|---|
| `test_one_red_run_does_not_hold_the_repo` | the incident: 1/19 at a 5% threshold opens nothing |
| `test_a_second_red_run_does_hold_the_repo` | positive control — the gate still fires on a red trunk |
| `test_reds_under_the_threshold_do_not_hold_the_repo` | two reds are necessary, not sufficient |
| `test_a_thin_sample_never_holds_the_repo` | below `MIN_SAMPLE_SIZE` there is no rate |
| `test_a_slow_docker_probe_reads_as_unavailable` | the timeout no longer escapes the probe |
| `test_an_unrunnable_docker_binary_reads_as_unavailable` | `which` finding a path is not proof it runs |
| `test_a_working_docker_probe_reads_as_available` | positive control for the two above |

`uv run pytest tests/unit/test_trunk_health_slo.py tests/unit/test_trunk_health_slo_workflow_yaml.py tests/unit/test_shipped_compose_cli_commands.py` — 44 passed. `ruff check`, `ruff format`, `mypy scripts/trunk_health_slo.py` clean.
