### PR TITLE
feat(quality): empirical confidence helper with a Hoeffding confidence sequence

### DIFF
--- a/scripts/trunk_health_slo.py
+++ b/scripts/trunk_health_slo.py
@@ -94,18 +94,14 @@ def trunk_is_red_now(runs: list[dict]) -> bool:
     green. The andon exists to stop merges piling onto a broken main, and this
     is the question that actually answers.
     """
-    completed = [
-        r for r in runs if r.get("conclusion") not in ("cancelled", "skipped", None)
-    ]
+    completed = [r for r in runs if r.get("conclusion") not in ("cancelled", "skipped", None)]
     if not completed:
         return False
     newest = max(completed, key=lambda r: str(r.get("created_at", "")))
     return newest.get("conclusion") in ("failure", "timed_out")
 
 
-def marker_should_open(
-    total: int, red: int, red_pct: int, threshold_pct: int, *, trunk_red_now: bool
-) -> bool:
+def marker_should_open(total: int, red: int, red_pct: int, threshold_pct: int, *, trunk_red_now: bool) -> bool:
     """Whether this sample justifies holding every merge in the repo.
 
     Kept as its own function because the andon decision is the only thing
@@ -141,9 +137,7 @@ def main() -> None:
     total, red, red_pct = score_runs(runs)
 
     insufficient = total < MIN_SAMPLE_SIZE
-    unstable = marker_should_open(
-        total, red, red_pct, args.threshold_pct, trunk_red_now=trunk_is_red_now(runs)
-    )
+    unstable = marker_should_open(total, red, red_pct, args.threshold_pct, trunk_red_now=trunk_is_red_now(runs))
 
     # Output for GitHub Actions
     github_output = os.environ.get("GITHUB_OUTPUT")

--- a/src/bernstein/core/quality/empirical_confidence.py
+++ b/src/bernstein/core/quality/empirical_confidence.py
@@ -1,5 +1,12 @@
 """Empirical confidence from outcome history.
 
+This module provides:
+
+* :func:`confidence` - Sample-size-gated empirical confidence from outcome history.
+* :func:`hoeffding_confidence_sequence` - Time-uniform confidence bounds based on
+  Hoeffding's inequality for binary outcomes.
+"""
+
 Records per-decision outcomes in an append-only SQLite table and exposes a
 sample-size-gated confidence query. The query refuses to return a value when
 the sample size is below a documented threshold; callers fall back to a
@@ -361,6 +368,82 @@ def confidence(agent_type: str, decision_key: str) -> Confidence:
     return _get_default_query().get(agent_type, decision_key)
 
 
+# ---------------------------------------------------------------------------
+# Hoeffding confidence sequence for binary outcomes
+# ---------------------------------------------------------------------------
+
+
+def hoeffding_confidence_sequence(k: int, n: int, alpha: float) -> tuple[float, float]:
+    """Return Hoeffding time-uniform confidence bound for k successes in n trials.
+
+    The Hoeffding bound is valid simultaneously at every sample size, so stopping
+    when the lower bound exceeds the threshold is legitimate at any n.
+
+    Args:
+        k: Number of successes
+        n: Total trials
+        alpha: Error level (target false-admission rate)
+
+    Returns:
+        (lower_bound, upper_bound) for the true success probability, canonically
+        rounded to 10 decimal places for byte-stable reproducibility.
+
+    Raises:
+        ValueError: If k > n, n < 0, or k < 0.
+    """
+    if n < 0:
+        msg = f"n must be non-negative, got {n}"
+        raise ValueError(msg)
+    if k < 0:
+        msg = f"k must be non-negative, got {k}"
+        raise ValueError(msg)
+    if k > n:
+        msg = f"k cannot exceed n ({k} > {n})"
+        raise ValueError(msg)
+
+    if n == 0:
+        return (0.0, 1.0)
+
+    p_hat = k / n
+
+    # Hoeffding bound: lower_bound = p_hat - sqrt(ln(2/delta)/(2*n))
+    # where delta is the error level (alpha)
+    # Compute ln(2/delta) using math.log, then canonical_round it before using
+    import math
+
+    ln_term = math.log(2.0 / alpha)
+    ln_term_canonical = canonical_round(ln_term)
+
+    bound = math.sqrt(ln_term_canonical / (2.0 * n))
+    bound_canonical = canonical_round(bound)
+
+    lower_bound = p_hat - bound_canonical
+    upper_bound = p_hat + bound_canonical
+
+    # Clamp to [0, 1]
+    lower_clamped = max(0.0, lower_bound)
+    upper_clamped = min(1.0, upper_bound)
+
+    return (canonical_round(lower_clamped), canonical_round(upper_clamped))
+
+
+def canonical_round(value: float, places: int = 10) -> float:
+    """Round value to places decimals with round-half-to-even.
+
+    This is a simplified copy of the canonical_round function from significance.py
+    to avoid circular imports and keep this module dependency-free.
+    """
+    import math
+    from decimal import ROUND_HALF_EVEN, Decimal
+
+    if math.isnan(value) or math.isinf(value):
+        msg = f"cannot canonically round non-finite value {value!r}"
+        raise ValueError(msg)
+    quantum = Decimal(1).scaleb(-places)
+    quantised = Decimal(value).quantize(quantum, rounding=ROUND_HALF_EVEN)
+    return float(quantised) + 0.0
+
+
 __all__ = [
     "DEFAULT_MIN_SAMPLES",
     "DEFAULT_PRIOR",
@@ -368,6 +451,7 @@ __all__ = [
     "ConfidenceQuery",
     "confidence",
     "default_db_path",
+    "hoeffding_confidence_sequence",
     "record_outcome",
     "reset_default_query",
 ]

--- a/src/bernstein/core/quality/empirical_confidence.py
+++ b/src/bernstein/core/quality/empirical_confidence.py
@@ -5,7 +5,6 @@ This module provides:
 * :func:`confidence` - Sample-size-gated empirical confidence from outcome history.
 * :func:`hoeffding_confidence_sequence` - Time-uniform confidence bounds based on
   Hoeffding's inequality for binary outcomes.
-"""
 
 Records per-decision outcomes in an append-only SQLite table and exposes a
 sample-size-gated confidence query. The query refuses to return a value when

--- a/tests/unit/scripts/test_bump_version.py
+++ b/tests/unit/scripts/test_bump_version.py
@@ -117,9 +117,7 @@ def test_bump_accepts_a_version_whose_notes_exist(
     bump_module.NOTES_DIR = notes
 
     calls: list[list[str]] = []
-    monkeypatch.setattr(
-        bump_module.subprocess, "run", lambda cmd, **kw: calls.append(list(cmd)) or None
-    )
+    monkeypatch.setattr(bump_module.subprocess, "run", lambda cmd, **kw: calls.append(list(cmd)) or None)
     assert bump_module.main(["3.4.5"]) == 0
     assert 'version = "3.4.5"' in pyproject.read_text(encoding="utf-8")
     assert len(calls) == 2, "the bump still regenerates the lockfile and the manifests"

--- a/tests/unit/test_hoeffding_confidence_sequence.py
+++ b/tests/unit/test_hoeffding_confidence_sequence.py
@@ -144,12 +144,13 @@ class TestCanonicalRound:
 
     def test_round_half_even(self):
         """Test round-half-to-even behavior."""
-        # 0.5 rounds to nearest even (0)
-        assert canonical_round(0.5) == 0.0
-        # 1.5 rounds to nearest even (2)
-        assert canonical_round(1.5) == 2.0
-        # 2.5 rounds to nearest even (2)
-        assert canonical_round(2.5) == 2.0
+        # canonical_round quantises at `places` decimals, so half-even only
+        # shows at places=0; the default of 10 leaves these values untouched.
+        assert canonical_round(0.5, places=0) == 0.0
+        assert canonical_round(1.5, places=0) == 2.0
+        assert canonical_round(2.5, places=0) == 2.0
+        # At the default precision the value is preserved exactly.
+        assert canonical_round(0.5) == 0.5
 
     def test_negative_zero_normalized(self):
         """Negative zero should be normalized to positive zero."""

--- a/tests/unit/test_hoeffding_confidence_sequence.py
+++ b/tests/unit/test_hoeffding_confidence_sequence.py
@@ -85,9 +85,9 @@ class TestHoeffdingConfidenceSequence:
 
         # Check that values are rounded (not too many decimal places)
         def count_decimal_places(x: float) -> int:
-            s = f"{x:.15f}".rstrip('0')
-            if '.' in s:
-                return len(s.split('.')[1])
+            s = f"{x:.15f}".rstrip("0")
+            if "." in s:
+                return len(s.split(".")[1])
             return 0
 
         # Canonically rounded values should have at most 10 decimal places
@@ -161,17 +161,17 @@ class TestCanonicalRound:
     def test_nan_raises(self):
         """NaN should raise ValueError."""
         with pytest.raises(ValueError, match="cannot canonically round non-finite"):
-            canonical_round(float('nan'))
+            canonical_round(float("nan"))
 
     def test_inf_raises(self):
         """Infinity should raise ValueError."""
         with pytest.raises(ValueError, match="cannot canonically round non-finite"):
-            canonical_round(float('inf'))
+            canonical_round(float("inf"))
 
     def test_negative_inf_raises(self):
         """Negative infinity should raise ValueError."""
         with pytest.raises(ValueError, match="cannot canonically round non-finite"):
-            canonical_round(float('-inf'))
+            canonical_round(float("-inf"))
 
     def test_precision(self):
         """Results should be precise to 10 decimal places."""

--- a/tests/unit/test_hoeffding_confidence_sequence.py
+++ b/tests/unit/test_hoeffding_confidence_sequence.py
@@ -1,0 +1,185 @@
+"""Tests for hoeffding_confidence_sequence."""
+
+import math
+import pytest
+
+from bernstein.core.quality.empirical_confidence import (
+    hoeffding_confidence_sequence,
+    canonical_round,
+)
+
+
+class TestHoeffdingConfidenceSequence:
+    """Tests for the Hoeffding confidence sequence function."""
+
+    def test_zero_trials(self):
+        """n=0 should return the full interval [0, 1]."""
+        lower, upper = hoeffding_confidence_sequence(0, 0, 0.05)
+        assert lower == 0.0
+        assert upper == 1.0
+
+    def test_all_successes(self):
+        """All successes should have upper bound at 1.0."""
+        lower, upper = hoeffding_confidence_sequence(10, 10, 0.05)
+        assert upper == 1.0
+        assert lower > 0.5  # Should be fairly high with 10/10
+
+    def test_all_failures(self):
+        """All failures should have lower bound at 0.0."""
+        lower, upper = hoeffding_confidence_sequence(0, 10, 0.05)
+        assert lower == 0.0
+        assert upper < 0.5  # Should be fairly low with 0/10
+
+    def test_half_successes(self):
+        """Half successes should have interval centered near 0.5."""
+        lower, upper = hoeffding_confidence_sequence(5, 10, 0.05)
+        # p_hat = 0.5, interval should be symmetric around 0.5
+        assert lower < 0.5
+        assert upper > 0.5
+        # Check symmetry (within rounding)
+        mid = (lower + upper) / 2
+        assert abs(mid - 0.5) < 0.001
+
+    def test_increasing_n_narrows_interval(self):
+        """As n increases, the interval should narrow."""
+        lower_10, upper_10 = hoeffding_confidence_sequence(5, 10, 0.05)
+        lower_100, upper_100 = hoeffding_confidence_sequence(50, 100, 0.05)
+        
+        # Both maintain same proportion
+        assert abs((lower_10 + upper_10) / 2 - 0.5) < 0.001
+        assert abs((lower_100 + upper_100) / 2 - 0.5) < 0.001
+        
+        # But larger n has narrower interval
+        width_10 = upper_10 - lower_10
+        width_100 = upper_100 - lower_100
+        assert width_100 < width_10
+
+    def test_smaller_alpha_narrows_interval(self):
+        """Smaller alpha (lower error rate) gives wider interval."""
+        lower_05, upper_05 = hoeffding_confidence_sequence(5, 10, 0.05)
+        lower_01, upper_01 = hoeffding_confidence_sequence(5, 10, 0.01)
+        
+        # Smaller alpha means more conservative (wider) interval
+        width_05 = upper_05 - lower_05
+        width_01 = upper_01 - lower_01
+        assert width_01 > width_05
+
+    def test_bounds_within_zero_one(self):
+        """Bounds should always be in [0, 1]."""
+        # Test edge cases
+        for k, n in [(0, 1), (1, 1), (0, 100), (100, 100), (50, 100)]:
+            for alpha in [0.01, 0.05, 0.10]:
+                lower, upper = hoeffding_confidence_sequence(k, n, alpha)
+                assert 0.0 <= lower <= 1.0
+                assert 0.0 <= upper <= 1.0
+                assert lower <= upper
+
+    def test_deterministic_reproducible(self):
+        """Same inputs should give identical outputs."""
+        result1 = hoeffding_confidence_sequence(7, 13, 0.05)
+        result2 = hoeffding_confidence_sequence(7, 13, 0.05)
+        assert result1 == result2
+
+    def test_canonical_rounding_applied(self):
+        """Results should be canonically rounded to 10 decimal places."""
+        lower, upper = hoeffding_confidence_sequence(7, 13, 0.05)
+        
+        # Check that values are rounded (not too many decimal places)
+        def count_decimal_places(x: float) -> int:
+            s = f"{x:.15f}".rstrip('0')
+            if '.' in s:
+                return len(s.split('.')[1])
+            return 0
+        
+        # Canonically rounded values should have at most 10 decimal places
+        assert count_decimal_places(lower) <= 10
+        assert count_decimal_places(upper) <= 10
+
+    def test_k_greater_than_n_raises(self):
+        """k > n should raise ValueError."""
+        with pytest.raises(ValueError, match="k cannot exceed n"):
+            hoeffding_confidence_sequence(11, 10, 0.05)
+
+    def test_negative_k_raises(self):
+        """Negative k should raise ValueError."""
+        with pytest.raises(ValueError, match="k must be non-negative"):
+            hoeffding_confidence_sequence(-1, 10, 0.05)
+
+    def test_negative_n_raises(self):
+        """Negative n should raise ValueError."""
+        with pytest.raises(ValueError, match="n must be non-negative"):
+            hoeffding_confidence_sequence(0, -1, 0.05)
+
+    def test_hoeffding_formula_correctness(self):
+        """Verify the Hoeffding bound formula is correctly applied."""
+        # For k=10, n=20, alpha=0.05
+        # p_hat = 0.5
+        # ln(2/alpha) = ln(40) ≈ 3.6888...
+        # bound = sqrt(ln(2/alpha) / (2*n)) = sqrt(3.6888... / 40) ≈ 0.3036...
+        # lower ≈ 0.5 - 0.3036 ≈ 0.1964
+        # upper ≈ 0.5 + 0.3036 ≈ 0.8036
+        
+        lower, upper = hoeffding_confidence_sequence(10, 20, 0.05)
+        
+        # Verify approximate values (accounting for canonical rounding)
+        assert 0.19 < lower < 0.20
+        assert 0.80 < upper < 0.81
+
+    def test_time_uniform_validity(self):
+        """Test that bound is valid at different stopping points."""
+        # Simulate accumulating observations
+        # The bound should be valid at each n
+        alpha = 0.05
+        true_p = 0.7  # Assume true success rate
+        
+        # With many trials, the interval should contain true_p most of the time
+        k = 70  # Observed successes
+        n = 100  # Total trials
+        lower, upper = hoeffding_confidence_sequence(k, n, alpha)
+        
+        # p_hat = 0.7, the interval should contain 0.7
+        assert lower <= 0.7 <= upper
+
+
+class TestCanonicalRound:
+    """Tests for the canonical_round helper function."""
+
+    def test_round_half_even(self):
+        """Test round-half-to-even behavior."""
+        # 0.5 rounds to nearest even (0)
+        assert canonical_round(0.5) == 0.0
+        # 1.5 rounds to nearest even (2)
+        assert canonical_round(1.5) == 2.0
+        # 2.5 rounds to nearest even (2)
+        assert canonical_round(2.5) == 2.0
+
+    def test_negative_zero_normalized(self):
+        """Negative zero should be normalized to positive zero."""
+        result = canonical_round(-0.0)
+        assert result == 0.0
+        assert str(result) == "0.0"  # Not "-0.0"
+
+    def test_nan_raises(self):
+        """NaN should raise ValueError."""
+        with pytest.raises(ValueError, match="cannot canonically round non-finite"):
+            canonical_round(float('nan'))
+
+    def test_inf_raises(self):
+        """Infinity should raise ValueError."""
+        with pytest.raises(ValueError, match="cannot canonically round non-finite"):
+            canonical_round(float('inf'))
+
+    def test_negative_inf_raises(self):
+        """Negative infinity should raise ValueError."""
+        with pytest.raises(ValueError, match="cannot canonically round non-finite"):
+            canonical_round(float('-inf'))
+
+    def test_precision(self):
+        """Results should be precise to 10 decimal places."""
+        # A value with many decimal places
+        x = 1.234567890123456789
+        rounded = canonical_round(x)
+        
+        # Should be rounded to 10 decimal places
+        # The rounded value should be reproducible
+        assert rounded == canonical_round(x)

--- a/tests/unit/test_hoeffding_confidence_sequence.py
+++ b/tests/unit/test_hoeffding_confidence_sequence.py
@@ -1,11 +1,10 @@
 """Tests for hoeffding_confidence_sequence."""
 
-import math
 import pytest
 
 from bernstein.core.quality.empirical_confidence import (
-    hoeffding_confidence_sequence,
     canonical_round,
+    hoeffding_confidence_sequence,
 )
 
 
@@ -44,11 +43,11 @@ class TestHoeffdingConfidenceSequence:
         """As n increases, the interval should narrow."""
         lower_10, upper_10 = hoeffding_confidence_sequence(5, 10, 0.05)
         lower_100, upper_100 = hoeffding_confidence_sequence(50, 100, 0.05)
-        
+
         # Both maintain same proportion
         assert abs((lower_10 + upper_10) / 2 - 0.5) < 0.001
         assert abs((lower_100 + upper_100) / 2 - 0.5) < 0.001
-        
+
         # But larger n has narrower interval
         width_10 = upper_10 - lower_10
         width_100 = upper_100 - lower_100
@@ -58,7 +57,7 @@ class TestHoeffdingConfidenceSequence:
         """Smaller alpha (lower error rate) gives wider interval."""
         lower_05, upper_05 = hoeffding_confidence_sequence(5, 10, 0.05)
         lower_01, upper_01 = hoeffding_confidence_sequence(5, 10, 0.01)
-        
+
         # Smaller alpha means more conservative (wider) interval
         width_05 = upper_05 - lower_05
         width_01 = upper_01 - lower_01
@@ -83,14 +82,14 @@ class TestHoeffdingConfidenceSequence:
     def test_canonical_rounding_applied(self):
         """Results should be canonically rounded to 10 decimal places."""
         lower, upper = hoeffding_confidence_sequence(7, 13, 0.05)
-        
+
         # Check that values are rounded (not too many decimal places)
         def count_decimal_places(x: float) -> int:
             s = f"{x:.15f}".rstrip('0')
             if '.' in s:
                 return len(s.split('.')[1])
             return 0
-        
+
         # Canonically rounded values should have at most 10 decimal places
         assert count_decimal_places(lower) <= 10
         assert count_decimal_places(upper) <= 10
@@ -118,9 +117,9 @@ class TestHoeffdingConfidenceSequence:
         # bound = sqrt(ln(2/alpha) / (2*n)) = sqrt(3.6888... / 40) ≈ 0.3036...
         # lower ≈ 0.5 - 0.3036 ≈ 0.1964
         # upper ≈ 0.5 + 0.3036 ≈ 0.8036
-        
+
         lower, upper = hoeffding_confidence_sequence(10, 20, 0.05)
-        
+
         # Verify approximate values (accounting for canonical rounding)
         assert 0.19 < lower < 0.20
         assert 0.80 < upper < 0.81
@@ -130,13 +129,12 @@ class TestHoeffdingConfidenceSequence:
         # Simulate accumulating observations
         # The bound should be valid at each n
         alpha = 0.05
-        true_p = 0.7  # Assume true success rate
-        
+
         # With many trials, the interval should contain true_p most of the time
         k = 70  # Observed successes
         n = 100  # Total trials
         lower, upper = hoeffding_confidence_sequence(k, n, alpha)
-        
+
         # p_hat = 0.7, the interval should contain 0.7
         assert lower <= 0.7 <= upper
 
@@ -179,7 +177,7 @@ class TestCanonicalRound:
         # A value with many decimal places
         x = 1.234567890123456789
         rounded = canonical_round(x)
-        
+
         # Should be rounded to 10 decimal places
         # The rounded value should be reproducible
         assert rounded == canonical_round(x)

--- a/tests/unit/test_publish_workflow_yaml.py
+++ b/tests/unit/test_publish_workflow_yaml.py
@@ -414,9 +414,7 @@ def test_release_body_still_appends_the_generated_changelog(
 ) -> None:
     """Contributor credits live in the generated changelog; keep it below the notes."""
     run = _step_run(workflow, RELEASE_JOB, "Create release")
-    assert "releases/generate-notes" in run, (
-        "the generated changelog must be fetched and appended, not dropped"
-    )
+    assert "releases/generate-notes" in run, "the generated changelog must be fetched and appended, not dropped"
     notes_pos = run.find("docs/release-notes/")
     generated_pos = run.find("releases/generate-notes")
     assert notes_pos < generated_pos, "hand-written notes come first, changelog after"
@@ -426,9 +424,5 @@ def test_release_creation_does_not_fall_back_to_generated_notes_only(
     workflow: dict[str, Any],
 ) -> None:
     run = _step_run(workflow, RELEASE_JOB, "Create release")
-    commands = "\n".join(
-        line for line in run.splitlines() if not line.lstrip().startswith("#")
-    )
-    assert "--generate-notes" not in commands, (
-        "--generate-notes publishes the machine changelog as the whole body"
-    )
+    commands = "\n".join(line for line in run.splitlines() if not line.lstrip().startswith("#"))
+    assert "--generate-notes" not in commands, "--generate-notes publishes the machine changelog as the whole body"

--- a/tests/unit/test_trunk_health_slo.py
+++ b/tests/unit/test_trunk_health_slo.py
@@ -189,13 +189,16 @@ def test_reds_under_the_threshold_do_not_hold_the_repo() -> None:
 
 def test_a_thin_sample_never_holds_the_repo() -> None:
     """Below MIN_SAMPLE_SIZE there is no rate to speak of."""
-    assert marker_should_open(
-        total=MIN_SAMPLE_SIZE - 1,
-        red=MIN_SAMPLE_SIZE - 1,
-        red_pct=100,
-        threshold_pct=5,
-        trunk_red_now=True,
-    ) is False
+    assert (
+        marker_should_open(
+            total=MIN_SAMPLE_SIZE - 1,
+            red=MIN_SAMPLE_SIZE - 1,
+            red_pct=100,
+            threshold_pct=5,
+            trunk_red_now=True,
+        )
+        is False
+    )
 
 
 def _run(conclusion: str, created_at: str) -> dict[str, str]:
@@ -225,12 +228,8 @@ def test_marker_stays_shut_when_trunk_is_green_again() -> None:
     The andon exists to stop merges piling onto a broken main, so a main whose
     newest run is green releases it.
     """
-    assert marker_should_open(
-        total=27, red=2, red_pct=7, threshold_pct=5, trunk_red_now=False
-    ) is False
+    assert marker_should_open(total=27, red=2, red_pct=7, threshold_pct=5, trunk_red_now=False) is False
 
 
 def test_marker_opens_when_the_rate_is_over_and_trunk_is_red_now() -> None:
-    assert marker_should_open(
-        total=27, red=2, red_pct=7, threshold_pct=5, trunk_red_now=True
-    ) is True
+    assert marker_should_open(total=27, red=2, red_pct=7, threshold_pct=5, trunk_red_now=True) is True


### PR DESCRIPTION
Adds an empirical-confidence helper with a Hoeffding confidence sequence, plus its unit tests, for #4177.

The run produced these four commits but its verification gate failed at pytest on one assertion in the run own test file: `canonical_round(0.5) == 0.0`. `canonical_round` quantises at `places` decimals and defaults to 10, so `0.5` is preserved and the assertion could never hold. The test now asserts half-even at `places=0`, where the behaviour is observable, and pins the default precision as value-preserving. The implementation is unchanged.

Closes #4177
