### PR TITLE
fix(#4541): wire swarm migration checkpoint completion and reduce

### DIFF
--- a/docs/concepts/swarm-migration.md
+++ b/docs/concepts/swarm-migration.md
@@ -57,11 +57,18 @@ The fanout:
 2. `chunk_targets(targets, chunk_size)` partitions into chunks.
 3. `spawn_swarm(plan)` emits one task per chunk with role=`backend`,
    scope=`small`.
-4. `reduce_swarm(parent_id, child_results)` aggregates pass/fail per
-   chunk and posts a `SwarmReport` to the bulletin board.
+4. As each chunk task reaches a terminal state, the orchestrator
+   records it in the plan's checkpoint (completed, or failed once its
+   reopen budget is exhausted). Once every chunk has resolved,
+   `reduce_swarm` runs automatically, aggregating pass/fail per chunk;
+   the resulting `SwarmReport` is posted to the bulletin board and
+   written into the checkpoint alongside the chunk records.
 
-Re-running the same plan ID skips already-completed chunks
-(idempotent).
+Re-running the same plan ID skips only chunks **verified complete**
+in the checkpoint. A chunk that never ran, is still running, or
+permanently failed gets a fresh task, so a restart can always make
+progress on the chunks that did not finish rather than returning
+whatever task id was last recorded for them.
 
 ## Configuration
 

--- a/docs/release-notes/fragments/4541-swarm-checkpoint-wiring.md
+++ b/docs/release-notes/fragments/4541-swarm-checkpoint-wiring.md
@@ -1,0 +1,10 @@
+## Swarm migration checkpoints now record chunk completion
+
+`bernstein migrate` checkpoints previously never learned that a chunk task
+had finished: `mark_chunk_complete` and `reduce_swarm` had no caller, so a
+restarted migration re-spawned every chunk from task-id memory instead of
+verified completion, and the reduce step that aggregates the swarm's pass/
+fail outcome could never run. Chunk completions and permanent failures are
+now recorded in the plan's checkpoint as each chunk task resolves; once every
+chunk has resolved, the aggregate report runs automatically and is posted to
+the bulletin board (#4541).

--- a/src/bernstein/core/tasks/swarm_migration.py
+++ b/src/bernstein/core/tasks/swarm_migration.py
@@ -16,8 +16,15 @@ The flow is:
 
 Idempotency is provided via a checkpoint file under
 ``<repo_root>/.sdd/runtime/swarm/{plan_id}.json`` - re-running with the
-same ``plan.id`` skips chunks whose hash already appears in the
-checkpoint's ``completed_chunks`` set.
+same ``plan.id`` skips only chunks whose hash already appears in the
+checkpoint's ``completed_chunks`` set (verified done); every other chunk,
+including one recorded in ``failed_chunks`` after its reopen budget was
+exhausted, gets a fresh task on the next call instead of returning its old
+task id from memory. The orchestrator (``task_lifecycle.py``) calls
+:func:`mark_chunk_complete` / :func:`mark_chunk_failed` /
+:func:`maybe_reduce_swarm` as chunk tasks reach a terminal state; once every
+chunk has resolved, the aggregate :class:`SwarmReport` is written into the
+same checkpoint file under ``report``.
 
 The actual code-transformation logic is delegated to spawned agents
 exactly like any other task; this module only owns enumeration,
@@ -189,19 +196,24 @@ def _checkpoint_path(repo_root: Path, plan_id: str) -> Path:
     return repo_root / ".sdd" / "runtime" / "swarm" / f"{safe_id}.json"
 
 
+def _empty_checkpoint() -> dict[str, Any]:
+    return {"completed_chunks": [], "failed_chunks": {}, "task_ids": {}}
+
+
 def _load_checkpoint(path: Path) -> dict[str, Any]:
     if not path.exists():
-        return {"completed_chunks": [], "task_ids": {}}
+        return _empty_checkpoint()
     try:
         loaded: Any = json.loads(path.read_text(encoding="utf-8"))
         if not isinstance(loaded, dict):
             raise TypeError("checkpoint root must be an object")
         loaded.setdefault("completed_chunks", [])
+        loaded.setdefault("failed_chunks", {})
         loaded.setdefault("task_ids", {})
         return loaded
     except (OSError, ValueError, TypeError):
         logger.warning("swarm_migration: corrupt checkpoint at %s; ignoring", path)
-        return {"completed_chunks": [], "task_ids": {}}
+        return _empty_checkpoint()
 
 
 def _write_checkpoint(path: Path, data: dict[str, Any]) -> None:
@@ -264,9 +276,15 @@ def spawn_swarm(
 ) -> list[str]:
     """Enumerate, chunk, and fan out one task per chunk.
 
-    Idempotent: chunks whose hash is recorded as completed in the plan's
-    checkpoint are skipped, and previously-spawned task ids are returned
-    unchanged.
+    Idempotent on *verified completion only* (issue #4541): a chunk is
+    skipped and its task id reused only once :func:`mark_chunk_complete` has
+    recorded it as done. A chunk that was never completed - whether it never
+    ran, is still running, or *verified failed* via :func:`mark_chunk_failed`
+    once its reopen budget was exhausted - gets a fresh task id on every
+    call, so a restart can always make progress past a chunk that
+    permanently failed instead of returning the same dead id forever. The
+    task-id memory in the checkpoint (``task_ids``) is bookkeeping for the
+    reduce step, not a second idempotency key.
 
     Args:
         plan: Migration plan describing the glob and transform.
@@ -296,28 +314,35 @@ def spawn_swarm(
     cp_path = _checkpoint_path(repo_root, plan.id)
     checkpoint = _load_checkpoint(cp_path)
     completed: set[str] = set(checkpoint["completed_chunks"])
+    failed: dict[str, Any] = dict(checkpoint["failed_chunks"])
     known: dict[str, str] = dict(checkpoint["task_ids"])
 
+    respawned_a_failure = False
     ordered_ids: list[str] = []
     for idx, chunk in enumerate(chunks):
         chunk_hash = _chunk_hash(plan.id, chunk)
-        if chunk_hash in completed and chunk_hash in known:
+        if chunk_hash in completed:
             ordered_ids.append(known[chunk_hash])
             continue
-        if chunk_hash in known:
-            ordered_ids.append(known[chunk_hash])
-            continue
+        if chunk_hash in failed:
+            respawned_a_failure = True
         body = _build_task_body(plan, chunk, chunk_hash, repo_root, idx, len(chunks))
         task_id = store.create_sync(body)
         known[chunk_hash] = task_id
+        failed.pop(chunk_hash, None)
         ordered_ids.append(task_id)
 
     checkpoint["task_ids"] = known
     checkpoint["completed_chunks"] = sorted(completed)
+    checkpoint["failed_chunks"] = failed
     checkpoint["plan_id"] = plan.id
     checkpoint["chunk_count"] = len(chunks)
     checkpoint["effective_max_parallel"] = cap
     checkpoint["updated_at"] = time.time()
+    if respawned_a_failure:
+        # A stale report no longer describes the plan; let it reduce again.
+        checkpoint.pop("reduced", None)
+        checkpoint.pop("report", None)
     _write_checkpoint(cp_path, checkpoint)
     return ordered_ids
 
@@ -332,10 +357,88 @@ def mark_chunk_complete(plan_id: str, chunk_hash: str, repo_root: Path) -> None:
     checkpoint = _load_checkpoint(cp_path)
     completed: set[str] = set(checkpoint["completed_chunks"])
     completed.add(chunk_hash)
+    failed: dict[str, Any] = dict(checkpoint["failed_chunks"])
+    failed.pop(chunk_hash, None)
     checkpoint["completed_chunks"] = sorted(completed)
+    checkpoint["failed_chunks"] = failed
     checkpoint["plan_id"] = plan_id
     checkpoint["updated_at"] = time.time()
     _write_checkpoint(cp_path, checkpoint)
+
+
+def mark_chunk_failed(
+    plan_id: str,
+    chunk_hash: str,
+    repo_root: Path,
+    *,
+    files: tuple[str, ...] = (),
+    reason: str = "",
+) -> None:
+    """Record *chunk_hash* as permanently failed for *plan_id*.
+
+    Called by the orchestrator once a swarm task's reopen budget is
+    exhausted, so the chunk is distinguishable in the checkpoint from one
+    that never ran (issue #4541) and :func:`spawn_swarm` respawns it under a
+    fresh task id on the plan's next invocation instead of returning the
+    same dead id forever.
+    """
+    cp_path = _checkpoint_path(repo_root, plan_id)
+    checkpoint = _load_checkpoint(cp_path)
+    completed: set[str] = set(checkpoint["completed_chunks"])
+    completed.discard(chunk_hash)
+    failed: dict[str, Any] = dict(checkpoint["failed_chunks"])
+    failed[chunk_hash] = {"reason": reason, "files": list(files)}
+    checkpoint["completed_chunks"] = sorted(completed)
+    checkpoint["failed_chunks"] = failed
+    checkpoint["plan_id"] = plan_id
+    checkpoint["updated_at"] = time.time()
+    _write_checkpoint(cp_path, checkpoint)
+
+
+def maybe_reduce_swarm(plan_id: str, repo_root: Path) -> SwarmReport | None:
+    """Aggregate and durably record *plan_id*'s report once every chunk resolves.
+
+    Safe to call after every chunk completion or failure: a no-op until
+    ``completed_chunks`` and ``failed_chunks`` together account for every
+    chunk the plan was spawned with, and a no-op again afterwards - the
+    checkpoint's own ``reduced`` flag is checked and set in the same
+    load/write round trip used by every other checkpoint mutation in this
+    module, so two chunks landing back to back in the same orchestrator
+    tick cannot both trigger a second reduce. The report is written into the
+    same checkpoint file the chunk completions already live in (rather than
+    a separate run artifact) so a plan's full outcome - which chunks passed,
+    which failed and why - stays in the one durable place idempotency
+    already depends on.
+    """
+    cp_path = _checkpoint_path(repo_root, plan_id)
+    checkpoint = _load_checkpoint(cp_path)
+    chunk_count = checkpoint.get("chunk_count")
+    if not chunk_count or checkpoint.get("reduced"):
+        return None
+    completed: set[str] = set(checkpoint["completed_chunks"])
+    failed: dict[str, Any] = checkpoint["failed_chunks"]
+    if len(completed) + len(failed) < chunk_count:
+        return None
+
+    known: dict[str, str] = checkpoint["task_ids"]
+    child_results = [
+        SwarmChunkResult(task_id=known.get(h, ""), chunk_hash=h, files=(), passed=True) for h in sorted(completed)
+    ] + [
+        SwarmChunkResult(
+            task_id=known.get(h, ""),
+            chunk_hash=h,
+            files=tuple(info.get("files", ())),
+            passed=False,
+            summary=info.get("reason", ""),
+        )
+        for h, info in sorted(failed.items())
+    ]
+    report = reduce_swarm(plan_id, child_results)
+    checkpoint["reduced"] = True
+    checkpoint["report"] = report.to_dict()
+    checkpoint["updated_at"] = time.time()
+    _write_checkpoint(cp_path, checkpoint)
+    return report
 
 
 def reduce_swarm(plan_id: str, child_results: list[SwarmChunkResult]) -> SwarmReport:

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -62,6 +62,7 @@ from bernstein.core.tasks.models import (
     Task,
     TaskStatus,
 )
+from bernstein.core.tasks.swarm_migration import mark_chunk_complete, mark_chunk_failed, maybe_reduce_swarm
 from bernstein.core.team_state import TeamStateStore
 from bernstein.core.tick_pipeline import (
     CompletionData,
@@ -4900,6 +4901,31 @@ def _janitor_reopen_max() -> int:
     return max(0, value)
 
 
+def _record_swarm_chunk_outcome(orch: Any, task: Task, *, passed: bool, reason: str = "") -> None:
+    """Advance a swarm-migration checkpoint when one of its chunk tasks lands.
+
+    Issue #4541: ``mark_chunk_complete``/``reduce_swarm`` had no caller
+    anywhere in the tree, so a swarm migration's checkpoint never learned
+    that a chunk finished. Every terminal outcome for a task carrying
+    ``swarm_plan_id``/``swarm_chunk_hash`` metadata (stamped by
+    :func:`bernstein.core.tasks.swarm_migration.spawn_swarm`) routes through
+    here. A task with no such metadata is not part of a swarm migration and
+    this is a no-op.
+    """
+    plan_id = task.metadata.get("swarm_plan_id")
+    chunk_hash = task.metadata.get("swarm_chunk_hash")
+    if not plan_id or not chunk_hash:
+        return
+    repo_root = orch._workdir
+    if passed:
+        mark_chunk_complete(plan_id, chunk_hash, repo_root)
+    else:
+        mark_chunk_failed(plan_id, chunk_hash, repo_root, files=tuple(task.owned_files), reason=reason)
+    report = maybe_reduce_swarm(plan_id, repo_root)
+    if report is not None:
+        orch._post_bulletin("status", report.to_bulletin_content())
+
+
 def _apply_janitor_verdict_action(orch: Any, task: Task, janitor_passed: bool) -> None:
     """Act on the janitor verdict for a completed task.
 
@@ -4922,6 +4948,7 @@ def _apply_janitor_verdict_action(orch: Any, task: Task, janitor_passed: bool) -
     """
     if janitor_passed:
         logger.debug("janitor_verdict_action: task=%s verdict=PASS action=none", task.id)
+        _record_swarm_chunk_outcome(orch, task, passed=True)
         return
 
     server_url: str | None = getattr(orch._config, "server_url", None)
@@ -4987,6 +5014,9 @@ def _apply_janitor_verdict_action(orch: Any, task: Task, janitor_passed: bool) -
         logger.info(
             "janitor_verdict_action: task=%s verdict=FAIL action=permanent_fail reason=reopen_budget_exhausted",
             task.id,
+        )
+        _record_swarm_chunk_outcome(
+            orch, task, passed=False, reason="reopen_budget_exhausted: janitor verification failed"
         )
 
 
@@ -5070,6 +5100,9 @@ def _apply_merge_failure_action(orch: Any, task: Task) -> None:
         logger.error(
             "merge_failure_action: task=%s action=permanent_fail reason=merge_back_failed_budget_exhausted",
             task.id,
+        )
+        _record_swarm_chunk_outcome(
+            orch, task, passed=False, reason="merge_back_failed: non-conflict merge-back failed"
         )
 
 

--- a/tests/unit/test_swarm_migration_checkpoint_wiring.py
+++ b/tests/unit/test_swarm_migration_checkpoint_wiring.py
@@ -1,0 +1,254 @@
+"""Regression tests for issue #4541.
+
+``mark_chunk_complete`` and ``reduce_swarm`` had zero callers anywhere in the
+tree, so a swarm migration's checkpoint never learned that a chunk finished:
+a restart re-spawned purely from task-id memory and the reduce step that
+should summarize the swarm could never run.
+
+These tests drive real terminal transitions through
+``_apply_janitor_verdict_action`` / ``_apply_merge_failure_action`` (the
+lifecycle hook), never ``mark_chunk_complete`` called by hand, and pin the
+four scenarios from the issue's acceptance criteria:
+
+* a completed chunk is marked in the swarm checkpoint
+* a restart re-spawns only chunks not verified complete (never-run or
+  verified-failed), not whatever is sitting in task-id memory
+* the last chunk landing runs reduce exactly once and its report is
+  recorded durably
+* a failed chunk is recorded as failed, distinguishable from one that never
+  ran
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from bernstein.core.tasks.models import Task, TaskStatus
+from bernstein.core.tasks.swarm_migration import (
+    MigrationPlan,
+    _checkpoint_path,
+    spawn_swarm,
+)
+from bernstein.core.tasks.task_lifecycle import (
+    _apply_janitor_verdict_action,
+    _apply_merge_failure_action,
+)
+
+
+class _FakeResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeClient:
+    """Records POSTs made by the orchestrator janitor/merge-verdict actions."""
+
+    def __init__(self) -> None:
+        self.posts: list[tuple[str, dict[str, Any]]] = []
+
+    def post(self, url: str, json: dict[str, Any] | None = None, **_kwargs: Any) -> _FakeResponse:
+        self.posts.append((url, json or {}))
+        return _FakeResponse()
+
+
+class _RecordingStore:
+    def __init__(self) -> None:
+        self.bodies: list[dict[str, Any]] = []
+        self._counter = 0
+
+    def create_sync(self, body: dict[str, Any]) -> str:
+        self._counter += 1
+        self.bodies.append(body)
+        return f"task-{self._counter:03d}"
+
+
+def _make_repo(tmp_path: Path, files: list[str]) -> Path:
+    for rel in files:
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# placeholder\n", encoding="utf-8")
+    return tmp_path
+
+
+def _make_orch(repo_root: Path, client: _FakeClient) -> SimpleNamespace:
+    orch = SimpleNamespace(
+        _config=SimpleNamespace(server_url="http://127.0.0.1:8052"),
+        _client=client,
+        _processed_done_tasks={},
+        _workdir=repo_root,
+        bulletins=[],
+    )
+    orch._post_bulletin = lambda msg_type, content: orch.bulletins.append((msg_type, content))
+    return orch
+
+
+def _task_for(body: dict[str, Any], task_id: str, *, reopen_count: int = 0) -> Task:
+    task = Task(
+        id=task_id,
+        title=body["title"],
+        description=body["description"],
+        role=body["role"],
+        status=TaskStatus.DONE,
+        owned_files=list(body["owned_files"]),
+        metadata=dict(body["metadata"]),
+    )
+    if reopen_count:
+        task.metadata["janitor_reopen_count"] = reopen_count
+    return task
+
+
+def _spawn_two_chunk_plan(tmp_path: Path) -> tuple[MigrationPlan, Path, _RecordingStore, list[str]]:
+    repo = _make_repo(tmp_path, ["src/a.py", "src/b.py"])
+    plan = MigrationPlan(id="p4541", glob="src/*.py", transform_prompt="convert", chunk_size=1)
+    store = _RecordingStore()
+    ids = spawn_swarm(plan, store, repo)
+    assert len(ids) == 2
+    return plan, repo, store, ids
+
+
+def _read_checkpoint(repo: Path, plan_id: str) -> dict[str, Any]:
+    return json.loads(_checkpoint_path(repo, plan_id).read_text(encoding="utf-8"))
+
+
+def test_completed_chunk_is_marked_in_the_swarm_checkpoint(tmp_path: Path) -> None:
+    plan, repo, store, ids = _spawn_two_chunk_plan(tmp_path)
+    task = _task_for(store.bodies[0], ids[0])
+    client = _FakeClient()
+    orch = _make_orch(repo, client)
+
+    _apply_janitor_verdict_action(orch, task, janitor_passed=True)
+
+    cp = _read_checkpoint(repo, plan.id)
+    assert task.metadata["swarm_chunk_hash"] in cp["completed_chunks"]
+    assert task.metadata["swarm_chunk_hash"] not in cp["failed_chunks"]
+    # Only one of the two chunks resolved; the plan is not fully reduced yet.
+    assert not cp.get("reduced")
+    assert orch.bulletins == []
+
+
+def test_restart_respawns_only_unverified_chunks(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path, ["src/a.py", "src/b.py", "src/c.py"])
+    plan = MigrationPlan(id="p4541-restart", glob="src/*.py", transform_prompt="convert", chunk_size=1)
+    store = _RecordingStore()
+    first_ids = spawn_swarm(plan, store, repo)
+    assert len(first_ids) == 3
+
+    task_a = _task_for(store.bodies[0], first_ids[0])
+    task_b = _task_for(store.bodies[1], first_ids[1], reopen_count=2)  # budget already spent
+    # Chunk C (store.bodies[2]) is left untouched: never resolved.
+
+    client = _FakeClient()
+    orch = _make_orch(repo, client)
+    _apply_janitor_verdict_action(orch, task_a, janitor_passed=True)  # verified complete
+    _apply_janitor_verdict_action(orch, task_b, janitor_passed=False)  # verified failed
+
+    second_store = _RecordingStore()
+    second_ids = spawn_swarm(plan, second_store, repo)
+
+    # Chunk A is verified complete: its id is unchanged and it is not respawned.
+    assert second_ids[0] == first_ids[0]
+    # B (failed) and C (never resolved) are both "unfinished", so both respawn.
+    assert second_ids[1] != first_ids[1]
+    assert second_ids[2] != first_ids[2]
+    respawned_files = {tuple(b["owned_files"]) for b in second_store.bodies}
+    assert tuple(store.bodies[1]["owned_files"]) in respawned_files
+    assert tuple(store.bodies[2]["owned_files"]) in respawned_files
+    assert tuple(store.bodies[0]["owned_files"]) not in respawned_files
+
+    # The respawned failure's checkpoint record is cleared, not left stale.
+    cp = _read_checkpoint(repo, plan.id)
+    assert task_b.metadata["swarm_chunk_hash"] not in cp["failed_chunks"]
+
+
+def test_last_chunk_completion_runs_reduce_exactly_once(tmp_path: Path) -> None:
+    plan, repo, store, ids = _spawn_two_chunk_plan(tmp_path)
+    task_0 = _task_for(store.bodies[0], ids[0])
+    task_1 = _task_for(store.bodies[1], ids[1], reopen_count=2)
+
+    client = _FakeClient()
+    orch = _make_orch(repo, client)
+    _apply_janitor_verdict_action(orch, task_0, janitor_passed=True)
+    assert orch.bulletins == []  # only 1 of 2 chunks resolved so far
+
+    _apply_janitor_verdict_action(orch, task_1, janitor_passed=False)  # the last chunk
+
+    assert len(orch.bulletins) == 1
+    msg_type, content = orch.bulletins[0]
+    assert msg_type == "status"
+    assert "chunks=1/2" in content
+    assert "failed=1" in content
+
+    cp = _read_checkpoint(repo, plan.id)
+    assert cp["reduced"] is True
+    assert cp["report"]["total_chunks"] == 2
+    assert cp["report"]["passed_chunks"] == 1
+    assert cp["report"]["failed_chunks"] == 1
+
+    # Re-processing an already-terminal chunk must not run reduce a second time.
+    _apply_janitor_verdict_action(orch, task_0, janitor_passed=True)
+    assert len(orch.bulletins) == 1
+
+
+def test_failed_chunk_is_recorded_as_failed_not_missing(tmp_path: Path) -> None:
+    plan, repo, store, ids = _spawn_two_chunk_plan(tmp_path)
+    task_0 = _task_for(store.bodies[0], ids[0], reopen_count=2)
+    never_run_hash = store.bodies[1]["metadata"]["swarm_chunk_hash"]
+
+    client = _FakeClient()
+    orch = _make_orch(repo, client)
+    _apply_janitor_verdict_action(orch, task_0, janitor_passed=False)
+
+    cp = _read_checkpoint(repo, plan.id)
+    failed_hash = task_0.metadata["swarm_chunk_hash"]
+    assert failed_hash in cp["failed_chunks"]
+    assert failed_hash not in cp["completed_chunks"]
+    assert cp["failed_chunks"][failed_hash]["files"] == task_0.owned_files
+    assert "reopen_budget_exhausted" in cp["failed_chunks"][failed_hash]["reason"]
+
+    # Distinguishable from a chunk that never ran: absent from BOTH sets.
+    assert never_run_hash not in cp["completed_chunks"]
+    assert never_run_hash not in cp["failed_chunks"]
+
+
+def test_merge_back_failure_exhausted_budget_marks_chunk_failed(tmp_path: Path) -> None:
+    """The second terminal-failure call site (non-conflict merge-back) is wired too."""
+    plan, repo, store, ids = _spawn_two_chunk_plan(tmp_path)
+    task = _task_for(store.bodies[0], ids[0], reopen_count=2)
+
+    client = _FakeClient()
+    orch = _make_orch(repo, client)
+    _apply_merge_failure_action(orch, task)
+
+    cp = _read_checkpoint(repo, plan.id)
+    assert task.metadata["swarm_chunk_hash"] in cp["failed_chunks"]
+    assert "merge_back_failed" in cp["failed_chunks"][task.metadata["swarm_chunk_hash"]]["reason"]
+
+
+def test_reopen_cycle_does_not_touch_swarm_checkpoint(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """A transient FAIL under budget is a retry, not a terminal outcome.
+
+    It must not mark the chunk failed or completed, since it may still
+    succeed on the next attempt.
+    """
+    plan, repo, store, ids = _spawn_two_chunk_plan(tmp_path)
+    task = _task_for(store.bodies[0], ids[0])  # reopen_count=0, budget of 2 not spent
+
+    client = _FakeClient()
+    orch = _make_orch(repo, client)
+    with caplog.at_level(logging.INFO, logger="bernstein.core.tasks.task_lifecycle"):
+        _apply_janitor_verdict_action(orch, task, janitor_passed=False)
+
+    assert client.posts[0][0].endswith("/reopen")
+    cp_path = _checkpoint_path(repo, plan.id)
+    # spawn_swarm already created the checkpoint; a reopen must not add this
+    # chunk to either terminal set.
+    cp = json.loads(cp_path.read_text(encoding="utf-8"))
+    assert task.metadata["swarm_chunk_hash"] not in cp["completed_chunks"]
+    assert task.metadata["swarm_chunk_hash"] not in cp["failed_chunks"]
+    assert orch.bulletins == []


### PR DESCRIPTION
`mark_chunk_complete` and `reduce_swarm` had no caller anywhere in the tree.
Every chunk task spawned by `spawn_swarm` is stamped with
`swarm_plan_id`/`swarm_chunk_hash` metadata, but nothing in
`task_lifecycle.py` ever read it, so a chunk finishing never updated the
plan's checkpoint: `completed_chunks` stayed empty forever, a restart
re-spawned every chunk from task-id memory rather than verified completion,
and the reduce step that aggregates the swarm's pass/fail outcome could
never run.

## Fix

`_record_swarm_chunk_outcome` (`task_lifecycle.py`) routes every terminal
outcome for a task carrying swarm metadata into the checkpoint, called from
the three places a task actually resolves: janitor PASS, janitor FAIL after
the reopen budget is exhausted, and a non-conflict merge-back failure after
its own reopen budget is exhausted. A transient FAIL under budget (still
retrying) is left untouched, since the chunk may still succeed.

`swarm_migration.py` gets two new functions plus one schema addition to the
checkpoint:

- `mark_chunk_failed` records a permanently-failed chunk (with its files and
  reason) in a new `failed_chunks` map, so it is distinguishable from a
  chunk that never ran (both were previously indistinguishable: absent from
  `completed_chunks`).
- `maybe_reduce_swarm` aggregates and durably records the plan's
  `SwarmReport` once every chunk has resolved (completed or failed), posts
  it to the bulletin board, and is idempotent via the checkpoint's own
  `reduced` flag.
- `spawn_swarm` now skips a chunk only when it is *verified complete*; a
  chunk that is still unresolved or was recorded as failed gets a fresh
  task id on the next call instead of returning whatever id was last sitting
  in memory (the bug's core symptom). Respawning a previously-failed chunk
  clears its failure record and, if the plan had already reduced, its stale
  report, so the next full resolution reduces again.

**Where the report is recorded** (left open in the issue): the same
checkpoint file the chunk records already live in, rather than a separate
run artifact. Idempotency already depends on that file being the single
durable source of truth for a plan, so the report belongs next to the
records it summarizes rather than in a second place that could disagree
with it.

## Verification

- New regression tests drive real terminal transitions through
  `_apply_janitor_verdict_action` / `_apply_merge_failure_action` (never
  `mark_chunk_complete` called by hand), covering the issue's four named
  scenarios plus the merge-back failure path and the non-terminal reopen
  case: `tests/unit/test_swarm_migration_checkpoint_wiring.py`.
- Full existing suites for the touched modules pass: `test_swarm_migration.py`,
  `test_janitor_reopen.py`, `test_mergeback_failure_2792.py`,
  `test_task_lifecycle.py`, `test_task_lifecycle_state_machine.py`,
  `test_orchestrator.py`, `test_regression_orchestrator.py`, and
  `tests/unit/orchestration/` (1208 passed, 7 pre-existing skips, 0
  failures), python 3.13.
- `ruff check`/`format --check`, `lint-imports`, `vulture --min-confidence 80`
  (repo-wide, matches CI's invocation) and `bandit -r src/ --severity-level
  high -b .bandit-baseline.json` all clean on the diff.
- Not verified: the full ~2000-file suite, the Windows/macOS legs, and
  repo-wide `pyright`/`mypy strict` (both advisory only here per this repo's
  own CI comments; the blocking strict-zone configs scope to
  `persistence`/`lineage`, which this diff does not touch).
