### PR TITLE
docs: refresh the curated context files against their subtrees

### DIFF
--- a/src/bernstein/adapters/AGENTS.md
+++ b/src/bernstein/adapters/AGENTS.md
@@ -1,8 +1,7 @@
 # CLI agent adapters
 
-One adapter per upstream coding-agent CLI (claude, codex, gemini,
-aider, goose, and 40+ more). An adapter turns a task prompt into a CLI
-invocation and streams results back; flat layout, one module per tool.
+One adapter per upstream coding-agent CLI (claude, codex, gemini, aider, goose, 40+ more):
+a task prompt becomes a CLI invocation and results stream back. One module per tool.
 
 ## Key files
 
@@ -13,6 +12,7 @@ invocation and streams results back; flat layout, one module per tool.
 | `capability_profile.py` | Declarative adapter capability profiles and profile factory |
 | `skills_injector.py` | Copies sanitized skill markdown into the worktree at dispatch |
 | `canary.py` | Nightly conformance canary matrix over adapter contracts |
+| `goose_stream_parser.py` | Parses Goose `--output-format stream-json`; token accounting rides the terminal `envelope` event |
 | `http_429_classifier.py` | Classifies HTTP 429 errors into standing quotas vs. transient rate limits |
 | `onboarding.py` | Interactive probe and capability discovery for newly installed agent CLIs |
 | `mock.py` | Mock agent for zero-API-key demos; produces the same completion evidence real agents do (`Modified:` log lines plus a per-fix commit scoped to the mutated file) |
@@ -37,4 +37,4 @@ Both layouts are current; follow whichever one an adapter already uses, and
 run one file at a time. Contract checks live under `tests/contract/`;
 live-binary conformance is opt-in via the `--live` pytest flag.
 
-<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-08-27 against this subtree; the notes above still hold. -->

--- a/src/bernstein/cli/AGENTS.md
+++ b/src/bernstein/cli/AGENTS.md
@@ -14,6 +14,7 @@ group and registers every subcommand; implementations live in
 | `helpers.py` | Shared console and utility helpers |
 | `run_cmd.py` | `bernstein run` entry; bootstrap/confirm split into siblings |
 | `commands/identity_attest_cmd.py` | `bernstein identity attest` run attestation CLI commands |
+| `commands/insights_cmd.py` | `bernstein insights`: analytics read out of task traces |
 
 ## Invariants
 
@@ -34,4 +35,4 @@ Single files only, e.g.
 `uv run pytest tests/unit/test_agents_md_cmd.py -x -q`; most commands
 have a matching `test_<name>_cmd.py` under `tests/unit/`.
 
-<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-08-27 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/orchestration/AGENTS.md
+++ b/src/bernstein/core/orchestration/AGENTS.md
@@ -15,6 +15,7 @@ repeat. Coordination is plain Python, never an LLM (ADR-006).
 | `trigger_manager.py` | Evaluates `triggers.yaml` rules into `TriggerEvent`s (event and cron sources) |
 | `worker.py` | `bernstein-worker` process wrapper for spawned CLI agents |
 | `run_closure_owner.py` | Universal authenticated run closure owner |
+| `issue_claim.py` | Claim etiquette for coordinator-free issue intake: recognises a run's own claim, detects a stale one |
 
 Heavy lifting lives in siblings: `../tasks/task_lifecycle.py` (claim, spawn, retry,
 completion) and `../agents/` (spawner, heartbeat, crash detection, reaping).
@@ -22,8 +23,7 @@ completion) and `../agents/` (spawner, heartbeat, crash detection, reaping).
 ## Invariants
 
 - No LLM in any coordination path (`docs/decisions/006-no-embedded-llm.md`).
-- The tick loop is single-threaded by design; do not add concurrent
-  ticks without restoring a tick guard (`orchestrator.py` docstring).
+- The tick loop is single-threaded by design; do not add concurrent ticks without restoring a tick guard (`orchestrator.py`).
 - Replay is strict: a cache miss raises `ReplayMissError`, not a silent live call.
 - Prefer pure decision functions (`run_stall.py` is the model) so a
   criterion is testable without a tick loop, server, or real clock.
@@ -37,4 +37,4 @@ completion) and `../agents/` (spawner, heartbeat, crash detection, reaping).
 Single files only: `uv run pytest tests/unit/test_orchestrator.py -x -q`.
 Never run the full suite (see `tests/AGENTS.md`).
 
-<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-08-27 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/quality/AGENTS.md
+++ b/src/bernstein/core/quality/AGENTS.md
@@ -37,4 +37,4 @@ configurable gate pipeline plus the janitor's claim verification.
 Single files only, e.g. `uv run pytest tests/unit/test_quality_gates.py -x -q`;
 runner and pipeline behaviour lives in the `test_gate_*.py` files.
 
-<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-08-27 against this subtree; the notes above still hold. -->

--- a/src/bernstein/core/security/AGENTS.md
+++ b/src/bernstein/core/security/AGENTS.md
@@ -15,26 +15,26 @@ The HMAC-chained audit log, Ed25519 install identity, and approval / policy enfo
 | `result_receipt_bundle.py` | Result receipt bundle with offline DSSE verification |
 | `capability_delta.py` | Detects capability-widening changes across workflows and permission configs |
 | `surface_grant_delta.py` | Lineage gate grant analysis across diffs |
+| `key_derivation.py` | HKDF-SHA256 per-store key derivation with scheme versioning |
 
 ## Invariants
 
-- The HMAC key lives OUTSIDE the audit log directory and must be mode `0600`; a
-  group- or world-readable key is a hard error at load time (`audit.py`).
-- Event-type constants are append-only: add `EVENT_*` names, never edit or reuse
-  existing ones (`audit_chain.py` module docstring).
-- Chain helpers take the chain as a parameter (no singleton imports) and log through
-  `log_with_prev_digest`, so `prev_chain_digest` lands in the payload before the HMAC (`audit_chain.py`).
-- The audit chain is opt-in at runtime (`BERNSTEIN_AUDIT=1`, read in
-  `../orchestration/orchestrator.py`); features degrade without it.
-- Untrusted paths are opened, never compared: a path-comparison check validates
-  one lookup while the open performs another (`sigstore_attestation.py`).
-- Same rule for tenant writes: the whole subtree (`backlog`, `metrics`, `runtime`, `audit`, ...) is
-  created and opened through `TenantPaths.anchor` (`../persistence/anchored_write.py`), rotation
-  included. Needs `dir_fd` + `O_NOFOLLOW`; lacking either, the refusal narrows to the final
+- The HMAC key lives OUTSIDE the audit log directory at mode `0600`; anything more readable is a hard error at load time (`audit.py`).
+- Stores never share a key: each derives its own from the master by HKDF-SHA256
+  under a domain tag that is also prefixed into the chain hash preimage, so one
+  store's record cannot be replayed against another (`key_derivation.py` v2).
+- Event-type constants are append-only: add `EVENT_*` names, never edit or reuse existing ones (`audit_chain.py`).
+- Chain helpers take the chain as a parameter (no singletons) and log through
+  `log_with_prev_digest`, so `prev_chain_digest` is in the payload before the HMAC.
+- The audit chain is opt-in at runtime (`BERNSTEIN_AUDIT=1`, read in `../orchestration/orchestrator.py`); features degrade without it.
+- Untrusted paths are opened, never compared: a comparison validates one lookup while the open performs another (`sigstore_attestation.py`).
+- Same rule for tenant writes: the whole subtree is created and opened through
+  `TenantPaths.anchor` (`../persistence/anchored_write.py`), rotation included. It
+  needs `dir_fd` + `O_NOFOLLOW`; lacking either, the refusal narrows to the final
   component or vanishes, never weakens (`ANCHORED_{WRITE,ROTATE}_SUPPORTED`).
 
 ## Testing
 
 Single files only: `uv run pytest tests/unit/test_audit.py -x -q`.
 
-<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-08-27 against this subtree; the notes above still hold. -->

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,6 +1,6 @@
 # Test suite
 
-Layered pytest suite. `unit/` is the big one (2100+ files, no network);
+Layered pytest suite. `unit/` is the big one (2400+ files, no network);
 `integration/` needs a running server; `contract/` holds the adapter
 capability contracts; plus `property/`, `snapshot/`, `golden/`,
 `perf/`, `chaos/`, `stress/`, `pentest/`, and `benchmarks/`.
@@ -15,18 +15,18 @@ uv run python scripts/run_tests.py tests/unit/test_foo.py[::test_name]  # one fi
 
 ## Invariants
 
-- NEVER run bare `pytest` over the whole suite: retained test objects mean
-  2000+ files leak into 100+ GB of RAM. The isolated per-file runner caps
-  memory per file (`scripts/run_tests.py` docstring; `CONTRIBUTING.md`).
+- NEVER run bare `pytest` over the whole suite: retained test objects leak into 100+ GB of RAM.
+  The isolated per-file runner caps it (`scripts/run_tests.py`; `CONTRIBUTING.md`).
 - Markers are strict (`--strict-markers` in `pyproject.toml`);
   register a new marker there before using it.
 - Async tests carry an explicit `@pytest.mark.asyncio` (asyncio mode
   is strict).
 - Runtime type-checking via beartype is opt-in per environment
   (`BEARTYPE_USE_CLAW=enable`; CI's beartype job sets it, local defaults off).
-- Docs-guard tests (`unit/test_naming_policy_docs.py`,
-  `unit/test_nested_agents_context.py`) pin repo-level invariants;
-  extend them when adding gated docs.
+- Docs-guard tests (`unit/test_naming_policy_docs.py`, `unit/test_nested_agents_context.py`)
+  pin repo-level invariants; extend them when adding gated docs.
+- `unit/test_token_orphans.py` fails on a new caller-less module under `core/tokens/`;
+  its `KNOWN_ORPHANS` set only ever shrinks.
 - Tests for `scripts/*.py` load the script via importlib; git-derived
   behaviour runs on synthetic repos (`unit/test_context_staleness.py`).
 
@@ -37,4 +37,4 @@ uv run python scripts/run_tests.py tests/unit/test_foo.py[::test_name]  # one fi
 - Live adapter conformance tests are opt-in via the `--live` flag
   registered in `conftest.py`.
 
-<!-- Reviewed 2026-08-24 against this subtree; the notes above still hold. -->
+<!-- Reviewed 2026-08-27 against this subtree; the notes above still hold. -->


### PR DESCRIPTION
Six of the seven curated `AGENTS.md` files were flagged stale, so the staleness report fired on every pull request and stopped being read. This clears all six against what actually changed.

| File | What drifted |
|---|---|
| `adapters/` | `goose_stream_parser.py` — parses the `stream-json` events; token accounting rides the terminal `envelope` event |
| `cli/` | `commands/insights_cmd.py` |
| `core/orchestration/` | `issue_claim.py` — claim etiquette for intake runs with no coordinator |
| `core/security/` | `key_derivation.py`, and the invariant it introduces: stores no longer share an HMAC key, each derives its own under a domain tag that is also prefixed into the chain hash preimage |
| `tests/` | unit count had drifted from "2100+" to 2474; the tree-shape guard added with the token-orphan cleanup was undocumented |
| `core/quality/` | no module added or removed — the churn is inside the review contour the invariants already describe, so this one is a reconfirmation |

These files carry a 40-line budget, which is the point of them, so every addition displaces prose rather than being appended. The trims fold wrapped bullets onto single lines (the opening paragraph of each file is already one long line); no fact was dropped.

Verified locally: `scripts/check_context_staleness.py` reports 0 of 7 flagged, and `test_nested_agents_context.py`, `test_naming_policy_docs.py`, `test_context_staleness.py` pass (40 tests), line budget included.