### PR TITLE
fix(orchestrator): bound the planning window so a failed plan does not run to timeout

### DIFF
--- a/docs/release-notes/fragments/4529-planning-window.md
+++ b/docs/release-notes/fragments/4529-planning-window.md
@@ -1,0 +1,6 @@
+## A failed plan no longer runs out the clock
+
+A run whose planning task failed kept ticking with an empty ledger until it hit
+its wall-clock timeout, so a fast failure cost the same wall time as real work.
+The orchestrator now bounds the window it will wait for a first task and closes
+the run when that window passes with nothing planned (#4529).

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -142,7 +142,8 @@ class OrchestratorDefaults:
     # ran and failed). This prevents idling indefinitely when the planning
     # task fails and the ledger stays empty. Tunable via
     # ``tuning.orchestrator.planning_window_s`` or the
-    # ``BERNSTEIN_PLANNING_WINDOW_S`` env var (checked first).
+    # ``BERNSTEIN_PLANNING_WINDOW_S`` env var, which takes precedence and is
+    # read at the use site by ``run_stall.resolve_planning_window_s``.
     planning_window_s: float = 300.0  # 5 minutes
 
     max_dead_agents_kept: int = 20  # bounded dead-agent history for debugging

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -136,6 +136,15 @@ class OrchestratorDefaults:
     stalled_run_grace_s: float = 1800.0  # 30 min of zero forward progress
     stalled_run_ticks: int = 10  # consecutive no-progress quiescent ticks
 
+    # Planning window: if the planner fails and no tasks are ever spawned,
+    # terminate the run after this many seconds of an empty ledger (no tasks
+    # in any state) *after* having seen at least one task (i.e., planning
+    # ran and failed). This prevents idling indefinitely when the planning
+    # task fails and the ledger stays empty. Tunable via
+    # ``tuning.orchestrator.planning_window_s`` or the
+    # ``BERNSTEIN_PLANNING_WINDOW_S`` env var (checked first).
+    planning_window_s: float = 300.0  # 5 minutes
+
     max_dead_agents_kept: int = 20  # bounded dead-agent history for debugging
     max_processed_done: int = 500  # bounded done-task cache to limit memory
 

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -405,8 +405,12 @@ class Orchestrator:
         self._agents: dict[str, AgentSession] = {}
         self._lock_manager = FileLockManager(workdir)
         self._file_ownership: dict[str, str] = {}  # filepath -> agent_id (legacy alias; use _lock_manager)
-        self._ever_had_tasks: bool = False  # tracks if we've ever seen any tasks (to distinguish initial empty state from planning-failed state)
-        self._first_empty_ledger_ts: float | None = None   # timestamp when we first observed an empty ledger (no tasks in any state)
+        self._ever_had_tasks: bool = (
+            False  # tracks if we've ever seen any tasks (to distinguish initial empty state from planning-failed state)
+        )
+        self._first_empty_ledger_ts: float | None = (
+            None  # timestamp when we first observed an empty ledger (no tasks in any state)
+        )
         from bernstein.core.loop_detector import LoopDetector
 
         self._loop_detector = LoopDetector()
@@ -2152,21 +2156,28 @@ class Orchestrator:
         # every quiescent tick until confirmed.
         _raw_open = len(tasks_by_status.get("open", []))
         # Track if we've ever seen tasks to distinguish initial empty state from planning-failed state
-        total_tasks = len(tasks_by_status.get("open", [])) + len(tasks_by_status.get("claimed", [])) + len(tasks_by_status.get("done", [])) + len(tasks_by_status.get("failed", []))
+        total_tasks = (
+            len(tasks_by_status.get("open", []))
+            + len(tasks_by_status.get("claimed", []))
+            + len(tasks_by_status.get("done", []))
+            + len(tasks_by_status.get("failed", []))
+        )
         if total_tasks > 0:
             self._ever_had_tasks = True
             self._first_empty_ledger_ts = None  # reset if we see tasks again
         elif self._first_empty_ledger_ts is None:
             # First time seeing empty ledger
             self._first_empty_ledger_ts = time.time()
-        
+
         # Check if we should terminate due to planning window expiration
         # If we've ever had tasks (meaning planning ran) and now have an empty ledger
         # that has persisted beyond the planning window, terminate the run
-        if (self._ever_had_tasks and 
-            total_tasks == 0 and 
-            self._first_empty_ledger_ts is not None and
-            time.time() - self._first_empty_ledger_ts >= self._config.planning_window_s):
+        if (
+            self._ever_had_tasks
+            and total_tasks == 0
+            and self._first_empty_ledger_ts is not None
+            and time.time() - self._first_empty_ledger_ts >= self._config.planning_window_s
+        ):
             logger.info(
                 "Planning window expired (%.1fs) with empty ledger after having seen tasks - "
                 "terminating run to prevent indefinite idling",
@@ -2175,7 +2186,7 @@ class Orchestrator:
             self._closure_outcome = RunClosureOutcome.FAILED
             self._running = False
             return result
-        
+
         if not self._config.evolve_mode and result.open_tasks == result.active_agents == 0 and _raw_open == 0:
             refreshed_tasks_by_status = tasks_by_status
             try:

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -405,6 +405,8 @@ class Orchestrator:
         self._agents: dict[str, AgentSession] = {}
         self._lock_manager = FileLockManager(workdir)
         self._file_ownership: dict[str, str] = {}  # filepath -> agent_id (legacy alias; use _lock_manager)
+        self._ever_had_tasks: bool = False  # tracks if we've ever seen any tasks (to distinguish initial empty state from planning-failed state)
+        self._first_empty_ledger_ts: float | None = None   # timestamp when we first observed an empty ledger (no tasks in any state)
         from bernstein.core.loop_detector import LoopDetector
 
         self._loop_detector = LoopDetector()
@@ -2149,6 +2151,31 @@ class Orchestrator:
         # check, the self-stop, and shutdown-final regeneration re-run on
         # every quiescent tick until confirmed.
         _raw_open = len(tasks_by_status.get("open", []))
+        # Track if we've ever seen tasks to distinguish initial empty state from planning-failed state
+        total_tasks = len(tasks_by_status.get("open", [])) + len(tasks_by_status.get("claimed", [])) + len(tasks_by_status.get("done", [])) + len(tasks_by_status.get("failed", []))
+        if total_tasks > 0:
+            self._ever_had_tasks = True
+            self._first_empty_ledger_ts = None  # reset if we see tasks again
+        elif self._first_empty_ledger_ts is None:
+            # First time seeing empty ledger
+            self._first_empty_ledger_ts = time.time()
+        
+        # Check if we should terminate due to planning window expiration
+        # If we've ever had tasks (meaning planning ran) and now have an empty ledger
+        # that has persisted beyond the planning window, terminate the run
+        if (self._ever_had_tasks and 
+            total_tasks == 0 and 
+            self._first_empty_ledger_ts is not None and
+            time.time() - self._first_empty_ledger_ts >= self._config.planning_window_s):
+            logger.info(
+                "Planning window expired (%.1fs) with empty ledger after having seen tasks - "
+                "terminating run to prevent indefinite idling",
+                time.time() - self._first_empty_ledger_ts,
+            )
+            self._closure_outcome = RunClosureOutcome.FAILED
+            self._running = False
+            return result
+        
         if not self._config.evolve_mode and result.open_tasks == result.active_agents == 0 and _raw_open == 0:
             refreshed_tasks_by_status = tasks_by_status
             try:

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -104,6 +104,7 @@ from bernstein.core.orchestration.run_stall import (
     evaluate_run_stall,
     resolve_grace_s,
     resolve_min_ticks,
+    resolve_planning_window_s,
 )
 from bernstein.core.orchestration.schedule_projection import (
     SCHEDULE_PROJECTION_REV,
@@ -405,12 +406,6 @@ class Orchestrator:
         self._agents: dict[str, AgentSession] = {}
         self._lock_manager = FileLockManager(workdir)
         self._file_ownership: dict[str, str] = {}  # filepath -> agent_id (legacy alias; use _lock_manager)
-        self._ever_had_tasks: bool = (
-            False  # tracks if we've ever seen any tasks (to distinguish initial empty state from planning-failed state)
-        )
-        self._first_empty_ledger_ts: float | None = (
-            None  # timestamp when we first observed an empty ledger (no tasks in any state)
-        )
         from bernstein.core.loop_detector import LoopDetector
 
         self._loop_detector = LoopDetector()
@@ -2155,38 +2150,6 @@ class Orchestrator:
         # check, the self-stop, and shutdown-final regeneration re-run on
         # every quiescent tick until confirmed.
         _raw_open = len(tasks_by_status.get("open", []))
-        # Track if we've ever seen tasks to distinguish initial empty state from planning-failed state
-        total_tasks = (
-            len(tasks_by_status.get("open", []))
-            + len(tasks_by_status.get("claimed", []))
-            + len(tasks_by_status.get("done", []))
-            + len(tasks_by_status.get("failed", []))
-        )
-        if total_tasks > 0:
-            self._ever_had_tasks = True
-            self._first_empty_ledger_ts = None  # reset if we see tasks again
-        elif self._first_empty_ledger_ts is None:
-            # First time seeing empty ledger
-            self._first_empty_ledger_ts = time.time()
-
-        # Check if we should terminate due to planning window expiration
-        # If we've ever had tasks (meaning planning ran) and now have an empty ledger
-        # that has persisted beyond the planning window, terminate the run
-        if (
-            self._ever_had_tasks
-            and total_tasks == 0
-            and self._first_empty_ledger_ts is not None
-            and time.time() - self._first_empty_ledger_ts >= self._config.planning_window_s
-        ):
-            logger.info(
-                "Planning window expired (%.1fs) with empty ledger after having seen tasks - "
-                "terminating run to prevent indefinite idling",
-                time.time() - self._first_empty_ledger_ts,
-            )
-            self._closure_outcome = RunClosureOutcome.FAILED
-            self._running = False
-            return result
-
         if not self._config.evolve_mode and result.open_tasks == result.active_agents == 0 and _raw_open == 0:
             refreshed_tasks_by_status = tasks_by_status
             try:
@@ -2611,6 +2574,7 @@ class Orchestrator:
             now=time.time(),
             grace_s=grace_s,
             min_ticks=min_ticks,
+            planning_window_s=resolve_planning_window_s(self._config.planning_window_s),
         )
         if not verdict.stalled:
             logger.debug(
@@ -2659,7 +2623,13 @@ class Orchestrator:
         _stuck_ids = sorted(
             str(task.id) for status, tasks in settled.items() if status in ACTIVE_UNFINISHED_STATUSES for task in tasks
         )
-        if not _stuck_ids:
+        # An empty ledger has no task to fail, and that absence IS the
+        # verdict rather than a reason to doubt it: the planning task never
+        # landed a graph, so there is nothing to mark stuck and nothing that
+        # can arrive. Treating "no stuck task" as "run continues" here is
+        # what left that run ticking to its wall-clock timeout.
+        _ledger_empty = not any(settled.values())
+        if not _stuck_ids and not _ledger_empty:
             logger.info(
                 "run_stall_check: no actively-unfinished task left after the %.1fs settle "
                 "window (tick #%d) - run continues",

--- a/src/bernstein/core/orchestration/run_stall.py
+++ b/src/bernstein/core/orchestration/run_stall.py
@@ -93,6 +93,7 @@ TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "failed", "closed", "canc
 #: env var > yaml-tunable config field > ``core.defaults``.
 GRACE_ENV_VAR: str = "BERNSTEIN_STALLED_RUN_GRACE_S"
 MIN_TICKS_ENV_VAR: str = "BERNSTEIN_STALLED_RUN_TICKS"
+PLANNING_WINDOW_ENV_VAR: str = "BERNSTEIN_PLANNING_WINDOW_S"
 
 
 @dataclass(frozen=True)
@@ -167,6 +168,11 @@ def resolve_grace_s(config_value: float) -> float:
     return _resolve_float(GRACE_ENV_VAR, config_value)
 
 
+def resolve_planning_window_s(config_value: float) -> float:
+    """Resolve the planning window, env var taking precedence."""
+    return _resolve_float(PLANNING_WINDOW_ENV_VAR, config_value)
+
+
 def resolve_min_ticks(config_value: int) -> int:
     """Resolve the consecutive-tick floor, env var taking precedence."""
     raw = os.environ.get(MIN_TICKS_ENV_VAR)
@@ -195,6 +201,7 @@ def evaluate_run_stall(
     now: float,
     grace_s: float,
     min_ticks: int,
+    planning_window_s: float = 300.0,
 ) -> tuple[RunStallState, StallVerdict]:
     """Decide whether a zero-terminal quiescent run has stopped progressing.
 
@@ -236,12 +243,35 @@ def evaluate_run_stall(
     parked_ids.sort()
 
     # Condition 2a: no tasks at all is the pre-ingest startup window that
-    # the quiescence gate's zero-terminal guard exists to protect. Reset
-    # rather than accumulate, so the clock starts when work appears.
+    # the quiescence gate's zero-terminal guard exists to protect - but only
+    # for as long as planning could still land a graph. This used to reset the
+    # clock every tick, so the window had no end: a run whose planning task
+    # failed read as "startup" forever and ticked to its wall-clock timeout
+    # holding the workspace, with no open or claimed task to make it read as
+    # stalled either. The clock now accumulates, bounded by planning_window_s.
     if total == 0:
-        return RunStallState(), StallVerdict(
+        empty_fingerprint: tuple[tuple[str, str], ...] = ()
+        if prev.fingerprint != empty_fingerprint:
+            empty_state = RunStallState(fingerprint=empty_fingerprint, since_ts=now, observed_ticks=1)
+        else:
+            empty_state = replace(prev, observed_ticks=prev.observed_ticks + 1)
+        quiet_for_s = max(now - empty_state.since_ts, 0.0)
+        if empty_state.observed_ticks >= min_ticks and quiet_for_s >= planning_window_s:
+            return empty_state, StallVerdict(
+                stalled=True,
+                reason=(
+                    f"ledger empty for {quiet_for_s:.0f}s across "
+                    f"{empty_state.observed_ticks} quiescent tick(s) - planning never "
+                    "produced a task graph and no task can arrive"
+                ),
+                observed_ticks=empty_state.observed_ticks,
+                quiet_for_s=quiet_for_s,
+            )
+        return empty_state, StallVerdict(
             stalled=False,
-            reason="no tasks declared yet - startup window, not a stall",
+            reason=(f"no tasks declared yet - startup window ({quiet_for_s:.0f}s of {planning_window_s:.0f}s)"),
+            observed_ticks=empty_state.observed_ticks,
+            quiet_for_s=quiet_for_s,
         )
 
     # Condition 2b: only deliberately-parked tasks remain. Waiting on a

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -41,6 +41,18 @@ def _default_stalled_manager_threshold_s() -> float:
     return float(_defaults.ORCHESTRATOR.stalled_manager_threshold_s)
 
 
+def _default_planning_window_s() -> float:
+    """Return the current canonical planning window.
+
+    Reads from :mod:`bernstein.core.defaults` each call (same pattern as
+    :func:`_default_poll_interval_s`) so that ``tuning.orchestrator.
+    planning_window_s`` overrides from ``bernstein.yaml`` are honoured. The
+    ``BERNSTEIN_PLANNING_WINDOW_S`` env var is applied at the use site by
+    ``core.orchestration.run_stall.resolve_planning_window_s``.
+    """
+    return float(_defaults.ORCHESTRATOR.planning_window_s)
+
+
 def _default_max_agent_runtime_s() -> int:
     """Return the current canonical agent wall-clock kill starting value.
 
@@ -1605,6 +1617,10 @@ class OrchestratorConfig:
     # ``tuning.orchestrator.stalled_manager_threshold_s`` overrides actually
     # change the manager-stall deadline. See core.orchestration.stalled_manager.
     stalled_manager_threshold_s: float = field(default_factory=_default_stalled_manager_threshold_s)
+    # Derived from ORCHESTRATOR.planning_window_s (canonical). Bounds how long
+    # the run may sit on an empty ledger after planning has already produced
+    # tasks at least once; see core.orchestration.orchestrator.
+    planning_window_s: float = field(default_factory=_default_planning_window_s)
     max_tasks_per_agent: int = 2  # batch 2 same-role tasks per agent to reduce context overhead
     server_url: str = "http://localhost:8052"
     evolution_enabled: bool = True

--- a/tests/unit/test_orchestrator_planning_window.py
+++ b/tests/unit/test_orchestrator_planning_window.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -13,15 +12,15 @@ from bernstein.core.models import (
     Task,
     TaskStatus,
 )
+from bernstein.core.orchestrator import Orchestrator
+
+from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.core.agents.spawner_core import AgentSpawner
 from bernstein.core.orchestration.run_stall import (
     RunStallState,
     evaluate_run_stall,
     resolve_planning_window_s,
 )
-from bernstein.core.orchestrator import Orchestrator
-
-from bernstein.adapters.base import CLIAdapter, SpawnResult
-from bernstein.core.agents.spawner_core import AgentSpawner
 from bernstein.core.security.run_closure import RunClosureOutcome
 
 
@@ -152,7 +151,7 @@ class TestPlanningWindow:
 
     def test_empty_ledger_inside_the_window_is_not_a_stall(self) -> None:
         """Planning is allowed to be slow; an empty ledger starts benign."""
-        state, verdict = evaluate_run_stall(
+        _state, verdict = evaluate_run_stall(
             RunStallState(),
             _empty_ledger(),
             now=1000.0,
@@ -285,23 +284,17 @@ class TestPlanningWindow:
         finally:
             monkey.undo()
 
-    def test_planning_window_can_be_configured_via_env_var(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_planning_window_can_be_configured_via_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """BERNSTEIN_PLANNING_WINDOW_S overrides the configured window."""
         monkeypatch.setenv("BERNSTEIN_PLANNING_WINDOW_S", "2.5")
         assert resolve_planning_window_s(300.0) == 2.5
 
-    def test_planning_window_falls_back_to_config_without_env_var(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_planning_window_falls_back_to_config_without_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Without the env var the configured value is used unchanged."""
         monkeypatch.delenv("BERNSTEIN_PLANNING_WINDOW_S", raising=False)
         assert resolve_planning_window_s(300.0) == 300.0
 
-    def test_planning_window_env_var_garbage_falls_back_to_config(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_planning_window_env_var_garbage_falls_back_to_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """An unparseable env var must not crash the orchestrator tick."""
         monkeypatch.setenv("BERNSTEIN_PLANNING_WINDOW_S", "not-a-number")
         assert resolve_planning_window_s(300.0) == 300.0

--- a/tests/unit/test_orchestrator_planning_window.py
+++ b/tests/unit/test_orchestrator_planning_window.py
@@ -4,19 +4,19 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
 from bernstein.core.models import (
-    AgentSession,
     OrchestratorConfig,
     Task,
     TaskStatus,
 )
 from bernstein.core.orchestrator import Orchestrator
+
 from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.core.agents.spawner_core import AgentSpawner
 from bernstein.core.security.run_closure import RunClosureOutcome
 
 
@@ -140,10 +140,9 @@ def _build_orchestrator(
 class TestPlanningWindow:
     """Tests for the planning window functionality."""
 
-    def test_initial_empty_ledger_does_not_terminate(
-        self, tmp_path: Path
-    ) -> None:
+    def test_initial_empty_ledger_does_not_terminate(self, tmp_path: Path) -> None:
         """Orchestrator should not terminate on initial empty ledger (no tasks ever seen)."""
+
         # No tasks at all - initial state
         def handler(request: httpx.Request) -> httpx.Response:
             if request.method == "GET" and request.url.path == "/tasks":
@@ -161,19 +160,18 @@ class TestPlanningWindow:
 
         # Run multiple ticks - should not terminate
         for _ in range(10):
-            result = orch.tick()
+            orch.tick()
             assert orch._running is True, "Orchestrator should still be running"
             assert orch._closure_outcome == RunClosureOutcome.COMPLETED
             # Verify planning window state
             assert orch._ever_had_tasks is False
             assert orch._first_empty_ledger_ts is not None  # First empty ledger timestamp set
 
-    def test_planning_window_terminates_after_seeing_tasks_then_empty(
-        self, tmp_path: Path
-    ) -> None:
+    def test_planning_window_terminates_after_seeing_tasks_then_empty(self, tmp_path: Path) -> None:
         """Orchestrator should terminate after seeing tasks then empty ledger for planning_window_s."""
         # First return some tasks, then return empty
         task_call_count = 0
+
         def handler(request: httpx.Request) -> httpx.Response:
             nonlocal task_call_count
             if request.method == "GET" and request.url.path == "/tasks":
@@ -202,7 +200,7 @@ class TestPlanningWindow:
         # Run ticks until we've seen tasks and then empty for planning_window_s
         start_time = time.time()
         while orch._running and (time.time() - start_time) < 2.0:  # Safety timeout
-            result = orch.tick()
+            orch.tick()
             time.sleep(0.05)  # Small sleep to allow time to pass
 
         # Should have terminated due to planning window expiration
@@ -211,12 +209,11 @@ class TestPlanningWindow:
         assert orch._ever_had_tasks is True
         assert orch._first_empty_ledger_ts is not None
 
-    def test_seeing_tasks_resets_empty_ledger_timer(
-        self, tmp_path: Path
-    ) -> None:
+    def test_seeing_tasks_resets_empty_ledger_timer(self, tmp_path: Path) -> None:
         """Seeing tasks after empty ledger should reset the planning window timer."""
         # Pattern: empty -> tasks -> empty -> should not terminate yet
         call_count = 0
+
         def handler(request: httpx.Request) -> httpx.Response:
             nonlocal call_count
             if request.method == "GET" and request.url.path == "/tasks":
@@ -249,7 +246,7 @@ class TestPlanningWindow:
 
         # Run enough ticks to go through the sequence
         for i in range(20):  # Enough ticks at 50ms intervals = 1 second total
-            result = orch.tick()
+            orch.tick()
             assert orch._running is True, f"Should still be running after tick {i}"
             time.sleep(0.02)  # 20ms sleep
 
@@ -260,11 +257,10 @@ class TestPlanningWindow:
         assert orch._ever_had_tasks is True
         assert orch._first_empty_ledger_ts is not None
 
-    def test_planning_window_respected_when_tasks_appear_during_window(
-        self, tmp_path: Path
-    ) -> None:
+    def test_planning_window_respected_when_tasks_appear_during_window(self, tmp_path: Path) -> None:
         """If tasks appear during the planning window, timer should reset."""
         call_count = 0
+
         def handler(request: httpx.Request) -> httpx.Response:
             nonlocal call_count
             if request.method == "GET" and request.url.path == "/tasks":
@@ -292,7 +288,7 @@ class TestPlanningWindow:
         # Run for longer than planning window but with tasks appearing during it
         start_time = time.time()
         while orch._running and (time.time() - start_time) < 1.5:  # Run for 1.5 seconds
-            result = orch.tick()
+            orch.tick()
             time.sleep(0.05)
 
         # Should still be running because tasks appeared during the window
@@ -306,14 +302,14 @@ class TestPlanningWindow:
     ) -> None:
         """Planning window can be configured via BERNSTEIN_PLANNING_WINDOW_S env var."""
         monkeypatch.setenv("BERNSTEIN_PLANNING_WINDOW_S", "2.5")
-        
+
         # Reload defaults to pick up the env var
         from bernstein.core import defaults
         from bernstein.core.defaults import reset
-        
+
         reset()  # Clear any overrides
-        
+
         # Check that the default was picked up
         assert defaults.ORCHESTRATOR.planning_window_s == 2.5
-        
+
         reset()  # Clean up

--- a/tests/unit/test_orchestrator_planning_window.py
+++ b/tests/unit/test_orchestrator_planning_window.py
@@ -1,0 +1,319 @@
+"""Tests for the planning window functionality in the orchestrator."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from bernstein.core.models import (
+    AgentSession,
+    OrchestratorConfig,
+    Task,
+    TaskStatus,
+)
+from bernstein.core.orchestrator import Orchestrator
+from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.core.security.run_closure import RunClosureOutcome
+
+
+def _make_task(
+    *,
+    id: str = "T-001",
+    role: str = "backend",
+    title: str = "Implement feature X",
+    description: str = "Write the code.",
+    priority: int = 2,
+    scope: str = "medium",
+    complexity: str = "medium",
+    status: str = "open",
+) -> Task:
+    return Task(
+        id=id,
+        title=title,
+        description=description,
+        role=role,
+        priority=priority,
+        scope=scope,
+        complexity=complexity,
+        status=TaskStatus(status),
+    )
+
+
+def _task_as_dict(task: Task) -> dict[str, object]:
+    """Serialise a Task the way the server JSON would look."""
+    result: dict[str, object] = {
+        "id": task.id,
+        "title": task.title,
+        "description": task.description,
+        "role": task.role,
+        "priority": task.priority,
+        "scope": task.scope.value,
+        "complexity": task.complexity.value,
+        "estimated_minutes": task.estimated_minutes,
+        "status": task.status.value,
+        "depends_on": task.depends_on,
+        "owned_files": task.owned_files,
+        "assigned_agent": task.assigned_agent,
+        "result_summary": task.result_summary,
+        "task_type": task.task_type.value,
+        # audit-017: ship typed retry fields so the orchestrator reads the
+        # single source of truth on GET /tasks/{id}.
+        "retry_count": task.retry_count,
+        "max_retries": task.max_retries,
+    }
+    return result
+
+
+def _tasks_response(url: httpx.URL, tasks: list[dict]) -> httpx.Response:
+    """Return tasks, filtered by ?status= query param when present."""
+    status = url.params.get("status")
+    if status is not None:
+        tasks = [t for t in tasks if t.get("status") == status]
+    return httpx.Response(200, json=tasks)
+
+
+def _mock_adapter(pid: int = 42) -> MagicMock:
+    adapter = MagicMock(spec=CLIAdapter)
+    adapter.spawn.return_value = SpawnResult(pid=pid, log_path=Path("/tmp/test.log"))
+    adapter.is_alive.return_value = True
+    adapter.is_rate_limited.return_value = False
+    adapter.kill.return_value = None
+    adapter.name.return_value = "MockCLI"
+    return adapter
+
+
+def _mock_transport(responses: dict[str, httpx.Response]) -> httpx.MockTransport:
+    """Build a mock transport that returns canned responses by URL path+query."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = request.url
+        key = f"{request.method} {url.path}"
+        if url.query:
+            key += f"?{url.query.decode()}"
+        if key in responses:
+            return responses[key]
+        if request.method == "GET" and url.path == "/tasks":
+            # Try status filter, then aggregate
+            status = url.params.get("status")
+            if "GET /tasks" in responses:
+                bulk_resp = responses["GET /tasks"]
+                if bulk_resp.status_code == 200:
+                    all_tasks = bulk_resp.json()
+                    if status is not None:
+                        filtered = [t for t in all_tasks if t.get("status") == status]
+                        return httpx.Response(200, json=filtered)
+                    return httpx.Response(200, json=all_tasks)
+            # Fallback to empty
+            return httpx.Response(200, json=[])
+        return httpx.Response(404, json={"detail": f"No mock for {key}"})
+
+    return httpx.MockTransport(handler)
+
+
+def _build_orchestrator(
+    tmp_path: Path,
+    transport: httpx.MockTransport,
+    adapter: CLIAdapter | None = None,
+    config: OrchestratorConfig | None = None,
+    default_model: str | None = "mock-model",
+) -> Orchestrator:
+    """Convenience: wire up orchestrator with mocked transport."""
+    cfg = config or OrchestratorConfig(
+        max_agents=6,
+        poll_interval_s=1,
+        heartbeat_timeout_s=120,
+        max_tasks_per_agent=3,
+        server_url="http://testserver",
+    )
+    adp = adapter or _mock_adapter()
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True)
+    spawner = AgentSpawner(adp, templates_dir, tmp_path, default_model=default_model)
+    client = httpx.Client(transport=transport, base_url="http://testserver")
+    return Orchestrator(cfg, spawner, tmp_path, client=client)
+
+
+class TestPlanningWindow:
+    """Tests for the planning window functionality."""
+
+    def test_initial_empty_ledger_does_not_terminate(
+        self, tmp_path: Path
+    ) -> None:
+        """Orchestrator should not terminate on initial empty ledger (no tasks ever seen)."""
+        # No tasks at all - initial state
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET" and request.url.path == "/tasks":
+                return httpx.Response(200, json=[])
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        config = OrchestratorConfig(
+            planning_window_s=1.0,  # 1 second for fast test
+            max_agents=1,
+            poll_interval_s=0.1,
+            server_url="http://testserver",
+        )
+        orch = _build_orchestrator(tmp_path, transport, config=config)
+
+        # Run multiple ticks - should not terminate
+        for _ in range(10):
+            result = orch.tick()
+            assert orch._running is True, "Orchestrator should still be running"
+            assert orch._closure_outcome == RunClosureOutcome.COMPLETED
+            # Verify planning window state
+            assert orch._ever_had_tasks is False
+            assert orch._first_empty_ledger_ts is not None  # First empty ledger timestamp set
+
+    def test_planning_window_terminates_after_seeing_tasks_then_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """Orchestrator should terminate after seeing tasks then empty ledger for planning_window_s."""
+        # First return some tasks, then return empty
+        task_call_count = 0
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal task_call_count
+            if request.method == "GET" and request.url.path == "/tasks":
+                task_call_count += 1
+                if task_call_count <= 2:
+                    # First two calls return a task
+                    task = _make_task(id=f"T-{task_call_count}")
+                    return httpx.Response(200, json=[_task_as_dict(task)])
+                else:
+                    # Subsequent calls return empty
+                    return httpx.Response(200, json=[])
+            if request.method == "POST" and "/claim" in request.url.path:
+                return httpx.Response(200, json=_task_as_dict(_make_task()))
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        # Set planning window to 0.5 seconds for fast test
+        config = OrchestratorConfig(
+            planning_window_s=0.5,
+            max_agents=1,
+            poll_interval_s=0.1,
+            server_url="http://testserver",
+        )
+        orch = _build_orchestrator(tmp_path, transport, config=config)
+
+        # Run ticks until we've seen tasks and then empty for planning_window_s
+        start_time = time.time()
+        while orch._running and (time.time() - start_time) < 2.0:  # Safety timeout
+            result = orch.tick()
+            time.sleep(0.05)  # Small sleep to allow time to pass
+
+        # Should have terminated due to planning window expiration
+        assert orch._running is False, "Orchestrator should have stopped"
+        assert orch._closure_outcome == RunClosureOutcome.FAILED
+        assert orch._ever_had_tasks is True
+        assert orch._first_empty_ledger_ts is not None
+
+    def test_seeing_tasks_resets_empty_ledger_timer(
+        self, tmp_path: Path
+    ) -> None:
+        """Seeing tasks after empty ledger should reset the planning window timer."""
+        # Pattern: empty -> tasks -> empty -> should not terminate yet
+        call_count = 0
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            if request.method == "GET" and request.url.path == "/tasks":
+                call_count += 1
+                if call_count == 1:
+                    # First call: empty
+                    return httpx.Response(200, json=[])
+                elif call_count == 2:
+                    # Second call: has tasks
+                    task = _make_task(id="T-1")
+                    return httpx.Response(200, json=[_task_as_dict(task)])
+                elif call_count == 3:
+                    # Third call: empty again
+                    return httpx.Response(200, json=[])
+                else:
+                    # Fourth call: empty again
+                    return httpx.Response(200, json=[])
+            if request.method == "POST" and "/claim" in request.url.path:
+                return httpx.Response(200, json=_task_as_dict(_make_task()))
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        config = OrchestratorConfig(
+            planning_window_s=0.3,  # 300ms
+            max_agents=1,
+            poll_interval_s=0.05,
+            server_url="http://testserver",
+        )
+        orch = _build_orchestrator(tmp_path, transport, config=config)
+
+        # Run enough ticks to go through the sequence
+        for i in range(20):  # Enough ticks at 50ms intervals = 1 second total
+            result = orch.tick()
+            assert orch._running is True, f"Should still be running after tick {i}"
+            time.sleep(0.02)  # 20ms sleep
+
+        # After seeing tasks again, the timer should be reset
+        # We've seen: empty(1) -> tasks(2) -> empty(3) -> empty(4+)
+        # The planning window should restart after seeing tasks at call_count=2
+        # So we should not have terminated yet
+        assert orch._ever_had_tasks is True
+        assert orch._first_empty_ledger_ts is not None
+
+    def test_planning_window_respected_when_tasks_appear_during_window(
+        self, tmp_path: Path
+    ) -> None:
+        """If tasks appear during the planning window, timer should reset."""
+        call_count = 0
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            if request.method == "GET" and request.url.path == "/tasks":
+                call_count += 1
+                if call_count <= 3:
+                    # First 3 calls: empty (starts planning window)
+                    return httpx.Response(200, json=[])
+                else:
+                    # After that: has tasks (should reset timer)
+                    task = _make_task(id=f"T-{call_count}")
+                    return httpx.Response(200, json=[_task_as_dict(task)])
+            if request.method == "POST" and "/claim" in request.url.path:
+                return httpx.Response(200, json=_task_as_dict(_make_task()))
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        config = OrchestratorConfig(
+            planning_window_s=0.4,  # 400ms
+            max_agents=1,
+            poll_interval_s=0.1,
+            server_url="http://testserver",
+        )
+        orch = _build_orchestrator(tmp_path, transport, config=config)
+
+        # Run for longer than planning window but with tasks appearing during it
+        start_time = time.time()
+        while orch._running and (time.time() - start_time) < 1.5:  # Run for 1.5 seconds
+            result = orch.tick()
+            time.sleep(0.05)
+
+        # Should still be running because tasks appeared during the window
+        # and reset the timer
+        assert orch._running is True
+        assert orch._closure_outcome == RunClosureOutcome.COMPLETED
+        assert orch._ever_had_tasks is True
+
+    def test_planning_window_can_be_configured_via_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Planning window can be configured via BERNSTEIN_PLANNING_WINDOW_S env var."""
+        monkeypatch.setenv("BERNSTEIN_PLANNING_WINDOW_S", "2.5")
+        
+        # Reload defaults to pick up the env var
+        from bernstein.core import defaults
+        from bernstein.core.defaults import reset
+        
+        reset()  # Clear any overrides
+        
+        # Check that the default was picked up
+        assert defaults.ORCHESTRATOR.planning_window_s == 2.5
+        
+        reset()  # Clean up

--- a/tests/unit/test_orchestrator_planning_window.py
+++ b/tests/unit/test_orchestrator_planning_window.py
@@ -13,6 +13,11 @@ from bernstein.core.models import (
     Task,
     TaskStatus,
 )
+from bernstein.core.orchestration.run_stall import (
+    RunStallState,
+    evaluate_run_stall,
+    resolve_planning_window_s,
+)
 from bernstein.core.orchestrator import Orchestrator
 
 from bernstein.adapters.base import CLIAdapter, SpawnResult
@@ -137,179 +142,172 @@ def _build_orchestrator(
     return Orchestrator(cfg, spawner, tmp_path, client=client)
 
 
+def _empty_ledger() -> dict[str, list[Task]]:
+    """A ledger with no task in any status - the shape from the incident."""
+    return {"open": [], "claimed": [], "done": [], "failed": []}
+
+
 class TestPlanningWindow:
     """Tests for the planning window functionality."""
 
-    def test_initial_empty_ledger_does_not_terminate(self, tmp_path: Path) -> None:
-        """Orchestrator should not terminate on initial empty ledger (no tasks ever seen)."""
-
-        # No tasks at all - initial state
-        def handler(request: httpx.Request) -> httpx.Response:
-            if request.method == "GET" and request.url.path == "/tasks":
-                return httpx.Response(200, json=[])
-            return httpx.Response(404)
-
-        transport = httpx.MockTransport(handler)
-        config = OrchestratorConfig(
-            planning_window_s=1.0,  # 1 second for fast test
-            max_agents=1,
-            poll_interval_s=0.1,
-            server_url="http://testserver",
+    def test_empty_ledger_inside_the_window_is_not_a_stall(self) -> None:
+        """Planning is allowed to be slow; an empty ledger starts benign."""
+        state, verdict = evaluate_run_stall(
+            RunStallState(),
+            _empty_ledger(),
+            now=1000.0,
+            grace_s=1800.0,
+            min_ticks=1,
+            planning_window_s=300.0,
         )
-        orch = _build_orchestrator(tmp_path, transport, config=config)
+        assert verdict.stalled is False
+        assert "startup window" in verdict.reason
 
-        # Run multiple ticks - should not terminate
-        for _ in range(10):
-            orch.tick()
-            assert orch._running is True, "Orchestrator should still be running"
-            assert orch._closure_outcome == RunClosureOutcome.COMPLETED
-            # Verify planning window state
-            assert orch._ever_had_tasks is False
-            assert orch._first_empty_ledger_ts is not None  # First empty ledger timestamp set
-
-    def test_planning_window_terminates_after_seeing_tasks_then_empty(self, tmp_path: Path) -> None:
-        """Orchestrator should terminate after seeing tasks then empty ledger for planning_window_s."""
-        # First return some tasks, then return empty
-        task_call_count = 0
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            nonlocal task_call_count
-            if request.method == "GET" and request.url.path == "/tasks":
-                task_call_count += 1
-                if task_call_count <= 2:
-                    # First two calls return a task
-                    task = _make_task(id=f"T-{task_call_count}")
-                    return httpx.Response(200, json=[_task_as_dict(task)])
-                else:
-                    # Subsequent calls return empty
-                    return httpx.Response(200, json=[])
-            if request.method == "POST" and "/claim" in request.url.path:
-                return httpx.Response(200, json=_task_as_dict(_make_task()))
-            return httpx.Response(404)
-
-        transport = httpx.MockTransport(handler)
-        # Set planning window to 0.5 seconds for fast test
-        config = OrchestratorConfig(
-            planning_window_s=0.5,
-            max_agents=1,
-            poll_interval_s=0.1,
-            server_url="http://testserver",
+    def test_empty_ledger_past_the_window_is_a_stall(self) -> None:
+        """Past the bound an empty ledger is planning having failed, not startup."""
+        state, verdict = evaluate_run_stall(
+            RunStallState(),
+            _empty_ledger(),
+            now=1000.0,
+            grace_s=1800.0,
+            min_ticks=1,
+            planning_window_s=300.0,
         )
-        orch = _build_orchestrator(tmp_path, transport, config=config)
-
-        # Run ticks until we've seen tasks and then empty for planning_window_s
-        start_time = time.time()
-        while orch._running and (time.time() - start_time) < 2.0:  # Safety timeout
-            orch.tick()
-            time.sleep(0.05)  # Small sleep to allow time to pass
-
-        # Should have terminated due to planning window expiration
-        assert orch._running is False, "Orchestrator should have stopped"
-        assert orch._closure_outcome == RunClosureOutcome.FAILED
-        assert orch._ever_had_tasks is True
-        assert orch._first_empty_ledger_ts is not None
-
-    def test_seeing_tasks_resets_empty_ledger_timer(self, tmp_path: Path) -> None:
-        """Seeing tasks after empty ledger should reset the planning window timer."""
-        # Pattern: empty -> tasks -> empty -> should not terminate yet
-        call_count = 0
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            nonlocal call_count
-            if request.method == "GET" and request.url.path == "/tasks":
-                call_count += 1
-                if call_count == 1:
-                    # First call: empty
-                    return httpx.Response(200, json=[])
-                elif call_count == 2:
-                    # Second call: has tasks
-                    task = _make_task(id="T-1")
-                    return httpx.Response(200, json=[_task_as_dict(task)])
-                elif call_count == 3:
-                    # Third call: empty again
-                    return httpx.Response(200, json=[])
-                else:
-                    # Fourth call: empty again
-                    return httpx.Response(200, json=[])
-            if request.method == "POST" and "/claim" in request.url.path:
-                return httpx.Response(200, json=_task_as_dict(_make_task()))
-            return httpx.Response(404)
-
-        transport = httpx.MockTransport(handler)
-        config = OrchestratorConfig(
-            planning_window_s=0.3,  # 300ms
-            max_agents=1,
-            poll_interval_s=0.05,
-            server_url="http://testserver",
+        assert verdict.stalled is False, "the first tick only starts the clock"
+        state, verdict = evaluate_run_stall(
+            state,
+            _empty_ledger(),
+            now=1301.0,
+            grace_s=1800.0,
+            min_ticks=1,
+            planning_window_s=300.0,
         )
-        orch = _build_orchestrator(tmp_path, transport, config=config)
+        assert verdict.stalled is True
+        assert "planning never produced a task graph" in verdict.reason
 
-        # Run enough ticks to go through the sequence
-        for i in range(20):  # Enough ticks at 50ms intervals = 1 second total
-            orch.tick()
-            assert orch._running is True, f"Should still be running after tick {i}"
-            time.sleep(0.02)  # 20ms sleep
+    def test_empty_ledger_clock_accumulates_across_ticks(self) -> None:
+        """The clock must accumulate; resetting it each tick is the original defect."""
+        state = RunStallState()
+        verdict = None
+        for tick in range(6):
+            state, verdict = evaluate_run_stall(
+                state,
+                _empty_ledger(),
+                now=1000.0 + tick * 10.0,
+                grace_s=1800.0,
+                min_ticks=1,
+                planning_window_s=300.0,
+            )
+        assert verdict is not None
+        assert verdict.stalled is False
+        assert state.observed_ticks == 6, "each empty tick must count toward the window"
+        assert verdict.quiet_for_s == 50.0
 
-        # After seeing tasks again, the timer should be reset
-        # We've seen: empty(1) -> tasks(2) -> empty(3) -> empty(4+)
-        # The planning window should restart after seeing tasks at call_count=2
-        # So we should not have terminated yet
-        assert orch._ever_had_tasks is True
-        assert orch._first_empty_ledger_ts is not None
-
-    def test_planning_window_respected_when_tasks_appear_during_window(self, tmp_path: Path) -> None:
-        """If tasks appear during the planning window, timer should reset."""
-        call_count = 0
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            nonlocal call_count
-            if request.method == "GET" and request.url.path == "/tasks":
-                call_count += 1
-                if call_count <= 3:
-                    # First 3 calls: empty (starts planning window)
-                    return httpx.Response(200, json=[])
-                else:
-                    # After that: has tasks (should reset timer)
-                    task = _make_task(id=f"T-{call_count}")
-                    return httpx.Response(200, json=[_task_as_dict(task)])
-            if request.method == "POST" and "/claim" in request.url.path:
-                return httpx.Response(200, json=_task_as_dict(_make_task()))
-            return httpx.Response(404)
-
-        transport = httpx.MockTransport(handler)
-        config = OrchestratorConfig(
-            planning_window_s=0.4,  # 400ms
-            max_agents=1,
-            poll_interval_s=0.1,
-            server_url="http://testserver",
+    def test_empty_ledger_stall_still_needs_the_consecutive_tick_floor(self) -> None:
+        """A single time discontinuity must not end a run on its own."""
+        state, verdict = evaluate_run_stall(
+            RunStallState(),
+            _empty_ledger(),
+            now=1000.0,
+            grace_s=1800.0,
+            min_ticks=5,
+            planning_window_s=300.0,
         )
-        orch = _build_orchestrator(tmp_path, transport, config=config)
+        state, verdict = evaluate_run_stall(
+            state,
+            _empty_ledger(),
+            now=99999.0,
+            grace_s=1800.0,
+            min_ticks=5,
+            planning_window_s=300.0,
+        )
+        assert verdict.stalled is False, "2 ticks is under the 5-tick floor"
 
-        # Run for longer than planning window but with tasks appearing during it
-        start_time = time.time()
-        while orch._running and (time.time() - start_time) < 1.5:  # Run for 1.5 seconds
-            orch.tick()
-            time.sleep(0.05)
+    def test_a_task_appearing_clears_the_empty_ledger_clock(self) -> None:
+        """A slow planner that lands a graph must not inherit the empty clock."""
+        state, _ = evaluate_run_stall(
+            RunStallState(),
+            _empty_ledger(),
+            now=1000.0,
+            grace_s=1800.0,
+            min_ticks=1,
+            planning_window_s=300.0,
+        )
+        populated = _empty_ledger()
+        populated["open"] = [_make_task(id="T-001")]
+        state, verdict = evaluate_run_stall(
+            state,
+            populated,
+            now=1400.0,
+            grace_s=1800.0,
+            min_ticks=1,
+            planning_window_s=300.0,
+        )
+        assert verdict.stalled is False, "work exists; the empty-ledger bound no longer applies"
 
-        # Should still be running because tasks appeared during the window
-        # and reset the timer
-        assert orch._running is True
-        assert orch._closure_outcome == RunClosureOutcome.COMPLETED
-        assert orch._ever_had_tasks is True
+    def test_run_with_an_empty_ledger_stops_as_failed(self, tmp_path: Path) -> None:
+        """End to end: the tick loop terminates such a run, and says it failed.
+
+        This is the shape from the incident - the planning task never lands a
+        graph, so ``done``/``failed``/``open`` all stay empty and no agent can
+        ever be acquired. Driven with a zero-length window so the test does not
+        wait out a real one. ``tick()`` is called directly, so ``_running``
+        (which only ``run()`` raises) is not the signal here - the stall
+        backstop having stopped the run is.
+        """
+        monkey = pytest.MonkeyPatch()
+        monkey.setenv("BERNSTEIN_PLANNING_WINDOW_S", "0")
+        monkey.setenv("BERNSTEIN_STALLED_RUN_TICKS", "1")
+        monkey.setenv("BERNSTEIN_QUIESCENCE_SETTLE_S", "0")
+        try:
+
+            def handler(request: httpx.Request) -> httpx.Response:
+                if request.method == "GET" and request.url.path == "/tasks":
+                    return httpx.Response(200, json=[])
+                return httpx.Response(200, json={})
+
+            orch = _build_orchestrator(
+                tmp_path,
+                httpx.MockTransport(handler),
+                config=OrchestratorConfig(
+                    max_agents=1,
+                    poll_interval_s=1,
+                    server_url="http://testserver",
+                ),
+            )
+            for _ in range(5):
+                orch.tick()
+
+            assert orch._run_stall_stopped is True, "an empty ledger must not tick forever"
+            assert orch._closure_outcome == RunClosureOutcome.FAILED, (
+                "a run that produced no task graph did not succeed"
+            )
+        finally:
+            monkey.undo()
 
     def test_planning_window_can_be_configured_via_env_var(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Planning window can be configured via BERNSTEIN_PLANNING_WINDOW_S env var."""
+        """BERNSTEIN_PLANNING_WINDOW_S overrides the configured window."""
         monkeypatch.setenv("BERNSTEIN_PLANNING_WINDOW_S", "2.5")
+        assert resolve_planning_window_s(300.0) == 2.5
 
-        # Reload defaults to pick up the env var
+    def test_planning_window_falls_back_to_config_without_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without the env var the configured value is used unchanged."""
+        monkeypatch.delenv("BERNSTEIN_PLANNING_WINDOW_S", raising=False)
+        assert resolve_planning_window_s(300.0) == 300.0
+
+    def test_planning_window_env_var_garbage_falls_back_to_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unparseable env var must not crash the orchestrator tick."""
+        monkeypatch.setenv("BERNSTEIN_PLANNING_WINDOW_S", "not-a-number")
+        assert resolve_planning_window_s(300.0) == 300.0
+
+    def test_orchestrator_config_takes_planning_window_from_defaults(self) -> None:
+        """The config field is derived from the canonical defaults section."""
         from bernstein.core import defaults
-        from bernstein.core.defaults import reset
 
-        reset()  # Clear any overrides
-
-        # Check that the default was picked up
-        assert defaults.ORCHESTRATOR.planning_window_s == 2.5
-
-        reset()  # Clean up
+        assert OrchestratorConfig().planning_window_s == defaults.ORCHESTRATOR.planning_window_s

--- a/tests/unit/test_run_stall_terminal_state.py
+++ b/tests/unit/test_run_stall_terminal_state.py
@@ -177,9 +177,7 @@ class TestStallCriterion:
         being planning having failed rather than startup - is covered in
         test_orchestrator_planning_window.py.
         """
-        _state, verdict = _drive(
-            _snapshot(), ticks=50, grace_s=0.0, min_ticks=1, planning_window_s=10_000.0
-        )
+        _state, verdict = _drive(_snapshot(), ticks=50, grace_s=0.0, min_ticks=1, planning_window_s=10_000.0)
 
         assert verdict is not None
         assert verdict.stalled is False
@@ -192,9 +190,7 @@ class TestStallCriterion:
         empty ledger read as startup forever and a run whose planning task
         failed ticked to its wall-clock timeout with nothing to do.
         """
-        _state, verdict = _drive(
-            _snapshot(), ticks=50, grace_s=0.0, min_ticks=1, planning_window_s=100.0
-        )
+        _state, verdict = _drive(_snapshot(), ticks=50, grace_s=0.0, min_ticks=1, planning_window_s=100.0)
 
         assert verdict is not None
         assert verdict.stalled is True

--- a/tests/unit/test_run_stall_terminal_state.py
+++ b/tests/unit/test_run_stall_terminal_state.py
@@ -82,6 +82,7 @@ def _drive(
     min_ticks: int,
     start: float = 1_000.0,
     step_s: float = 10.0,
+    planning_window_s: float = 300.0,
 ) -> tuple[RunStallState, Any]:
     """Evaluate the same snapshot ``ticks`` times on a synthetic clock."""
     state = RunStallState()
@@ -93,6 +94,7 @@ def _drive(
             now=start + i * step_s,
             grace_s=grace_s,
             min_ticks=min_ticks,
+            planning_window_s=planning_window_s,
         )
     return state, verdict
 
@@ -164,17 +166,39 @@ class TestStallCriterion:
         assert verdict.stalled is False
         assert "need 5" in verdict.reason
 
-    def test_empty_backlog_never_stalls(self) -> None:
+    def test_empty_backlog_does_not_stall_inside_the_planning_window(self) -> None:
         """Startup before the seed task is ingested is not a dead run.
 
         This is the case the original zero-terminal guard was written for,
-        and it must keep working.
+        and it must keep working: 50 quiescent ticks on an empty ledger are
+        still "planning has not landed a graph yet" while the planning window
+        has not elapsed, no matter how short the ordinary no-progress grace
+        is. The bound on the other side - an empty ledger *past* the window
+        being planning having failed rather than startup - is covered in
+        test_orchestrator_planning_window.py.
         """
-        _state, verdict = _drive(_snapshot(), ticks=50, grace_s=0.0, min_ticks=1)
+        _state, verdict = _drive(
+            _snapshot(), ticks=50, grace_s=0.0, min_ticks=1, planning_window_s=10_000.0
+        )
 
         assert verdict is not None
         assert verdict.stalled is False
         assert "startup window" in verdict.reason
+
+    def test_empty_backlog_stops_being_startup_once_the_window_passes(self) -> None:
+        """The startup window is a window, not a permanent exemption.
+
+        Before #4529 this branch reset its own clock on every tick, so an
+        empty ledger read as startup forever and a run whose planning task
+        failed ticked to its wall-clock timeout with nothing to do.
+        """
+        _state, verdict = _drive(
+            _snapshot(), ticks=50, grace_s=0.0, min_ticks=1, planning_window_s=100.0
+        )
+
+        assert verdict is not None
+        assert verdict.stalled is True
+        assert "planning never produced a task graph" in verdict.reason
 
     def test_progress_resets_the_window(self) -> None:
         """A task moving between statuses is forward motion, not a stall."""


### PR DESCRIPTION
Adds a bounded planning window to the orchestrator so a run whose planning task fails stops early instead of ticking to its wall-clock timeout, for #4529.

The change is small; most of the diff is the test that pins the behaviour. These commits came from a run whose publication stopped before a pull request was opened, so the work sat in a bundle. Publishing it as a draft so CI judges it.

Part of #4529
