### PR TITLE
fix(auth): dispatch honours the factory-resolved opt-out again

### DIFF
--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -813,8 +813,15 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
     ) -> StarletteResponse:
         path = request.url.path
 
-        # Opt-out: pass every request through unauthenticated.
-        if auth_disabled_via_opt_out():
+        # Opt-out: pass every request through unauthenticated. Two signals
+        # can switch auth off and dispatch must honour both: the flag the app
+        # factory resolved from configuration (``auth.enabled: false`` arrives
+        # here as ``auth_disabled=True``) and the process-level environment
+        # opt-out, read live so a variable exported after the middleware was
+        # constructed still counts. Reading only the environment here silently
+        # re-enabled auth for config-opted-out deployments: the constructor
+        # kept resolving ``self._auth_disabled`` and nothing read it.
+        if self._auth_disabled or auth_disabled_via_opt_out():
             # No credential is presented in this mode, so there is no
             # principal to derive a scope from and the caller's own
             # ``X-Tenant-Id`` is the only tenant signal that exists.  Honour

--- a/tests/unit/test_auth_middleware_defaults.py
+++ b/tests/unit/test_auth_middleware_defaults.py
@@ -420,6 +420,38 @@ def test_auth_disabled_opt_out_passes_requests_through(
     assert response.status_code == 200
 
 
+def test_config_resolved_opt_out_survives_without_the_env_var() -> None:
+    """``auth_disabled=True`` from the factory must bypass the gate by itself.
+
+    The app factory resolves ``auth.enabled: false`` from configuration and
+    passes it here as a constructor argument; the environment variable is a
+    separate, process-level signal. A dispatch that consults only the
+    environment silently re-enables auth for config-opted-out deployments
+    while the constructor keeps resolving a flag nobody reads -- which is
+    exactly what shipped once, unnoticed, inside an unrelated change.
+    """
+    SSOAuthMiddleware._warned_disabled = False
+    client = _build_app(legacy_token="secret", auth_disabled=True)
+
+    response = client.post("/tasks")
+
+    assert response.status_code == 200
+
+
+def test_env_opt_out_set_after_construction_still_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The environment signal is read at dispatch time, not cached at init."""
+    monkeypatch.delenv("BERNSTEIN_AUTH_DISABLED", raising=False)
+    SSOAuthMiddleware._warned_disabled = False
+    client = _build_app(legacy_token="secret")
+    # Build the middleware stack (lazy) while auth is still on.
+    assert client.post("/tasks").status_code == 401
+
+    monkeypatch.setenv("BERNSTEIN_AUTH_DISABLED", "1")
+    assert client.post("/tasks").status_code == 200
+
+
 def test_auth_disabled_logs_loud_warning(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     """Opting out must emit a loud WARNING so operators notice."""
     monkeypatch.setenv("BERNSTEIN_AUTH_DISABLED", "1")


### PR DESCRIPTION
## Problem

`SSOAuthMiddleware.dispatch` gates its unauthenticated pass-through on `auth_disabled_via_opt_out()` alone — a live read of `BERNSTEIN_AUTH_DISABLED`. The constructor still resolves the factory argument (`auth.enabled: false` in configuration arrives as `auth_disabled=True`) into `self._auth_disabled`, but nothing reads that attribute any more. The regression shipped inside #4577, which is about skill collision guards; the middleware line was unrelated to that change.

Net effect: a deployment that disables auth by configuration logs the loud "auth is DISABLED" warning at startup and then returns 401 on every protected route anyway. The documented opt-out surface (`docs/security/manager-auth.md`) no longer matched behaviour.

## Fix

Dispatch honours both signals:

```python
if self._auth_disabled or auth_disabled_via_opt_out():
```

The live environment read is kept on purpose — a variable exported after the middleware stack is built still counts, which is the one property the #4577 change added.

## Tests

- `test_config_resolved_opt_out_survives_without_the_env_var` — `auth_disabled=True` from the factory bypasses the gate with no env var set; fails before this fix.
- `test_env_opt_out_set_after_construction_still_counts` — pins the live-read property so honouring the flag cannot regress the env path.

Both run in the existing `test_auth_middleware_defaults.py` suite (33 passed).