### PR TITLE
chore(ci): ratchet coverage baseline up to 84.22%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
   "diff_coverage_floor_percent": 88,
-  "head_sha": "1320b8da47a20a35456e02d9790cbb53a7427514",
-  "line_rate": 0.842,
-  "run_id": "32970317478",
-  "total_coverage_percent": 84.2,
-  "updated_at": "2026-08-26T14:55:03+00:00"
+  "head_sha": "f3a65b8c3ce345e149f250e39aa6bcf4a6d530d9",
+  "line_rate": 0.8422,
+  "run_id": "32972568476",
+  "total_coverage_percent": 84.22,
+  "updated_at": "2026-08-26T16:15:13+00:00"
 }


### PR DESCRIPTION
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **84.22%**.

Measured on `f3a65b8c3ce345e149f250e39aa6bcf4a6d530d9` from the
`coverage-report` artifact of CI run
[32972568476](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/32972568476).
Those, and the raw Cobertura `line-rate` the percentage was
rounded from, are recorded in the baseline, so the number in the
diff can be re-derived from the file itself:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.