### PR TITLE
fix(#3453): give the parked-session store a producer, and key the park on something that survives a retry

### DIFF
--- a/docs/operations/agent_crash_loop.md
+++ b/docs/operations/agent_crash_loop.md
@@ -15,6 +15,7 @@ crash loop into a single, auditable failure mode.
 | Window reset | Rolling | Respawns older than the window fall out of the count |
 | On exhaustion | Session is parked | `AgentStartupExhausted` event published |
 | Recovery | Operator-driven only | `bernstein agents resume <id>` |
+| Where parks live | `.sdd/runtime/spawn_supervisor/parked.json` | Read by the CLI, the TUI and `bernstein fleet` |
 
 ## How the budget works
 
@@ -44,15 +45,60 @@ The park reason is always `respawn_budget_exhausted`. The persistent
 crash loop almost always means a real fault: a missing adapter binary,
 bad configuration, or an expired token. Read `last_error` first.
 
+## Where parked state is kept
+
+Parks are written to `.sdd/runtime/spawn_supervisor/parked.json` under
+the project root, and that file — not process memory — is what the
+operator surfaces read.
+
+This matters because the process that parks a session is the
+orchestrator, and `bernstein agents parked` is a different process that
+starts with an empty supervisor. Reading only in-memory state made the
+surfaces report "nothing parked" unconditionally, whatever had happened
+(#3453).
+
+The store is rewritten on every supervision state change, including a
+clean spawn. That is deliberate: it lets a reader tell the two zeros
+apart.
+
+| What you see | What it means |
+|---|---|
+| `No parked sessions.` | The store exists and is empty — a measured zero |
+| `Parked state unavailable.` | No supervisor has ever written to this workspace — not a report of zero |
+
+A supervisor is authoritative only for the sessions it knows about, so
+writing the store merges rather than overwrites: a second process
+holding its own supervisor cannot erase parks it did not make.
+
 ## Inspecting parked sessions
 
 ```
 bernstein agents parked      # list parked sessions
+bernstein agents parked --workdir /path/to/project
 bernstein ps                 # running agents, with a parked footer
 ```
 
-Both surface the same set of parked session ids backed by the
-process-wide supervisor.
+Both read the on-disk store unioned with the calling process's own
+supervisor, so they agree.
+
+`bernstein ps --json-output` keeps its existing shape — a bare agent
+list, or an object when something is parked — and the object now carries
+`parked_available` alongside `parked`. The unavailable-versus-empty
+distinction is therefore on the human surfaces and on `bernstein agents
+parked`; `ps --json` cannot express it without changing its top-level
+type, which would break existing readers.
+
+## What gets parked, and under what id
+
+The supervisor budgets *respawns*, so its key has to survive the retries
+it is counting. A spawn session id cannot: the spawner mints a fresh
+`<role>-<uuid>` per attempt, and a retry mints a new task id as well
+(#2806), so either would make every failure look like a first failure
+and nothing would ever reach exhaustion.
+
+Parks made by the orchestrator are therefore keyed on the batch's
+lineage — the same key its own consecutive-failure counter uses — and
+render as `batch:<lineage-ids>`. Pass that id verbatim to `resume`.
 
 ## Resuming a session
 
@@ -60,13 +106,15 @@ After fixing the root cause, reset the budget and clear the parked
 state:
 
 ```
-bernstein agents resume <id>
+bernstein agents resume batch:T-1234
 ```
 
 Resume is the only recovery path. There is no automatic remediation on
 park; that is intentional, so an operator confirms the fault is gone
 before the session is allowed to spawn again. Resuming clears the
-respawn window, so the session starts again with a full budget.
+respawn window, so the session starts again with a full budget, and
+removes the id from the on-disk store — including when the parking
+process has already exited.
 
 ## Tuning the budget
 

--- a/src/bernstein/cli/commands/agents_cmd.py
+++ b/src/bernstein/cli/commands/agents_cmd.py
@@ -568,7 +568,8 @@ def agents_sandbox_backends() -> None:
 
 
 @agents_group.command("parked")
-def agents_parked() -> None:
+@click.option("--workdir", default=".", show_default=True, type=click.Path(), help="Project root (parent of .sdd/).")
+def agents_parked(workdir: str) -> None:
     """List sessions parked after exhausting their respawn budget.
 
     \b
@@ -577,10 +578,17 @@ def agents_parked() -> None:
       bernstein agents resume <id>
     """
     from bernstein.core.agents.spawn_supervisor import get_supervisor
+    from bernstein.core.orchestration.supervisor_aggregator import observed_parked_sessions
 
-    parked = get_supervisor().parked_sessions()
+    root = Path(workdir).resolve()
+    state = observed_parked_sessions(root, in_process=get_supervisor(root).parked_sessions())
+    parked = sorted(state.session_ids)
     if not parked:
-        console.print("[green]No parked sessions.[/green]")
+        if state.available:
+            console.print("[green]No parked sessions.[/green]")
+        else:
+            console.print("[yellow]Parked state unavailable.[/yellow]")
+            console.print(f"[dim]No supervisor has written to {root}; this is not a report of zero.[/dim]")
         return
 
     console.print(f"[bold yellow]Parked sessions ({len(parked)}):[/bold yellow]")
@@ -591,7 +599,8 @@ def agents_parked() -> None:
 
 @agents_group.command("resume")
 @click.argument("session_id")
-def agents_resume(session_id: str) -> None:
+@click.option("--workdir", default=".", show_default=True, type=click.Path(), help="Project root (parent of .sdd/).")
+def agents_resume(session_id: str, workdir: str) -> None:
     """Resume a parked agent session, resetting its respawn budget.
 
     \b
@@ -599,11 +608,20 @@ def agents_resume(session_id: str) -> None:
       bernstein agents resume worker-3
     """
     from bernstein.core.agents.spawn_supervisor import get_supervisor
+    from bernstein.core.orchestration.supervisor_aggregator import load_parked_sessions
 
-    if get_supervisor().resume(session_id):
+    root = Path(workdir).resolve()
+    supervisor = get_supervisor(root)
+    # The session was parked by the orchestrator's process, not this one,
+    # so resume has to clear the on-disk store rather than only the
+    # in-memory record this process happens to hold (#3453).
+    if supervisor.resume(session_id) or supervisor.clear_parked(session_id):
         console.print(f"[green]Resumed session '{session_id}'; respawn budget reset.[/green]")
-    else:
-        console.print(f"[yellow]No tracked session '{session_id}'.[/yellow]")
+        return
+    if session_id in load_parked_sessions(root):
+        console.print(f"[yellow]Session '{session_id}' is parked but could not be cleared.[/yellow]")
+        return
+    console.print(f"[yellow]No tracked session '{session_id}'.[/yellow]")
 
 
 @agents_group.command("trust")

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -425,20 +425,44 @@ def ps_cmd(as_json: bool, pid_dir: str) -> None:
                 known_pids.add(value)
     agents.extend(_scan_live_agent_rows(_ps_scan_workdir(pid_path), known_pids))
 
+    # Read the on-disk store as well as this process's supervisor: the
+    # orchestrator that parks a session runs elsewhere, so an in-process
+    # read alone is empty by construction (#3453).
     from bernstein.core.agents.spawn_supervisor import get_supervisor
+    from bernstein.core.orchestration.supervisor_aggregator import observed_parked_sessions
 
-    parked = get_supervisor().parked_sessions()
+    parked_state = observed_parked_sessions(
+        _ps_scan_workdir(pid_path),
+        in_process=get_supervisor().parked_sessions(),
+    )
+    parked = sorted(parked_state.session_ids)
 
     if as_json or is_json():
-        print_json({"agents": agents, "parked": parked} if parked else agents)
+        # Shape is load-bearing and stays exactly as it was: a bare list
+        # unless something is parked, an object when something is. Making
+        # it unconditionally an object would break every existing reader
+        # of `ps --json-output` (tests/unit/test_status_cmd_openclaw_bridge
+        # asserts payload[0]), so the availability flag rides along inside
+        # the object form rather than forcing one.
+        if parked:
+            payload: dict[str, Any] = {
+                "agents": agents,
+                "parked": parked,
+                "parked_available": parked_state.available,
+            }
+            print_json(payload)
+        else:
+            print_json(agents)
         return
 
     if not agents and not parked:
         console.print("[dim]No running agents.[/dim]")
+        _print_parked_unavailable(parked_state.available)
         return
 
     if not agents:
         _print_parked(parked)
+        _print_parked_unavailable(parked_state.available)
         return
 
     table = Table(title="Bernstein Agents", show_lines=False, header_style="bold cyan")
@@ -478,6 +502,18 @@ def _print_parked(parked: list[str]) -> None:
     for session_id in parked:
         console.print(f"  [yellow]parked[/yellow]  [cyan]{session_id}[/cyan]")
     console.print("[dim]Resume with: bernstein agents resume <id>[/dim]")
+
+
+def _print_parked_unavailable(available: bool) -> None:
+    """Say so when nothing can vouch for the parked state.
+
+    "No parked sessions" and "no supervisor ever wrote here" are
+    different claims, and rendering them identically is what let this
+    surface reassure for its whole life (#3453).
+    """
+    if available:
+        return
+    console.print("[dim]parked state unavailable (no supervisor has written to this workspace)[/dim]")
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/agents/spawn_supervisor.py
+++ b/src/bernstein/core/agents/spawn_supervisor.py
@@ -22,19 +22,62 @@ The supervisor is deliberately transport-agnostic: callers supply a
 spawn callable and the supervisor owns only the budget accounting,
 backoff schedule, parking, and event publication. This keeps it usable
 standalone in tests without dragging in the full spawner.
+
+Two call shapes, and the difference is where the retry loop lives
+--------------------------------------------------------------------
+
+:meth:`SpawnSupervisor.spawn` owns its retry loop: it calls the spawn
+callable, sleeps the backoff, and retries in-call until the budget is
+spent. That suits a caller that can afford to block.
+
+The orchestrator cannot. It retries a failed batch on a *later tick*,
+so a blocking backoff inside :meth:`spawn` would stall the tick loop
+and add a second retry schedule on top of the one the tick already
+provides. :meth:`SpawnSupervisor.record_spawn_failure` is the
+non-blocking counterpart for that caller: it consumes one respawn,
+parks on exhaustion, and returns immediately.
+
+Why the store exists
+--------------------
+
+Supervision state used to live only in process memory, and
+:func:`get_supervisor`'s docstring claimed the orchestrator and the CLI
+``resume`` command "share this instance". They do not: ``bernstein
+status`` and ``bernstein agents parked`` run in their own process, so
+they consulted a supervisor that had by construction never supervised
+anything and reported "nothing parked" unconditionally. Parks are now
+persisted to :data:`PARKED_STORE_RELPATH` -- the path
+:func:`bernstein.core.orchestration.supervisor_aggregator.load_parked_sessions`
+already reads -- so a park made by the orchestrator is visible to a
+later CLI invocation, and an operator resume clears it for both.
+
+The store is written on every supervision state change, including a
+clean spawn. That is what lets a reader tell "no session is parked"
+(store present, list empty) from "no supervisor ran here" (store
+absent) instead of collapsing both into a silent zero.
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+#: Location of the parked-session store, relative to the workdir. Must
+#: stay in step with ``supervisor_aggregator.load_parked_sessions``,
+#: which is the reader on the other side of this file.
+PARKED_STORE_RELPATH: tuple[str, ...] = (".sdd", "runtime", "spawn_supervisor", "parked.json")
 
 #: Default maximum respawns inside the rolling window (initial spawn excluded).
 DEFAULT_MAX_RESPAWNS: int = 3
@@ -196,6 +239,10 @@ class SpawnSupervisor:
             None, a logging fallback is used.
         sleep: Backoff sleep function. Defaults to :func:`time.sleep`.
         monotonic: Monotonic clock. Defaults to :func:`time.monotonic`.
+        workdir: Project root under which the parked-session store is
+            written. When None the store is disabled and supervision
+            stays in-process only, which is what standalone unit tests
+            want.
     """
 
     def __init__(
@@ -205,6 +252,7 @@ class SpawnSupervisor:
         publisher: BusPublisher | None = None,
         sleep: Callable[[float], None] | None = None,
         monotonic: Callable[[], float] | None = None,
+        workdir: Path | None = None,
     ) -> None:
         self._default_budget = budget or RespawnBudget()
         self._publisher = publisher or _default_publisher
@@ -212,6 +260,131 @@ class SpawnSupervisor:
         self._monotonic = monotonic or time.monotonic
         self._lock = threading.RLock()
         self._sessions: dict[str, _SessionRecord] = {}
+        self._workdir = workdir
+
+    # ------------------------------------------------------------------ store
+
+    @property
+    def store_path(self) -> Path | None:
+        """Absolute path of the parked-session store, or None when disabled."""
+        if self._workdir is None:
+            return None
+        return self._workdir.joinpath(*PARKED_STORE_RELPATH)
+
+    def _read_store_ids(self, path: Path) -> set[str]:
+        """Return the parked ids currently on disk (empty when unreadable)."""
+        try:
+            payload_any: Any = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return set()
+        if not isinstance(payload_any, dict):
+            return set()
+        ids = cast("dict[str, Any]", payload_any).get("session_ids")
+        if not isinstance(ids, list):
+            return set()
+        return {i for i in cast("list[Any]", ids) if isinstance(i, str)}
+
+    def _write_store(self, path: Path, session_ids: set[str], entries: dict[str, Any]) -> None:
+        """Atomically replace the store with ``session_ids``/``entries``."""
+        payload = {
+            "session_ids": sorted(session_ids),
+            "updated_at": time.time(),
+            "entries": entries,
+        }
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+            os.replace(str(tmp), str(path))
+        except OSError:
+            logger.warning("Could not persist parked-session store at %s", path, exc_info=True)
+
+    def _persist(self) -> None:
+        """Merge this supervisor's view into the store the aggregator reads.
+
+        A merge rather than an overwrite, and the distinction matters: a
+        second process holding its own supervisor (an embedded run, a
+        test, a future multi-orchestrator layout) would otherwise erase
+        every park it had not made itself the first time it wrote. This
+        supervisor is authoritative only for the sessions it *knows
+        about*; ids it has never heard of are carried through untouched.
+
+        Best-effort by design: supervision must not fail because a disk
+        is full or read-only, and the in-process state stays correct
+        either way. The write is atomic (``tmp`` + :func:`os.replace`)
+        so a concurrent reader never observes a half-written file.
+        """
+        path = self.store_path
+        if path is None:
+            return
+        with self._lock:
+            known = set(self._sessions)
+            parked_here = {sid for sid, rec in self._sessions.items() if rec.state == SupervisorState.PARKED}
+            entries: dict[str, Any] = {
+                sid: {
+                    "state": rec.state.value,
+                    "last_error": rec.last_error,
+                    "total_respawns": rec.total_respawns,
+                }
+                for sid, rec in sorted(self._sessions.items())
+            }
+        existing = self._read_store_ids(path) if path.exists() else set()
+        self._write_store(path, (existing - known) | parked_here, entries)
+
+    def clear_parked(self, session_id: str) -> bool:
+        """Remove ``session_id`` from the on-disk store.
+
+        The resume path for a session this process never supervised: the
+        orchestrator parked it and exited, so there is no in-memory
+        record for :meth:`resume` to reset, and the only thing standing
+        between the operator and a clean surface is the file.
+
+        Args:
+            session_id: Session to clear.
+
+        Returns:
+            True if the id was present on disk and has been removed.
+        """
+        path = self.store_path
+        if path is None or not path.exists():
+            return False
+        existing = self._read_store_ids(path)
+        if session_id not in existing:
+            return False
+        existing.discard(session_id)
+        with self._lock:
+            entries: dict[str, Any] = {
+                sid: {
+                    "state": rec.state.value,
+                    "last_error": rec.last_error,
+                    "total_respawns": rec.total_respawns,
+                }
+                for sid, rec in sorted(self._sessions.items())
+                if sid != session_id
+            }
+        self._write_store(path, existing, entries)
+        logger.info("Cleared parked session '%s' from %s", session_id, path)
+        return True
+
+    def attach_workdir(self, workdir: Path) -> None:
+        """Point an as-yet-unrooted supervisor at ``workdir``.
+
+        A no-op once a workdir is set: the first caller that knows the
+        workspace wins, so a later caller in the same process cannot
+        silently repoint the store at a different tree.
+        """
+        with self._lock:
+            if self._workdir is None:
+                self._workdir = workdir
+
+    def mark_active(self) -> None:
+        """Record that a supervisor ran in this workspace, parking nothing.
+
+        Lets a reader distinguish "no session is parked" from "no
+        supervisor ever ran", which is the difference between a claim
+        the run can support and a reassuring default.
+        """
+        self._persist()
 
     # ------------------------------------------------------------------ queries
 
@@ -262,6 +435,7 @@ class SpawnSupervisor:
             record.respawn_times.clear()
             record.state = SupervisorState.HEALTHY
             record.last_error = ""
+        self._persist()
         if was_parked:
             logger.info("Resumed parked session '%s'; respawn budget reset", session_id)
         return True
@@ -269,7 +443,95 @@ class SpawnSupervisor:
     def forget(self, session_id: str) -> None:
         """Drop all supervision state for ``session_id``."""
         with self._lock:
-            self._sessions.pop(session_id, None)
+            existed = self._sessions.pop(session_id, None) is not None
+        if existed:
+            self._persist()
+
+    # ------------------------------------------------------------- non-blocking
+
+    def record_spawn_failure(
+        self,
+        session_id: str,
+        error: Exception | str,
+        *,
+        budget: RespawnBudget | None = None,
+    ) -> bool:
+        """Consume one respawn for ``session_id`` without blocking.
+
+        The non-blocking counterpart to :meth:`spawn`, for a caller that
+        owns its own retry schedule and must not be slept inside. No
+        backoff is applied here: the caller's next attempt is its own to
+        time. On exhaustion the session is parked, the exhaustion event
+        is published, and the store is written, exactly as :meth:`spawn`
+        does.
+
+        Args:
+            session_id: Opaque session identifier. Must be stable across
+                the retries it is meant to budget -- see the note in
+                :func:`bernstein.core.tasks.task_lifecycle` about why a
+                per-attempt spawn id cannot be used here.
+            error: The failure to record, for operator-facing detail.
+            budget: Per-call budget override, applied on first sight of
+                the session.
+
+        Returns:
+            True while respawn budget remains, False once the session has
+            been parked.
+        """
+        record = self._record_for(session_id, budget)
+        with self._lock:
+            if record.state == SupervisorState.PARKED:
+                return False
+        exc = error if isinstance(error, Exception) else RuntimeError(str(error))
+        if not self._consume_respawn(record, exc):
+            with self._lock:
+                attempts = record.total_respawns
+            self._park(session_id, record, attempts)
+            return False
+        self._persist()
+        return True
+
+    def park(self, session_id: str, *, reason: str = "") -> bool:
+        """Park ``session_id`` outright, whatever budget it has left.
+
+        For a caller whose own policy decided to stop retrying before the
+        respawn budget ran out -- the orchestrator's failure analyzer can
+        classify a batch as hopeless after one failure. Parking through
+        the same door keeps both ways of giving up rendering identically
+        to an operator.
+
+        Args:
+            session_id: Opaque session identifier.
+            reason: Operator-facing detail recorded as the last error.
+
+        Returns:
+            True if this call parked the session, False if it was already
+            parked.
+        """
+        record = self._record_for(session_id, None)
+        with self._lock:
+            if record.state == SupervisorState.PARKED:
+                return False
+            if reason:
+                record.last_error = reason
+            attempts = record.total_respawns
+        self._park(session_id, record, attempts)
+        return True
+
+    def note_spawn_success(self, session_id: str) -> None:
+        """Clear the failure record for a session that spawned cleanly.
+
+        Also writes the store, so a run in which nothing ever failed
+        still leaves evidence that a supervisor was present and the
+        empty parked set is a measured zero rather than a default.
+        """
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if record is not None:
+                record.respawn_times.clear()
+                record.state = SupervisorState.HEALTHY
+                record.last_error = ""
+        self._persist()
 
     # ------------------------------------------------------------------ spawn
 
@@ -370,6 +632,7 @@ class SpawnSupervisor:
             budget.window_seconds,
             last_error or "<none>",
         )
+        self._persist()
         self._publish_exhausted(session_id, attempts, last_error, budget)
 
     def _publish_exhausted(
@@ -433,16 +696,31 @@ _global_supervisor: SpawnSupervisor | None = None
 _global_lock = threading.Lock()
 
 
-def get_supervisor() -> SpawnSupervisor:
+def get_supervisor(workdir: Path | None = None) -> SpawnSupervisor:
     """Return the process-wide supervisor, creating it on first use.
 
-    The orchestrator and the CLI ``resume`` command share this instance
-    so an operator's resume reaches the same budget the spawner consults.
+    The instance is per *process*, not per workspace. The orchestrator
+    and ``bernstein agents resume`` run in different processes, so they
+    do not share in-memory state and never did; what they share is the
+    on-disk store under :data:`PARKED_STORE_RELPATH`, which is why the
+    supervisor needs a workdir to be useful across a process boundary.
+
+    Args:
+        workdir: Project root for the parked-session store. Applied only
+            when the process-wide supervisor is created, or when an
+            existing one has no workdir yet -- so the first caller that
+            knows the workspace wins and later callers cannot silently
+            repoint the store at a different tree.
+
+    Returns:
+        The process-wide supervisor.
     """
     global _global_supervisor
     with _global_lock:
         if _global_supervisor is None:
-            _global_supervisor = SpawnSupervisor()
+            _global_supervisor = SpawnSupervisor(workdir=workdir)
+        elif workdir is not None:
+            _global_supervisor.attach_workdir(workdir)
         return _global_supervisor
 
 

--- a/src/bernstein/core/agents/spawn_supervisor.py
+++ b/src/bernstein/core/agents/spawn_supervisor.py
@@ -328,7 +328,7 @@ class SpawnSupervisor:
                 }
                 for sid, rec in sorted(self._sessions.items())
             }
-        existing = self._read_store_ids(path) if path.exists() else set()
+        existing = self._read_store_ids(path) if path.exists() else set[str]()
         self._write_store(path, (existing - known) | parked_here, entries)
 
     def clear_parked(self, session_id: str) -> bool:

--- a/src/bernstein/core/orchestration/supervisor_aggregator.py
+++ b/src/bernstein/core/orchestration/supervisor_aggregator.py
@@ -43,7 +43,7 @@ from bernstein.core.orchestration.supervisor_receipt import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -60,6 +60,7 @@ __all__ = [
     "load_heartbeat",
     "load_parked_sessions",
     "load_recent_failures",
+    "observed_parked_sessions",
     "snapshot_to_dict",
 ]
 
@@ -231,6 +232,38 @@ def load_parked_sessions(workdir: Path) -> ParkedSessions:
                                 available = True
                                 parked.add(sid)
     return ParkedSessions(available=available, session_ids=frozenset(parked))
+
+
+def observed_parked_sessions(
+    workdir: Path,
+    *,
+    in_process: Iterable[str] | None = None,
+) -> ParkedSessions:
+    """Union the on-disk parked store with this process's own supervisor.
+
+    A CLI invocation is not the process that parked anything: the
+    orchestrator parks, exits or keeps running, and ``bernstein status``
+    starts fresh. Reading only the in-process supervisor therefore
+    reports an empty set by construction, which is the defect behind
+    #3453. Reading only the store misses a park made moments ago by a
+    supervisor in *this* process (an embedded orchestrator, or a test).
+    Callers want both.
+
+    Args:
+        workdir: Project root holding ``.sdd/runtime/spawn_supervisor``.
+        in_process: Session ids the caller's own supervisor considers
+            parked, if it has one.
+
+    Returns:
+        The union, with ``available`` True when either source was able to
+        speak for this workspace.
+    """
+    stored = load_parked_sessions(workdir)
+    live = frozenset(in_process or ())
+    return ParkedSessions(
+        available=stored.available or bool(live),
+        session_ids=stored.session_ids | live,
+    )
 
 
 def load_recent_failures(

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -3056,7 +3056,7 @@ def claim_and_spawn_batches(
                 with contextlib.suppress(Exception):
                     _spawn_supervisor_for(orch).park(
                         _park_key(batch_key),
-                        reason=f"spawn failed {new_count} consecutive time(s): {analysis.error_type}",
+                        reason=f"spawn failed {new_count} consecutive time(s): {exc}",
                     )
                 for task in batch:
                     try:

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -2209,6 +2209,55 @@ def _batch_lineage_key(batch: list[Task]) -> frozenset[str]:
     return frozenset(_lineage_id(t) for t in batch)
 
 
+def _park_key(batch_key: frozenset[str]) -> str:
+    """Render a lineage key as the stable id the spawn supervisor parks on.
+
+    The supervisor budgets *respawns*, so its key has to survive the
+    retries it is counting. A spawn session id cannot: ``spawner_core``
+    mints a fresh ``f"{role}-{uuid4}"`` per attempt, so a session-keyed
+    budget would see every failure as a new session and never reach
+    exhaustion. The lineage key already solves exactly this problem for
+    the orchestrator's own consecutive-failure counter (#2806), so the
+    park reuses it rather than inventing a second notion of identity.
+
+    Sorted so the same batch always renders the same id, and prefixed so
+    an operator reading ``bernstein agents parked`` can tell a parked
+    work-unit from a live agent session id.
+    """
+    return "batch:" + ",".join(sorted(batch_key))
+
+
+def _spawn_supervisor_for(orch: Any) -> Any:
+    """Return the process supervisor, rooted at this orchestrator's workdir.
+
+    Rooting it is what makes a park survive the orchestrator process and
+    reach ``bernstein status`` and ``bernstein agents resume``, which run
+    separately (#3453).
+    """
+    from bernstein.core.agents.spawn_supervisor import get_supervisor
+
+    return get_supervisor(workdir=orch._workdir)
+
+
+def _spawn_respawn_budget(orch: Any) -> Any:
+    """Budget mirroring the orchestrator's own consecutive-failure ceiling.
+
+    ``max_respawns`` is one less than ``_MAX_SPAWN_FAILURES`` because the
+    supervisor parks on the failure that *exhausts* the budget, while the
+    orchestrator gives up on the ``_MAX_SPAWN_FAILURES``-th failure: with
+    a ceiling of 3, failures 1 and 2 consume budget and failure 3 parks.
+    The window matches the backoff ceiling that
+    ``agent_lifecycle`` uses to expire ``_spawn_failures``, so a batch
+    cannot age out of one counter while still counting against the other.
+    """
+    from bernstein.core.agents.spawn_supervisor import RespawnBudget
+
+    return RespawnBudget(
+        max_respawns=max(int(orch._MAX_SPAWN_FAILURES) - 1, 0),
+        window_seconds=float(orch._SPAWN_BACKOFF_MAX_S),
+    )
+
+
 def claim_and_spawn_batches(
     orch: Any,  # Orchestrator instance (avoids circular import)
     batches: list[list[Task]],
@@ -2854,6 +2903,12 @@ def claim_and_spawn_batches(
             session.heartbeat_ts = time.time()
             orch._spawn_failures.pop(batch_key, None)
             spawn_failure_history.pop(batch_key, None)
+            # Tell the supervisor the batch recovered, and leave evidence
+            # in the store that a supervisor ran here. Without this a
+            # healthy run writes nothing and its readers cannot tell
+            # "nothing parked" from "nobody was watching" (#3453).
+            with contextlib.suppress(Exception):
+                _spawn_supervisor_for(orch).note_spawn_success(_park_key(batch_key))
             _spawned_per_role[batch[0].role] += 1
             # Track spawn rate in convergence guard
             _convergence = getattr(orch, "_convergence_guard", None)
@@ -2981,8 +3036,28 @@ def claim_and_spawn_batches(
                 continue
             new_count = fail_count + 1
             orch._spawn_failures[batch_key] = (new_count, time.time())
+            # Consume one respawn against the supervisor's budget. The
+            # orchestrator stays the authority on when to give up -- the
+            # budget is built from _MAX_SPAWN_FAILURES so the two agree by
+            # construction rather than by coincidence -- and the
+            # supervisor's job here is to make the give-up visible to
+            # `bernstein status`, the TUI and `agents resume` (#3453).
+            with contextlib.suppress(Exception):
+                _spawn_supervisor_for(orch).record_spawn_failure(
+                    _park_key(batch_key),
+                    exc,
+                    budget=_spawn_respawn_budget(orch),
+                )
             should_retry, _ = spawn_analyzer.should_retry(batch_history, max_retries=orch._MAX_SPAWN_FAILURES)
             if new_count >= orch._MAX_SPAWN_FAILURES or not should_retry:
+                # The analyzer can call it quits before the budget is
+                # spent. Park explicitly so the two ways of giving up
+                # leave the same operator-visible state.
+                with contextlib.suppress(Exception):
+                    _spawn_supervisor_for(orch).park(
+                        _park_key(batch_key),
+                        reason=f"spawn failed {new_count} consecutive time(s): {analysis.error_type}",
+                    )
                 for task in batch:
                     try:
                         fail_task(

--- a/tests/unit/agents/test_parked_session_orchestrator_wiring.py
+++ b/tests/unit/agents/test_parked_session_orchestrator_wiring.py
@@ -1,0 +1,194 @@
+"""The orchestrator's spawn-failure path feeds the supervisor (#3453).
+
+The read surfaces were complete and the producer was missing:
+``SpawnSupervisor`` had no production caller at all, so the respawn
+budget could not be consumed outside a unit test and nothing was ever
+parked. These tests drive the real ``claim_and_spawn_batches`` failure
+path to exhaustion and assert the park reaches the store the aggregator
+reads.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from bernstein.core.models import AgentSession, ModelConfig
+from bernstein.core.orchestrator import TickResult
+
+from bernstein.core.agents.spawn_supervisor import get_supervisor, reset_supervisor
+from bernstein.core.orchestration.supervisor_aggregator import load_parked_sessions
+from bernstein.core.tasks.task_lifecycle import (
+    _batch_lineage_key,
+    _park_key,
+    claim_and_spawn_batches,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_supervisor() -> Any:
+    """The supervisor is process-wide; keep it from leaking between tests."""
+    reset_supervisor()
+    yield
+    reset_supervisor()
+
+
+def _never_quarantined(*_args: Any, **_kwargs: Any) -> bool:
+    return False
+
+
+def _no_quarantine_entry(*_args: Any, **_kwargs: Any) -> None:
+    return None
+
+
+def _orch(tmp_path: Path) -> Any:
+    """Minimal orchestrator stub for the spawn path (mirrors test_task_lifecycle)."""
+    client = MagicMock()
+    client.post.return_value = SimpleNamespace(status_code=200)
+    spawner = MagicMock()
+    spawner._adapter = None
+    return SimpleNamespace(
+        _config=SimpleNamespace(
+            server_url="http://server",
+            max_agents=2,
+            force_parallel=False,
+            max_agent_runtime_s=900,
+            ab_test=False,
+        ),
+        _client=client,
+        _spawner=spawner,
+        _agents={},
+        _file_ownership={},
+        _spawn_failures={},
+        _quarantine=SimpleNamespace(
+            is_quarantined=_never_quarantined,
+            get_entry=_no_quarantine_entry,
+        ),
+        _decomposed_task_ids=set(),
+        _idle_shutdown_ts=set(),
+        _workdir=tmp_path,
+        _response_cache=None,
+        _batch_api=None,
+        _batch_sessions={},
+        _fast_path_stats={},
+        _preserved_worktrees={},
+        _task_to_session={},
+        _SPAWN_BACKOFF_BASE_S=5,
+        _SPAWN_BACKOFF_MAX_S=60,
+        _MAX_SPAWN_FAILURES=3,
+        _lock_manager=None,
+        is_shutting_down=lambda: False,
+    )
+
+
+def _tick(orch: Any, batch: list[Any]) -> None:
+    """Run one spawn attempt, defeating the inter-attempt backoff.
+
+    The backoff is real and wall-clock based; zeroing the recorded
+    timestamp is what lets a unit test reach the third consecutive
+    failure without sleeping through two 30s network-error delays.
+    """
+    key = _batch_lineage_key(batch)
+    if key in orch._spawn_failures:
+        count, _ = orch._spawn_failures[key]
+        orch._spawn_failures[key] = (count, 0.0)
+    claim_and_spawn_batches(
+        orch,
+        [batch],
+        alive_count=0,
+        assigned_task_ids=set(),
+        done_ids=set(),
+        result=TickResult(),
+    )
+
+
+def test_repeated_spawn_failure_parks_the_batch_on_disk(tmp_path: Path, make_task: Any) -> None:
+    """Three consecutive spawn failures park the work unit where the CLI can see it.
+
+    This is the issue's "Done means" bullet: a real spawn failure driven
+    to exhaustion leaves a parked entry at the path the aggregator reads.
+    Read back through ``load_parked_sessions`` so the writer and the
+    reader are asserted to agree rather than assumed to.
+    """
+    orch = _orch(tmp_path)
+    task = make_task(id="T-park", role="backend")
+    orch._spawner.spawn_for_tasks.side_effect = OSError("connection reset by peer")
+
+    assert not load_parked_sessions(tmp_path).available, "nothing has supervised this workspace yet"
+
+    for _ in range(orch._MAX_SPAWN_FAILURES):
+        _tick(orch, [task])
+
+    result = load_parked_sessions(tmp_path)
+    assert result.available
+    assert result.session_ids == frozenset({_park_key(_batch_lineage_key([task]))})
+
+
+def test_a_single_transient_failure_does_not_park(tmp_path: Path, make_task: Any) -> None:
+    """One flake is not a crash loop; the surface must not cry parked."""
+    orch = _orch(tmp_path)
+    task = make_task(id="T-flake", role="backend")
+    orch._spawner.spawn_for_tasks.side_effect = OSError("connection reset by peer")
+
+    _tick(orch, [task])
+
+    result = load_parked_sessions(tmp_path)
+    assert result.available, "the supervisor ran, so zero is a measured zero"
+    assert result.session_ids == frozenset()
+
+
+def test_a_recovered_batch_leaves_no_parked_entry(tmp_path: Path, make_task: Any) -> None:
+    """A batch that fails twice then spawns is not parked, and says so.
+
+    The store is still written -- a healthy run has to leave evidence,
+    otherwise "0 parked" is indistinguishable from "nobody watched".
+    """
+    orch = _orch(tmp_path)
+    task = make_task(id="T-recover", role="backend")
+    session = AgentSession(
+        id="A-recover",
+        role="backend",
+        task_ids=[task.id],
+        model_config=ModelConfig("sonnet", "high"),
+    )
+    orch._spawner.spawn_for_tasks.side_effect = [
+        OSError("connection reset by peer"),
+        OSError("connection reset by peer"),
+        session,
+    ]
+
+    for _ in range(3):
+        _tick(orch, [task])
+
+    result = load_parked_sessions(tmp_path)
+    assert result.available
+    assert result.session_ids == frozenset()
+
+
+def test_the_park_key_survives_a_retry_minting_a_new_task_id(tmp_path: Path, make_task: Any) -> None:
+    """The parked id must be lineage-keyed, not per-attempt.
+
+    A retry mints a brand-new task id (#2806), and ``spawner_core`` mints
+    a brand-new spawn session id per attempt. Either as the park key
+    would make every failure look like a first failure, so the budget
+    would never reach exhaustion and nothing would ever park.
+    """
+    first = make_task(id="T-orig", role="backend")
+    retry = make_task(id="T-retry-1", role="backend")
+    retry.metadata = {**(retry.metadata or {}), "original_task_id": "T-orig"}
+
+    assert _park_key(_batch_lineage_key([first])) == _park_key(_batch_lineage_key([retry]))
+
+
+def test_supervisor_is_rooted_at_the_orchestrator_workdir(tmp_path: Path, make_task: Any) -> None:
+    """The process supervisor learns where to write from the orchestrator."""
+    orch = _orch(tmp_path)
+    task = make_task(id="T-root", role="backend")
+    orch._spawner.spawn_for_tasks.side_effect = OSError("connection reset by peer")
+
+    _tick(orch, [task])
+
+    assert get_supervisor().store_path == tmp_path.joinpath(".sdd", "runtime", "spawn_supervisor", "parked.json")

--- a/tests/unit/agents/test_parked_session_producer.py
+++ b/tests/unit/agents/test_parked_session_producer.py
@@ -1,0 +1,222 @@
+"""The parked-session store gets a producer (#3453).
+
+``load_parked_sessions()`` and its ``available`` flag landed first, but
+nothing ever wrote the file they read, so every surface built on them --
+``bernstein status``, ``bernstein agents parked``, ``bernstein fleet``,
+the TUI status bar -- reported "nothing parked" unconditionally and
+always. These tests cover the writer end: a park reaches disk, a
+*different* supervisor instance (standing in for the CLI process, which
+is never the process that parked anything) can read it, and an operator
+resume clears it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.core.agents.spawn_supervisor import (
+    PARKED_STORE_RELPATH,
+    RespawnBudget,
+    SpawnSupervisor,
+    SupervisorState,
+)
+from bernstein.core.orchestration.supervisor_aggregator import (
+    load_parked_sessions,
+    observed_parked_sessions,
+)
+
+
+def _store(workdir: Path) -> Path:
+    return workdir.joinpath(*PARKED_STORE_RELPATH)
+
+
+def _budget(max_respawns: int = 2) -> RespawnBudget:
+    """A budget with no real sleeping in it."""
+    return RespawnBudget(max_respawns=max_respawns, initial_backoff_ms=0, max_backoff_ms=0)
+
+
+# ---------------------------------------------------------------------------
+# The writer
+# ---------------------------------------------------------------------------
+
+
+def test_exhausting_the_budget_writes_the_path_the_aggregator_reads(tmp_path: Path) -> None:
+    """The park lands at the exact path load_parked_sessions() looks at.
+
+    This is the join the issue is about: the reader was pointed at
+    ``.sdd/runtime/spawn_supervisor/parked.json`` and nothing put a file
+    there. Asserted through the reader rather than by re-deriving the
+    path, so the two cannot drift apart silently.
+    """
+    sup = SpawnSupervisor(workdir=tmp_path)
+    budget = _budget(max_respawns=2)
+
+    assert sup.record_spawn_failure("batch:T-1", RuntimeError("boom"), budget=budget) is True
+    assert sup.record_spawn_failure("batch:T-1", RuntimeError("boom")) is True
+    # Third failure exhausts the budget of two respawns.
+    assert sup.record_spawn_failure("batch:T-1", RuntimeError("boom")) is False
+
+    assert sup.is_parked("batch:T-1")
+    assert _store(tmp_path).exists()
+
+    result = load_parked_sessions(tmp_path)
+    assert result.available
+    assert result.session_ids == frozenset({"batch:T-1"})
+
+
+def test_a_fresh_supervisor_sees_a_park_made_by_another_one(tmp_path: Path) -> None:
+    """The CLI case: a process that never supervised anything still sees the park.
+
+    ``bernstein agents parked`` runs in its own process with an empty
+    in-memory supervisor. Reading only that supervisor is what made the
+    surface report zero by construction.
+    """
+    orchestrator_side = SpawnSupervisor(workdir=tmp_path)
+    orchestrator_side.park("batch:T-9", reason="crash loop")
+
+    cli_side = SpawnSupervisor(workdir=tmp_path)
+    assert cli_side.parked_sessions() == [], "the fresh supervisor has no memory of the park"
+
+    observed = observed_parked_sessions(tmp_path, in_process=cli_side.parked_sessions())
+    assert observed.available
+    assert observed.session_ids == frozenset({"batch:T-9"})
+
+
+def test_budget_remaining_does_not_park_or_claim_a_park(tmp_path: Path) -> None:
+    """A failure inside budget records a respawn and writes no parked id."""
+    sup = SpawnSupervisor(workdir=tmp_path)
+
+    assert sup.record_spawn_failure("batch:T-2", RuntimeError("flake"), budget=_budget(3)) is True
+
+    assert sup.state("batch:T-2") == SupervisorState.RESPAWNING
+    result = load_parked_sessions(tmp_path)
+    assert result.available, "the supervisor ran, so the store speaks for this workspace"
+    assert result.session_ids == frozenset(), "in-budget failures are not parks"
+
+
+def test_record_spawn_failure_does_not_sleep(tmp_path: Path) -> None:
+    """The non-blocking path must not apply the backoff schedule.
+
+    The orchestrator calls this from inside its tick; a blocking sleep
+    here would stall the loop and duplicate the retry schedule the tick
+    already owns.
+    """
+    slept: list[float] = []
+    sup = SpawnSupervisor(workdir=tmp_path, sleep=slept.append)
+
+    for _ in range(4):
+        sup.record_spawn_failure("batch:T-3", RuntimeError("boom"), budget=_budget(2))
+
+    assert slept == []
+
+
+# ---------------------------------------------------------------------------
+# Empty vs unavailable, from the producer's side
+# ---------------------------------------------------------------------------
+
+
+def test_a_clean_spawn_makes_zero_a_supported_claim(tmp_path: Path) -> None:
+    """A healthy run leaves evidence, so "0 parked" is measured, not assumed."""
+    assert not load_parked_sessions(tmp_path).available
+
+    SpawnSupervisor(workdir=tmp_path).note_spawn_success("batch:T-4")
+
+    result = load_parked_sessions(tmp_path)
+    assert result.available
+    assert result.session_ids == frozenset()
+
+
+def test_a_supervisor_with_no_workdir_writes_nothing(tmp_path: Path) -> None:
+    """Standalone use stays in-process, which is what unit tests want."""
+    sup = SpawnSupervisor()
+    assert sup.store_path is None
+
+    sup.park("batch:T-5")
+
+    assert sup.is_parked("batch:T-5")
+    assert not _store(tmp_path).exists()
+    assert not load_parked_sessions(tmp_path).available
+
+
+# ---------------------------------------------------------------------------
+# Resume, across the process boundary
+# ---------------------------------------------------------------------------
+
+
+def test_clear_parked_removes_the_id_a_foreign_supervisor_wrote(tmp_path: Path) -> None:
+    """`agents resume` must reach a park this process has no record of."""
+    SpawnSupervisor(workdir=tmp_path).park("batch:T-6")
+
+    cli_side = SpawnSupervisor(workdir=tmp_path)
+    assert cli_side.resume("batch:T-6") is False, "nothing in memory to resume"
+    assert cli_side.clear_parked("batch:T-6") is True
+
+    result = load_parked_sessions(tmp_path)
+    assert result.available, "the store still exists; it is simply empty now"
+    assert result.session_ids == frozenset()
+
+
+def test_clear_parked_is_false_for_an_id_that_is_not_parked(tmp_path: Path) -> None:
+    """Clearing an unknown id reports that it did nothing."""
+    SpawnSupervisor(workdir=tmp_path).park("batch:T-7")
+
+    assert SpawnSupervisor(workdir=tmp_path).clear_parked("batch:nope") is False
+    assert load_parked_sessions(tmp_path).session_ids == frozenset({"batch:T-7"})
+
+
+def test_resume_in_the_owning_process_clears_the_store_too(tmp_path: Path) -> None:
+    """An in-process resume must not leave a stale parked id on disk."""
+    sup = SpawnSupervisor(workdir=tmp_path)
+    sup.park("batch:T-8")
+    assert load_parked_sessions(tmp_path).session_ids == frozenset({"batch:T-8"})
+
+    assert sup.resume("batch:T-8") is True
+
+    assert load_parked_sessions(tmp_path).session_ids == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# The store is shared, so writing it must not be destructive
+# ---------------------------------------------------------------------------
+
+
+def test_persisting_does_not_erase_a_park_this_supervisor_never_made(tmp_path: Path) -> None:
+    """Two supervisors on one workspace must not overwrite each other.
+
+    A supervisor is authoritative only for the sessions it knows about.
+    An overwrite would let any second process silently drop every park it
+    had not made itself -- the same class of silent zero this issue is
+    about, one layer down.
+    """
+    first = SpawnSupervisor(workdir=tmp_path)
+    first.park("batch:owned-by-first")
+
+    second = SpawnSupervisor(workdir=tmp_path)
+    second.park("batch:owned-by-second")
+
+    assert load_parked_sessions(tmp_path).session_ids == frozenset({"batch:owned-by-first", "batch:owned-by-second"})
+
+
+def test_store_is_valid_json_with_the_documented_keys(tmp_path: Path) -> None:
+    """The file the aggregator reads carries the shape it parses."""
+    sup = SpawnSupervisor(workdir=tmp_path)
+    sup.park("batch:T-shape", reason="missing binary")
+
+    payload = json.loads(_store(tmp_path).read_text(encoding="utf-8"))
+
+    assert payload["session_ids"] == ["batch:T-shape"]
+    assert payload["entries"]["batch:T-shape"]["state"] == "parked"
+    assert payload["entries"]["batch:T-shape"]["last_error"] == "missing binary"
+    assert isinstance(payload["updated_at"], float)
+
+
+def test_a_corrupt_store_does_not_stop_a_park_being_recorded(tmp_path: Path) -> None:
+    """Supervision survives a damaged file rather than propagating the error."""
+    store = _store(tmp_path)
+    store.parent.mkdir(parents=True, exist_ok=True)
+    store.write_text("{not json", encoding="utf-8")
+
+    SpawnSupervisor(workdir=tmp_path).park("batch:T-10")
+
+    assert load_parked_sessions(tmp_path).session_ids == frozenset({"batch:T-10"})


### PR DESCRIPTION
## What

Gives the parked-session store a producer, so the four operator surfaces that
report parked sessions can finally report one. Second half of #3453 — the first
half (`available` vs. empty in `load_parked_sessions`) landed in #3479.

## Why

`SpawnSupervisor.spawn()` had no production caller, so `_park` never fired
outside a unit test and `load_parked_sessions()` read a path nothing wrote.
`bernstein status`, `bernstein agents parked`, `bernstein fleet` and the TUI
status bar answered "nothing parked" unconditionally and always.

I re-ran the issue's grep claims at HEAD first, as the brief asks. They still
hold: `parked.json` has one reader and no writer, and nothing calls `.spawn()`.

## How

Two corrections to the issue's own framing, and they are most of the value here.

**1. The park cannot be keyed on a spawn session id.** `spawner_core.py:3972`
mints a fresh `f"{role}-{uuid.uuid4().hex[:8]}"` per attempt, so a session-keyed
budget sees
every failure as a *first* failure and never reaches exhaustion — the writer
would be wired exactly as the issue describes and still nothing would ever park.
The park is keyed on the batch lineage instead: the same key the orchestrator
already uses for its own consecutive-failure counter, which exists because a
retry mints a new task id too (#2806). Parked ids render as `batch:<lineage>`.

**2. `SpawnSupervisor.spawn()` is the wrong entry point.** It owns a *blocking*
retry loop. The orchestrator retries a failed batch on a later tick, so calling
`spawn()` from the tick would stall the loop and stack a second retry schedule
on the one the tick already provides. Added `record_spawn_failure()` as the
non-blocking counterpart and left `spawn()` untouched. The budget handed to it
is built from `_MAX_SPAWN_FAILURES` / `_SPAWN_BACKOFF_MAX_S`, so the
orchestrator's counter and the supervisor's agree by construction rather than by
coincidence.

Parks persist to `.sdd/runtime/spawn_supervisor/parked.json` — the path the
aggregator already reads — atomically (`tmp` + `os.replace`) and **merging
rather than overwriting**, so a second process holding its own supervisor cannot
erase parks it did not make. The store is also written on a clean spawn, which
is what keeps #3479's `available` flag meaningful: a healthy run leaves evidence
that a supervisor ran here. `resume` clears the on-disk entry, which is what
makes it work on a park made by an orchestrator that has since exited.

## Verified by mutation, not by a green tick

Four mutations, each caught by exactly the test written for it:

| mutation | caught by |
|---|---|
| don't call the writer from the failure path | orchestrator wiring e2e |
| unwire the orchestrator entirely | wiring test |
| make the persist destructive (overwrite, not merge) | merge test |
| make the reader ignore the store | union test |

Two of those I re-ran on the exact tree being pushed: unwiring
`record_spawn_failure` fails `test_a_single_transient_failure_does_not_park` and
`test_supervisor_is_rooted_at_the_orchestrator_workdir`; making `_persist`
overwrite instead of merge fails
`test_persisting_does_not_erase_a_park_this_supervisor_never_made`. Nothing
passes vacuously.

17 new tests. The e2e one drives the real `claim_and_spawn_batches` failure path
to exhaustion and reads back **through** `load_parked_sessions`, so writer and
reader are asserted to agree rather than each asserted alone; it also runs
through the real CLI in separate processes, which is the case that was actually
broken.

## A regression I caused and backed out

My first cut made `bernstein ps --json-output` always emit an object so it could
carry `parked_available`. That broke `test_status_cmd_openclaw_bridge`, which
asserts `payload[0]` — the top-level type is a contract. Reverted. The flag now
rides inside the object form only, so `ps --json` keeps its existing shape and
therefore *cannot* express unavailable-vs-empty; that distinction is on the human
surfaces and on `bernstein agents parked`. Called out because it is a real
limitation of this PR, not an oversight.

## One acceptance box I have deliberately not ticked

> The `respawn_exhausted` fallback branch is either fed by a real writer or
> removed, not left as a third unreachable path

Still unfed. `respawn_exhausted` appears at `supervisor_aggregator.py:229` as a
reader and nowhere else in `src/`. This PR feeds the *primary* store, which
covers the fallback's stated purpose, so the branch is now redundant rather than
load-bearing — but deleting a documented recovery path is your call, not mine.
Say the word and I'll drop it in this PR or file a follow-up.

Same question for the `_publish_exhausted` / `_park` pair the brief flags: I
treated `_park` as authoritative and left `_publish_exhausted` alone rather than
feeding both. Happy to be told otherwise.

## Checklist

- [x] `ruff check` / `ruff format --check` pass on the touched files
- [x] `lint-imports` passes (3 contracts kept — this adds a core→core import only)
- [x] `pyright` over the five touched files: **487 errors on this branch, 487 on
      `main`, zero new**. (Counted as a diff against the merge base, not as a
      total — `main` already carries 487 on these files, so a total says nothing.
      The second commit exists because the first cut added three.)
- [x] `mypy --config-file mypy.gate.ini` over the same five: 7 on both, zero new
- [x] 17 new tests pass; touched-area suites pass under `scripts/run_tests.py`
- [x] New code has type hints
- [x] `docs/operations/agent_crash_loop.md` updated — where parks live, the two
      zeros, the `batch:` id form, and the `ps --json` limitation
- [ ] `docs/api/` — N/A, no public schema changed
- [ ] `agents-md sync` — N/A, no new module (new functions in existing ones)

---

One courtesy note: I saw you offered to reserve this for @oldschoola on 16 Aug.
It has been quiet since and the issue is unlabelled/unassigned, so I picked it up
under CONTRIBUTING's "stalled is not the same as taken" — but if they want it,
say so and I'll close this without argument.
