### PR TITLE
fix(ci): release the andon once main is green again

### DIFF
--- a/scripts/trunk_health_slo.py
+++ b/scripts/trunk_health_slo.py
@@ -84,14 +84,41 @@ def score_runs(runs: list[dict]) -> tuple[int, int, int]:
     return total, red, red_pct
 
 
-def marker_should_open(total: int, red: int, red_pct: int, threshold_pct: int) -> bool:
+def trunk_is_red_now(runs: list[dict]) -> bool:
+    """Whether the newest completed CI run on main failed.
+
+    The red rate is a property of a 24-hour window, so it stays over threshold
+    long after main itself recovers. On 2026-08-26 two infrastructure failures
+    (a contended docker probe and a macOS runner that could not download its
+    actions) held every merge in the repository while main's own newest run was
+    green. The andon exists to stop merges piling onto a broken main, and this
+    is the question that actually answers.
+    """
+    completed = [
+        r for r in runs if r.get("conclusion") not in ("cancelled", "skipped", None)
+    ]
+    if not completed:
+        return False
+    newest = max(completed, key=lambda r: str(r.get("created_at", "")))
+    return newest.get("conclusion") in ("failure", "timed_out")
+
+
+def marker_should_open(
+    total: int, red: int, red_pct: int, threshold_pct: int, *, trunk_red_now: bool
+) -> bool:
     """Whether this sample justifies holding every merge in the repo.
 
     Kept as its own function because the andon decision is the only thing
     this script does that anyone has to trust, and an expression inlined in
     ``main`` is reachable only by driving argv and the network.
+
+    ``trunk_red_now`` is the release condition: a rate-only gate keeps holding
+    merges for the rest of the window after the trunk is fixed, including the
+    hotfix that fixed it.
     """
     if total < MIN_SAMPLE_SIZE:
+        return False
+    if not trunk_red_now:
         return False
     return red >= MIN_RED_RUNS and red_pct >= threshold_pct
 
@@ -114,7 +141,9 @@ def main() -> None:
     total, red, red_pct = score_runs(runs)
 
     insufficient = total < MIN_SAMPLE_SIZE
-    unstable = marker_should_open(total, red, red_pct, args.threshold_pct)
+    unstable = marker_should_open(
+        total, red, red_pct, args.threshold_pct, trunk_red_now=trunk_is_red_now(runs)
+    )
 
     # Output for GitHub Actions
     github_output = os.environ.get("GITHUB_OUTPUT")

--- a/tests/unit/test_trunk_health_slo.py
+++ b/tests/unit/test_trunk_health_slo.py
@@ -4,7 +4,12 @@ from unittest.mock import patch
 from urllib.parse import quote
 
 from scripts import trunk_health_slo
-from scripts.trunk_health_slo import MIN_SAMPLE_SIZE, marker_should_open, score_runs
+from scripts.trunk_health_slo import (
+    MIN_SAMPLE_SIZE,
+    marker_should_open,
+    score_runs,
+    trunk_is_red_now,
+)
 
 
 def test_score_runs_counts_only_failures():
@@ -165,7 +170,7 @@ def test_one_red_run_does_not_hold_the_repo() -> None:
     the 24h window. At these sample sizes a percentage threshold below
     1/MIN_SAMPLE_SIZE is a zero-tolerance gate wearing a rate's clothes.
     """
-    assert marker_should_open(total=19, red=1, red_pct=5, threshold_pct=5) is False
+    assert marker_should_open(total=19, red=1, red_pct=5, threshold_pct=5, trunk_red_now=True) is False
 
 
 def test_a_second_red_run_does_hold_the_repo() -> None:
@@ -174,14 +179,58 @@ def test_a_second_red_run_does_hold_the_repo() -> None:
     Without this the test above is satisfied by a function that never opens
     a marker at all.
     """
-    assert marker_should_open(total=19, red=2, red_pct=10, threshold_pct=5) is True
+    assert marker_should_open(total=19, red=2, red_pct=10, threshold_pct=5, trunk_red_now=True) is True
 
 
 def test_reds_under_the_threshold_do_not_hold_the_repo() -> None:
     """Two reds are necessary, not sufficient - the rate still has to cross."""
-    assert marker_should_open(total=100, red=2, red_pct=2, threshold_pct=5) is False
+    assert marker_should_open(total=100, red=2, red_pct=2, threshold_pct=5, trunk_red_now=True) is False
 
 
 def test_a_thin_sample_never_holds_the_repo() -> None:
     """Below MIN_SAMPLE_SIZE there is no rate to speak of."""
-    assert marker_should_open(total=MIN_SAMPLE_SIZE - 1, red=MIN_SAMPLE_SIZE - 1, red_pct=100, threshold_pct=5) is False
+    assert marker_should_open(
+        total=MIN_SAMPLE_SIZE - 1,
+        red=MIN_SAMPLE_SIZE - 1,
+        red_pct=100,
+        threshold_pct=5,
+        trunk_red_now=True,
+    ) is False
+
+
+def _run(conclusion: str, created_at: str) -> dict[str, str]:
+    return {"conclusion": conclusion, "created_at": created_at}
+
+
+def test_latest_verdict_is_the_newest_completed_run() -> None:
+    runs = [
+        _run("success", "2026-08-26T20:00:00Z"),
+        _run("failure", "2026-08-26T11:00:00Z"),
+        _run("cancelled", "2026-08-26T21:00:00Z"),
+    ]
+    assert trunk_is_red_now(runs) is False
+
+
+def test_latest_verdict_reads_red_when_the_newest_completed_run_failed() -> None:
+    runs = [
+        _run("failure", "2026-08-26T20:00:00Z"),
+        _run("success", "2026-08-26T11:00:00Z"),
+    ]
+    assert trunk_is_red_now(runs) is True
+
+
+def test_marker_stays_shut_when_trunk_is_green_again() -> None:
+    """Two infrastructure failures held every merge in the repository for a
+    full day while main itself was green: the rate alone latches on history.
+    The andon exists to stop merges piling onto a broken main, so a main whose
+    newest run is green releases it.
+    """
+    assert marker_should_open(
+        total=27, red=2, red_pct=7, threshold_pct=5, trunk_red_now=False
+    ) is False
+
+
+def test_marker_opens_when_the_rate_is_over_and_trunk_is_red_now() -> None:
+    assert marker_should_open(
+        total=27, red=2, red_pct=7, threshold_pct=5, trunk_red_now=True
+    ) is True


### PR DESCRIPTION
The andon gate opened on 2026-08-26 for a 7% red rate over 24 hours. Both red
runs were infrastructure: a contended `docker compose version` probe on one
runner, and a macOS runner that could not download its actions. Main's own
newest CI run was green throughout, and every PR in the repository was held.

The gate's stated purpose is to stop merges piling on top of a broken main.
The red rate cannot answer that question: it is a property of the window, so
it stays over threshold for the rest of the day after main recovers -- and it
holds the hotfix that would clear it along with everything else.

`marker_should_open` now also requires that the newest completed CI run on
main failed. A trunk that is genuinely broken still latches the gate. A trunk
that has recovered releases it at the next scheduled check. The rate, the
minimum sample size and the minimum red count are unchanged, so a single red
run still cannot open the marker.

Tests pin the new verdict (newest completed run wins, cancelled runs are not
verdicts) and both sides of the decision: an over-threshold rate with a green
trunk stays shut, an over-threshold rate with a red trunk opens.
