### PR TITLE
chore(ci): ratchet coverage baseline up to 84.2%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
   "diff_coverage_floor_percent": 88,
-  "head_sha": "a6b0c3382eed7141b697bdeacaedd711aea0b17a",
-  "line_rate": 0.8414,
-  "run_id": "32774754848",
-  "total_coverage_percent": 84.14,
-  "updated_at": "2026-08-24T21:25:34+00:00"
+  "head_sha": "1320b8da47a20a35456e02d9790cbb53a7427514",
+  "line_rate": 0.842,
+  "run_id": "32970317478",
+  "total_coverage_percent": 84.2,
+  "updated_at": "2026-08-26T14:55:03+00:00"
 }

--- a/tests/unit/core/tasks/test_blob_artifact.py
+++ b/tests/unit/core/tasks/test_blob_artifact.py
@@ -53,6 +53,7 @@ def test_blob_artifact_roundtrips_declare_complete_verify():
 
         # Verify the artifact using the receipt
         from bernstein.core.lineage.artifact_record import verify_artifact
+
         sdd_dir = workdir / ".sdd"
         sink_root = sdd_dir / "artifacts"
         verification_result = verify_artifact(
@@ -98,6 +99,7 @@ def test_one_byte_mutation_fails_blob_verification():
 
         # Verify the artifact should fail
         from bernstein.core.lineage.artifact_record import verify_artifact
+
         sdd_dir = workdir / ".sdd"
         verification_result = verify_artifact(
             task_id=completion.receipt.task_id,


### PR DESCRIPTION
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **84.2%**.

Measured on `1320b8da47a20a35456e02d9790cbb53a7427514` from the
`coverage-report` artifact of CI run
[32970317478](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/32970317478).
Those, and the raw Cobertura `line-rate` the percentage was
rounded from, are recorded in the baseline, so the number in the
diff can be re-derived from the file itself:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.