### PR TITLE
fix(docs): attribute context-file staleness only to PR-contributed commits (#4634)

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -143,16 +143,20 @@ jobs:
         # in drift-publish tracks accumulated flags in a single issue.
         env:
           BASELINE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set +e
-          baseline_args=()
+          check_args=()
           if [ -n "${BASELINE_SHA}" ]; then
-            baseline_args=(--baseline "${BASELINE_SHA}")
+            check_args+=(--baseline "${BASELINE_SHA}")
           fi
-          python scripts/check_context_staleness.py "${baseline_args[@]}" > staleness-report.md
+          if [ -n "${HEAD_SHA}" ]; then
+            check_args+=(--ref "${HEAD_SHA}")
+          fi
+          python scripts/check_context_staleness.py "${check_args[@]}" > staleness-report.md
           rc=$?
           echo "report_rc=${rc}" >> "$GITHUB_OUTPUT"
-          python scripts/check_context_staleness.py "${baseline_args[@]}" --json > staleness-report.json
+          python scripts/check_context_staleness.py "${check_args[@]}" --json > staleness-report.json
           clean=$(python -c "import json; print(json.load(open('staleness-report.json')).get('clean', False))" 2>/dev/null || echo "unknown")
           new_flags=$(python -c "import json; print(len(json.load(open('staleness-report.json')).get('newly_flagged', [])))" 2>/dev/null || echo "0")
           echo "clean=${clean}" >> "$GITHUB_OUTPUT"

--- a/docs/release-notes/fragments/4634-docs-drift-staleness-pr-scope.md
+++ b/docs/release-notes/fragments/4634-docs-drift-staleness-pr-scope.md
@@ -1,0 +1,1 @@
+Measure context-file staleness on pull requests over PR-contributed commits only (#4634).

--- a/scripts/check_context_staleness.py
+++ b/scripts/check_context_staleness.py
@@ -311,20 +311,34 @@ def compute_report(repo: Path, ref: str, baseline: str | None = None) -> Stalene
 
     With ``baseline``, each flagged entry is additionally marked
     ``newly_flagged`` when the same context file was not flagged at the
-    baseline commit — the signal the PR surface keys on.
+    baseline commit AND the commits between baseline and ref contributed
+    churn to that context file's scope.
     """
     ref_sha = _git(repo, "rev-parse", "--verify", f"{ref}^{{commit}}").strip()
     baseline_sha: str | None = None
     baseline_flagged: set[str] = set()
+    merge_base_sha: str | None = None
+
     if baseline is not None:
         baseline_sha = _git(repo, "rev-parse", "--verify", f"{baseline}^{{commit}}").strip()
-        baseline_flagged = {entry.context.path for entry in _compute_entries(repo, baseline_sha) if entry.flagged}
+        try:
+            merge_base_sha = _git(repo, "merge-base", baseline_sha, ref_sha).strip()
+        except subprocess.CalledProcessError:
+            merge_base_sha = baseline_sha
+        baseline_flagged = {entry.context.path for entry in _compute_entries(repo, merge_base_sha) if entry.flagged}
 
     report = StalenessReport(ref=ref_sha, baseline=baseline_sha)
     report.entries = _compute_entries(repo, ref_sha)
-    if baseline_sha is not None:
+    if baseline_sha is not None and merge_base_sha is not None:
         for entry in report.entries:
-            entry.newly_flagged = entry.flagged and entry.context.path not in baseline_flagged
+            if not entry.flagged or entry.context.path in baseline_flagged:
+                entry.newly_flagged = False
+                continue
+            files_changed, insertions, deletions, mod_add, mod_rem = _net_diff(
+                repo, merge_base_sha, ref_sha, entry.context.scope
+            )
+            has_churn = files_changed > 0 or (insertions + deletions) > 0 or mod_add > 0 or mod_rem > 0
+            entry.newly_flagged = has_churn
     return report
 
 

--- a/tests/unit/test_context_staleness.py
+++ b/tests/unit/test_context_staleness.py
@@ -283,6 +283,56 @@ def test_baseline_marks_only_newly_flagged(tmp_path: Path, staleness) -> None:
     assert [e.context.path for e in report.newly_flagged] == ["src/beta/AGENTS.md"]
 
 
+def test_pr_branch_does_not_inherit_staleness_from_concurrent_main_commits(tmp_path: Path, staleness) -> None:
+    """A pull request branch is only flagged for scopes the PR itself modified (#4634).
+
+    Builds two branches from one base, lands an unrelated commit in a curated scope
+    on the default branch, and asserts the untouched branch reports zero newly-flagged
+    files while the branch that actually edited that scope reports one.
+    """
+    env = _git_env(tmp_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, env, "-c", "init.defaultBranch=main", "init", "--quiet")
+    for pkg in ("alpha", "beta"):
+        _write(repo, f"src/{pkg}/AGENTS.md", f"# {pkg} context\n")
+        _write(repo, f"src/{pkg}/mod.py", "".join(f"LINE_{i} = {i}\n" for i in range(10)))
+    _git(repo, env, "add", "-A")
+    _git(repo, env, "commit", "--quiet", "-m", "seed: two scoped context files")
+    base_sha = _git(repo, env, "rev-parse", "HEAD")
+
+    # Create branch 1: untouched scope (only edits an unrelated file)
+    _git(repo, env, "checkout", "-b", "branch-untouched", base_sha)
+    _write(repo, "README.md", "# Bernstein Docs\n")
+    _git(repo, env, "add", "-A")
+    _git(repo, env, "commit", "--quiet", "-m", "docs: update readme")
+    untouched_sha = _git(repo, env, "rev-parse", "HEAD")
+
+    # Create branch 2: edits src/alpha (crosses threshold)
+    _git(repo, env, "checkout", "-b", "branch-alpha", base_sha)
+    _big_rewrite(repo, env, rel="src/alpha/mod.py")
+    alpha_sha = _git(repo, env, "rev-parse", "HEAD")
+
+    # On main (default branch), land an unrelated commit that pushes src/beta over threshold
+    _git(repo, env, "checkout", "main")
+    _big_rewrite(repo, env, rel="src/beta/mod.py")
+    main_sha = _git(repo, env, "rev-parse", "HEAD")
+
+    # Untouched branch tested against main: 0 newly flagged files
+    payload_untouched = _run_json(repo, env, "--ref", untouched_sha, "--baseline", main_sha)
+    assert payload_untouched["newly_flagged"] == []
+
+    report_untouched = staleness.compute_report(repo, untouched_sha, main_sha)
+    assert report_untouched.newly_flagged == []
+
+    # Branch that actually edited alpha tested against main: 1 newly flagged file (alpha)
+    payload_alpha = _run_json(repo, env, "--ref", alpha_sha, "--baseline", main_sha)
+    assert payload_alpha["newly_flagged"] == ["src/alpha/AGENTS.md"]
+
+    report_alpha = staleness.compute_report(repo, alpha_sha, main_sha)
+    assert [e.context.path for e in report_alpha.newly_flagged] == ["src/alpha/AGENTS.md"]
+
+
 def test_committed_overlay_is_repo_scoped_and_flags_on_lines_only(tmp_path: Path, staleness) -> None:
     env = _git_env(tmp_path)
     repo = tmp_path / "repo"


### PR DESCRIPTION
Fixes #4634

### Problem
`docs-drift.yml` runs `scripts/check_context_staleness.py` on pull requests with `--baseline ${{ github.event.pull_request.base.sha }}`. However, because `HEAD` checked out in GitHub Actions is the PR merge ref, any commits merged into the default branch between `base.sha` and `HEAD` were evaluated as churn and attributed to the PR. Consequently, unrelated pull requests (such as lockfile bumps) inherited staleness from concurrent merges on `main` and received comments listing context files they never touched.

### Solution
1. **Accurate PR Churn Attribution (`scripts/check_context_staleness.py`)**:
   - In `compute_report()`, find `merge_base_sha` between `baseline` and `ref`.
   - Calculate baseline flagged status at `merge_base_sha` (the commit where the PR diverged).
   - Only mark a context file `newly_flagged = True` if the commits on the PR branch (`merge_base_sha..ref`) actually introduced changes (`_net_diff()`) into that context file's scope.
2. **Targeted Ref Passing in CI (`.github/workflows/docs-drift.yml`)**:
   - Passed `--ref "${HEAD_SHA}"` (`github.event.pull_request.head.sha`) alongside `--baseline "${BASELINE_SHA}"` so staleness is computed directly over the PR branch commits.
3. **Design Decision (Full table with clear new-flag markings)**:
   - Preserved the full table in markdown reports while explicitly marking `(newly flagged in this range)` for files the PR pushed over threshold. This gives full context visibility without masking new additions.
4. **Behavioral Test & Hygiene**:
   - Added test `test_pr_branch_does_not_inherit_staleness_from_concurrent_main_commits` in `tests/unit/test_context_staleness.py` that branches from a shared base, adds commits to `main` under a curated scope, and asserts the untouched branch reports 0 newly flagged files while the branch that edited the scope reports 1.
   - Verified 25/25 unit tests passing.
   - Added release note fragment `docs/release-notes/fragments/4634-docs-drift-staleness-pr-scope.md`.
