### PR TITLE
fix: report git failures in PR descriptions instead of claiming no changes

### DIFF
--- a/docs/release-notes/fragments/4669-pr-body-git-failures.md
+++ b/docs/release-notes/fragments/4669-pr-body-git-failures.md
@@ -1,0 +1,6 @@
+- `bernstein pr` now reports when git could not describe the branch instead of
+  writing a description that says the branch changed nothing. Provenance is
+  built only from a diff that exists, so a pull request never carries a digest
+  of the empty string beside a command to verify it. Descriptions also open
+  with a one-line summary of size, gates and cost, list files as a table, and
+  fold the diff-stat away.

--- a/src/bernstein/cli/commands/pr_cmd.py
+++ b/src/bernstein/cli/commands/pr_cmd.py
@@ -73,6 +73,9 @@ def _run_git(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+_GIT_ERROR_MAX_CHARS = 200
+
+
 def _current_branch(cwd: Path) -> str:
     """Return the current git branch, or ``"HEAD"`` when detached."""
     result = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=cwd)
@@ -81,16 +84,38 @@ def _current_branch(cwd: Path) -> str:
     return result.stdout.strip() or "HEAD"
 
 
-def _diff_stat(cwd: Path, base: str, head: str) -> str:
-    """Return ``git diff --stat base..head`` (empty string on failure)."""
-    result = _run_git(["diff", "--stat", f"{base}..{head}"], cwd=cwd)
-    if result.returncode != 0:
+def _git_error(result: subprocess.CompletedProcess) -> str:
+    """Summarise a failed git invocation in one line.
+
+    A description is written from what git answers.  When git does not
+    answer, the description must say so rather than describe the silence:
+    an unanswered query is not a negative answer.  This returns the line
+    the caller reports; ``""`` means the invocation succeeded.
+    """
+    if result.returncode == 0:
         return ""
-    return result.stdout
+    stderr = result.stderr
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8", "replace")
+    message = " ".join((stderr or "").split()) or f"git exited {result.returncode}"
+    return message[:_GIT_ERROR_MAX_CHARS]
 
 
-def _diff_bytes(cwd: Path, base: str, head: str) -> bytes:
-    """Return ``git diff base..head`` as raw bytes (empty on failure).
+def _diff_stat(cwd: Path, base: str, head: str) -> tuple[str, str]:
+    """Return ``(git diff --stat base..head, error)``.
+
+    ``error`` is non-empty when git could not answer.  It is kept separate
+    from the output so an unreadable diff is never rendered as an empty one
+    -- the two are indistinguishable to a reader and only one of them means
+    the branch changed nothing.
+    """
+    result = _run_git(["diff", "--stat", f"{base}..{head}"], cwd=cwd)
+    error = _git_error(result)
+    return ("" if error else result.stdout), error
+
+
+def _diff_bytes(cwd: Path, base: str, head: str) -> tuple[bytes, str]:
+    """Return ``(git diff base..head as raw bytes, error)``.
 
     Bytes, not text: the diff is hashed, and decoding it would make the hash
     depend on this process's error handling rather than on the diff.
@@ -102,20 +127,18 @@ def _diff_bytes(cwd: Path, base: str, head: str) -> bytes:
         timeout=60,
         check=False,
     )
-    if result.returncode != 0:
-        return b""
-    return result.stdout
+    error = _git_error(result)
+    return (b"" if error else result.stdout), error
 
 
-def _commit_log(cwd: Path, base: str, head: str) -> str:
-    """Return the branch's commits with per-file churn, for ranking."""
+def _commit_log(cwd: Path, base: str, head: str) -> tuple[str, str]:
+    """Return ``(the branch's commits with per-file churn, error)``."""
     result = _run_git(
         ["log", f"--format={COMMIT_LOG_FORMAT}", "--numstat", "--no-color", f"{base}..{head}"],
         cwd=cwd,
     )
-    if result.returncode != 0:
-        return ""
-    return result.stdout
+    error = _git_error(result)
+    return ("" if error else result.stdout), error
 
 
 def _enrich_summary_with_git(summary: SessionSummary, cwd: Path) -> SessionSummary:
@@ -134,14 +157,52 @@ def _enrich_summary_with_git(summary: SessionSummary, cwd: Path) -> SessionSumma
         when they were missing from the original.
     """
     branch = summary.branch if summary.branch not in ("", "HEAD") else _current_branch(cwd)
-    diff_stat = summary.diff_stat or _diff_stat(cwd, summary.base_branch, branch)
-    commits = summary.commits or parse_commit_log(_commit_log(cwd, summary.base_branch, branch))
-    provenance = summary.provenance or build_provenance(
-        diff=_diff_bytes(cwd, summary.base_branch, branch),
-        journal_head=summary.journal_head,
-    )
+    errors: list[str] = []
 
-    return replace(summary, branch=branch, diff_stat=diff_stat, commits=commits, provenance=provenance)
+    diff_stat = summary.diff_stat
+    if not diff_stat:
+        diff_stat, error = _diff_stat(cwd, summary.base_branch, branch)
+        if error:
+            errors.append(f"diff --stat: {error}")
+
+    commits = summary.commits
+    if not commits:
+        raw, error = _commit_log(cwd, summary.base_branch, branch)
+        commits = parse_commit_log(raw)
+        if error:
+            errors.append(f"log: {error}")
+
+    # Provenance binds the description to a diff a verifier can recompute.
+    # An empty diff hashes to the SHA-256 of the empty string, which is a
+    # well-formed digest of nothing: published under a "verify this" command
+    # it is a receipt that cannot be honoured. Bind only a diff that exists.
+    provenance = summary.provenance
+    if provenance is None:
+        diff, error = _diff_bytes(cwd, summary.base_branch, branch)
+        if error:
+            errors.append(f"diff: {error}")
+        if diff:
+            provenance = build_provenance(diff=diff, journal_head=summary.journal_head)
+
+    git_error = summary.git_error or "; ".join(errors)
+    if git_error:
+        # The publish log is where this gets diagnosed. Without the line, a
+        # description written from an unanswered git reads as a run that
+        # changed nothing, and nothing in the log says otherwise.
+        click.echo(
+            f"warning: git could not describe {summary.base_branch}..{branch} ({git_error}); "
+            "the description says so instead of claiming the branch is empty",
+            err=True,
+        )
+
+    return replace(
+        summary,
+        branch=branch,
+        diff_stat=diff_stat,
+        commits=commits,
+        provenance=provenance,
+        git_error=git_error,
+    )
 
 
 def _push_branch(branch: str, cwd: Path) -> tuple[bool, str]:

--- a/src/bernstein/core/integrations/pr_gen.py
+++ b/src/bernstein/core/integrations/pr_gen.py
@@ -893,6 +893,9 @@ def _format_gates(gates: tuple[GateResult, ...]) -> str:
 
 def _format_cost(cost: CostBreakdown) -> str:
     """Render the cost section as a markdown list."""
+    if cost.total_usd == 0 and cost.total_tokens == 0:
+        return "- _No cost was recorded for this session._"
+
     lines: list[str] = [
         f"- **Total:** ${cost.total_usd:.2f}",
         f"- **Tokens:** {cost.total_tokens:,}",
@@ -1029,13 +1032,15 @@ def _format_changes(session: SessionSummary) -> str:
 
 def _format_provenance(provenance: ChangeProvenance) -> str:
     """Render the Provenance block binding the description to its diff."""
-    return "\n".join(
-        [
-            f"- **Diff:** `{provenance.diff_hash}`",
-            f"- **Journal head:** `{provenance.journal_head or 'unrecorded'}`",
-            "- **Verify:** `bernstein review-receipt verify --pr <this PR> --issue <issue.md> --diff <pr.diff>`",
-        ]
-    )
+    lines = [f"- **Diff:** `{provenance.diff_hash}`"]
+    # A run that left no journal head has nothing to say here. The word
+    # "unrecorded" beside a verify command reads as a missing recording
+    # rather than as a run that never anchored one, and it is the line
+    # readers ask about first.
+    if provenance.journal_head:
+        lines.append(f"- **Journal head:** `{provenance.journal_head}`")
+    lines.append("- **Verify:** `bernstein review-receipt verify --pr <this PR> --issue <issue.md> --diff <pr.diff>`")
+    return "\n".join(lines)
 
 
 def _format_evidence(evidence: EvidenceSummary) -> str:

--- a/src/bernstein/core/integrations/pr_gen.py
+++ b/src/bernstein/core/integrations/pr_gen.py
@@ -198,6 +198,17 @@ _MAX_FILES_LISTED = 20
 # How much of the linked issue's body the Problem section quotes.
 _PROBLEM_MAX_CHARS = 600
 
+# SHA-256 of zero bytes. `compute_diff_hash(b"")` returns it, and it is a
+# well-formed digest of nothing: printed under "verify this" it is a receipt
+# no verifier can honour. Recognised here so no caller can publish one.
+_EMPTY_DIFF_HASH_SUFFIX = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+_DIFF_STAT_SUMMARY_RE = re.compile(
+    r"(?P<files>\d+)\s+files?\s+changed"
+    r"(?:,\s*(?P<added>\d+)\s+insertions?\(\+\))?"
+    r"(?:,\s*(?P<removed>\d+)\s+deletions?\(-\))?"
+)
+
 #: Verdict recorded on a receipt that attests a pull-request description
 #: rather than a code review, so the two are told apart on read-back.
 DESCRIPTION_VERDICT = "description"
@@ -383,6 +394,10 @@ class SessionSummary:
             :class:`ChangeProvenance`.
         provenance: The description's binding to the diff it describes, or
             ``None`` when no diff was available to hash.
+        git_error: Why git could not describe the branch, when it could
+            not.  A failed query and an empty answer look identical once
+            they reach this dataclass, so the reason travels with them and
+            the description reports it instead of claiming no changes.
     """
 
     session_id: str
@@ -400,6 +415,7 @@ class SessionSummary:
     commits: tuple[CommitRecord, ...] = ()
     journal_head: str = ""
     provenance: ChangeProvenance | None = None
+    git_error: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -821,16 +837,46 @@ def _first_paragraph(text: str) -> str:
     stripped = text.strip()
     if not stripped:
         return ""
-    for block in re.split(r"\n\s*\n", stripped):
-        lines = [line.strip() for line in block.splitlines()]
-        kept = [line for line in lines if line and not line.startswith("#")]
-        paragraph = " ".join(kept).strip()
+    blocks = re.split(r"\n\s*\n", stripped)
+    for index, block in enumerate(blocks):
+        paragraph = _flatten_block(block)
         if not paragraph:
             continue
-        if len(paragraph) > _PROBLEM_MAX_CHARS:
-            return paragraph[:_PROBLEM_MAX_CHARS].rstrip() + "…"
-        return paragraph
+        # "Two release tracks, going forward:" is not a problem statement, it
+        # is the sentence before one. A paragraph that ends on a colon
+        # introduces the block beneath it, so take that block too rather than
+        # publishing the lead-in alone.
+        if paragraph.endswith(":") and index + 1 < len(blocks):
+            continuation = _flatten_block(blocks[index + 1])
+            if continuation:
+                paragraph = f"{paragraph} {continuation}".strip()
+        return _cap(paragraph)
     return ""
+
+
+def _flatten_block(block: str) -> str:
+    """Flatten one markdown block to a single line of prose.
+
+    Headings are dropped; list markers and blockquote markers are stripped so
+    a bulleted block reads as a sentence rather than as broken markdown.
+    """
+    kept: list[str] = []
+    for raw in block.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        line = re.sub(r"^>\s*", "", line)
+        line = re.sub(r"^(?:[-*+]|\d+\.)\s+", "", line)
+        if line:
+            kept.append(line)
+    return " ".join(kept).strip()
+
+
+def _cap(text: str) -> str:
+    """Truncate ``text`` to the problem-statement budget, with an ellipsis."""
+    if len(text) > _PROBLEM_MAX_CHARS:
+        return text[:_PROBLEM_MAX_CHARS].rstrip() + "…"
+    return text
 
 
 def _format_gates(gates: tuple[GateResult, ...]) -> str:
@@ -867,11 +913,22 @@ def _format_cost(cost: CostBreakdown) -> str:
 
 
 def _format_diff_stat(diff_stat: str) -> str:
-    """Render the diff-stat in a fenced code block, or a fallback line."""
+    """Render the diff-stat, folded away, or a fallback line."""
     stripped = diff_stat.strip()
     if not stripped:
         return "_No changes recorded for this session._"
-    return f"```\n{stripped}\n```"
+    return "\n".join(
+        [
+            "<details>",
+            "<summary>Full diff-stat</summary>",
+            "",
+            "```",
+            stripped,
+            "```",
+            "",
+            "</details>",
+        ]
+    )
 
 
 def _format_merged_changes(merged: tuple[MergedChange, ...]) -> str:
@@ -890,10 +947,14 @@ def _format_merged_changes(merged: tuple[MergedChange, ...]) -> str:
 def _format_file_lines(files: Iterable[FileChange]) -> list[str]:
     """Render the files a commit touched, largest change first."""
     ordered = sorted(files, key=lambda f: (-f.churn, f.path))
-    lines = [f"- `{change.path}` (+{change.added}/-{change.removed})" for change in ordered[:_MAX_FILES_LISTED]]
-    remaining = len(ordered) - len(lines)
+    if not ordered:
+        return []
+    shown = ordered[:_MAX_FILES_LISTED]
+    lines = ["| File | Change |", "| --- | --- |"]
+    lines += [f"| `{change.path}` | +{change.added} / -{change.removed} |" for change in shown]
+    remaining = len(ordered) - len(shown)
     if remaining > 0:
-        lines.append(f"- _…and {remaining} more file(s)._")
+        lines.append(f"| _…and {remaining} more file(s)_ | |")
     return lines
 
 
@@ -957,6 +1018,11 @@ def _format_changes(session: SessionSummary) -> str:
     if session.merged_changes:
         blocks.append(_format_merged_changes(session.merged_changes))
     if not blocks:
+        if session.git_error:
+            return (
+                "> ⚠️ **The diff could not be read.** This description was composed without it.\n"
+                f"> git said: `{session.git_error}`"
+            )
         return _format_diff_stat("")
     return "\n\n".join(blocks)
 
@@ -992,6 +1058,73 @@ def _format_evidence(evidence: EvidenceSummary) -> str:
     )
 
 
+def _churn(session: SessionSummary) -> tuple[int, int, int] | None:
+    """Return ``(files, added, removed)`` for the branch, or ``None``.
+
+    The commits are the first source because they carry per-file numbers.
+    The diff-stat's summary line is the fallback for a session whose commits
+    were not parsed.  ``None`` means neither could say, which is the case a
+    headline must not invent a number for.
+    """
+    paths: dict[str, tuple[int, int]] = {}
+    for commit in session.commits:
+        if commit.is_merge:
+            continue
+        for change in commit.files:
+            added, removed = paths.get(change.path, (0, 0))
+            paths[change.path] = (added + change.added, removed + change.removed)
+    if paths:
+        return len(paths), sum(a for a, _ in paths.values()), sum(r for _, r in paths.values())
+
+    match = _DIFF_STAT_SUMMARY_RE.search(session.diff_stat)
+    if match:
+        return (
+            int(match.group("files")),
+            int(match.group("added") or 0),
+            int(match.group("removed") or 0),
+        )
+    return None
+
+
+def _format_headline(session: SessionSummary) -> str:
+    """Render the one-line summary that opens the body.
+
+    A reviewer opening a pull request asks three questions before any other:
+    how big is it, did the checks pass, what did it cost.  The line answers
+    all three above the fold so the rest of the description is optional
+    reading rather than a search.
+    """
+    segments: list[str] = []
+
+    churn = _churn(session)
+    if churn is not None:
+        files, added, removed = churn
+        plural = "" if files == 1 else "s"
+        segments.append(f"**{files} file{plural}** · +{added} / -{removed}")
+
+    failed = [gate for gate in session.gates if not gate.passed]
+    if session.gates:
+        passed = len(session.gates) - len(failed)
+        segments.append(f"**{passed}/{len(session.gates)} gates passed**")
+
+    if session.cost.total_usd > 0:
+        segments.append(f"**${session.cost.total_usd:.2f}**")
+
+    if session.git_error:
+        marker = "⚠️"
+        segments.append("**the diff could not be read**")
+    elif failed:
+        marker = "❌"
+    elif session.gates:
+        marker = "✅"
+    else:
+        marker = "📝"
+
+    if not segments:
+        return ""
+    return f"> {marker} " + " · ".join(segments)
+
+
 def build_pr_body(session: SessionSummary) -> str:
     """Render the full markdown body for a pull request.
 
@@ -1019,7 +1152,12 @@ def build_pr_body(session: SessionSummary) -> str:
     # with a single regex.
     short_id = session.session_id[:12] if session.session_id else "unknown"
 
-    parts: list[str] = [
+    parts: list[str] = []
+    headline = _format_headline(session)
+    if headline:
+        parts += [headline, ""]
+
+    parts += [
         "## Problem",
         _problem_statement(session),
         "",
@@ -1043,7 +1181,7 @@ def build_pr_body(session: SessionSummary) -> str:
     # any diff. The block below is what makes this one checkable: the diff it
     # was composed from and the journal head of the run that produced it, both
     # recomputable by ``review-receipt verify``.
-    if session.provenance is not None:
+    if session.provenance is not None and not session.provenance.diff_hash.endswith(_EMPTY_DIFF_HASH_SUFFIX):
         parts += [
             "## Provenance",
             _format_provenance(session.provenance),

--- a/tests/unit/test_pr_description_from_change.py
+++ b/tests/unit/test_pr_description_from_change.py
@@ -507,16 +507,9 @@ def test_git_failures_reach_the_description_instead_of_being_swallowed(tmp_path:
 
 
 def test_a_colon_lead_in_absorbs_the_block_it_introduces() -> None:
-    """"Two release tracks, going forward:" is the sentence before a problem."""
+    """ "Two release tracks, going forward:" is the sentence before a problem."""
     body = build_pr_body(
-        _summary(
-            issue_problem=(
-                "Two release tracks, going forward:\n"
-                "\n"
-                "- stable ships monthly\n"
-                "- edge ships nightly\n"
-            )
-        )
+        _summary(issue_problem=("Two release tracks, going forward:\n\n- stable ships monthly\n- edge ships nightly\n"))
     )
     problem = body.split("## Problem", 1)[1].split("## Change", 1)[0]
 
@@ -536,10 +529,31 @@ def test_the_body_opens_with_the_size_the_gates_and_the_cost() -> None:
 
 
 def test_a_failed_gate_shows_in_the_headline() -> None:
-    body = build_pr_body(
-        _summary(gates=(GateResult(name="tests", passed=False, detail="3 failed"),))
-    )
+    body = build_pr_body(_summary(gates=(GateResult(name="tests", passed=False, detail="3 failed"),)))
     headline = body.splitlines()[0]
 
     assert "❌" in headline
     assert "0/1 gates passed" in headline
+
+
+def test_a_run_without_a_journal_head_does_not_advertise_one() -> None:
+    """``Journal head: unrecorded`` reads as a lost recording, not an absent one."""
+    body = build_pr_body(_summary(provenance=build_provenance(diff=b"diff --git a/x b/x\n")))
+    provenance = body.split("## Provenance", 1)[1].split("## Cost", 1)[0]
+
+    assert "unrecorded" not in provenance
+    assert "Journal head" not in provenance
+
+
+def test_a_journal_head_is_shown_when_the_run_anchored_one() -> None:
+    body = build_pr_body(_summary(provenance=build_provenance(diff=b"diff --git a/x b/x\n", journal_head="deadbeef")))
+
+    assert "**Journal head:** `deadbeef`" in body
+
+
+def test_a_session_with_no_cost_says_so_in_one_line() -> None:
+    body = build_pr_body(_summary(cost=CostBreakdown()))
+    cost = body.split("## Cost", 1)[1].split("---", 1)[0]
+
+    assert "No cost was recorded" in cost
+    assert "Effective rate" not in cost

--- a/tests/unit/test_pr_description_from_change.py
+++ b/tests/unit/test_pr_description_from_change.py
@@ -255,7 +255,7 @@ def test_the_change_section_names_the_dominant_commit_and_its_files() -> None:
 
     assert "derive a per-store key with HKDF-SHA256" in change
     assert "src/bernstein/core/storage/keys.py" in change
-    assert "+120/-4" in change
+    assert "+120 / -4" in change
 
 
 def test_the_change_section_labels_housekeeping_rather_than_hiding_it() -> None:
@@ -438,3 +438,108 @@ def test_body_is_a_registered_pr_option() -> None:
     from bernstein.cli.commands.pr_cmd import pr_cmd
 
     assert "--body" in {param.opts[0] for param in pr_cmd.params}
+
+
+# ---------------------------------------------------------------------------
+# What a description may claim when git does not answer
+# ---------------------------------------------------------------------------
+
+
+def test_a_git_failure_is_not_reported_as_a_branch_that_changed_nothing() -> None:
+    """An unanswered query is not a negative answer.
+
+    ``git diff`` returning non-zero used to be indistinguishable from a
+    branch with no diff: both reached the body as an empty string, and the
+    body asserted the branch changed nothing. Nine of the ten fleet pull
+    requests open on 2026-08-27 said that about branches full of work.
+    """
+    body = build_pr_body(_summary(diff_stat="", commits=(), git_error="fatal: bad object main"))
+    change = body.split("## Change", 1)[1].split("## Verification", 1)[0]
+
+    assert "No changes recorded" not in change
+    assert "could not be read" in change
+    assert "fatal: bad object main" in change
+
+
+def test_a_description_never_carries_a_receipt_for_an_empty_diff() -> None:
+    """A digest of nothing is not provenance.
+
+    ``compute_diff_hash(b"")`` is a well-formed SHA-256, and printing it
+    beside ``review-receipt verify`` publishes a receipt no verifier can
+    honour. The section is omitted instead.
+    """
+    empty = build_provenance(diff=b"")
+    body = build_pr_body(_summary(provenance=empty))
+
+    assert "## Provenance" not in body
+    assert empty.diff_hash not in body
+
+
+def test_a_receipt_for_a_real_diff_is_still_published() -> None:
+    real = build_provenance(diff=b"diff --git a/x b/x\n+one line\n")
+    body = build_pr_body(_summary(provenance=real))
+
+    assert "## Provenance" in body
+    assert real.diff_hash in body
+
+
+def test_git_failures_reach_the_description_instead_of_being_swallowed(tmp_path: Path) -> None:
+    """Proven against real git, in a directory that is not a repository.
+
+    A mocked failure would prove the branch is written; only a real
+    non-zero git proves the failure survives the subprocess boundary.
+    """
+    from bernstein.cli.commands.pr_cmd import _enrich_summary_with_git
+
+    enriched = _enrich_summary_with_git(
+        _summary(diff_stat="", commits=(), provenance=None, branch="some-branch"),
+        tmp_path,
+    )
+
+    assert enriched.git_error
+    assert enriched.provenance is None
+    assert "No changes recorded" not in build_pr_body(enriched)
+
+
+# ---------------------------------------------------------------------------
+# What a reader sees first
+# ---------------------------------------------------------------------------
+
+
+def test_a_colon_lead_in_absorbs_the_block_it_introduces() -> None:
+    """"Two release tracks, going forward:" is the sentence before a problem."""
+    body = build_pr_body(
+        _summary(
+            issue_problem=(
+                "Two release tracks, going forward:\n"
+                "\n"
+                "- stable ships monthly\n"
+                "- edge ships nightly\n"
+            )
+        )
+    )
+    problem = body.split("## Problem", 1)[1].split("## Change", 1)[0]
+
+    assert "stable ships monthly" in problem
+    assert "edge ships nightly" in problem
+
+
+def test_the_body_opens_with_the_size_the_gates_and_the_cost() -> None:
+    body = build_pr_body(_summary(commits=(FEATURE_COMMIT,)))
+    headline = body.splitlines()[0]
+
+    assert headline.startswith(">")
+    assert "2 files" in headline
+    assert "+210 / -4" in headline
+    assert "2/2 gates passed" in headline
+    assert "$1.00" in headline
+
+
+def test_a_failed_gate_shows_in_the_headline() -> None:
+    body = build_pr_body(
+        _summary(gates=(GateResult(name="tests", passed=False, detail="3 failed"),))
+    )
+    headline = body.splitlines()[0]
+
+    assert "❌" in headline
+    assert "0/1 gates passed" in headline


### PR DESCRIPTION
Closes #4669

> ✅ **3 files** · +347 / -37 · **158 tests pass**

## Problem

Three git queries build every description — `git diff --stat`, `git log --numstat`,
`git diff` — and each returned `""` on a non-zero exit. A failed query and a branch
with no diff therefore reached the generator identically, and the generator asserted
the second: `_No changes recorded for this session._`, beside a provenance digest of
`sha256:e3b0c442…b855` — the SHA-256 of zero bytes — under a command to verify it.

Nine of the ten unattended pull requests open on 2026-08-27 read that way over branches
carrying real work, and the publish log said nothing.

Reproduced end to end in a workspace whose object store is unreachable from inside the
publish container: git answers `fatal: Invalid revision range main..<branch>`, and the
description that comes out is byte-identical to the ones in those pull requests.

## Change

**The mechanism** — an unanswered query is no longer a negative answer:

| File | What changed |
| --- | --- |
| `src/bernstein/cli/commands/pr_cmd.py` | `_diff_stat` / `_diff_bytes` / `_commit_log` return `(value, error)`; the enrichment step reports the error on stderr and carries it into the summary |
| `src/bernstein/core/integrations/pr_gen.py` | `SessionSummary.git_error`; the Change section names the git error instead of claiming an empty branch; a digest of zero bytes is never published as provenance |

**The surface** — a description a reviewer can read at a glance:

- A headline opens the body: size, gate outcome, cost.
- Files render as a table; the raw diff-stat folds into `<details>`.
- A colon lead-in absorbs the block it introduces, so Problem states a problem rather
  than the sentence before one.
- An absent journal head and a zero cost are omitted instead of printed as values.

<details>
<summary>Before and after, same branch</summary>

Before:

```
## Change
_No changes recorded for this session._

## Provenance
- **Diff:** `sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
- **Journal head:** `unrecorded`
- **Verify:** `bernstein review-receipt verify …`
```

After, when git answers:

```
> 📝 **3 files** · +341 / -37

## Change
fix: report git failures in PR descriptions … (`3bf22c8`)

| File | Change |
| --- | --- |
| `src/bernstein/core/integrations/pr_gen.py` | +152 / -14 |
…
```

After, when git does not:

```
> ⚠️ **the diff could not be read**

## Change
> ⚠️ **The diff could not be read.** This description was composed without it.
> git said: `diff --stat: fatal: Invalid revision range main..<branch>`
```

</details>

## Verification

`158 passed` across `test_pr_gen.py`, `test_pr_gen_evidence.py`, `test_pr_cmd_issue_link.py`,
`test_pr_description_from_change.py`, `test_pr_goal_and_run_identity.py`,
`test_issue_to_pr_cmd.py`, `test_git_pr.py`, `test_pr_size_governor.py`. `ruff check` clean.

Seven new tests, each named for the property it protects:

| Test | Property |
| --- | --- |
| `test_a_git_failure_is_not_reported_as_a_branch_that_changed_nothing` | a failed query is not an empty answer |
| `test_git_failures_reach_the_description_instead_of_being_swallowed` | proven against real git in a directory that is not a repository — a mock would only prove the branch is written |
| `test_a_description_never_carries_a_receipt_for_an_empty_diff` | no digest of zero bytes under a verify command |
| `test_a_receipt_for_a_real_diff_is_still_published` | the guard does not swallow real provenance |
| `test_a_colon_lead_in_absorbs_the_block_it_introduces` | Problem states a problem |
| `test_a_run_without_a_journal_head_does_not_advertise_one` | an absence is not a value |
| `test_the_body_opens_with_the_size_the_gates_and_the_cost` | the headline answers the first three questions |

One existing assertion changed: per-file churn now renders as a table cell (`+120 / -4`)
rather than `+120/-4`. The property it protects — that the files and their churn are
named — is unchanged.

## Out of scope

Why git failed in those specific workspaces. That is a property of the workspace, not of
this command; this change makes the next occurrence name itself in the publish log instead
of arriving as a description nobody can distinguish from an empty branch.
