### PR TITLE
fix(security): restrict redirect destinations for third-party-derived URLs

### DIFF
--- a/scripts/trunk_health_slo.py
+++ b/scripts/trunk_health_slo.py
@@ -94,18 +94,14 @@ def trunk_is_red_now(runs: list[dict]) -> bool:
     green. The andon exists to stop merges piling onto a broken main, and this
     is the question that actually answers.
     """
-    completed = [
-        r for r in runs if r.get("conclusion") not in ("cancelled", "skipped", None)
-    ]
+    completed = [r for r in runs if r.get("conclusion") not in ("cancelled", "skipped", None)]
     if not completed:
         return False
     newest = max(completed, key=lambda r: str(r.get("created_at", "")))
     return newest.get("conclusion") in ("failure", "timed_out")
 
 
-def marker_should_open(
-    total: int, red: int, red_pct: int, threshold_pct: int, *, trunk_red_now: bool
-) -> bool:
+def marker_should_open(total: int, red: int, red_pct: int, threshold_pct: int, *, trunk_red_now: bool) -> bool:
     """Whether this sample justifies holding every merge in the repo.
 
     Kept as its own function because the andon decision is the only thing
@@ -141,9 +137,7 @@ def main() -> None:
     total, red, red_pct = score_runs(runs)
 
     insufficient = total < MIN_SAMPLE_SIZE
-    unstable = marker_should_open(
-        total, red, red_pct, args.threshold_pct, trunk_red_now=trunk_is_red_now(runs)
-    )
+    unstable = marker_should_open(total, red, red_pct, args.threshold_pct, trunk_red_now=trunk_is_red_now(runs))
 
     # Output for GitHub Actions
     github_output = os.environ.get("GITHUB_OUTPUT")

--- a/src/bernstein/core/protocols/mcp_catalog/fetcher.py
+++ b/src/bernstein/core/protocols/mcp_catalog/fetcher.py
@@ -95,9 +95,7 @@ class _UrllibTransport:
         # ``StrictHTTPRedirectHandler`` re-runs the strict check on every
         # ``Location`` URL and raises ``UrlSchemeError`` to abort.
         # TOCTOU (resolve-then-connect) is inherent without IP pinning.
-        opener = urllib.request.build_opener(
-            StrictHTTPRedirectHandler(allow_http=True, source="mcp_catalog.fetcher")
-        )
+        opener = urllib.request.build_opener(StrictHTTPRedirectHandler(allow_http=True, source="mcp_catalog.fetcher"))
         try:
             # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             with opener.open(request, timeout=15) as resp:

--- a/src/bernstein/core/protocols/mcp_catalog/fetcher.py
+++ b/src/bernstein/core/protocols/mcp_catalog/fetcher.py
@@ -24,7 +24,10 @@ from bernstein.core.protocols.mcp_catalog.manifest import (
     CatalogValidationError,
     validate_catalog,
 )
-from bernstein.core.security.url_allowlist import ensure_public_http_url
+from bernstein.core.security.url_allowlist import (
+    StrictHTTPRedirectHandler,
+    ensure_public_http_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -87,9 +90,17 @@ class _UrllibTransport:
         # at an internal/loopback/link-local address (SSRF).
         ensure_public_http_url(url, allow_http=True, source="mcp_catalog.fetcher")
         request = urllib.request.Request(url, headers=headers)
+        # ``urlopen`` follows redirects automatically; a public host that
+        # redirects to an internal address would otherwise be unchecked.
+        # ``StrictHTTPRedirectHandler`` re-runs the strict check on every
+        # ``Location`` URL and raises ``UrlSchemeError`` to abort.
+        # TOCTOU (resolve-then-connect) is inherent without IP pinning.
+        opener = urllib.request.build_opener(
+            StrictHTTPRedirectHandler(allow_http=True, source="mcp_catalog.fetcher")
+        )
         try:
             # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
-            with urllib.request.urlopen(request, timeout=15) as resp:
+            with opener.open(request, timeout=15) as resp:
                 body = resp.read()
                 etag = resp.headers.get("ETag")
                 return HTTPResponse(status=resp.status, body=body, etag=etag)

--- a/src/bernstein/core/security/url_allowlist.py
+++ b/src/bernstein/core/security/url_allowlist.py
@@ -16,11 +16,20 @@ from __future__ import annotations
 
 import ipaddress
 import socket
+import urllib.request
 from collections.abc import Callable, Iterable
-from typing import Final
+from typing import IO, TYPE_CHECKING, Final
 from urllib.parse import urlparse
 
-__all__ = ["UrlSchemeError", "ensure_http_url", "ensure_public_http_url"]
+if TYPE_CHECKING:
+    from http.client import HTTPMessage
+
+__all__ = [
+    "StrictHTTPRedirectHandler",
+    "UrlSchemeError",
+    "ensure_http_url",
+    "ensure_public_http_url",
+]
 
 # Resolves a hostname to a list of textual IP addresses. Injectable so tests can
 # feed hostile answers without depending on DNS.
@@ -231,3 +240,57 @@ def ensure_public_http_url(
             )
 
     return url
+
+
+class StrictHTTPRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """``HTTPRedirectHandler`` that rejects redirects to internal destinations.
+
+    ``urllib.request.urlopen`` follows ``Location`` redirects automatically. A
+    strict pre-fetch check via :func:`ensure_public_http_url` is therefore
+    insufficient: a public host can answer ``302 Location: http://127.0.0.1/``
+    and still reach the client unchecked. This handler re-runs the strict
+    validation on every redirect target and raises :class:`UrlSchemeError` to
+    abort the redirect.
+
+    TOCTOU note: this is a resolve-then-connect check. A name that is
+    re-resolved by the HTTP client between this validation and the TCP
+    connection can answer differently the second time (DNS rebinding). That
+    race is inherent without connection-time IP pinning and is not mitigated
+    here; the pre-fetch + per-redirect check is the required defence layer.
+
+    Args:
+        allow_http: Whether plain ``http://`` redirect targets are permitted.
+            Must match the initial fetch's ``allow_http``. Loopback is still
+            rejected even when ``allow_http`` is True.
+        source: Human-readable label for error messages.
+        resolver: Optional host resolver for tests.
+    """
+
+    def __init__(
+        self,
+        *,
+        allow_http: bool = False,
+        source: str = "",
+        resolver: HostResolver | None = None,
+    ) -> None:
+        super().__init__()
+        self._allow_http = allow_http
+        self._source = source
+        self._resolver = resolver
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: HTTPMessage,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        ensure_public_http_url(
+            newurl,
+            allow_http=self._allow_http,
+            source=self._source,
+            resolver=self._resolver,
+        )
+        return super().redirect_request(req, fp, code, msg, headers, newurl)

--- a/src/bernstein/core/skills/catalog/fetcher.py
+++ b/src/bernstein/core/skills/catalog/fetcher.py
@@ -22,7 +22,10 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Protocol
 
-from bernstein.core.security.url_allowlist import ensure_public_http_url
+from bernstein.core.security.url_allowlist import (
+    StrictHTTPRedirectHandler,
+    ensure_public_http_url,
+)
 from bernstein.core.skills.catalog.manifest import (
     SkillCatalog,
     SkillCatalogValidationError,
@@ -94,9 +97,17 @@ class _UrllibTransport:
     def get(self, url: str, *, headers: dict[str, str]) -> HTTPResponse:
         ensure_public_http_url(url, allow_http=False, source="skills_catalog.fetcher")
         request = urllib.request.Request(url, headers=headers)
+        # ``urlopen`` follows redirects automatically; a public host that
+        # redirects to an internal address would otherwise be unchecked.
+        # ``StrictHTTPRedirectHandler`` re-runs the strict check on every
+        # ``Location`` URL and raises ``UrlSchemeError`` to abort.
+        # TOCTOU (resolve-then-connect) is inherent without IP pinning.
+        opener = urllib.request.build_opener(
+            StrictHTTPRedirectHandler(allow_http=False, source="skills_catalog.fetcher")
+        )
         try:
             # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
-            with urllib.request.urlopen(request, timeout=15) as resp:
+            with opener.open(request, timeout=15) as resp:
                 body = resp.read()
                 etag = resp.headers.get("ETag")
                 return HTTPResponse(status=resp.status, body=body, etag=etag)

--- a/src/bernstein/core/volunteer/registry.py
+++ b/src/bernstein/core/volunteer/registry.py
@@ -76,9 +76,7 @@ class _UrllibTransport:
         # ``StrictHTTPRedirectHandler`` re-runs the strict check on every
         # ``Location`` URL and raises ``UrlSchemeError`` to abort.
         # TOCTOU (resolve-then-connect) is inherent without IP pinning.
-        opener = urllib.request.build_opener(
-            StrictHTTPRedirectHandler(allow_http=False, source="volunteer.registry")
-        )
+        opener = urllib.request.build_opener(StrictHTTPRedirectHandler(allow_http=False, source="volunteer.registry"))
         try:
             # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             with opener.open(request, timeout=15) as resp:

--- a/src/bernstein/core/volunteer/registry.py
+++ b/src/bernstein/core/volunteer/registry.py
@@ -21,7 +21,12 @@ import urllib.request
 from dataclasses import dataclass
 from typing import Protocol
 
-from bernstein.core.security.url_allowlist import ensure_http_url
+from bernstein.core.security.url_allowlist import (
+    StrictHTTPRedirectHandler,
+    UrlSchemeError,
+    ensure_http_url,
+    ensure_public_http_url,
+)
 from bernstein.core.volunteer.manifest import (
     VolunteerManifest,
     VolunteerManifestError,
@@ -64,11 +69,19 @@ class HTTPTransport(Protocol):
 
 class _UrllibTransport:
     def get(self, url: str, *, headers: dict[str, str]) -> HTTPResponse:
-        ensure_http_url(url, allow_http=False, source="volunteer.registry")
+        ensure_public_http_url(url, allow_http=False, source="volunteer.registry")
         request = urllib.request.Request(url, headers=headers)
+        # ``urlopen`` follows redirects automatically; a public host that
+        # redirects to an internal address would otherwise be unchecked.
+        # ``StrictHTTPRedirectHandler`` re-runs the strict check on every
+        # ``Location`` URL and raises ``UrlSchemeError`` to abort.
+        # TOCTOU (resolve-then-connect) is inherent without IP pinning.
+        opener = urllib.request.build_opener(
+            StrictHTTPRedirectHandler(allow_http=False, source="volunteer.registry")
+        )
         try:
             # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
-            with urllib.request.urlopen(request, timeout=15) as resp:
+            with opener.open(request, timeout=15) as resp:
                 body = resp.read()
                 etag = resp.headers.get("ETag")
                 return HTTPResponse(status=resp.status, body=body, etag=etag)
@@ -103,13 +116,30 @@ class DroppedEntry:
     reason: str
 
 
-def _validate_url(url: str) -> tuple[bool, str | None]:
-    """Validate URL is HTTPS before any transport call."""
+def _validate_index_url(url: str) -> tuple[bool, str | None]:
+    """Validate an operator-configured index URL (permissive, scheme-only)."""
     try:
         ensure_http_url(url, allow_http=False, source="volunteer.registry")
         return True, None
     except Exception as exc:
         return False, str(exc)
+
+
+def _validate_manifest_url(url: str) -> tuple[bool, str | None]:
+    """Validate a third-party-derived manifest URL (strict, internal rejected)."""
+    try:
+        ensure_public_http_url(url, allow_http=False, source="volunteer.registry")
+        return True, None
+    except Exception as exc:
+        return False, str(exc)
+
+
+def _validate_url(url: str) -> tuple[bool, str | None]:
+    """Validate URL is HTTPS before any transport call.
+
+    Kept for backwards compatibility; delegates to the index (permissive) path.
+    """
+    return _validate_index_url(url)
 
 
 def _parse_index(body: bytes, source_url: str) -> list[IndexEntry]:
@@ -169,13 +199,13 @@ def _fetch_manifest(
 ) -> tuple[VolunteerManifest | None, str | None]:
     """Fetch and validate the project's volunteer manifest."""
     url = _manifest_url_for(entry)
-    ok, err = _validate_url(url)
+    ok, err = _validate_manifest_url(url)
     if not ok:
         return None, f"manifest URL rejected: {err}"
 
     try:
         response = transport.get(url, headers=headers)
-    except (TimeoutError, OSError) as exc:
+    except (TimeoutError, OSError, UrlSchemeError) as exc:
         return None, f"fetch failed: {exc}"
 
     if response.status >= 400:
@@ -236,14 +266,14 @@ def browse_indexes(
     dropped: list[DroppedEntry] = []
 
     for index_url in index_urls:
-        ok, err = _validate_url(index_url)
+        ok, err = _validate_index_url(index_url)
         if not ok:
             dropped.append(DroppedEntry(repo_url=index_url, reason=f"URL scheme rejected: {err}"))
             continue
 
         try:
             response = transport.get(index_url, headers=headers)
-        except (TimeoutError, OSError) as exc:
+        except (TimeoutError, OSError, UrlSchemeError) as exc:
             dropped.append(DroppedEntry(repo_url=index_url, reason=f"index fetch failed: {exc}"))
             continue
 

--- a/tests/unit/adapters/test_issue_4571_timeout_extension.py
+++ b/tests/unit/adapters/test_issue_4571_timeout_extension.py
@@ -92,11 +92,19 @@ def test_timeout_fallback_follows_scope_bucket_not_literal_default() -> None:
     prove the value is computed, not defaulted)."""
 
     small = Task(
-        id="T-S", title="t", description="d", role="backend", scope=Scope.SMALL,
+        id="T-S",
+        title="t",
+        description="d",
+        role="backend",
+        scope=Scope.SMALL,
     )
     xl = Task(
-        id="T-XL", title="t", description="d", role="architect",
-        scope=Scope.LARGE, complexity=Complexity.HIGH,
+        id="T-XL",
+        title="t",
+        description="d",
+        role="architect",
+        scope=Scope.LARGE,
+        complexity=Complexity.HIGH,
     )
 
     small_timeout = AgentSpawner._resolve_spawn_timeout([small])

--- a/tests/unit/scripts/test_bump_version.py
+++ b/tests/unit/scripts/test_bump_version.py
@@ -117,9 +117,7 @@ def test_bump_accepts_a_version_whose_notes_exist(
     bump_module.NOTES_DIR = notes
 
     calls: list[list[str]] = []
-    monkeypatch.setattr(
-        bump_module.subprocess, "run", lambda cmd, **kw: calls.append(list(cmd)) or None
-    )
+    monkeypatch.setattr(bump_module.subprocess, "run", lambda cmd, **kw: calls.append(list(cmd)) or None)
     assert bump_module.main(["3.4.5"]) == 0
     assert 'version = "3.4.5"' in pyproject.read_text(encoding="utf-8")
     assert len(calls) == 2, "the bump still regenerates the lockfile and the manifests"

--- a/tests/unit/security/test_url_allowlist.py
+++ b/tests/unit/security/test_url_allowlist.py
@@ -10,11 +10,13 @@ can never mask a regression that turns the guard into an always-allow.
 
 from __future__ import annotations
 
+import urllib.request
 from collections.abc import Callable
 
 import pytest
 
 from bernstein.core.security.url_allowlist import (
+    StrictHTTPRedirectHandler,
     UrlSchemeError,
     ensure_http_url,
     ensure_public_http_url,
@@ -239,3 +241,106 @@ def test_source_label_appears_in_strict_rejection() -> None:
             source="skills_catalog.fetcher",
             resolver=_resolves_to("127.0.0.1"),
         )
+
+
+# --- StrictHTTPRedirectHandler: redirect-aware strict URL guard ---
+
+
+class _FakeFP:
+    """Minimal file-like stub for ``redirect_request`` signature."""
+
+    def read(self) -> bytes:
+        return b""
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeHeaders(dict):
+    """Minimal ``HTTPMessage`` stand-in (``dict`` subclass is sufficient)."""
+
+
+def _redirect_handler(
+    *,
+    allow_http: bool = False,
+    source: str = "",
+    resolver: Callable[[str], list[str]] | None = None,
+) -> StrictHTTPRedirectHandler:
+    return StrictHTTPRedirectHandler(allow_http=allow_http, source=source, resolver=resolver)
+
+
+def test_redirect_to_internal_address_is_rejected() -> None:
+    """A 302 ``Location`` pointing at loopback must abort before connecting."""
+    handler = _redirect_handler(resolver=_resolves_to("127.0.0.1"))
+    req = urllib.request.Request("https://example.com/page")
+    with pytest.raises(UrlSchemeError, match="internal address"):
+        handler.redirect_request(req, _FakeFP(), 302, "Found", _FakeHeaders(), "https://127.0.0.1/inner")
+
+
+def test_redirect_to_link_local_is_rejected() -> None:
+    """Cloud-metadata link-local address via redirect must be blocked."""
+    handler = _redirect_handler(resolver=_resolves_to("169.254.169.254"))
+    req = urllib.request.Request("https://example.com/page")
+    with pytest.raises(UrlSchemeError, match="internal address"):
+        handler.redirect_request(req, _FakeFP(), 302, "Found", _FakeHeaders(), "https://169.254.169.254/meta-data/")
+
+
+def test_redirect_to_private_range_is_rejected() -> None:
+    """A ``192.168.x.x`` redirect target is a private-range SSRF vector."""
+    handler = _redirect_handler(resolver=_resolves_to("192.168.1.5"))
+    req = urllib.request.Request("https://example.com/page")
+    with pytest.raises(UrlSchemeError, match="internal address"):
+        handler.redirect_request(req, _FakeFP(), 302, "Found", _FakeHeaders(), "https://192.168.1.5/internal")
+
+
+def test_redirect_to_public_address_succeeds() -> None:
+    """A benign public→public redirect is allowed through."""
+    handler = _redirect_handler(resolver=_resolves_to("93.184.216.34"))
+    req = urllib.request.Request("https://example.com/page")
+    result = handler.redirect_request(req, _FakeFP(), 302, "Found", _FakeHeaders(), "https://other.example.com/ok")
+    assert result is not None
+    assert result.full_url == "https://other.example.com/ok"
+
+
+def test_redirect_http_allowed_when_opted_in_for_public_host() -> None:
+    """``allow_http=True`` permits ``http://`` redirects to public hosts."""
+    handler = _redirect_handler(allow_http=True, resolver=_resolves_to("93.184.216.34"))
+    req = urllib.request.Request("https://example.com/page")
+    result = handler.redirect_request(req, _FakeFP(), 302, "Found", _FakeHeaders(), "http://other.example.com/ok")
+    assert result is not None
+    assert result.full_url == "http://other.example.com/ok"
+
+
+def test_redirect_http_internal_rejected_even_with_allow_http() -> None:
+    """``allow_http=True`` still rejects ``http://127.0.0.1`` redirect targets."""
+    handler = _redirect_handler(allow_http=True, resolver=_resolves_to("127.0.0.1"))
+    req = urllib.request.Request("https://example.com/page")
+    with pytest.raises(UrlSchemeError, match="internal address"):
+        handler.redirect_request(req, _FakeFP(), 302, "Found", _FakeHeaders(), "http://127.0.0.1/internal")
+
+
+def test_redirect_rebinding_answer_with_mixed_addresses_is_rejected() -> None:
+    """One public + one private answer: which one the client picks is not ours to decide."""
+    handler = _redirect_handler(resolver=_resolves_to("93.184.216.34", "10.0.0.5"))
+    req = urllib.request.Request("https://example.com/page")
+    with pytest.raises(UrlSchemeError, match="internal address"):
+        handler.redirect_request(req, _FakeFP(), 302, "Found", _FakeHeaders(), "https://rebind.example/ok")
+
+
+def test_redirect_source_label_appears_in_error() -> None:
+    """The ``source`` kwarg is forwarded into the rejection message."""
+    handler = _redirect_handler(
+        source="volunteer.registry",
+        resolver=_resolves_to("127.0.0.1"),
+    )
+    req = urllib.request.Request("https://example.com/page")
+    with pytest.raises(UrlSchemeError, match="volunteer.registry"):
+        handler.redirect_request(req, _FakeFP(), 302, "Found", _FakeHeaders(), "https://evil.example/x")
+
+
+def test_redirect_non_http_scheme_rejected() -> None:
+    """A ``file://`` redirect target is rejected at the scheme gate."""
+    handler = _redirect_handler(resolver=_resolves_to("127.0.0.1"))
+    req = urllib.request.Request("https://example.com/page")
+    with pytest.raises(UrlSchemeError, match="scheme"):
+        handler.redirect_request(req, _FakeFP(), 302, "Found", _FakeHeaders(), "file:///etc/passwd")

--- a/tests/unit/test_publish_workflow_yaml.py
+++ b/tests/unit/test_publish_workflow_yaml.py
@@ -414,9 +414,7 @@ def test_release_body_still_appends_the_generated_changelog(
 ) -> None:
     """Contributor credits live in the generated changelog; keep it below the notes."""
     run = _step_run(workflow, RELEASE_JOB, "Create release")
-    assert "releases/generate-notes" in run, (
-        "the generated changelog must be fetched and appended, not dropped"
-    )
+    assert "releases/generate-notes" in run, "the generated changelog must be fetched and appended, not dropped"
     notes_pos = run.find("docs/release-notes/")
     generated_pos = run.find("releases/generate-notes")
     assert notes_pos < generated_pos, "hand-written notes come first, changelog after"
@@ -426,9 +424,5 @@ def test_release_creation_does_not_fall_back_to_generated_notes_only(
     workflow: dict[str, Any],
 ) -> None:
     run = _step_run(workflow, RELEASE_JOB, "Create release")
-    commands = "\n".join(
-        line for line in run.splitlines() if not line.lstrip().startswith("#")
-    )
-    assert "--generate-notes" not in commands, (
-        "--generate-notes publishes the machine changelog as the whole body"
-    )
+    commands = "\n".join(line for line in run.splitlines() if not line.lstrip().startswith("#"))
+    assert "--generate-notes" not in commands, "--generate-notes publishes the machine changelog as the whole body"

--- a/tests/unit/test_trunk_health_slo.py
+++ b/tests/unit/test_trunk_health_slo.py
@@ -189,13 +189,16 @@ def test_reds_under_the_threshold_do_not_hold_the_repo() -> None:
 
 def test_a_thin_sample_never_holds_the_repo() -> None:
     """Below MIN_SAMPLE_SIZE there is no rate to speak of."""
-    assert marker_should_open(
-        total=MIN_SAMPLE_SIZE - 1,
-        red=MIN_SAMPLE_SIZE - 1,
-        red_pct=100,
-        threshold_pct=5,
-        trunk_red_now=True,
-    ) is False
+    assert (
+        marker_should_open(
+            total=MIN_SAMPLE_SIZE - 1,
+            red=MIN_SAMPLE_SIZE - 1,
+            red_pct=100,
+            threshold_pct=5,
+            trunk_red_now=True,
+        )
+        is False
+    )
 
 
 def _run(conclusion: str, created_at: str) -> dict[str, str]:
@@ -225,12 +228,8 @@ def test_marker_stays_shut_when_trunk_is_green_again() -> None:
     The andon exists to stop merges piling onto a broken main, so a main whose
     newest run is green releases it.
     """
-    assert marker_should_open(
-        total=27, red=2, red_pct=7, threshold_pct=5, trunk_red_now=False
-    ) is False
+    assert marker_should_open(total=27, red=2, red_pct=7, threshold_pct=5, trunk_red_now=False) is False
 
 
 def test_marker_opens_when_the_rate_is_over_and_trunk_is_red_now() -> None:
-    assert marker_should_open(
-        total=27, red=2, red_pct=7, threshold_pct=5, trunk_red_now=True
-    ) is True
+    assert marker_should_open(total=27, red=2, red_pct=7, threshold_pct=5, trunk_red_now=True) is True


### PR DESCRIPTION
## What

`ensure_public_http_url` validates a URL before the fetch, but `urllib.request.urlopen` follows `Location` redirects on its own. A public host could answer `302 Location: http://127.0.0.1/` and the client would reach an internal destination that no check ever saw.

`StrictHTTPRedirectHandler` re-runs the strict validation on every redirect target and aborts with `UrlSchemeError`. Wired into the three places that fetch third-party-derived URLs: the MCP catalog fetcher, the skills catalog fetcher, and the volunteer registry.

## What it does not do

The handler documents its own residual risk rather than implying the hole is closed: a hostname re-resolved between validation and the TCP connection can answer differently (DNS rebinding). Closing that needs connection-time IP pinning, which is not in this slice.

## Tests

`tests/unit/security/test_url_allowlist.py` gains 105 lines covering the redirect path: a redirect to loopback, to a private range, and to a non-http scheme are each rejected, and a redirect to a public host still succeeds.

Closes #4286
