### PR TITLE
test: state the sandbox precondition instead of inferring it from the env

### DIFF
--- a/docs/integrations/plugin-sdk.md
+++ b/docs/integrations/plugin-sdk.md
@@ -209,8 +209,8 @@ from bernstein.core.trigger_sources.registry import (
     list_trigger_source_names,
 )
 
-list_trigger_source_names()   # ['artifact', 'file_watch', 'jira', 'odata_poll']
-get_trigger_source("jira")    # the registered class
+list_trigger_source_names()  # ['artifact', 'file_watch', 'jira', 'odata_poll']
+get_trigger_source("jira")  # the registered class
 ```
 
 A malformed entry in either group is skipped with a warning naming it; it never

--- a/tests/unit/test_mutation_setup.py
+++ b/tests/unit/test_mutation_setup.py
@@ -173,14 +173,24 @@ class TestKeyMutationScenarios:
         finally:
             os.environ.pop("BERNSTEIN_SANDBOX", None)
 
-    def test_guardrails_no_relax_outside_sandbox(self) -> None:
-        """Outside a sandbox, DENY decisions must stay DENY (mutant might always relax)."""
-        import os
+    def test_guardrails_no_relax_outside_sandbox(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Outside a sandbox, DENY decisions must stay DENY (mutant might always relax).
 
+        ``BERNSTEIN_SANDBOX`` is only one of the signals ``is_sandboxed()``
+        reads; ``/.dockerenv`` and the cgroup markers are others. Clearing the
+        env var alone therefore does not describe "outside a sandbox" when the
+        suite itself runs in a container - which is how the fleet's own
+        verification gate runs it - and the test failed there for a reason
+        that had nothing to do with the code under test. Pinning
+        ``is_sandboxed`` states the precondition the assertion actually needs,
+        so the test means the same thing on a runner VM and in a container.
+        """
+        from bernstein.core import guardrails
         from bernstein.core.guardrails import relax_sandboxed
         from bernstein.core.policy_engine import DecisionType, PermissionDecision
 
-        os.environ.pop("BERNSTEIN_SANDBOX", None)
+        monkeypatch.delenv("BERNSTEIN_SANDBOX", raising=False)
+        monkeypatch.setattr(guardrails, "is_sandboxed", lambda: False)
         deny_decision = PermissionDecision(type=DecisionType.DENY, reason="outside sandbox")
         result = relax_sandboxed([deny_decision], check_name="file_permissions")
         # Without sandbox, no relaxation should occur

--- a/tests/unit/test_mutation_setup.py
+++ b/tests/unit/test_mutation_setup.py
@@ -185,9 +185,10 @@ class TestKeyMutationScenarios:
         ``is_sandboxed`` states the precondition the assertion actually needs,
         so the test means the same thing on a runner VM and in a container.
         """
-        from bernstein.core import guardrails
         from bernstein.core.guardrails import relax_sandboxed
         from bernstein.core.policy_engine import DecisionType, PermissionDecision
+
+        from bernstein.core import guardrails
 
         monkeypatch.delenv("BERNSTEIN_SANDBOX", raising=False)
         monkeypatch.setattr(guardrails, "is_sandboxed", lambda: False)


### PR DESCRIPTION
`test_guardrails_no_relax_outside_sandbox` clears `BERNSTEIN_SANDBOX` and then asserts that a DENY decision is not relaxed. `is_sandboxed()` reads three signals, though, and the env var is only the first: `/.dockerenv` and the cgroup markers are the others. Clearing the variable therefore does not put the process outside a sandbox — it only removes one of the ways the process can be recognised as being in one.

On a runner VM that distinction never shows up, so the test has always passed in CI. Run the same test inside a container and `is_sandboxed()` returns `True` on `/.dockerenv`, `relax_sandboxed` relaxes the decision exactly as designed, and the assertion fails for a reason that has nothing to do with the code under test:

```
tests/unit/test_mutation_setup.py::TestKeyMutationScenarios::test_guardrails_no_relax_outside_sandbox
E   AssertionError: assert <DecisionType.ALLOW: 'allow'> == <DecisionType.DENY: 'deny'>
```

That is not a hypothetical environment. Verification runs in a container, and this test is reachable from the reverse-importer closure of several hub modules, so any change that pulls it in fails on a red that no diff caused — and the work is set aside for a failure in an unrelated file. Reproduced on `origin/main` with no changes applied at all: 1 failed, 10 passed.

The fix states the precondition the assertion actually needs. `monkeypatch.setattr` pins `is_sandboxed` to `False` instead of hoping the ambient environment supplies that answer, so the test means the same thing on a runner VM and in a container. The env var is still cleared, so the test also keeps documenting that the variable alone does not relax anything.

The mutation-testing property is unchanged: a mutant that drops the `is_sandboxed()` guard from `relax_sandboxed` still relaxes the DENY and is still caught.

Verified in both environments: 11 passed on a runner and 11 passed inside a container, where it was 1 failed / 10 passed before.
