### PR TITLE
fix(orchestration): cap priority age boost to prevent starvation of fresh P1 tasks (#4675)

### DIFF
--- a/docs/release-notes/fragments/4675-cap-priority-age-boost.md
+++ b/docs/release-notes/fragments/4675-cap-priority-age-boost.md
@@ -1,0 +1,1 @@
+Cap fair-scheduling priority age-boost to 2 steps and expose tuning parameters (#4675).

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -167,6 +167,13 @@ class OrchestratorDefaults:
     # ``tuning.orchestrator.max_agent_runtime_s``.
     max_agent_runtime_s: int = 1800  # 30 min
 
+    # Fair scheduling priority age-boost tuning (#4675).
+    # Tasks waiting longer than priority_age_threshold_s receive a priority
+    # boost of priority_boost_step per elapsed block, capped at max_priority_age_boost.
+    priority_age_threshold_s: float = 300.0  # 5 minutes
+    priority_boost_step: int = 1  # priority step boosted per threshold period
+    max_priority_age_boost: int = 2  # maximum cumulative boost allowed from aging
+
 
 # ---------------------------------------------------------------------------
 # Spawn / Agent defaults

--- a/src/bernstein/core/orchestration/tick_pipeline.py
+++ b/src/bernstein/core/orchestration/tick_pipeline.py
@@ -17,6 +17,7 @@ from typing_extensions import TypedDict
 
 from bernstein.core.backlog_parser import parse_backlog_text
 from bernstein.core.context_collapse import staged_context_collapse
+from bernstein.core.defaults import ORCHESTRATOR
 from bernstein.core.models import Task, TaskType
 from bernstein.core.orchestration.best_of_n import is_best_of_n, task_n
 
@@ -33,6 +34,7 @@ logger = logging.getLogger(__name__)
 # Fair scheduling: age threshold in seconds after which lower-priority tasks get boosted
 _PRIORITY_AGE_THRESHOLD_SECONDS = 300  # 5 minutes
 _PRIORITY_BOOST_AMOUNT = 1  # Boost priority by 1 (lower value = higher priority)
+_MAX_PRIORITY_AGE_BOOST = 2  # Maximum cumulative boost allowed from aging (#4675)
 
 
 def _task_affinity_config(task: Task) -> dict[str, object]:
@@ -499,6 +501,10 @@ def group_by_role(
     agent_affinity: dict[str, str] | None = None,
     cost_estimates: dict[str, float] | None = None,
     budget_remaining_usd: float | None = None,
+    *,
+    age_threshold_seconds: float | None = None,
+    boost_amount: int | None = None,
+    max_age_boost: int | None = None,
 ) -> list[list[Task]]:
     """Group open tasks by role into batches of up to max_per_batch.
 
@@ -515,8 +521,9 @@ def group_by_role(
     If alive_per_role is provided, batches are further reordered to prioritize
     roles with zero alive agents (starving roles) before well-served roles.
 
-    Fair scheduling: tasks waiting longer than PRIORITY_AGE_THRESHOLD_SECONDS
-    get their effective priority boosted to prevent P1 tasks from starving P2/P3.
+    Fair scheduling: tasks waiting longer than priority_age_threshold_s
+    get their effective priority boosted up to max_priority_age_boost steps
+    to prevent P1 tasks from indefinitely starving P2/P3 tasks (#4675).
 
     Agent affinity: when agent_affinity is provided, tasks that prefer the same
     agent (downstream of a completed task) are merged into the same affinity
@@ -544,6 +551,9 @@ def group_by_role(
             so expensive work runs earlier while budget is still available.
         budget_remaining_usd: Current budget remaining. Used only to disable the
             cost-aware secondary sort once no spend remains.
+        age_threshold_seconds: Optional override for age threshold in seconds.
+        boost_amount: Optional override for priority boost step per threshold period.
+        max_age_boost: Optional override for maximum cumulative priority boost steps.
 
     Returns:
         List of batches, each a list of same-role tasks, round-robin interleaved.
@@ -557,6 +567,21 @@ def group_by_role(
 
     # Calculate current time for age-based priority boosting
     current_time = time.time() if task_created_at else None
+    effective_threshold = (
+        age_threshold_seconds
+        if age_threshold_seconds is not None
+        else getattr(ORCHESTRATOR, "priority_age_threshold_s", _PRIORITY_AGE_THRESHOLD_SECONDS)
+    )
+    effective_boost_amount = (
+        boost_amount
+        if boost_amount is not None
+        else getattr(ORCHESTRATOR, "priority_boost_step", _PRIORITY_BOOST_AMOUNT)
+    )
+    effective_max_boost = (
+        max_age_boost
+        if max_age_boost is not None
+        else getattr(ORCHESTRATOR, "max_priority_age_boost", _MAX_PRIORITY_AGE_BOOST)
+    )
 
     def _sort_key(t: Task) -> tuple[float, float, float, int, str]:
         # Priority boost for upgrade proposals: subtract 1 from priority value
@@ -571,9 +596,10 @@ def group_by_role(
         age_boost = 0
         if current_time is not None and task_created_at and t.id in task_created_at:
             age_seconds = current_time - task_created_at[t.id]
-            if age_seconds > _PRIORITY_AGE_THRESHOLD_SECONDS:
-                # Boost priority by 1 for each threshold period exceeded
-                age_boost = int(age_seconds / _PRIORITY_AGE_THRESHOLD_SECONDS) * _PRIORITY_BOOST_AMOUNT
+            if effective_threshold > 0 and age_seconds > effective_threshold:
+                # Boost priority by boost_amount for each threshold period exceeded, capped at max_age_boost
+                raw_boost = int(age_seconds / effective_threshold) * effective_boost_amount
+                age_boost = min(raw_boost, effective_max_boost) if effective_max_boost is not None else raw_boost
 
         # Effective priority: lower is better
         effective_priority = priority_boost - age_boost

--- a/tests/unit/test_fair_scheduling.py
+++ b/tests/unit/test_fair_scheduling.py
@@ -157,3 +157,135 @@ def test_fair_scheduling_mixed_roles() -> None:
 
     # Roles should be interleaved, not all of one role first
     assert min(qa_indices) < max(backend_indices), "Roles should be interleaved"
+
+
+def test_priority_age_boost_is_capped_after_many_blocks() -> None:
+    """A task that has waited 10 threshold blocks gains only the cap (default: 2) (#4675)."""
+    current_time = time.time()
+    # P4 task waiting 10 blocks (3000s, threshold 300s)
+    # Raw boost would be 10, but cap is 2 -> effective priority = 4 - 2 = 2.
+    old_p4 = Task(
+        id="old-p4",
+        title="Old P4 task",
+        description="Low priority backlog item",
+        role="backend",
+        priority=4,
+        created_at=current_time - 3000,
+    )
+    # Fresh P2 task (effective priority = 2, priority = 2)
+    fresh_p2 = Task(
+        id="fresh-p2",
+        title="Fresh P2 task",
+        description="Normal priority task",
+        role="backend",
+        priority=2,
+        created_at=current_time,
+    )
+    # Fresh P3 task (effective priority = 3)
+    fresh_p3 = Task(
+        id="fresh-p3",
+        title="Fresh P3 task",
+        description="Minor task",
+        role="backend",
+        priority=3,
+        created_at=current_time,
+    )
+
+    task_created_at = {
+        old_p4.id: old_p4.created_at,
+        fresh_p2.id: fresh_p2.created_at,
+        fresh_p3.id: fresh_p3.created_at,
+    }
+    batches = group_by_role(
+        [old_p4, fresh_p2, fresh_p3],
+        max_per_batch=1,
+        task_created_at=task_created_at,
+    )
+    ordered_ids = [b[0].id for b in batches]
+
+    # With cap=2:
+    # fresh-p2 (effective 2, priority 2) < old-p4 (effective 2, priority 4) < fresh-p3 (effective 3)
+    # If uncapped, old-p4 would have effective priority -6 and come first.
+    assert ordered_ids == ["fresh-p2", "old-p4", "fresh-p3"]
+
+
+def test_fresh_p1_outranks_capped_boost_p3() -> None:
+    """A fresh P1 task strictly outranks a P3 task that has reached maximum age boost (#4675)."""
+    current_time = time.time()
+    fresh_p1 = Task(
+        id="fresh-p1",
+        title="Critical urgent bug",
+        description="P1 urgent",
+        role="backend",
+        priority=1,
+        created_at=current_time,
+    )
+    # P3 task waiting 10 blocks (3000s, threshold 300s) -> capped at boost 2 -> effective priority 1
+    old_p3 = Task(
+        id="old-p3-parked",
+        title="Parked P3 item",
+        description="P3 backlog",
+        role="backend",
+        priority=3,
+        created_at=current_time - 3000,
+    )
+
+    task_created_at = {
+        fresh_p1.id: fresh_p1.created_at,
+        old_p3.id: old_p3.created_at,
+    }
+    batches = group_by_role(
+        [old_p3, fresh_p1],
+        max_per_batch=1,
+        task_created_at=task_created_at,
+    )
+    ordered_ids = [b[0].id for b in batches]
+
+    # Fresh P1 must come before old P3
+    assert ordered_ids == ["fresh-p1", "old-p3-parked"]
+
+
+def test_custom_tuning_knobs_respected() -> None:
+    """group_by_role respects explicit age_threshold_seconds, boost_amount, and max_age_boost overrides."""
+    current_time = time.time()
+    task_p3 = Task(
+        id="task-p3",
+        title="P3 task",
+        description="P3",
+        role="backend",
+        priority=3,
+        created_at=current_time - 200,
+    )
+    task_p2 = Task(
+        id="task-p2",
+        title="P2 task",
+        description="P2",
+        role="backend",
+        priority=2,
+        created_at=current_time,
+    )
+
+    task_created_at = {task_p3.id: task_p3.created_at, task_p2.id: task_p2.created_at}
+
+    # With threshold=100s, boost=1, max_boost=2: task_p3 has waited 200s -> boost 2 -> effective priority 1
+    # effective priority 1 beats task_p2 effective priority 2
+    batches_boosted = group_by_role(
+        [task_p2, task_p3],
+        max_per_batch=1,
+        task_created_at=task_created_at,
+        age_threshold_seconds=100.0,
+        boost_amount=1,
+        max_age_boost=2,
+    )
+    assert [b[0].id for b in batches_boosted] == ["task-p3", "task-p2"]
+
+    # With max_boost=0 (disabled aging): task_p2 priority 2 beats task_p3 priority 3
+    batches_no_boost = group_by_role(
+        [task_p2, task_p3],
+        max_per_batch=1,
+        task_created_at=task_created_at,
+        age_threshold_seconds=100.0,
+        boost_amount=1,
+        max_age_boost=0,
+    )
+    assert [b[0].id for b in batches_no_boost] == ["task-p2", "task-p3"]


### PR DESCRIPTION
Fixes #4675

### Problem
The scheduler previously boosted waiting task priority by 1 step per 300s threshold period without an upper limit (`_PRIORITY_AGE_THRESHOLD_SECONDS = 300`). Consequently, a low-priority task (e.g. P3 or P4) that remained in the backlog for several hours accumulated unbounded boost, permanently outranking incoming fresh P1 tasks and inverting operator priorities.

### Solution
1. **Bounded Age Boost**:
   - Added `max_priority_age_boost` (default: 2) in `OrchestratorDefaults` and `_MAX_PRIORITY_AGE_BOOST` in `tick_pipeline.py`.
   - Bounded the computed age boost via `min(raw_boost, max_age_boost)` in `group_by_role()`, ensuring old tasks gain at most 2 boost steps.
2. **Exposed Tuning Knobs**:
   - Added `priority_age_threshold_s` (default: 300.0s), `priority_boost_step` (default: 1), and `max_priority_age_boost` (default: 2) to `OrchestratorDefaults`.
   - Exposed keyword parameters `age_threshold_seconds`, `boost_amount`, and `max_age_boost` on `group_by_role()` for explicit configuration.
3. **Tests & Hygiene**:
   - Added `test_priority_age_boost_is_capped_after_many_blocks` proving a task waiting 10 threshold blocks gains only the 2-step cap.
   - Added `test_fresh_p1_outranks_capped_boost_p3` proving a fresh P1 task strictly outranks a capped-boost P3 task.
   - Added `test_custom_tuning_knobs_respected` verifying custom threshold, step, and cap overrides.
   - Verified 30/30 fair-scheduling and orchestrator unit tests passing.
   - Added release note fragment `docs/release-notes/fragments/4675-cap-priority-age-boost.md`.
