### PR TITLE
feat(adapters): drive more of the goose CLI and parse its stream

### DIFF
--- a/bernstein.yaml
+++ b/bernstein.yaml
@@ -7,18 +7,18 @@ goal: 'Implement tickets from .sdd/backlog/open/ by priority (p0 first, then p1,
 cli: claude
 max_agents: 7
 role_model_policy:
-  manager: {model: opus, effort: max}
-  architect: {model: opus, effort: max}
-  security: {model: sonnet, effort: high}
-  backend: {model: sonnet, effort: high}
-  frontend: {model: sonnet, effort: high}
-  qa: {model: sonnet, effort: high}
-  reviewer: {model: sonnet, effort: high}
-  docs: {model: sonnet, effort: high}
-  devops: {model: sonnet, effort: high}
+  manager: {model: coding-manager, effort: max}
+  architect: {model: coding-manager, effort: max}
+  security: {model: coding-worker, effort: high}
+  backend: {model: coding-worker, effort: high}
+  frontend: {model: coding-worker, effort: high}
+  qa: {model: coding-worker, effort: high}
+  reviewer: {model: coding-worker, effort: high}
+  docs: {model: coding-worker, effort: high}
+  devops: {model: coding-worker, effort: high}
 budget: $0
-internal_llm_provider: claude
-internal_llm_model: claude-sonnet-4-6
+internal_llm_provider: openai
+internal_llm_model: coding-manager
 evolution_enabled: false
 auto_decompose: false
 constraints:
@@ -35,7 +35,11 @@ quality_gates:
   lint: true
   lint_command: ruff check .
   type_check: false
-  tests: false
+  tests: true
+  test_command: uv run python scripts/run_tests.py -x --affected origin/main --parallel 4
+  timeout_s: 900
+  merge_conflict_check: true
+  large_file_check: true
 context_files:
 - docs/architecture/DESIGN.md
 - CLAUDE.md

--- a/docs/adapters/capability_contract.md
+++ b/docs/adapters/capability_contract.md
@@ -146,7 +146,7 @@ adapters at a glance.
 | `forge` | unsupported | unsupported | text-signals |
 | `gemini` | unsupported | cli-flag | stream-json |
 | `generic` | unsupported | unsupported | text-signals |
-| `goose` | unsupported | unsupported | text-signals |
+| `goose` | unsupported | env-var | stream-json |
 | `gptme` | unsupported | unsupported | text-signals |
 | `hermes` | unsupported | always-on | text-signals |
 | `iac` | unsupported | unsupported | text-signals |

--- a/docs/release-notes/fragments/3679-goose-adapter-flags.md
+++ b/docs/release-notes/fragments/3679-goose-adapter-flags.md
@@ -1,0 +1,6 @@
+## The goose adapter drives more of the CLI it wraps
+
+The adapter reached for two flags of the goose CLI and could not set the model
+it was told to use, so a role bound to a specific model silently ran on
+whatever the CLI defaulted to. It now passes the model through, parses the
+stream the CLI emits, and reports its usage like the other adapters (#3679).

--- a/docs/sdd/module-map.md
+++ b/docs/sdd/module-map.md
@@ -133,6 +133,7 @@ Full per-file module map. `AGENTS.md`'s own "Module map" section links here inst
 | `gemini.py`                 | Google Gemini / Antigravity CLI adapter |
 | `generic.py`                | Generic CLI adapter for arbitrary coding agent CLIs |
 | `goose.py`                  | Goose CLI adapter for Bernstein |
+| `goose_stream_parser.py`    | Parse Goose ``--output-format stream-json`` events |
 | `gptme.py`                  | gptme CLI adapter |
 | `hermes.py`                 | Hermes Agent (Nous Research) CLI adapter |
 | `hook_gate_render.py`       | Render in-process verification-gate hooks for capable adapters (issue #2360) |

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -726,10 +726,15 @@ STRATEGY_MATRIX: dict[str, AdapterStrategy] = {
     "droid": AdapterStrategy(),
     "forge": AdapterStrategy(),
     "generic": AdapterStrategy(),
-    # Goose speaks ACP natively; Bernstein consumes its lifecycle over the
-    # JSON-RPC client transport and journals each event content-addressed,
-    # so its stdout lifecycle parser is bypassed.
-    "goose": AdapterStrategy(event_channel=EventChannel.ACP),
+    # Goose emits NDJSON under --output-format stream-json whose events carry
+    # tokens/cost_usd and an error event (the authoritative failure signal;
+    # status:'completed' is a constant not a verdict). Dangerous mode is the
+    # GOOSE_MODE env var (auto/approve/smart_approve/chat), set explicitly by
+    # the adapter, not a CLI flag.
+    "goose": AdapterStrategy(
+        event_channel=EventChannel.STREAM_JSON,
+        dangerous_mode=DangerousModeStrategy.ENV_VAR,
+    ),
     "gptme": AdapterStrategy(),
     # Hermes is driven through its one-shot mode, which auto-bypasses approvals
     # rather than exposing a flag to do so - the CLI is unattended by

--- a/src/bernstein/adapters/capability_profile.py
+++ b/src/bernstein/adapters/capability_profile.py
@@ -1158,8 +1158,13 @@ _PROFILE_LIST: tuple[AdapterCapabilityProfile, ...] = (
             prompt_flag="--text",
         ),
         mcp_client=True,
-        event_channel=EventChannel.ACP,
-        notes="Goose (AAIF). Speaks ACP natively; model flag is optional and module-supplied.",
+        event_channel=EventChannel.STREAM_JSON,
+        dangerous_mode=DangerousModeStrategy.ENV_VAR,
+        notes=(
+            "Goose (AAIF). Spawned as `goose run --text` and parsed from its own "
+            "stream; autonomy is set through GOOSE_MODE. Model flag is optional "
+            "and module-supplied."
+        ),
     ),
 )
 

--- a/src/bernstein/adapters/goose.py
+++ b/src/bernstein/adapters/goose.py
@@ -24,6 +24,7 @@ import subprocess
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
+from bernstein.adapters._contract import DangerousModeStrategy
 from bernstein.adapters.base import (
     DEFAULT_TIMEOUT_SECONDS,
     CLIAdapter,
@@ -31,6 +32,7 @@ from bernstein.adapters.base import (
     build_worker_cmd,
 )
 from bernstein.adapters.env_isolation import build_filtered_env
+from bernstein.core.defaults import COST
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -55,6 +57,29 @@ class GooseAdapter(CLIAdapter):
     Integrates with the Goose CLI agent.
     GitHub: https://github.com/aaif-goose/goose
     """
+
+    def _goose_mode(self) -> str:
+        """Return the GOOSE_MODE autonomy policy for this spawn.
+
+        Goose controls autonomy via the ``GOOSE_MODE`` env var (``auto``,
+        ``approve``, ``smart_approve``, ``chat``); there is no CLI flag. The
+        policy is pinned on every spawn from the adapter's declared
+        dangerous-mode strategy so an un-pinned spawn never inherits the
+        operator's own ``GOOSE_MODE``. A permissive strategy (``auto``) lets
+        the agent act unattended; anything else is restricted (``approve``)
+        so a headless run fails fast instead of blocking on a prompt nobody
+        answers.
+        """
+        declared = getattr(self.strategy(), "dangerous_mode", DangerousModeStrategy.UNSUPPORTED)
+        if not isinstance(declared, DangerousModeStrategy):
+            declared = DangerousModeStrategy.UNSUPPORTED
+        if declared in (
+            DangerousModeStrategy.ENV_VAR,
+            DangerousModeStrategy.CLI_FLAG,
+            DangerousModeStrategy.ALWAYS_ON,
+        ):
+            return "auto"
+        return "approve"
 
     def spawn(
         self,
@@ -93,7 +118,24 @@ class GooseAdapter(CLIAdapter):
 
         model_id = _MODEL_MAP.get(model_config.model, model_config.model)
 
-        cmd = ["goose", "run", "--text", prompt]
+        # Max turns derived from effort and task scope, mirroring the claude
+        # adapter's computation so large tasks get proportionally more turns.
+        effort = getattr(model_config, "effort", "normal")
+        base_turns = COST.effort_base_turns.get(effort, 50)
+        scope_multiplier = COST.scope_multipliers.get(task_scope, 1.5)
+        max_turns = int(base_turns * scope_multiplier)
+
+        cmd = [
+            "goose",
+            "run",
+            "--text",
+            prompt,
+            "--output-format",
+            "stream-json",
+            "--no-session",
+            "--max-turns",
+            str(max_turns),
+        ]
         if model_id:
             cmd += ["--model", model_id]
 
@@ -115,6 +157,11 @@ class GooseAdapter(CLIAdapter):
         env = build_filtered_env(
             ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY", "GOOGLE_API_KEY"],
         )
+        # Pin the autonomy policy AFTER the allow-list so the worker sees the
+        # adapter's value whatever the operator's own environment holds.
+        # ``GOOSE_MODE`` is deliberately not in ``build_filtered_env``'s
+        # extra_keys - it is set explicitly here, never inherited.
+        env["GOOSE_MODE"] = self._goose_mode()
         with log_path.open("w") as log_file:
             try:
                 proc = subprocess.Popen(

--- a/src/bernstein/adapters/goose_stream_parser.py
+++ b/src/bernstein/adapters/goose_stream_parser.py
@@ -1,0 +1,138 @@
+"""Parse Goose ``--output-format stream-json`` events.
+
+Goose emits newline-delimited JSON under ``--output-format stream-json``. The
+authoritative accounting rides on a terminal ``envelope`` event whose
+``metadata`` carries the provider's own token breakdown (``tokens`` with
+``total``/``input``/``output``/``cache_read``/``cache_write``) and a
+``cost_usd`` figure. Errors surface as separate ``error`` events.
+
+Upstream quirk (issue #3679): ``goose run`` returns ``Ok(())`` on every
+terminal path once the agent started, and ``metadata.status`` is the literal
+``"completed"`` in both the success and the error match arms. Under
+``--output-format stream-json`` an ``error`` event is emitted but a
+``complete`` event still follows and the exit status is still 0. So the
+``error`` event is the authoritative failure signal - ``status: "completed"``
+must NOT be treated as success.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, cast
+
+#: Envelope event type carrying the provider's token/cost accounting.
+_EVENT_ENVELOPE = "envelope"
+#: Error event type - the authoritative failure signal.
+_EVENT_ERROR = "error"
+#: The literal status value goose writes in both terminal match arms.
+_STATUS_COMPLETED = "completed"
+
+
+@dataclass(frozen=True)
+class GooseStreamResult:
+    """Parsed outcome of a Goose stream-json session log.
+
+    Attributes:
+        tokens_in: Input tokens from the envelope's ``tokens.input``.
+        tokens_out: Output tokens from the envelope's ``tokens.output``.
+        cost_usd: Provider-reported cost from the envelope's ``cost_usd``.
+        error: Error message when an ``error`` event was seen, else None.
+        completed: Whether an envelope with ``status == "completed"`` was seen.
+    """
+
+    tokens_in: int = 0
+    tokens_out: int = 0
+    cost_usd: float = 0.0
+    error: str | None = None
+    completed: bool = False
+
+    @property
+    def is_success(self) -> bool:
+        """Whether the run succeeded.
+
+        Success is the ABSENCE of an ``error`` event, never the presence of a
+        ``completed`` envelope - goose emits ``status: "completed"`` in both
+        the success and error match arms, so ``completed`` alone is not a
+        success signal.
+        """
+        return self.error is None
+
+
+def _as_dict(value: Any) -> dict[str, Any] | None:
+    """Return ``value`` as a ``dict[str, Any]`` when it is a mapping, else None."""
+    return cast("dict[str, Any]", value) if isinstance(value, dict) else None
+
+
+def _coerce_int(value: Any) -> int:
+    """Return ``value`` as a non-negative int, or ``0`` when not coercible."""
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return result if result > 0 else 0
+
+
+def _coerce_float(value: Any) -> float:
+    """Return ``value`` as a non-negative float, or ``0.0`` when not coercible."""
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return result if result > 0 else 0.0
+
+
+def parse_goose_stream(text: str) -> GooseStreamResult:
+    """Parse Goose stream-json NDJSON into a :class:`GooseStreamResult`.
+
+    Args:
+        text: Raw session-log text (line-delimited stream-json).
+
+    Returns:
+        A :class:`GooseStreamResult` with the envelope's token/cost
+        accounting and the first ``error`` event message (if any).
+    """
+    tokens_in = 0
+    tokens_out = 0
+    cost_usd = 0.0
+    error: str | None = None
+    completed = False
+
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        rec_dict = _as_dict(rec)
+        if rec_dict is None:
+            continue
+
+        event_type = rec_dict.get("type")
+        if event_type == _EVENT_ERROR:
+            message = rec_dict.get("message") or rec_dict.get("error") or "goose error"
+            error = str(message)
+            continue
+        if event_type != _EVENT_ENVELOPE:
+            continue
+
+        metadata = _as_dict(rec_dict.get("metadata"))
+        if metadata is None:
+            continue
+        if metadata.get("status") == _STATUS_COMPLETED:
+            completed = True
+        tokens = _as_dict(metadata.get("tokens"))
+        if tokens is not None:
+            tokens_in = _coerce_int(tokens.get("input"))
+            tokens_out = _coerce_int(tokens.get("output"))
+        cost_usd = _coerce_float(metadata.get("cost_usd"))
+
+    return GooseStreamResult(
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        cost_usd=cost_usd,
+        error=error,
+        completed=completed,
+    )

--- a/src/bernstein/core/cost/cli_adapter_usage.py
+++ b/src/bernstein/core/cost/cli_adapter_usage.py
@@ -159,11 +159,68 @@ def _record_usage(rec: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
+def _envelope_in_out(rec: dict[str, Any]) -> tuple[int, int] | None:
+    """Extract ``(input, output)`` from a goose stream-json envelope record.
+
+    Goose's ``--output-format stream-json`` carries the provider's own
+    cumulative accounting on a terminal ``envelope`` event under
+    ``metadata.tokens`` (``input``/``output``/``cache_read``/``cache_write``/
+    ``total``). Returns None when the record is not an envelope or carries no
+    recognisable token counts.
+    """
+    if rec.get("type") != "envelope":
+        return None
+    metadata = _as_dict(rec.get("metadata"))
+    if metadata is None:
+        return None
+    tokens = _as_dict(metadata.get("tokens"))
+    if tokens is None:
+        return None
+    tokens_in, tokens_out = _extract_in_out(tokens)
+    if tokens_in > 0 or tokens_out > 0:
+        return tokens_in, tokens_out
+    return None
+
+
+def _extract_cost_usd(text: str) -> float:
+    """Extract the provider-reported ``cost_usd`` from a goose envelope.
+
+    Goose's envelope ``metadata`` carries an upstream ``cost_usd`` figure that
+    is more authoritative than the price-model estimate derived from token
+    counts, so it is written into the ``.tokens`` sidecar record for the cost
+    path to prefer.
+
+    Args:
+        text: Raw session-log text (line-delimited stream-json).
+
+    Returns:
+        The envelope's ``cost_usd``, or ``0.0`` when absent/uncoercible.
+    """
+    for rec in _records_from_text(text):
+        if rec.get("type") != "envelope":
+            continue
+        metadata = _as_dict(rec.get("metadata"))
+        if metadata is None:
+            continue
+        cost = metadata.get("cost_usd")
+        if cost is None:
+            continue
+        try:
+            value = float(cost)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return value
+    return 0.0
+
+
 def parse_stream_json_usage(text: str) -> tuple[int, int, str]:
     """Parse qwen-code stream-json output into ``(in, out, model)`` tokens.
 
     Precedence, most authoritative first, so counts are never double-summed:
 
+    0. The goose stream-json ``envelope`` event's ``metadata.tokens`` - the
+       provider's own cumulative per-session accounting.
     1. ``stats.models`` / ``metrics.models`` - the provider's own cumulative
        per-session breakdown (``tokens.prompt`` / ``tokens.completion``).
     2. The terminal ``result`` message's cumulative ``usage`` block.
@@ -186,6 +243,13 @@ def parse_stream_json_usage(text: str) -> tuple[int, int, str]:
         fallback_model = _record_model(rec)
         if fallback_model:
             break
+
+    # 0. Goose stream-json envelope - the provider's own cumulative
+    #    per-session accounting (``metadata.tokens``).
+    for rec in records:
+        envelope = _envelope_in_out(rec)
+        if envelope is not None:
+            return envelope[0], envelope[1], fallback_model
 
     # 1. Authoritative provider breakdown.
     for rec in records:
@@ -276,7 +340,8 @@ def capture_cli_adapter_usage(
     """Recover CLI-adapter token usage and materialise the recovery sidecar.
 
     Parses the adapter's structured session log and, when it carries real
-    token counts, appends a ``{"ts", "in", "out"}`` record to the
+    token counts, appends a ``{"ts", "in", "out"}`` record (plus an optional
+    ``cost_usd`` when the log reports one) to the
     orchestrator-root ``.sdd/runtime/<session_id>.tokens`` sidecar - the exact
     file
     :func:`bernstein.core.agents.agent_lifecycle._read_runner_cost_usd` reads
@@ -322,9 +387,15 @@ def capture_cli_adapter_usage(
 
     try:
         sidecar_path.parent.mkdir(parents=True, exist_ok=True)
-        record = json.dumps({"ts": time.time(), "in": tokens_in, "out": tokens_out})
+        record: dict[str, Any] = {"ts": time.time(), "in": tokens_in, "out": tokens_out}
+        # Goose's envelope carries an upstream ``cost_usd`` that is more
+        # authoritative than the price-model estimate derived from token
+        # counts; carry it on the record so the cost path can prefer it.
+        cost_usd = _extract_cost_usd(text)
+        if cost_usd > 0:
+            record["cost_usd"] = cost_usd
         with sidecar_path.open("a", encoding="utf-8") as fh:
-            fh.write(record + "\n")
+            fh.write(json.dumps(record) + "\n")
     except OSError as exc:
         # "tokens" here is the usage-count sidecar file, not a credential.
         # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure

--- a/tests/contract/contracts/goose.yaml
+++ b/tests/contract/contracts/goose.yaml
@@ -30,6 +30,9 @@ auth:
 required_flags:
   - "--text"
   - "--model"
+  - "--output-format"
+  - "--no-session"
+  - "--max-turns"
 required_subcommands:
   - "run"
 # Goose sub-flags live under ``goose run --help``.

--- a/tests/unit/adapters/test_acp_channel.py
+++ b/tests/unit/adapters/test_acp_channel.py
@@ -37,14 +37,21 @@ def _lines(frames: list[dict]) -> list[bytes]:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("name", ["kilo", "goose"])
+@pytest.mark.parametrize("name", ["kilo"])
 def test_migrated_adapters_declare_acp_channel(name: str) -> None:
     assert strategy_for(name).event_channel is EventChannel.ACP
 
 
-@pytest.mark.parametrize("name", ["kilo", "goose"])
+@pytest.mark.parametrize("name", ["kilo"])
 def test_adapter_speaks_acp_true_for_migrated(name: str) -> None:
     assert adapter_speaks_acp(name) is True
+
+
+def test_goose_declares_stream_json_not_acp() -> None:
+    # goose is spawned as "goose run --text <prompt>" and emits its own
+    # stream, not ACP JSON-RPC lifecycle frames.
+    assert strategy_for("goose").event_channel is EventChannel.STREAM_JSON
+    assert adapter_speaks_acp("goose") is False
 
 
 def test_adapter_speaks_acp_false_for_text_signal_adapter() -> None:

--- a/tests/unit/adapters/test_capability_enums.py
+++ b/tests/unit/adapters/test_capability_enums.py
@@ -207,7 +207,7 @@ def test_continuation_optin_matches_the_resume_declaration() -> None:
 
 
 def test_acp_channel_adapters_declared() -> None:
-    for name in ("kilo", "goose"):
+    for name in ("kilo",):
         assert strategy_for(name).event_channel is EventChannel.ACP
 
 

--- a/tests/unit/adapters/test_goose_adapter.py
+++ b/tests/unit/adapters/test_goose_adapter.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import shlex
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -17,7 +18,9 @@ import pytest
 import yaml
 from bernstein.core.models import ModelConfig
 
+from bernstein.adapters._contract import DangerousModeStrategy
 from bernstein.adapters.goose import GooseAdapter
+from bernstein.adapters.goose_stream_parser import parse_goose_stream
 from bernstein.core.routing.llm import _CLI_FLAGS
 
 CONTRACT_PATH = Path(__file__).resolve().parents[2] / "contract" / "contracts" / "goose.yaml"
@@ -55,6 +58,28 @@ def _spawn_and_capture(tmp_path: Path, **overrides: Any) -> list[str]:
     return _inner_argv(list(mock_popen.call_args[0][0]))
 
 
+def _spawn_and_capture_env(tmp_path: Path, **overrides: Any) -> dict[str, str]:
+    """Spawn the adapter with Popen patched; return the spawned env dict."""
+    kwargs: dict[str, Any] = {
+        "prompt": "Refactor the auth module",
+        "workdir": tmp_path,
+        "model_config": ModelConfig(model="sonnet", effort="normal"),
+        "session_id": "backend-goose-task-1",
+        "mcp_config": None,
+        "task_scope": "medium",
+        "budget_multiplier": 1.0,
+        "system_addendum": "",
+        "timeout_seconds": 0,
+    }
+    kwargs.update(overrides)
+    with patch("subprocess.Popen") as mock_popen:
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_popen.return_value = mock_proc
+        GooseAdapter().spawn(**kwargs)
+    return mock_popen.call_args[1]["env"]
+
+
 def test_spawn_does_not_pass_singular_instruction_flag(tmp_path: Path) -> None:
     """``--instruction`` is rejected by goose's parser (exit 2); never emit it."""
     argv = _spawn_and_capture(tmp_path)
@@ -88,7 +113,7 @@ def test_contract_fixture_declares_only_flags_goose_accepts() -> None:
     assert "--instruction" not in spec["required_flags"]
 
 
-@pytest.mark.parametrize("flag", ["--text", "--model"])
+@pytest.mark.parametrize("flag", ["--text", "--model", "--output-format", "--no-session", "--max-turns"])
 def test_contract_fixture_covers_the_flags_the_adapter_spawns(flag: str, tmp_path: Path) -> None:
     """Every flag the adapter always passes is guarded by the drift contract."""
     spec = yaml.safe_load(CONTRACT_PATH.read_text(encoding="utf-8"))
@@ -103,7 +128,17 @@ def test_spawn_without_a_model_is_still_a_valid_invocation(tmp_path: Path) -> No
     a model-less spawn malformed.
     """
     argv = _spawn_and_capture(tmp_path, model_config=ModelConfig(model="", effort="normal"))
-    assert argv == ["goose", "run", "--text", "Refactor the auth module"]
+    assert argv == [
+        "goose",
+        "run",
+        "--text",
+        "Refactor the auth module",
+        "--output-format",
+        "stream-json",
+        "--no-session",
+        "--max-turns",
+        "37",
+    ]
 
 
 def test_internal_llm_provider_path_uses_the_run_subcommand() -> None:
@@ -116,3 +151,92 @@ def test_internal_llm_provider_path_uses_the_run_subcommand() -> None:
     prompt_flag, model_flag, extra = _CLI_FLAGS["goose"]
     argv = ["goose", *shlex.split(prompt_flag), "PROMPT", *shlex.split(model_flag), "MODEL", *extra]
     assert argv == ["goose", "run", "--text", "PROMPT", "--model", "MODEL"]
+
+
+def test_spawn_passes_output_format_stream_json(tmp_path: Path) -> None:
+    """Every spawn requests ``--output-format stream-json`` for the envelope."""
+    argv = _spawn_and_capture(tmp_path)
+    assert "--output-format" in argv
+    assert argv[argv.index("--output-format") + 1] == "stream-json"
+
+
+def test_spawn_passes_no_session(tmp_path: Path) -> None:
+    """Every spawn passes ``--no-session`` so runs never resume a prior one."""
+    argv = _spawn_and_capture(tmp_path)
+    assert "--no-session" in argv
+
+
+def test_spawn_passes_max_turns_derived_from_scope(tmp_path: Path) -> None:
+    """``--max-turns`` scales with task scope (effort ``normal`` → base 25)."""
+    expected = {
+        "small": 25,  # 25 * 1.0
+        "medium": 37,  # 25 * 1.5
+        "large": 50,  # 25 * 2.0
+    }
+    for scope, turns in expected.items():
+        argv = _spawn_and_capture(tmp_path, task_scope=scope)
+        assert argv[argv.index("--max-turns") + 1] == str(turns)
+
+
+def test_goose_mode_permissive_when_dangerous_mode_on(tmp_path: Path) -> None:
+    """A permissive dangerous-mode strategy pins ``GOOSE_MODE=auto``."""
+    with patch.object(
+        GooseAdapter,
+        "strategy",
+        return_value=SimpleNamespace(dangerous_mode=DangerousModeStrategy.ENV_VAR),
+    ):
+        env = _spawn_and_capture_env(tmp_path)
+    assert env["GOOSE_MODE"] == "auto"
+
+
+def test_goose_mode_restricted_when_dangerous_mode_off(tmp_path: Path) -> None:
+    """A non-permissive dangerous-mode strategy pins ``GOOSE_MODE=approve``."""
+    with patch.object(
+        GooseAdapter,
+        "strategy",
+        return_value=SimpleNamespace(dangerous_mode=DangerousModeStrategy.UNSUPPORTED),
+    ):
+        env = _spawn_and_capture_env(tmp_path)
+    assert env["GOOSE_MODE"] == "approve"
+
+
+def test_goose_mode_not_inherited_from_operator_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An operator's ``GOOSE_MODE`` never leaks into the spawned env."""
+    monkeypatch.setenv("GOOSE_MODE", "chat")
+    env = _spawn_and_capture_env(tmp_path)
+    assert env["GOOSE_MODE"] == "approve"
+
+
+def test_error_event_is_failure_signal() -> None:
+    """An ``error`` event marks the run failed regardless of any envelope."""
+    stream = '{"type":"error","message":"provider failure"}\n'
+    result = parse_goose_stream(stream)
+    assert result.is_success is False
+    assert result.error == "provider failure"
+
+
+def test_completed_status_not_treated_as_success() -> None:
+    """``status: "completed"`` alone is not success - an error event is."""
+    stream = (
+        '{"type":"error","message":"provider failure"}\n'
+        '{"type":"envelope","metadata":{"status":"completed","tokens":{"input":10,"output":5},"cost_usd":0.01}}\n'
+    )
+    result = parse_goose_stream(stream)
+    assert result.completed is True
+    assert result.is_success is False
+    assert result.error == "provider failure"
+
+
+def test_tokens_and_cost_from_envelope() -> None:
+    """The envelope's token breakdown and ``cost_usd`` are extracted."""
+    stream = (
+        '{"type":"envelope","metadata":{"status":"completed",'
+        '"tokens":{"total":15,"input":10,"output":5,"cache_read":2,"cache_write":1},'
+        '"cost_usd":0.0123}}\n'
+    )
+    result = parse_goose_stream(stream)
+    assert result.tokens_in == 10
+    assert result.tokens_out == 5
+    assert result.cost_usd == 0.0123
+    assert result.completed is True
+    assert result.is_success is True

--- a/tests/unit/adapters/test_goose_adapter.py
+++ b/tests/unit/adapters/test_goose_adapter.py
@@ -204,7 +204,8 @@ def test_goose_mode_not_inherited_from_operator_env(tmp_path: Path, monkeypatch:
     """An operator's ``GOOSE_MODE`` never leaks into the spawned env."""
     monkeypatch.setenv("GOOSE_MODE", "chat")
     env = _spawn_and_capture_env(tmp_path)
-    assert env["GOOSE_MODE"] == "approve"
+    assert env["GOOSE_MODE"] != "chat"
+    assert env["GOOSE_MODE"] == "auto"
 
 
 def test_error_event_is_failure_signal() -> None:


### PR DESCRIPTION
Extends the Goose adapter to drive more of the CLI it wraps, adds a stream parser for its output, and threads the usage accounting through, for #3679.

These commits came from a run whose publication stopped before a pull request was opened, so the work sat in a bundle. Publishing it as a draft so CI judges it rather than leaving it unreviewed on disk. The branch is from 2026-08-24, so it may need a rebase onto current main.

Part of #3679
