### PR TITLE
fix(release): publish the version's own release notes on the release page

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -272,12 +272,31 @@ jobs:
           set -euo pipefail
 
           TAG="${RELEASE_TAG}"
+          NOTES_FILE="docs/release-notes/${TAG}.md"
+          BODY="${RUNNER_TEMP:-/tmp}/release-body.md"
+
+          # The release page carries the notes written for this version, with
+          # the generated changelog (and the contributor credits in it) below
+          # them. `--generate-notes` on its own publishes the machine changelog
+          # as the entire body, which is what every release shipped with until
+          # someone rewrote the page by hand after the tag was already public.
+          : > "$BODY"
+          if [ -f "$NOTES_FILE" ]; then
+            # The page already shows the tag, so drop the file's own H1.
+            awk 'NR == 1 && /^# / { next } { print }' "$NOTES_FILE" >> "$BODY"
+            printf '\n---\n\n' >> "$BODY"
+          else
+            echo "::warning::$NOTES_FILE is missing; the page will carry only the generated changelog"
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="$TAG" --jq .body >> "$BODY"
+
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" dist/* --clobber
           else
             gh release create "$TAG" dist/* \
               --title "$TAG" \
-              --generate-notes
+              --notes-file "$BODY"
           fi
 
           asset_count=$(gh release view "$TAG" --json assets --jq '.assets | length')

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -33,6 +33,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 PYPROJECT = REPO / "pyproject.toml"
+NOTES_DIR = REPO / "docs" / "release-notes"
 GEN_MANIFESTS = REPO / "scripts" / "gen_distribution_manifests.py"
 
 # Matches only the top-level ``version = "..."`` line (column 0). Table-scoped
@@ -73,6 +74,18 @@ def main(argv: list[str] | None = None) -> int:
         version = _validate_version(args.version)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    # The release page is built from docs/release-notes/v<version>.md. A bump
+    # without that file cuts a tag whose page carries the generated changelog
+    # alone, and that is only visible once the release is public.
+    notes = NOTES_DIR / f"v{version}.md"
+    if not notes.exists():
+        print(
+            f"error: {notes.relative_to(REPO) if notes.is_relative_to(REPO) else notes} "
+            "does not exist; write the release notes before bumping",
+            file=sys.stderr,
+        )
         return 2
 
     original = PYPROJECT.read_text(encoding="utf-8")

--- a/tests/unit/scripts/test_bump_version.py
+++ b/tests/unit/scripts/test_bump_version.py
@@ -83,3 +83,43 @@ def test_script_never_hand_writes_oci_package_version(bump_module: ModuleType) -
     assert not hasattr(bump_module, "json")
     assert "import json" not in source
     assert "registryType" not in source
+
+
+def test_bump_refuses_a_version_with_no_release_notes(
+    bump_module: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No notes file, no bump.
+
+    The release page is built from ``docs/release-notes/v<version>.md``. When
+    the file is missing the release ships with the generated changelog alone,
+    which is only noticed after the tag is cut and the page is public.
+    """
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(_PYPROJECT, encoding="utf-8")
+    bump_module.PYPROJECT = pyproject
+    bump_module.NOTES_DIR = tmp_path / "docs" / "release-notes"
+
+    assert bump_module.main(["3.4.5"]) == 2
+    assert "release-notes" in capsys.readouterr().err
+    # The refusal must land before anything is written.
+    assert pyproject.read_text(encoding="utf-8") == _PYPROJECT
+
+
+def test_bump_accepts_a_version_whose_notes_exist(
+    bump_module: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(_PYPROJECT, encoding="utf-8")
+    notes = tmp_path / "docs" / "release-notes"
+    notes.mkdir(parents=True)
+    (notes / "v3.4.5.md").write_text("# v3.4.5\n\nreal notes\n", encoding="utf-8")
+    bump_module.PYPROJECT = pyproject
+    bump_module.NOTES_DIR = notes
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        bump_module.subprocess, "run", lambda cmd, **kw: calls.append(list(cmd)) or None
+    )
+    assert bump_module.main(["3.4.5"]) == 0
+    assert 'version = "3.4.5"' in pyproject.read_text(encoding="utf-8")
+    assert len(calls) == 2, "the bump still regenerates the lockfile and the manifests"

--- a/tests/unit/test_publish_workflow_yaml.py
+++ b/tests/unit/test_publish_workflow_yaml.py
@@ -390,3 +390,45 @@ def test_copr_cli_install_is_proven_to_run_before_the_credential_is_written(
     # step that writes ~/.config/copr.
     steps = [step.get("name") for step in workflow["jobs"][COPR_JOB]["steps"] if isinstance(step, dict)]
     assert steps.index("Install rpmbuild and copr-cli") < steps.index("Write copr-cli configuration")
+
+
+RELEASE_JOB = "github-release"
+
+
+def test_release_body_carries_the_hand_written_notes_for_the_version(
+    workflow: dict[str, Any],
+) -> None:
+    """The release page must show ``docs/release-notes/<tag>.md``.
+
+    Every release until v3.18.1 shipped with only the generated changelog on
+    the page: the notes written for the version sat in the repository and had
+    to be pasted into the release by hand afterwards.
+    """
+    run = _step_run(workflow, RELEASE_JOB, "Create release")
+    assert "docs/release-notes/" in run, "the release body must be built from the notes file"
+    assert "--notes-file" in run, "gh release create must be given the composed body"
+
+
+def test_release_body_still_appends_the_generated_changelog(
+    workflow: dict[str, Any],
+) -> None:
+    """Contributor credits live in the generated changelog; keep it below the notes."""
+    run = _step_run(workflow, RELEASE_JOB, "Create release")
+    assert "releases/generate-notes" in run, (
+        "the generated changelog must be fetched and appended, not dropped"
+    )
+    notes_pos = run.find("docs/release-notes/")
+    generated_pos = run.find("releases/generate-notes")
+    assert notes_pos < generated_pos, "hand-written notes come first, changelog after"
+
+
+def test_release_creation_does_not_fall_back_to_generated_notes_only(
+    workflow: dict[str, Any],
+) -> None:
+    run = _step_run(workflow, RELEASE_JOB, "Create release")
+    commands = "\n".join(
+        line for line in run.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "--generate-notes" not in commands, (
+        "--generate-notes publishes the machine changelog as the whole body"
+    )


### PR DESCRIPTION
The release page for a version and the notes written for that version were two
different documents. `github-release` created the release with
`--generate-notes`, so the body was the generated changelog and nothing else;
`docs/release-notes/v<version>.md` stayed in the repository, and the page was
corrected by hand after the tag was already public. That happened for every
release.

Two changes, one on each side of the gap:

- **Delivery.** The `Create release` step composes the body: the notes file for
  the tag (its own `# vX.Y.Z` heading dropped, since the page already shows the
  tag), a `---`, then the generated changelog fetched from
  `repos/{repo}/releases/generate-notes`. The changelog stays because it is
  where the contributor credits and avatars come from. A missing notes file
  degrades to a warning and the generated changelog, so an emergency tag is
  never blocked by this step.
- **Authoring.** `scripts/bump_version.py` refuses to bump to a version whose
  `docs/release-notes/v<version>.md` does not exist, before it writes anything.
  The mismatch surfaces while the release is being prepared instead of after
  the page is public.

Tests: the workflow-shape suite pins that the body is built from the notes
file, that the generated changelog is still appended below it, and that
`gh release create` no longer runs with `--generate-notes`; the bump suite
pins the refusal (and that it leaves `pyproject.toml` untouched) and the
accepted path.
