### PR TITLE
feat(review): show the reviewer the conventions already filed for this repo

### DIFF
--- a/docs/integrations/plugin-sdk.md
+++ b/docs/integrations/plugin-sdk.md
@@ -209,8 +209,8 @@ from bernstein.core.trigger_sources.registry import (
     list_trigger_source_names,
 )
 
-list_trigger_source_names()   # ['artifact', 'file_watch', 'jira', 'odata_poll']
-get_trigger_source("jira")    # the registered class
+list_trigger_source_names()  # ['artifact', 'file_watch', 'jira', 'odata_poll']
+get_trigger_source("jira")  # the registered class
 ```
 
 A malformed entry in either group is skipped with a warning naming it; it never

--- a/src/bernstein/core/knowledge/conventions.py
+++ b/src/bernstein/core/knowledge/conventions.py
@@ -50,6 +50,7 @@ import fnmatch
 import hashlib
 import json
 import logging
+import subprocess
 import time
 import uuid
 from dataclasses import dataclass
@@ -604,6 +605,73 @@ def file_review_correction(
     return signed_new
 
 
+def file_review_finding(
+    sdd_dir: Path,
+    workdir: Path,
+    task_id: str,
+    issue_text: str,
+    owned_files: list[str],
+    decided_by: str,
+    subject_symbol: str = "",
+) -> ConventionReceipt | None:
+    """File a review finding as a convention receipt, never breaking the caller.
+
+    Convenience wrapper mapping cross-model review-finding data onto
+    :func:`file_review_correction`. Derives ``base_commit_sha`` from the
+    workdir's HEAD and a ``subject_path`` from ``owned_files`` (the single file,
+    a brace-glob for several, ``*`` when none). Any filing failure (missing
+    git, conflict, I/O) is logged and swallowed so the review pipeline is never
+    interrupted by convention filing.
+
+    Args:
+        sdd_dir: Path to project .sdd directory.
+        workdir: Working directory of the codebase (used for git HEAD).
+        task_id: Identifier of the task whose review produced the finding.
+        issue_text: The review issue text, used as the rule text.
+        owned_files: Files the task owned; derive the subject path from these.
+        decided_by: Reviewer identity that decided the rule.
+        subject_symbol: Optional class/function symbol name in the subject path.
+
+    Returns:
+        The filed :class:`ConventionReceipt`, or ``None`` if filing failed.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+        base_commit_sha = result.stdout.strip()
+        if not base_commit_sha:
+            raise ValueError("git rev-parse returned an empty commit SHA")
+
+        if len(owned_files) == 1:
+            subject_path = owned_files[0]
+        elif len(owned_files) > 1:
+            subject_path = "{" + ",".join(owned_files) + "}"
+        else:
+            subject_path = "*"
+
+        return file_review_correction(
+            sdd_dir=sdd_dir,
+            workdir=workdir,
+            rule_text=issue_text,
+            subject_path=subject_path,
+            base_commit_sha=base_commit_sha,
+            subject_symbol=subject_symbol,
+            filing_finding_id=task_id,
+            decided_by=decided_by,
+            assertion_ref=None,
+        )
+    except Exception as exc:
+        logger.warning("file_review_finding: convention filing failed: %s", exc)
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Retirement
 # ---------------------------------------------------------------------------
@@ -948,6 +1016,7 @@ __all__ = [
     "detect_assertion_conflict",
     "expire_convention_receipt",
     "file_review_correction",
+    "file_review_finding",
     "get_active_conventions",
     "paths_overlap",
     "retire_convention_receipt",

--- a/src/bernstein/core/quality/cross_model_verifier.py
+++ b/src/bernstein/core/quality/cross_model_verifier.py
@@ -13,8 +13,13 @@ import json
 import logging
 import subprocess
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from bernstein.core.knowledge.conventions import (
+    file_review_finding,
+    get_active_conventions,
+)
 from bernstein.core.llm import call_llm
 from bernstein.core.persistence.fingerprint import default_store, memoize_persistent
 
@@ -108,7 +113,7 @@ dataclasses/TypedDict instead of raw dicts, ruff for lint/format.
 5. Scope - did the diff change files or behaviour clearly outside the task's \
 stated scope? Flag only clear overreach, not incidental changes.
 
-Output a JSON object with exactly these fields:
+{conventions_block}Output a JSON object with exactly these fields:
 {{
   "verdict": "approve | request_changes",
   "feedback": "One or two sentence summary",
@@ -209,11 +214,15 @@ def _get_diff(worktree_path: Path, owned_files: list[str]) -> str:
         return "(failed to get git diff)"
 
 
-def _build_prompt(task: Task, diff: str) -> str:
+def _build_prompt(task: Task, diff: str, conventions_block: str = "") -> str:
+    # ``conventions_block`` is pre-rendered by the caller and already ends
+    # in a blank line when non-empty, so an empty one leaves the prompt
+    # byte-identical to what it was before conventions existed.
     return _REVIEW_PROMPT_TEMPLATE.format(
         title=task.title,
         description=task.description[:2000],
         diff=diff,
+        conventions_block=conventions_block,
     )
 
 
@@ -324,7 +333,26 @@ async def verify_with_cross_model(
     if len(diff) > config.max_diff_chars:
         diff = diff[: config.max_diff_chars] + "\n... (truncated)"
 
-    prompt = _build_prompt(task, diff)
+    # Build conventions block for prompt injection
+    try:
+        # A worktree lives at .sdd/worktrees/<slug>, so the receipts sit one
+        # level up. A checkout that is not a worktree keeps its own .sdd.
+        parent_sdd = worktree_path.parent / ".sdd"
+        sdd_dir = parent_sdd if parent_sdd.exists() else worktree_path / ".sdd"
+        active_receipts, _ = get_active_conventions(sdd_dir, workdir=worktree_path)
+        if active_receipts:
+            conventions_block = (
+                "## Active conventions\n"
+                + "\n".join(f"- {r.rule_text} (file: {r.subject_path}, version: {r.version})" for r in active_receipts)
+                + "\n\n"
+            )
+        else:
+            conventions_block = ""
+    except Exception as exc:
+        logger.debug("cross_model_verifier: failed to load active conventions: %s", exc)
+        conventions_block = ""
+
+    prompt = _build_prompt(task, diff, conventions_block)
     logger.info(
         "cross_model_verifier: task=%s writer=%s reviewer=%s diff_chars=%d",
         task.id,
@@ -360,6 +388,22 @@ async def verify_with_cross_model(
         verdict.verdict,
         len(verdict.issues),
     )
+
+    # File convention receipts for request_changes verdicts (never break the pipeline on filing failure)
+    if verdict.verdict == "request_changes" and verdict.issues:
+        for issue in verdict.issues:
+            try:
+                file_review_finding(
+                    sdd_dir=sdd_dir,
+                    workdir=worktree_path,
+                    task_id=task.id,
+                    issue_text=issue,
+                    owned_files=task.owned_files,
+                    decided_by=verdict.reviewer_model,
+                )
+            except Exception as exc:
+                logger.warning("cross_model_verifier: convention filing failed for issue %r: %s", issue, exc)
+
     _record_rework_sample(task=task, worktree_path=worktree_path, writer_model=writer_model, verdict=verdict)
     return verdict
 

--- a/tests/unit/test_cross_model_verifier.py
+++ b/tests/unit/test_cross_model_verifier.py
@@ -355,6 +355,164 @@ class TestCrossModelVerifierConfigDefaults:
 
 
 # ---------------------------------------------------------------------------
+# Convention wiring tests
+# ---------------------------------------------------------------------------
+
+
+class TestConventionWiring:
+    @pytest.mark.asyncio
+    async def test_request_changes_files_convention_receipt(self, tmp_path: Path) -> None:
+        """When verify_with_cross_model returns request_changes with issues, file_review_correction() is called."""
+
+        # Initialize git repo in tmp_path so file_review_finding can get HEAD commit
+        (tmp_path / "placeholder.txt").write_text("placeholder\n", encoding="utf-8")
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=tmp_path, check=True, capture_output=True)
+
+        task = _make_task()
+        config = CrossModelVerifierConfig(enabled=True)
+        diff_response = MagicMock(stdout="+dangerous_code()\n")
+        reject_json = json.dumps(
+            {
+                "verdict": "request_changes",
+                "feedback": "Dangerous call.",
+                "issues": ["Unvalidated input", "Hardcoded secret"],
+            }
+        )
+
+        with (
+            patch("subprocess.run", return_value=diff_response),
+            patch(
+                "bernstein.core.cross_model_verifier.call_llm",
+                new=AsyncMock(return_value=reject_json),
+            ),
+            patch("bernstein.core.quality.cross_model_verifier.file_review_finding") as mock_file_review_finding,
+        ):
+            verdict = await verify_with_cross_model(task, tmp_path, "claude-sonnet", config)
+
+        assert verdict.verdict == "request_changes"
+        assert verdict.issues == ["Unvalidated input", "Hardcoded secret"]
+        # file_review_finding should be called once per issue
+        assert mock_file_review_finding.call_count == 2
+        mock_file_review_finding.assert_any_call(
+            sdd_dir=tmp_path / ".sdd",
+            workdir=tmp_path,
+            task_id=task.id,
+            issue_text="Unvalidated input",
+            owned_files=task.owned_files,
+            decided_by="google/gemini-flash-1.5",
+        )
+        mock_file_review_finding.assert_any_call(
+            sdd_dir=tmp_path / ".sdd",
+            workdir=tmp_path,
+            task_id=task.id,
+            issue_text="Hardcoded secret",
+            owned_files=task.owned_files,
+            decided_by="google/gemini-flash-1.5",
+        )
+
+    @pytest.mark.asyncio
+    async def test_approve_does_not_file(self, tmp_path: Path) -> None:
+        """When verify_with_cross_model returns approve, no convention receipts are filed."""
+
+        task = _make_task()
+        config = CrossModelVerifierConfig(enabled=True)
+        diff_response = MagicMock(stdout="+print('hello')\n")
+        approve_json = json.dumps({"verdict": "approve", "feedback": "Fine", "issues": []})
+
+        with (
+            patch("subprocess.run", return_value=diff_response),
+            patch(
+                "bernstein.core.cross_model_verifier.call_llm",
+                new=AsyncMock(return_value=approve_json),
+            ),
+            patch(
+                "bernstein.core.knowledge.conventions.file_review_finding",
+            ) as mock_file_review_finding,
+        ):
+            verdict = await verify_with_cross_model(task, tmp_path, "claude-sonnet", config)
+
+        assert verdict.verdict == "approve"
+        mock_file_review_finding.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_active_conventions_injected_into_prompt(self, tmp_path: Path) -> None:
+        """When active conventions exist, they appear in the review prompt."""
+        from bernstein.core.knowledge.conventions import (
+            file_review_correction,
+        )
+
+        # Pre-file a convention receipt
+        sdd_dir = tmp_path / ".sdd"
+        sdd_dir.mkdir(parents=True)
+        src_file = tmp_path / "src" / "api.py"
+        src_file.parent.mkdir(parents=True)
+        src_file.write_text("def handle_request(): pass\n", encoding="utf-8")
+
+        file_review_correction(
+            sdd_dir=sdd_dir,
+            workdir=tmp_path,
+            rule_text="Always validate request payloads before dispatching",
+            subject_path="src/api.py",
+            base_commit_sha="1111222233334444555566667777888899990000",
+            filing_finding_id="review-pr-42",
+            decided_by="reviewer-bob",
+        )
+
+        task = _make_task()
+        config = CrossModelVerifierConfig(enabled=True)
+        approve_json = json.dumps({"verdict": "approve", "feedback": "OK", "issues": []})
+
+        diff_response = MagicMock(stdout="+code\n")
+        captured_prompt: list[str] = []
+
+        async def fake_llm(prompt: str, **kwargs: object) -> str:
+            captured_prompt.append(prompt)
+            return approve_json
+
+        with (
+            patch("subprocess.run", return_value=diff_response),
+            patch("bernstein.core.cross_model_verifier.call_llm", new=fake_llm),
+        ):
+            await verify_with_cross_model(task, tmp_path, "claude-sonnet", config)
+
+        prompt = captured_prompt[0]
+        assert "## Active conventions" in prompt
+        assert "Always validate request payloads before dispatching" in prompt
+        assert "file: src/api.py" in prompt
+        assert "version: 1" in prompt
+
+    @pytest.mark.asyncio
+    async def test_filing_failure_does_not_break_review(self, tmp_path: Path) -> None:
+        """If git fails in file_review_finding, the review verdict is still returned."""
+        task = _make_task()
+        config = CrossModelVerifierConfig(enabled=True)
+        reject_json = json.dumps(
+            {
+                "verdict": "request_changes",
+                "feedback": "Issue found",
+                "issues": ["Some issue"],
+            }
+        )
+
+        with (
+            patch("subprocess.run", side_effect=OSError("git not available")),
+            patch(
+                "bernstein.core.cross_model_verifier.call_llm",
+                new=AsyncMock(return_value=reject_json),
+            ),
+        ):
+            verdict = await verify_with_cross_model(task, tmp_path, "claude-sonnet", config)
+
+        # Even though convention filing failed, we still got the verdict
+        assert verdict.verdict == "request_changes"
+        assert verdict.issues == ["Some issue"]
+
+
+# ---------------------------------------------------------------------------
 # Multi-voter path (voting_config set)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_lessons.py
+++ b/tests/unit/test_lessons.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import time
 from typing import TYPE_CHECKING
 
@@ -1138,3 +1139,68 @@ class TestConventionReceipts:
         # The expiry is a clean chain transition, not a tamper signal.
         audit_res = verify_conventions_audit(sdd_dir)
         assert audit_res.valid, audit_res.errors
+
+
+class TestFileReviewFinding:
+    def test_file_review_finding_returns_none_on_git_failure(self, tmp_path: Path) -> None:
+        """If git rev-parse fails, file_review_finding returns None."""
+        from bernstein.core.knowledge.conventions import file_review_finding
+
+        sdd_dir = tmp_path / ".sdd"
+        sdd_dir.mkdir(parents=True)
+        # Create a directory without git repo
+        workdir = tmp_path / "no-git"
+        workdir.mkdir()
+
+        result = file_review_finding(
+            sdd_dir=sdd_dir,
+            workdir=workdir,
+            task_id="task-123",
+            issue_text="Test issue",
+            owned_files=["src/test.py"],
+            decided_by="test-reviewer",
+        )
+
+        assert result is None
+
+    def test_file_review_finding_creates_receipt_on_success(self, tmp_path: Path) -> None:
+        """On successful git rev-parse, file_review_finding creates a convention receipt."""
+        from bernstein.core.knowledge.conventions import file_review_finding, get_active_conventions
+
+        sdd_dir = tmp_path / ".sdd"
+        sdd_dir.mkdir(parents=True)
+        # Initialize git repo
+        (tmp_path / "placeholder.txt").write_text("placeholder\n", encoding="utf-8")
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=tmp_path, check=True, capture_output=True)
+
+        workdir = tmp_path
+        result = file_review_finding(
+            sdd_dir=sdd_dir,
+            workdir=workdir,
+            task_id="task-456",
+            issue_text="Always validate user input",
+            owned_files=["src/input.py"],
+            decided_by="test-reviewer",
+        )
+
+        assert result is not None
+        assert result.rule_text == "Always validate user input"
+        assert result.subject_path == "src/input.py"
+        assert result.filing_finding_id == "task-456"
+        assert result.decided_by == "test-reviewer"
+        assert result.version == 1
+        assert result.status == "active"
+
+        # Verify it appears in active conventions
+        active, _ = get_active_conventions(sdd_dir, workdir=workdir)
+        assert len(active) == 1
+        assert active[0].receipt_id == result.receipt_id
+
+
+# ---------------------------------------------------------------------------
+# Convention receipts: review corrections & audit chain (Issue #3750)
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
`file_lesson()` had no caller on the review path. A correction a reviewer made once was never visible to the next review, so the same correction got re-typed on every PR that touched the same file.

**Two halves.**

- `conventions.py` gains `file_review_finding()`, which turns a review finding into an attested convention receipt anchored on the base commit.
- `cross_model_verifier` loads the active receipts for the worktree and renders them into the review prompt, so the model sees what has already been decided about these files before it forms a verdict.

The conventions block is a **named template field**, not a string spliced into a prompt sentence. Splicing meant an unrelated edit to the prompt wording would drop the conventions silently — which is the exact failure this change exists to stop. An empty block leaves the prompt byte-identical to what it was before conventions existed.

Receipt loading is best-effort: a repo with no `.sdd`, or a git that will not answer, reviews exactly as it did before — covered by `test_filing_failure_does_not_break_review`.

85 tests pass across `test_cross_model_verifier.py` and `test_lessons.py`; ruff check and format clean.

Closes #3750