### PR TITLE
test: state the sandbox premise instead of inheriting it from the host

### DIFF
--- a/tests/unit/test_guardrails_sandbox_scope.py
+++ b/tests/unit/test_guardrails_sandbox_scope.py
@@ -137,8 +137,19 @@ def test_file_permissions_relaxation_preserved(tmp_path: Path) -> None:
     assert "[SANDBOX RELAXED]" in result[0].reason
 
 
-def test_non_sandboxed_path_unchanged() -> None:
+def test_non_sandboxed_path_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
     """Outside a sandbox, nothing is relaxed regardless of check."""
+    # State the premise instead of inheriting it. The sibling tests above set
+    # BERNSTEIN_SANDBOX=1 to say "sandboxed"; this one said "not sandboxed" by
+    # saying nothing, and the autouse fixture only clears the environment
+    # variables. is_sandboxed() also reads /.dockerenv and the cgroup markers,
+    # so the premise silently inverts whenever the suite itself runs inside a
+    # container -- the test then asserts the opposite of what it means and
+    # fails for a reason that has nothing to do with the code under test.
+    monkeypatch.setattr(
+        "bernstein.core.security.guardrails.is_sandboxed",
+        lambda: False,
+    )
     ask = [PermissionDecision(type=DecisionType.ASK, reason="file outside task scope")]
     assert relax_sandboxed(ask, "scope_enforcement", scoped_mount=True)[0].type == DecisionType.ASK
     assert relax_sandboxed(ask, "file_permissions")[0].type == DecisionType.ASK


### PR DESCRIPTION
`test_non_sandboxed_path_unchanged` asserts that nothing is relaxed outside a sandbox. It establishes "outside a sandbox" by saying nothing: the module's autouse fixture clears `BERNSTEIN_SANDBOX` and `BERNSTEIN_SANDBOX_RUNTIME`, and the test relies on that being the whole story.

It is not. `is_sandboxed()` also returns True on `/.dockerenv` and on Docker/containerd markers in `/proc/1/cgroup` and `/proc/1/mountinfo`, none of which a fixture can clear. So the premise inverts whenever the suite itself runs inside a container: the test then asserts the opposite of what it means and fails, with a diff that points at guardrail code behaving exactly as designed.

```
>       assert relax_sandboxed(ask, "scope_enforcement", scoped_mount=True)[0].type == DecisionType.ASK
E       AssertionError: assert <DecisionType.ALLOW: 'allow'> == <DecisionType.ASK: 'ask'>
```

The two sibling tests in the same file already state their premise, setting `BERNSTEIN_SANDBOX=1` when they want a sandbox. This one now states its own by forcing the detector, so its verdict depends on the code under test rather than on where the suite happens to run.

Checked by running `tests/unit/test_guardrails_sandbox_scope.py` inside a container: 1 failed before, 6 passed after. It still fails if the `not is_sandboxed()` guard is removed from `relax_sandboxed`, so it keeps the property it was written for.
