### PR TITLE
fix(#4479): stop drain from re-admitting a dead prior-run agent from agents.json

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -34,3 +34,12 @@ rather than as its own attribution is exempted by hand there, with the reason.
   now resolved against the tree first, following only an unambiguous rename;
   a basename that is absent everywhere or matches several files keeps the
   original path so the command still fails honestly. (#4554)
+- `DrainCoordinator._discover_agents_from_agents_json` admitted every entry in
+  `agents.json` that had a session id and a pid, without checking whether that
+  pid was still alive, unlike its `_discover_agents_from_pid_files` sibling. If
+  a prior run crashed before its own cleanup phase deleted `agents.json`, the
+  next run's drain re-admitted that dead agent, found its still-on-disk
+  worktree branch genuinely ahead of main, and fed it to the post-drain merge
+  step: a foreign branch from a run that never spawned it. The legacy source
+  now requires the same liveness check the PID-file source already has.
+  (#4479)

--- a/src/bernstein/core/orchestration/drain.py
+++ b/src/bernstein/core/orchestration/drain.py
@@ -758,7 +758,7 @@ class DrainCoordinator:
             raw_pid = entry.get("pid", 0)
             pid = int(raw_pid) if isinstance(raw_pid, (int, str, float)) else 0
             worktree = str(entry.get("worktree_path", ""))
-            if session_id and pid:
+            if session_id and pid and _is_process_alive(pid):
                 self._agents.append(
                     AgentDrainStatus(
                         session_id=session_id,

--- a/tests/unit/test_drain.py
+++ b/tests/unit/test_drain.py
@@ -163,3 +163,36 @@ async def test_phase_cleanup_stops_infrastructure_and_removes_draining_flag(tmp_
 
     mock_stop.assert_called_once()
     assert draining_flag.exists() is False
+
+
+def _write_agents_json(tmp_path: Path, pid: int) -> None:
+    runtime_dir = tmp_path / ".sdd" / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    (runtime_dir / "agents.json").write_text(
+        json.dumps([{"session_id": "s-1", "role": "backend", "pid": pid, "worktree_path": ""}]),
+        encoding="utf-8",
+    )
+
+
+def test_discover_agents_from_agents_json_skips_dead_pid(tmp_path: Path) -> None:
+    coordinator = DrainCoordinator(tmp_path)
+    _write_agents_json(tmp_path, pid=999999)
+
+    from bernstein.core import drain as drain_module
+
+    with patch.object(drain_module, "_is_process_alive", return_value=False):
+        coordinator._discover_agents_from_agents_json()  # pyright: ignore[reportPrivateUsage]
+
+    assert coordinator._agents == []  # pyright: ignore[reportPrivateUsage]
+
+
+def test_discover_agents_from_agents_json_admits_live_pid(tmp_path: Path) -> None:
+    coordinator = DrainCoordinator(tmp_path)
+    _write_agents_json(tmp_path, pid=123)
+
+    from bernstein.core import drain as drain_module
+
+    with patch.object(drain_module, "_is_process_alive", return_value=True):
+        coordinator._discover_agents_from_agents_json()  # pyright: ignore[reportPrivateUsage]
+
+    assert [a.session_id for a in coordinator._agents] == ["s-1"]  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
## What

`_discover_agents_from_agents_json`, one of drain's two agent-discovery sources, now requires a discovered pid to be alive before admitting it, matching the check its `_discover_agents_from_pid_files` sibling already has.

## Why

Fixes #4479. If a prior run crashed before its own drain cleanup phase deleted `agents.json`, the next run's drain read that file, found the dead agent's entry, and admitted it purely on `session_id` and `pid` being truthy, with no liveness check. That dead agent's still-on-disk worktree branch is genuinely ahead of main (real completed work from the previous run), so `_detect_branches_ahead` picks it up and the post-drain merge step cherry-picks it into the current run's branch: a foreign branch merging into a run that never created it.

## How

Added `and _is_process_alive(pid)` to the same admission check, so a stale `agents.json` entry whose process no longer exists is skipped, exactly as the PID-file source already does. `agents.json` itself is still deleted during drain cleanup as before; this only stops a copy that survived a crash from being trusted.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (drain.py is outside the strict-gated zone; repo-wide pyright is advisory)
- [x] `uv run python scripts/run_tests.py -x` passes (targeted: `test_drain.py`, `test_drain_merge.py`)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (N/A, internal orchestration detail)
- [x] `docs/operations/<area>.md` updated (N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (N/A, no new module)
- [x] Tests cover the documented behaviour (added `docs/release-notes/unreleased.md` entry)

## Verification

- Two new tests in `tests/unit/test_drain.py`: `test_discover_agents_from_agents_json_skips_dead_pid` fails on main (dead pid still admitted) and passes on this branch; `test_discover_agents_from_agents_json_admits_live_pid` pins that a live pid is still admitted.
- `tests/unit/test_drain.py` and `tests/unit/test_drain_merge.py` both pass in full (Python 3.13, matching the PR-path CI matrix).
- `ruff check`/`ruff format --check` clean on the changed files, `lint-imports` contracts kept, `bandit` reports no high-severity findings on `drain.py`.
- Did not run the full test suite or the Windows/macOS legs; only the touched files and their direct test suites were verified locally.
