### PR TITLE
fix(tasks): report an unreachable spawn supervisor instead of suppressing it

### DIFF
--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -2910,8 +2910,14 @@ def claim_and_spawn_batches(
             # in the store that a supervisor ran here. Without this a
             # healthy run writes nothing and its readers cannot tell
             # "nothing parked" from "nobody was watching" (#3453).
-            with contextlib.suppress(Exception):
+            try:
                 _spawn_supervisor_for(orch).note_spawn_success(_park_key(batch_key))
+            except Exception:
+                logger.warning(
+                    "Could not record a clean spawn with the supervisor for task %s",
+                    batch[0].id,
+                    exc_info=True,
+                )
             _spawned_per_role[batch[0].role] += 1
             # Track spawn rate in convergence guard
             _convergence = getattr(orch, "_convergence_guard", None)
@@ -3045,21 +3051,33 @@ def claim_and_spawn_batches(
             # construction rather than by coincidence -- and the
             # supervisor's job here is to make the give-up visible to
             # `bernstein status`, the TUI and `agents resume` (#3453).
-            with contextlib.suppress(Exception):
+            try:
                 _spawn_supervisor_for(orch).record_spawn_failure(
                     _park_key(batch_key),
                     exc,
                     budget=_spawn_respawn_budget(orch),
+                )
+            except Exception:
+                logger.warning(
+                    "Could not record a spawn failure with the supervisor for task %s",
+                    batch[0].id,
+                    exc_info=True,
                 )
             should_retry, _ = spawn_analyzer.should_retry(batch_history, max_retries=orch._MAX_SPAWN_FAILURES)
             if new_count >= orch._MAX_SPAWN_FAILURES or not should_retry:
                 # The analyzer can call it quits before the budget is
                 # spent. Park explicitly so the two ways of giving up
                 # leave the same operator-visible state.
-                with contextlib.suppress(Exception):
+                try:
                     _spawn_supervisor_for(orch).park(
                         _park_key(batch_key),
                         reason=f"spawn failed {new_count} consecutive time(s): {exc}",
+                    )
+                except Exception:
+                    logger.warning(
+                        "Could not park task %s with the supervisor; the operator surfaces will not show it",
+                        batch[0].id,
+                        exc_info=True,
                     )
                 for task in batch:
                     try:

--- a/tests/unit/agents/test_parked_session_orchestrator_wiring.py
+++ b/tests/unit/agents/test_parked_session_orchestrator_wiring.py
@@ -192,3 +192,46 @@ def test_supervisor_is_rooted_at_the_orchestrator_workdir(tmp_path: Path, make_t
     _tick(orch, [task])
 
     assert get_supervisor().store_path == tmp_path.joinpath(".sdd", "runtime", "spawn_supervisor", "parked.json")
+
+
+def test_an_unreachable_supervisor_is_reported_where_an_operator_looks(
+    tmp_path: Path,
+    make_task: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A supervisor that cannot be reached leaves a warning, not silence.
+
+    Reaching the supervisor is best-effort on purpose: supervision must
+    never take down a spawn. But the failure it guards against looks
+    exactly like the defect this wiring exists to fix -- every operator
+    surface reporting "nothing parked" unconditionally. Swallowed with no
+    trace, the two are indistinguishable, and the run that finds out is
+    the one where an operator needed the park and it was not there.
+
+    The spawn itself must still proceed: the assertion is a warning *and*
+    a tick that did not raise.
+    """
+    import logging
+
+    from bernstein.core.tasks import task_lifecycle
+
+    def _unreachable(_orch: Any) -> Any:
+        raise RuntimeError("supervisor state directory is read-only")
+
+    monkeypatch.setattr(task_lifecycle, "_spawn_supervisor_for", _unreachable)
+
+    orch = _orch(tmp_path)
+    task = make_task(id="T-unreachable", role="backend")
+    orch._spawner.spawn_for_tasks.side_effect = OSError("connection reset by peer")
+
+    with caplog.at_level(logging.WARNING, logger="bernstein.core.tasks.task_lifecycle"):
+        for _ in range(orch._MAX_SPAWN_FAILURES):
+            _tick(orch, [task])
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "an unreachable supervisor was swallowed without a word"
+    assert any("supervisor" in r.getMessage().lower() for r in warnings), (
+        f"warned, but not about the supervisor: {[r.getMessage() for r in warnings]}"
+    )
+    assert any(r.exc_info for r in warnings), "the warning carries no traceback to act on"


### PR DESCRIPTION
Follow-up to #4636, as promised in review there.

The parked-session writer is reached from three call sites in `task_lifecycle`, all wrapped in `contextlib.suppress(Exception)`. Best-effort is the right call -- supervision must never take down a spawn -- but `suppress` has no handler body, so there is nowhere for the failure to go.

The failure it hides is precisely the one #3453 was about. If `get_supervisor(workdir=...)` raises -- a read-only `.sdd`, a signature drift -- every park vanishes and `bernstein status`, `bernstein agents parked`, `bernstein fleet` and the TUI go back to reporting "nothing parked" unconditionally. Nothing in any log an operator reads would say a writer had existed and failed.

`try`/`except` with `logger.warning(..., exc_info=True)` keeps the fail-open and leaves the evidence.

## Verified by mutation

`test_an_unreachable_supervisor_is_reported_where_an_operator_looks` drives the real `claim_and_spawn_batches` failure path with a supervisor that raises on construction, and asserts three things: the tick still completes, a WARNING names the supervisor, and it carries a traceback.

Reverting only the src change turns it red -- there is still a warning on that path (about marking the task failed), so the test asserts the *subject* of the warning rather than merely that one exists.

18 tests pass in the two parked-session suites; `ruff check` and `ruff format --check` are clean on both touched files.