### PR TITLE
feat(audit): write content-addressed hash tiles beside the sealed segments

### DIFF
--- a/docs/integrations/plugin-sdk.md
+++ b/docs/integrations/plugin-sdk.md
@@ -209,8 +209,8 @@ from bernstein.core.trigger_sources.registry import (
     list_trigger_source_names,
 )
 
-list_trigger_source_names()   # ['artifact', 'file_watch', 'jira', 'odata_poll']
-get_trigger_source("jira")    # the registered class
+list_trigger_source_names()  # ['artifact', 'file_watch', 'jira', 'odata_poll']
+get_trigger_source("jira")  # the registered class
 ```
 
 A malformed entry in either group is skipped with a warning naming it; it never

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -178,6 +178,11 @@ def seal_cmd(anchor_git: bool, allow_broken_chain: bool) -> None:
 
     seal_path = save_seal(seal, MERKLE_DIR)
 
+    # Generate content-addressed hash tiles for audit segments
+    from bernstein.core.persistence.tiles import generate_tiles
+
+    tile_paths = generate_tiles(AUDIT_DIR, seal)
+
     checkpoint = None
     if not allow_broken_chain:
         try:
@@ -209,6 +214,7 @@ def seal_cmd(anchor_git: bool, allow_broken_chain: bool) -> None:
     table.add_row("Entries", str(seal.get("entry_count", "-")))
     table.add_row("Sealed at", str(seal["sealed_at_iso"]))
     table.add_row("Seal file", str(seal_path))
+    table.add_row("Tiles", str(len(tile_paths)))
     if checkpoint is not None:
         extended = "extends previous" if checkpoint.get("extends_prev", True) else "acknowledged divergence"
         table.add_row("Checkpoint", f"pinned at {checkpoint.get('entry_count', '-')} entries ({extended})")

--- a/src/bernstein/core/persistence/tiles.py
+++ b/src/bernstein/core/persistence/tiles.py
@@ -161,9 +161,12 @@ def read_hash_tile(audit_dir: Path, segment_name: str) -> dict[str, Any] | None:
     """
     path = tile_hash_path(audit_dir, segment_name)
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        parsed: object = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
 
 
 def generate_tiles(audit_dir: Path, seal: dict[str, Any]) -> list[Path]:
@@ -229,18 +232,6 @@ def generate_tiles(audit_dir: Path, seal: dict[str, Any]) -> list[Path]:
 
         dest = tile_hash_path(audit_dir, segment)
 
-        if dest.is_file():
-            try:
-                existing: dict[str, Any] = json.loads(dest.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError) as exc:
-                msg = f"Existing tile is not valid JSON: {dest}"
-                raise ValueError(msg) from exc
-            existing_hash = existing.get("leaf_hash")
-            if existing_hash == leaf_hash:
-                continue
-            msg = f"Tile exists with different leaf_hash: {dest} (existing={existing_hash!r} new={leaf_hash!r})"
-            raise ValueError(msg)
-
         byte_len_raw = leaf.get("byte_len")
         byte_len: int | None = None
         if isinstance(byte_len_raw, int) and not isinstance(byte_len_raw, bool) and byte_len_raw >= 0:
@@ -273,6 +264,29 @@ def generate_tiles(audit_dir: Path, seal: dict[str, Any]) -> list[Path]:
             "algorithm": "sha256",
             "scheme": scheme,
         }
+
+        if dest.is_file():
+            try:
+                existing: dict[str, Any] = json.loads(dest.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                msg = f"Existing tile is not valid JSON: {dest}"
+                raise ValueError(msg) from exc
+            if existing.get("leaf_hash") == leaf_hash and existing.get("byte_len") == tile_byte_len:
+                # Same prefix, same hash: the tile already is what this seal
+                # would write.
+                continue
+            if existing.get("byte_len") == tile_byte_len:
+                # The same bytes hashing two ways is the one thing a tile
+                # exists to catch, so it stays fatal.
+                msg = (
+                    f"Tile exists for the same {tile_byte_len} bytes with a different "
+                    f"leaf_hash: {dest} (existing={existing.get('leaf_hash')!r} new={leaf_hash!r})"
+                )
+                raise ValueError(msg)
+            # Different length: the live segment grew between seals, which is
+            # what a live segment does. Refusing that failed the second seal
+            # of a run outright. The tile describes the prefix this seal
+            # covers, so the newer seal replaces it.
 
         tmp_path = dest.parent / (dest.name + ".tmp")
         tmp_path.write_text(json.dumps(tile_obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/src/bernstein/core/persistence/tiles.py
+++ b/src/bernstein/core/persistence/tiles.py
@@ -12,14 +12,21 @@ the live file (e.g. ``2026-08-24.jsonl``) - and holds the segment content as
 it existed at seal time (up to ``byte_len`` from the Merkle seal). Tiles are
 immutable after creation.
 
-This module defines only the READ side. Every function here is pure and
-never writes to the filesystem, so a verifier can run against a read-only
-audit directory.
+Hash tiles (slice 1, issue #3829) are content-addressed JSON manifests stored
+at ``<audit_dir>/tiles/<segment_name>.tile``. They record the raw
+``SHA-256`` of the sealed byte prefix so a future verifier can check content
+without re-deriving the domain-separated leaf.
+
+This module defines the READ side (snapshot tiles) and the WRITE side
+(hash tiles). Snapshot read functions remain pure and never write.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import hashlib
+import json
+import os
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -28,17 +35,34 @@ if TYPE_CHECKING:
 TILES_SUBDIR = "tiles"
 
 
-def tile_path(audit_dir: Path, segment_name: str) -> Path:
+def tile_path(audit_dir: Path, segment_name: str, suffix: str = "") -> Path:
     """Return the tile path for *segment_name* under *audit_dir*.
 
     Args:
         audit_dir: The audit directory.
         segment_name: Live segment file name (e.g. ``2026-08-24.jsonl``).
+        suffix: Optional suffix appended to the file name (e.g. ``".tile"``).
 
     Returns:
-        ``<audit_dir>/tiles/<segment_name>``.
+        ``<audit_dir>/tiles/<segment_name><suffix>``.
     """
-    return audit_dir / TILES_SUBDIR / segment_name
+    return audit_dir / TILES_SUBDIR / f"{segment_name}{suffix}"
+
+
+def tile_hash_path(audit_dir: Path, segment_name: str) -> Path:
+    """Return the hash-tile path for *segment_name*.
+
+    Hash tiles use the ``.tile`` suffix so they never collide with snapshot
+    tiles or live segment files.
+
+    Args:
+        audit_dir: The audit directory.
+        segment_name: Live segment file name.
+
+    Returns:
+        ``<audit_dir>/tiles/<segment_name>.tile``.
+    """
+    return tile_path(audit_dir, segment_name, suffix=".tile")
 
 
 def has_tile(audit_dir: Path, segment_name: str) -> bool:
@@ -78,6 +102,9 @@ def read_tile(audit_dir: Path, segment_name: str) -> bytes | None:
 def list_tile_segments(audit_dir: Path) -> list[str]:
     """Return the sorted segment names that have tiles under *audit_dir*.
 
+    Hash tiles (``*.tile``) are excluded so this continues to report only
+    snapshot tiles.
+
     Args:
         audit_dir: The audit directory.
 
@@ -87,13 +114,183 @@ def list_tile_segments(audit_dir: Path) -> list[str]:
     tiles_dir = audit_dir / TILES_SUBDIR
     if not tiles_dir.is_dir():
         return []
-    return sorted(p.name for p in tiles_dir.iterdir() if p.is_file())
+    return sorted(
+        p.name
+        for p in tiles_dir.iterdir()
+        if p.is_file() and not p.name.endswith(".tile") and not p.name.endswith(".tmp")
+    )
+
+
+def list_hash_tiles(audit_dir: Path) -> list[str]:
+    """Return sorted hash-tile file names (``*.tile``) under *audit_dir*.
+
+    Args:
+        audit_dir: The audit directory.
+
+    Returns:
+        Sorted list of hash-tile file names, empty when none exist.
+    """
+    tiles_dir = audit_dir / TILES_SUBDIR
+    if not tiles_dir.is_dir():
+        return []
+    return sorted(p.name for p in tiles_dir.iterdir() if p.is_file() and p.name.endswith(".tile"))
+
+
+def has_hash_tile(audit_dir: Path, segment_name: str) -> bool:
+    """Return whether a hash tile exists for *segment_name*.
+
+    Args:
+        audit_dir: The audit directory.
+        segment_name: Live segment file name.
+
+    Returns:
+        True when ``<segment>.tile`` exists.
+    """
+    return tile_hash_path(audit_dir, segment_name).is_file()
+
+
+def read_hash_tile(audit_dir: Path, segment_name: str) -> dict[str, Any] | None:
+    """Read the hash tile JSON for *segment_name*, or ``None`` if absent.
+
+    Args:
+        audit_dir: The audit directory.
+        segment_name: Live segment file name.
+
+    Returns:
+        Parsed tile dict, or ``None`` if missing or unreadable.
+    """
+    path = tile_hash_path(audit_dir, segment_name)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def generate_tiles(audit_dir: Path, seal: dict[str, Any]) -> list[Path]:
+    """Write content-addressed hash tiles for every leaf in *seal*.
+
+    Each leaf in ``seal["leaves"]`` produces a JSON file at
+    ``<audit_dir>/tiles/<segment>.tile`` with shape::
+
+        {
+            "segment": "2026-08-24.jsonl",
+            "leaf_hash": "<hex from seal>",
+            "byte_len": 1234,
+            "content_sha256": "<plain SHA-256 of prefix>",
+            "algorithm": "sha256",
+            "scheme": 2
+        }
+
+    The ``content_sha256`` is a plain ``SHA-256`` over the first
+    ``byte_len`` bytes of the segment file (no domain separation). When
+    ``byte_len`` is absent the entire file is hashed.
+
+    Tiles are written atomically via ``<name>.tile.tmp`` + ``os.replace``.
+    If a tile already exists with the same ``leaf_hash`` it is left
+    untouched (idempotent). If it exists with a different ``leaf_hash`` a
+    ``ValueError`` is raised and no rewrite occurs.
+
+    Args:
+        audit_dir: Audit directory containing the live ``*.jsonl`` segments.
+        seal: Seal dict as produced by
+            :func:`bernstein.core.persistence.merkle.compute_seal`.
+
+    Returns:
+        List of paths that were newly written in this call (empty on a
+        fully idempotent re-run).
+
+    Raises:
+        ValueError: If an existing tile carries a different ``leaf_hash``.
+    """
+    leaves = seal.get("leaves", [])
+    if not isinstance(leaves, list):
+        return []
+
+    raw_scheme = seal.get("scheme", 2)
+    if isinstance(raw_scheme, bool) or not isinstance(raw_scheme, int):
+        try:
+            raw_scheme = int(str(raw_scheme))
+        except (ValueError, TypeError):
+            raw_scheme = 2
+    scheme: int = int(raw_scheme)
+
+    tiles_dir = audit_dir / TILES_SUBDIR
+    tiles_dir.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+
+    for leaf in leaves:
+        if not isinstance(leaf, dict):
+            continue
+        segment = leaf.get("file")
+        leaf_hash = leaf.get("hash")
+        if not isinstance(segment, str) or not isinstance(leaf_hash, str):
+            continue
+
+        dest = tile_hash_path(audit_dir, segment)
+
+        if dest.is_file():
+            try:
+                existing: dict[str, Any] = json.loads(dest.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                msg = f"Existing tile is not valid JSON: {dest}"
+                raise ValueError(msg) from exc
+            existing_hash = existing.get("leaf_hash")
+            if existing_hash == leaf_hash:
+                continue
+            msg = f"Tile exists with different leaf_hash: {dest} (existing={existing_hash!r} new={leaf_hash!r})"
+            raise ValueError(msg)
+
+        byte_len_raw = leaf.get("byte_len")
+        byte_len: int | None = None
+        if isinstance(byte_len_raw, int) and not isinstance(byte_len_raw, bool) and byte_len_raw >= 0:
+            byte_len = byte_len_raw
+
+        segment_path = audit_dir / segment
+        if byte_len is not None:
+            try:
+                full = segment_path.read_bytes()
+            except OSError as exc:
+                msg = f"Segment file missing for tile: {segment_path}"
+                raise ValueError(msg) from exc
+            data = full[:byte_len]
+            tile_byte_len = byte_len
+        else:
+            try:
+                data = segment_path.read_bytes()
+            except OSError as exc:
+                msg = f"Segment file missing for tile: {segment_path}"
+                raise ValueError(msg) from exc
+            tile_byte_len = len(data)
+
+        content_sha256 = hashlib.sha256(data).hexdigest()
+
+        tile_obj: dict[str, Any] = {
+            "segment": segment,
+            "leaf_hash": leaf_hash,
+            "byte_len": tile_byte_len,
+            "content_sha256": content_sha256,
+            "algorithm": "sha256",
+            "scheme": scheme,
+        }
+
+        tmp_path = dest.parent / (dest.name + ".tmp")
+        tmp_path.write_text(json.dumps(tile_obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(tmp_path, dest)
+        written.append(dest)
+
+    return written
 
 
 __all__ = [
     "TILES_SUBDIR",
+    "generate_tiles",
+    "has_hash_tile",
     "has_tile",
+    "list_hash_tiles",
     "list_tile_segments",
+    "read_hash_tile",
     "read_tile",
+    "tile_hash_path",
     "tile_path",
 ]

--- a/tests/unit/test_tiles.py
+++ b/tests/unit/test_tiles.py
@@ -9,17 +9,27 @@ snapshots:
   raising.
 * ``list_tile_segments`` returns sorted segment names, empty when none.
 * No read function writes to the filesystem (read-only compatible).
+
+Hash-tile tests cover the write side (``generate_tiles``) for content-
+addressed audit segment manifests (issue #3829, slice 1).
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from bernstein.core.persistence.tiles import (
     TILES_SUBDIR,
+    generate_tiles,
+    has_hash_tile,
     has_tile,
+    list_hash_tiles,
     list_tile_segments,
+    read_hash_tile,
     read_tile,
+    tile_hash_path,
     tile_path,
 )
 
@@ -72,3 +82,320 @@ def test_read_functions_do_not_write(tmp_path: Path) -> None:
     has_tile(tmp_path, "2026-08-24.jsonl")
     list_tile_segments(tmp_path)
     assert not tmp_path.exists() or list(tmp_path.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Hash-tile write-side tests (generate_tiles, issue #3829 slice 1)
+# ---------------------------------------------------------------------------
+
+
+def _make_seal(segments: list[tuple[str, bytes]]) -> dict:
+    """Build a minimal seal dict mimicking compute_seal output shape."""
+    import hashlib
+
+    leaves = []
+    for name, content in segments:
+        leaves.append(
+            {
+                "file": name,
+                "hash": hashlib.sha256(b"\x00" + content).hexdigest(),
+                "byte_len": len(content),
+            }
+        )
+    return {
+        "root_hash": "fake-root",
+        "algorithm": "sha256",
+        "scheme": 2,
+        "leaf_count": len(leaves),
+        "leaves": leaves,
+        "origin": "",
+        "entry_count": 0,
+        "sealed_at": 0.0,
+        "sealed_at_iso": "2026-08-24T00:00:00Z",
+    }
+
+
+def _write_segments(audit_dir: Path, segments: list[tuple[str, bytes]]) -> None:
+    """Write segment files into audit_dir."""
+    for name, content in segments:
+        (audit_dir / name).write_bytes(content)
+
+
+def test_byte_identical_across_two_directories(tmp_path: Path) -> None:
+    """Two operators with identical segments produce byte-identical tiles."""
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+
+    segments = [
+        ("2026-08-24.jsonl", b'{"event":"a"}\n{"event":"b"}\n'),
+        ("2026-08-25.jsonl", b'{"event":"c"}\n'),
+    ]
+    _write_segments(dir_a, segments)
+    _write_segments(dir_b, segments)
+
+    seal = _make_seal(segments)
+
+    generate_tiles(dir_a, seal)
+    generate_tiles(dir_b, seal)
+
+    tiles_a = sorted(p.name for p in (dir_a / TILES_SUBDIR).iterdir() if p.suffix == ".tile")
+    tiles_b = sorted(p.name for p in (dir_b / TILES_SUBDIR).iterdir() if p.suffix == ".tile")
+
+    assert tiles_a == tiles_b
+    assert len(tiles_a) == 2
+
+    for name in tiles_a:
+        content_a = (dir_a / TILES_SUBDIR / name).read_bytes()
+        content_b = (dir_b / TILES_SUBDIR / name).read_bytes()
+        assert content_a == content_b, f"Tile {name} differs across directories"
+
+
+def test_immutability_existing_tiles_not_rewritten(tmp_path: Path) -> None:
+    """Appending to a segment does not rewrite its previously-written tile."""
+    segments = [("2026-08-24.jsonl", b'{"event":"a"}\n')]
+    _write_segments(tmp_path, segments)
+    seal = _make_seal(segments)
+
+    generate_tiles(tmp_path, seal)
+
+    tile_file = tile_hash_path(tmp_path, "2026-08-24.jsonl")
+    original_content = tile_file.read_bytes()
+    original_mtime = tile_file.stat().st_mtime_ns
+
+    # Append more data to the segment
+    (tmp_path / "2026-08-24.jsonl").write_bytes(b'{"event":"a"}\n{"event":"b"}\n')
+
+    # Regenerate tiles with the SAME seal (same byte_len as original)
+    generate_tiles(tmp_path, seal)
+
+    assert tile_file.read_bytes() == original_content
+    assert tile_file.stat().st_mtime_ns == original_mtime
+
+
+def test_idempotency_running_twice_writes_nothing(tmp_path: Path) -> None:
+    """Running generate_tiles twice with same input writes nothing the second time."""
+    segments = [
+        ("2026-08-24.jsonl", b'{"event":"a"}\n'),
+        ("2026-08-25.jsonl", b'{"event":"b"}\n'),
+    ]
+    _write_segments(tmp_path, segments)
+    seal = _make_seal(segments)
+
+    written1 = generate_tiles(tmp_path, seal)
+    assert len(written1) == 2
+
+    files_after_first = sorted(p.name for p in (tmp_path / TILES_SUBDIR).iterdir())
+    contents_after_first = {p.name: p.read_bytes() for p in (tmp_path / TILES_SUBDIR).iterdir()}
+
+    written2 = generate_tiles(tmp_path, seal)
+    assert len(written2) == 0
+
+    files_after_second = sorted(p.name for p in (tmp_path / TILES_SUBDIR).iterdir())
+    contents_after_second = {p.name: p.read_bytes() for p in (tmp_path / TILES_SUBDIR).iterdir()}
+
+    assert files_after_first == files_after_second
+    assert contents_after_first == contents_after_second
+
+
+def test_naming_no_conflicts_lowercase_tile_suffix(tmp_path: Path) -> None:
+    """Tile filenames use .tile suffix and never collide with segment filenames."""
+    segments = [
+        ("2026-08-24.jsonl", b'{"event":"a"}\n'),
+    ]
+    _write_segments(tmp_path, segments)
+    seal = _make_seal(segments)
+
+    generate_tiles(tmp_path, seal)
+
+    tiles_dir = tmp_path / TILES_SUBDIR
+    tile_names = [p.name for p in tiles_dir.iterdir() if p.is_file()]
+    segment_names = [p.name for p in tmp_path.iterdir() if p.is_file()]
+
+    for tn in tile_names:
+        assert tn.endswith(".tile"), f"Tile filename {tn} does not end with .tile"
+        assert tn not in segment_names, f"Tile filename {tn} collides with a segment filename"
+
+
+def test_conflicting_leaf_hash_raises_value_error(tmp_path: Path) -> None:
+    """A tile with a different leaf_hash must raise ValueError, not silently rewrite."""
+    segments = [("2026-08-24.jsonl", b'{"event":"a"}\n')]
+    _write_segments(tmp_path, segments)
+
+    seal1 = _make_seal(segments)
+    generate_tiles(tmp_path, seal1)
+
+    # Build a seal with a different leaf_hash for the same segment
+    import hashlib
+
+    different_content = b'{"event":"different"}\n'
+    different_hash = hashlib.sha256(b"\x00" + different_content).hexdigest()
+    seal2 = {
+        "root_hash": "fake-root-2",
+        "algorithm": "sha256",
+        "scheme": 2,
+        "leaf_count": 1,
+        "leaves": [{"file": "2026-08-24.jsonl", "hash": different_hash, "byte_len": len(different_content)}],
+        "origin": "",
+        "entry_count": 0,
+        "sealed_at": 0.0,
+        "sealed_at_iso": "2026-08-24T00:00:00Z",
+    }
+
+    with pytest.raises(ValueError, match="different leaf_hash"):
+        generate_tiles(tmp_path, seal2)
+
+
+def test_generate_tiles_creates_tiles_dir(tmp_path: Path) -> None:
+    """generate_tiles creates the tiles subdirectory if it does not exist."""
+    segments = [("2026-08-24.jsonl", b'{"event":"a"}\n')]
+    _write_segments(tmp_path, segments)
+    seal = _make_seal(segments)
+
+    assert not (tmp_path / TILES_SUBDIR).exists()
+    generate_tiles(tmp_path, seal)
+    assert (tmp_path / TILES_SUBDIR).is_dir()
+
+
+def test_generate_tiles_content_sha256_correct(tmp_path: Path) -> None:
+    """The content_sha256 field is the plain SHA-256 of the sealed byte prefix."""
+    import hashlib
+
+    content = b'{"event":"a"}\n{"event":"b"}\n'
+    segments = [("2026-08-24.jsonl", content)]
+    _write_segments(tmp_path, segments)
+    seal = _make_seal(segments)
+
+    generate_tiles(tmp_path, seal)
+
+    tile = read_hash_tile(tmp_path, "2026-08-24.jsonl")
+    assert tile is not None
+    assert tile["content_sha256"] == hashlib.sha256(content).hexdigest()
+    assert tile["byte_len"] == len(content)
+    assert tile["algorithm"] == "sha256"
+    assert tile["scheme"] == 2
+    assert tile["segment"] == "2026-08-24.jsonl"
+
+
+def test_generate_tiles_byte_len_prefix_hashing(tmp_path: Path) -> None:
+    """When byte_len is less than file size, only the prefix is hashed."""
+    import hashlib
+
+    full_content = b'{"event":"a"}\n{"event":"b"}\n'
+    segments = [("2026-08-24.jsonl", full_content)]
+    _write_segments(tmp_path, segments)
+
+    # Seal pins only the first 13 bytes (the first line)
+    prefix_len = 13
+    prefix = full_content[:prefix_len]
+    leaf_hash = hashlib.sha256(b"\x00" + prefix).hexdigest()
+
+    seal = {
+        "root_hash": "fake-root",
+        "algorithm": "sha256",
+        "scheme": 2,
+        "leaf_count": 1,
+        "leaves": [{"file": "2026-08-24.jsonl", "hash": leaf_hash, "byte_len": prefix_len}],
+        "origin": "",
+        "entry_count": 0,
+        "sealed_at": 0.0,
+        "sealed_at_iso": "2026-08-24T00:00:00Z",
+    }
+
+    generate_tiles(tmp_path, seal)
+
+    tile = read_hash_tile(tmp_path, "2026-08-24.jsonl")
+    assert tile is not None
+    assert tile["content_sha256"] == hashlib.sha256(prefix).hexdigest()
+    assert tile["byte_len"] == prefix_len
+
+
+def test_generate_tiles_no_byte_len_hashes_full_file(tmp_path: Path) -> None:
+    """When byte_len is absent from the seal leaf, the entire file is hashed."""
+    import hashlib
+
+    content = b'{"event":"a"}\n'
+    segments = [("2026-08-24.jsonl", content)]
+    _write_segments(tmp_path, segments)
+
+    leaf_hash = hashlib.sha256(b"\x00" + content).hexdigest()
+    seal = {
+        "root_hash": "fake-root",
+        "algorithm": "sha256",
+        "scheme": 2,
+        "leaf_count": 1,
+        "leaves": [{"file": "2026-08-24.jsonl", "hash": leaf_hash}],
+        "origin": "",
+        "entry_count": 0,
+        "sealed_at": 0.0,
+        "sealed_at_iso": "2026-08-24T00:00:00Z",
+    }
+
+    generate_tiles(tmp_path, seal)
+
+    tile = read_hash_tile(tmp_path, "2026-08-24.jsonl")
+    assert tile is not None
+    assert tile["content_sha256"] == hashlib.sha256(content).hexdigest()
+    assert tile["byte_len"] == len(content)
+
+
+def test_generate_tiles_atomic_write_no_tmp_left(tmp_path: Path) -> None:
+    """No .tmp files remain after generate_tiles."""
+    segments = [("2026-08-24.jsonl", b'{"event":"a"}\n')]
+    _write_segments(tmp_path, segments)
+    seal = _make_seal(segments)
+
+    generate_tiles(tmp_path, seal)
+
+    tiles_dir = tmp_path / TILES_SUBDIR
+    tmp_files = [p for p in tiles_dir.iterdir() if p.name.endswith(".tmp")]
+    assert len(tmp_files) == 0
+
+
+def test_list_hash_tiles_returns_sorted_names(tmp_path: Path) -> None:
+    """list_hash_tiles returns sorted .tile file names."""
+    segments = [
+        ("2026-08-26.jsonl", b"x\n"),
+        ("2026-08-24.jsonl", b"y\n"),
+        ("2026-08-25.jsonl", b"z\n"),
+    ]
+    _write_segments(tmp_path, segments)
+    seal = _make_seal(segments)
+
+    generate_tiles(tmp_path, seal)
+
+    result = list_hash_tiles(tmp_path)
+    assert result == [
+        "2026-08-24.jsonl.tile",
+        "2026-08-25.jsonl.tile",
+        "2026-08-26.jsonl.tile",
+    ]
+
+
+def test_has_hash_tile(tmp_path: Path) -> None:
+    """has_hash_tile reflects existence of a .tile file."""
+    segments = [("2026-08-24.jsonl", b'{"event":"a"}\n')]
+    _write_segments(tmp_path, segments)
+    seal = _make_seal(segments)
+
+    assert has_hash_tile(tmp_path, "2026-08-24.jsonl") is False
+    generate_tiles(tmp_path, seal)
+    assert has_hash_tile(tmp_path, "2026-08-24.jsonl") is True
+
+
+def test_generate_tiles_empty_seal(tmp_path: Path) -> None:
+    """An empty seal (no leaves) produces no tiles and does not error."""
+    seal = {
+        "root_hash": "empty",
+        "algorithm": "sha256",
+        "scheme": 2,
+        "leaf_count": 0,
+        "leaves": [],
+        "origin": "",
+        "entry_count": 0,
+        "sealed_at": 0.0,
+        "sealed_at_iso": "2026-08-24T00:00:00Z",
+    }
+    result = generate_tiles(tmp_path, seal)
+    assert result == []

--- a/tests/unit/test_tiles.py
+++ b/tests/unit/test_tiles.py
@@ -218,33 +218,55 @@ def test_naming_no_conflicts_lowercase_tile_suffix(tmp_path: Path) -> None:
         assert tn not in segment_names, f"Tile filename {tn} collides with a segment filename"
 
 
-def test_conflicting_leaf_hash_raises_value_error(tmp_path: Path) -> None:
-    """A tile with a different leaf_hash must raise ValueError, not silently rewrite."""
+def test_same_prefix_hashing_two_ways_raises_value_error(tmp_path: Path) -> None:
+    """The same byte range under two different leaf hashes is tampering, not a re-seal."""
     segments = [("2026-08-24.jsonl", b'{"event":"a"}\n')]
     _write_segments(tmp_path, segments)
-
     seal1 = _make_seal(segments)
     generate_tiles(tmp_path, seal1)
 
-    # Build a seal with a different leaf_hash for the same segment
+    # Same segment, same covered length, a leaf hash that does not match: the
+    # bytes under an already-written tile cannot hash two ways.
     import hashlib
 
-    different_content = b'{"event":"different"}\n'
-    different_hash = hashlib.sha256(b"\x00" + different_content).hexdigest()
+    covered = len(segments[0][1])
     seal2 = {
         "root_hash": "fake-root-2",
         "algorithm": "sha256",
         "scheme": 2,
         "leaf_count": 1,
-        "leaves": [{"file": "2026-08-24.jsonl", "hash": different_hash, "byte_len": len(different_content)}],
+        "leaves": [
+            {
+                "file": "2026-08-24.jsonl",
+                "hash": hashlib.sha256(b"\x00not-the-same").hexdigest(),
+                "byte_len": covered,
+            }
+        ],
         "origin": "",
         "entry_count": 0,
         "sealed_at": 0.0,
         "sealed_at_iso": "2026-08-24T00:00:00Z",
     }
-
-    with pytest.raises(ValueError, match="different leaf_hash"):
+    with pytest.raises(ValueError, match="different"):
         generate_tiles(tmp_path, seal2)
+
+
+def test_sealing_again_after_the_segment_grew_replaces_the_tile(tmp_path: Path) -> None:
+    """A live segment gains events between seals; the second seal must not fail."""
+    first = b'{"event":"a"}\n'
+    _write_segments(tmp_path, [("2026-08-24.jsonl", first)])
+    generate_tiles(tmp_path, _make_seal([("2026-08-24.jsonl", first)]))
+
+    # The segment is append-only and keeps growing while the run continues.
+    grown = first + b'{"event":"b"}\n'
+    _write_segments(tmp_path, [("2026-08-24.jsonl", grown)])
+    written = generate_tiles(tmp_path, _make_seal([("2026-08-24.jsonl", grown)]))
+
+    assert len(written) == 1
+    tile = read_hash_tile(tmp_path, "2026-08-24.jsonl")
+    assert tile is not None
+    # The tile describes the prefix the newer seal covers, not the older one.
+    assert tile["byte_len"] == len(grown)
 
 
 def test_generate_tiles_creates_tiles_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
Sealing an audit segment produced the segment and the seal, and nothing a third party could check a *single* segment against without replaying the whole chain.

This writes a hash tile next to each segment at seal time — a small deterministic record naming the segment and its digest — so one segment can be verified on its own.

Deterministic in the sense that matters here: the same segment and seal produce a byte-identical tile, so two operators sealing the same chain get the same tiles and a diff between them is a real divergence rather than a timestamp.

`tiles.py` also gains the read side (`list_hash_tiles`, `has_hash_tile`, `read_hash_tile`, `tile_hash_path`), and `audit seal` reports how many tiles it wrote.

21 tests cover generation, determinism, the path layout, and the read helpers. Full suite green locally apart from `test_guardrails_no_relax_outside_sandbox`, which fails on untouched `main` inside a container and is fixed by #4626.

Closes #3829