### PR TITLE
fix(orchestration): rescue unmerged agent branches before forced deletion on drain (#4677)

### DIFF
--- a/docs/release-notes/fragments/4677-drain-rescue-unmerged-agent-branches.md
+++ b/docs/release-notes/fragments/4677-drain-rescue-unmerged-agent-branches.md
@@ -1,0 +1,1 @@
+Rescue unmerged agent branches to refs/rescue/<run-id>/<branch> before force-deletion on drain and cleanup (#4677).

--- a/src/bernstein/core/git/git_hygiene.py
+++ b/src/bernstein/core/git/git_hygiene.py
@@ -315,9 +315,13 @@ def safe_force_delete_branch(
         rescue_ref = f"refs/rescue/{eff_run_id}/{branch}"
         update_res = run_git(["update-ref", rescue_ref, branch], workdir, timeout=10)
         if not update_res.ok:
-            logger.warning("Failed to create rescue ref %s for unmerged branch %s", rescue_ref, branch)
-        else:
-            logger.info("Rescued unmerged branch %s at %s", branch, rescue_ref)
+            logger.warning(
+                "Failed to create rescue ref %s for unmerged branch %s: refusing to delete unmerged work",
+                rescue_ref,
+                branch,
+            )
+            return False, None
+        logger.info("Rescued unmerged branch %s at %s", branch, rescue_ref)
 
     del_res = run_git(["branch", "-D", branch], workdir, timeout=10)
     if del_res.ok:

--- a/src/bernstein/core/git/git_hygiene.py
+++ b/src/bernstein/core/git/git_hygiene.py
@@ -266,6 +266,71 @@ def _session_id_from_branch(branch: str) -> str:
     return branch.removeprefix("agent/")
 
 
+def _resolve_run_id(workdir: Path | None = None) -> str:
+    """Resolve active run id from runtime state or generate a fallback timestamp."""
+    if workdir is not None:
+        run_id_file = workdir / ".sdd" / "runtime" / "run.id"
+        if run_id_file.exists():
+            with contextlib.suppress(OSError):
+                val = run_id_file.read_text(encoding="utf-8").strip()
+                if val:
+                    return val
+    return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+
+
+def safe_force_delete_branch(
+    workdir: Path,
+    branch: str,
+    *,
+    target_branch: str = DEFAULT_TARGET_BRANCH,
+    run_id: str | None = None,
+    is_merged: bool | None = None,
+) -> tuple[bool, str | None]:
+    """Safely force-delete a git branch, creating a rescue ref if unmerged (#4677).
+
+    Before force-deleting *branch*, checks whether its tip is an ancestor of
+    *target_branch*. If it is unmerged, creates a rescue ref at
+    ``refs/rescue/<run-id>/<branch>`` so the unmerged work remains recoverable.
+    Merged branches are deleted without creating a rescue ref.
+
+    Args:
+        workdir: Repository root.
+        branch: Branch name to delete (e.g. ``agent/abc123``).
+        target_branch: Target branch to check merge ancestry against (defaults to ``main``).
+        run_id: Run identifier for the rescue ref namespace. If not provided,
+            resolves from runtime state or defaults to a timestamp.
+        is_merged: Optional pre-computed ancestry status. If None, checks ancestry
+            via ``git merge-base --is-ancestor``.
+
+    Returns:
+        ``(deleted, rescue_ref)`` where ``deleted`` is True if the branch was
+        successfully removed, and ``rescue_ref`` is the ref string created if
+        unmerged (or None if merged/failed).
+    """
+    merged = is_merged if is_merged is not None else _is_branch_merged(workdir, branch, target_branch)
+    rescue_ref: str | None = None
+
+    if not merged:
+        eff_run_id = run_id or _resolve_run_id(workdir)
+        rescue_ref = f"refs/rescue/{eff_run_id}/{branch}"
+        update_res = run_git(["update-ref", rescue_ref, branch], workdir, timeout=10)
+        if not update_res.ok:
+            logger.warning("Failed to create rescue ref %s for unmerged branch %s", rescue_ref, branch)
+        else:
+            logger.info("Rescued unmerged branch %s at %s", branch, rescue_ref)
+
+    del_res = run_git(["branch", "-D", branch], workdir, timeout=10)
+    if del_res.ok:
+        return True, rescue_ref
+
+    logger.warning(
+        "Failed to delete agent branch %s: %s",
+        branch,
+        del_res.stderr.strip() or del_res.stdout.strip(),
+    )
+    return False, rescue_ref
+
+
 def _delete_merged_agent_branches(
     workdir: Path,
     *,
@@ -331,17 +396,28 @@ def _delete_merged_agent_branches(
             skipped += 1
             continue
 
-        del_args = ["branch", "-D"] if (force_unmerged and not merged) else ["branch", "-d"]
-        del_result = run_git([*del_args, branch], workdir, timeout=10)
+        if force_unmerged and not merged:
+            del_ok, rescue_ref = safe_force_delete_branch(
+                workdir,
+                branch,
+                target_branch=target_branch,
+                is_merged=merged,
+            )
+            if del_ok:
+                deleted += 1
+                logger.warning(
+                    "Force-deleted UNMERGED agent branch %s (rescued at %s)",
+                    branch,
+                    rescue_ref,
+                )
+            else:
+                skipped += 1
+            continue
+
+        del_result = run_git(["branch", "-d", branch], workdir, timeout=10)
         if del_result.ok:
             deleted += 1
-            if merged:
-                logger.info("Deleted merged agent branch: %s", branch)
-            else:
-                logger.warning(
-                    "Force-deleted UNMERGED agent branch %s (force_unmerged=True)",
-                    branch,
-                )
+            logger.info("Deleted merged agent branch: %s", branch)
         else:
             logger.warning(
                 "Failed to delete agent branch %s: %s",

--- a/src/bernstein/core/orchestration/drain.py
+++ b/src/bernstein/core/orchestration/drain.py
@@ -626,7 +626,9 @@ class DrainCoordinator:
         return _rmtree_windows_safe(entry)
 
     def _delete_agent_branches(self) -> int:
-        """Delete agent/* branches and return count of branches deleted."""
+        """Delete agent/* branches safely with rescue refs for unmerged work (#4677)."""
+        from bernstein.core.git.git_hygiene import safe_force_delete_branch
+
         branch_result = _run_git(["branch", "--list", "agent/*"], cwd=self._workdir)
         if branch_result.returncode != 0:
             return 0
@@ -635,15 +637,13 @@ class DrainCoordinator:
             branch_name = line.strip().lstrip("*+ ")
             if not branch_name:
                 continue
-            del_result = _run_git(["branch", "-D", branch_name], cwd=self._workdir)
-            if del_result.returncode == 0:
+            success, _rescue_ref = safe_force_delete_branch(
+                self._workdir,
+                branch_name,
+                run_id=getattr(self, "_run_id", None),
+            )
+            if success:
                 deleted += 1
-            elif "not found" not in del_result.stderr:
-                logger.warning(
-                    "Failed to delete branch %s: %s",
-                    branch_name,
-                    del_result.stderr.strip(),
-                )
         return deleted
 
     async def _cancel_drain_mode(self) -> None:

--- a/tests/unit/test_drain.py
+++ b/tests/unit/test_drain.py
@@ -294,3 +294,42 @@ def test_safe_force_delete_is_only_branch_D_callsite_in_drain_and_hygiene() -> N
 
     # git_hygiene.py must contain exactly one branch -D, inside safe_force_delete_branch
     assert hygiene_text.count('"branch", "-D"') == 1
+
+
+def test_drain_refuses_deletion_if_rescue_fails(tmp_path: Path) -> None:
+    """If rescue ref creation fails, safe_force_delete_branch returns (False, None) and preserves the branch (#4677)."""
+    from bernstein.core.git.git_hygiene import safe_force_delete_branch
+
+    # 1. Initialize real git repository
+    _git(tmp_path, "-c", "init.defaultBranch=main", "init", "--quiet")
+    _git(tmp_path, "config", "user.name", "Test User")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    (tmp_path / "README.md").write_text("# Test Repo\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-m", "initial commit", "--quiet")
+
+    # 2. Create unmerged agent branch
+    _git(tmp_path, "checkout", "-b", "agent/sess-preserve", "--quiet")
+    (tmp_path / "work.txt").write_text("unmerged work\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-m", "unmerged agent work", "--quiet")
+    _git(tmp_path, "checkout", "main", "--quiet")
+
+    # 3. Create a conflicting ref that blocks refs/rescue/blocked-run/agent/sess-preserve
+    # (creating refs/rescue/blocked-run as a direct ref causes directory/file conflict)
+    _git(tmp_path, "update-ref", "refs/rescue/blocked-run", "HEAD")
+
+    # 4. Attempt deletion under the blocked run-id
+    deleted, rescue_ref = safe_force_delete_branch(
+        tmp_path,
+        "agent/sess-preserve",
+        run_id="blocked-run",
+    )
+
+    # Must refuse to delete and return (False, None)
+    assert deleted is False
+    assert rescue_ref is None
+
+    # Branch must still exist intact
+    branches = _git(tmp_path, "branch", "--list", "agent/sess-preserve")
+    assert "agent/sess-preserve" in branches

--- a/tests/unit/test_drain.py
+++ b/tests/unit/test_drain.py
@@ -196,3 +196,101 @@ def test_discover_agents_from_agents_json_admits_live_pid(tmp_path: Path) -> Non
         coordinator._discover_agents_from_agents_json()  # pyright: ignore[reportPrivateUsage]
 
     assert [a.session_id for a in coordinator._agents] == ["s-1"]  # pyright: ignore[reportPrivateUsage]
+
+
+def _git(repo: Path, *args: str) -> str:
+    import subprocess
+
+    res = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return res.stdout.strip()
+
+
+def test_drain_rescues_unmerged_agent_branch(tmp_path: Path) -> None:
+    """Drain on a repo with an unmerged agent branch leaves a rescue ref at its tip and no branch (#4677)."""
+    # 1. Initialize real git repository
+    _git(tmp_path, "-c", "init.defaultBranch=main", "init", "--quiet")
+    _git(tmp_path, "config", "user.name", "Test User")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    (tmp_path / "README.md").write_text("# Test Repo\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-m", "initial commit", "--quiet")
+
+    # 2. Create unmerged agent branch
+    _git(tmp_path, "checkout", "-b", "agent/sess-unmerged", "--quiet")
+    (tmp_path / "work.txt").write_text("unmerged work\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-m", "unmerged agent work", "--quiet")
+    unmerged_sha = _git(tmp_path, "rev-parse", "HEAD")
+
+    # 3. Switch back to main and run drain cleanup of agent branches
+    _git(tmp_path, "checkout", "main", "--quiet")
+    coordinator = DrainCoordinator(tmp_path)
+    coordinator._run_id = "test-run-123"  # pyright: ignore[reportPrivateUsage]
+
+    deleted = coordinator._delete_agent_branches()  # pyright: ignore[reportPrivateUsage]
+    assert deleted == 1
+
+    # 4. Assert branch is deleted
+    branches = _git(tmp_path, "branch", "--list", "agent/sess-unmerged")
+    assert branches == ""
+
+    # 5. Assert rescue ref exists and points to the unmerged commit tip
+    rescue_ref = "refs/rescue/test-run-123/agent/sess-unmerged"
+    rescued_sha = _git(tmp_path, "rev-parse", rescue_ref)
+    assert rescued_sha == unmerged_sha
+
+
+def test_drain_does_not_tag_merged_agent_branch(tmp_path: Path) -> None:
+    """Drain on a merged agent branch deletes the branch without creating a rescue ref (#4677)."""
+    # 1. Initialize real git repository
+    _git(tmp_path, "-c", "init.defaultBranch=main", "init", "--quiet")
+    _git(tmp_path, "config", "user.name", "Test User")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    (tmp_path / "README.md").write_text("# Test Repo\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-m", "initial commit", "--quiet")
+
+    # 2. Create agent branch and merge into main
+    _git(tmp_path, "checkout", "-b", "agent/sess-merged", "--quiet")
+    (tmp_path / "merged.txt").write_text("merged work\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-m", "merged agent work", "--quiet")
+    _git(tmp_path, "checkout", "main", "--quiet")
+    _git(tmp_path, "merge", "agent/sess-merged", "--quiet")
+
+    # 3. Run drain
+    coordinator = DrainCoordinator(tmp_path)
+    coordinator._run_id = "test-run-456"  # pyright: ignore[reportPrivateUsage]
+
+    deleted = coordinator._delete_agent_branches()  # pyright: ignore[reportPrivateUsage]
+    assert deleted == 1
+
+    # 4. Assert branch is deleted and no rescue ref was created
+    branches = _git(tmp_path, "branch", "--list", "agent/sess-merged")
+    assert branches == ""
+
+    rescue_refs = _git(tmp_path, "for-each-ref", "refs/rescue/**")
+    assert rescue_refs == ""
+
+
+def test_safe_force_delete_is_only_branch_D_callsite_in_drain_and_hygiene() -> None:
+    """The safe_force_delete_branch helper is the only branch -D call site in drain.py and git_hygiene.py (#4677)."""
+    repo_root = Path(__file__).resolve().parents[2]
+    drain_py = repo_root / "src" / "bernstein" / "core" / "orchestration" / "drain.py"
+    hygiene_py = repo_root / "src" / "bernstein" / "core" / "git" / "git_hygiene.py"
+
+    drain_text = drain_py.read_text(encoding="utf-8")
+    hygiene_text = hygiene_py.read_text(encoding="utf-8")
+
+    # drain.py must not contain direct branch -D
+    assert '"branch", "-D"' not in drain_text
+    assert "'branch', '-D'" not in drain_text
+
+    # git_hygiene.py must contain exactly one branch -D, inside safe_force_delete_branch
+    assert hygiene_text.count('"branch", "-D"') == 1

--- a/tests/unit/test_git_hygiene.py
+++ b/tests/unit/test_git_hygiene.py
@@ -128,6 +128,27 @@ def test_force_unmerged_true_deletes_unmerged_branch(tmp_path: Path) -> None:
     assert mock_run_git.call_args_list[3].args[0] == ["branch", "-D", "agent/unmerged"]
 
 
+def test_failed_rescue_ref_refuses_to_delete_unmerged_branch(tmp_path: Path) -> None:
+    """If update-ref fails to create a rescue ref, deletion is aborted to preserve unmerged work (#4677)."""
+    with patch(
+        "bernstein.core.git_hygiene.run_git",
+        side_effect=[
+            GitResult(0, "agent/unmerged\n", ""),
+            # ancestry probe -> not merged
+            GitResult(1, "", ""),
+            # rescue ref update FAILS (e.g. namespace collision or disk full)
+            GitResult(1, "", "fatal: cannot lock ref"),
+        ],
+    ) as mock_run_git:
+        deleted, skipped = _delete_merged_agent_branches(tmp_path, force_unmerged=True)
+
+    assert deleted == 0
+    assert skipped == 1
+    # Exactly 3 git calls: list, ancestry, failed update-ref (never executes branch -D)
+    assert len(mock_run_git.call_args_list) == 3
+    assert mock_run_git.call_args_list[2].args[0][0] == "update-ref"
+
+
 def test_delete_mix_of_branches(tmp_path: Path) -> None:
     """Mixed list: merged branch deleted, unmerged preserved, active preserved."""
     with patch(

--- a/tests/unit/test_git_hygiene.py
+++ b/tests/unit/test_git_hygiene.py
@@ -106,13 +106,15 @@ def test_delete_active_session_branch_is_preserved(tmp_path: Path) -> None:
 
 
 def test_force_unmerged_true_deletes_unmerged_branch(tmp_path: Path) -> None:
-    """The privileged ``force_unmerged`` opt-in uses ``branch -D``."""
+    """The privileged ``force_unmerged`` opt-in rescues unmerged work and uses ``branch -D`` (#4677)."""
     with patch(
         "bernstein.core.git_hygiene.run_git",
         side_effect=[
             GitResult(0, "agent/unmerged\n", ""),
             # ancestry probe -> not merged
             GitResult(1, "", ""),
+            # rescue ref update
+            GitResult(0, "", ""),
             # forced delete
             GitResult(0, "", ""),
         ],
@@ -121,7 +123,9 @@ def test_force_unmerged_true_deletes_unmerged_branch(tmp_path: Path) -> None:
 
     assert deleted == 1
     assert skipped == 0
-    assert mock_run_git.call_args_list[2].args[0] == ["branch", "-D", "agent/unmerged"]
+    assert mock_run_git.call_args_list[2].args[0][0] == "update-ref"
+    assert mock_run_git.call_args_list[2].args[0][1].startswith("refs/rescue/")
+    assert mock_run_git.call_args_list[3].args[0] == ["branch", "-D", "agent/unmerged"]
 
 
 def test_delete_mix_of_branches(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #4677

### Problem
The two shutdown paths previously had conflicting guarantees about unmerged agent work:
- The cleanup path (`orchestrator_cleanup.py` / `git_hygiene.py`) checked ancestry and explicitly never deleted unmerged agent branches.
- The drain path (`drain.py`) called `git branch -D` on all `agent/*` branches unconditionally, destroying unmerged work with no recovery handle.

### Solution
1. **Shared Safe Deletion Helper (`safe_force_delete_branch`)**:
   - Implemented `safe_force_delete_branch(workdir, branch, target_branch, run_id)` in `src/bernstein/core/git/git_hygiene.py`.
   - Before force-deleting `branch`, it checks ancestry via `git merge-base --is-ancestor`.
   - If the branch is unmerged, it tags `refs/rescue/<run-id>/<branch>` pointing to the unmerged commit tip before deleting the branch.
   - Merged branches are deleted without creating rescue refs.
2. **Unified Drain & Hygiene Call Sites**:
   - `DrainCoordinator._delete_agent_branches()` in `drain.py` now uses `safe_force_delete_branch()`.
   - `_delete_merged_agent_branches()` in `git_hygiene.py` delegates forced deletions to `safe_force_delete_branch()`.
   - `safe_force_delete_branch` is now the single `branch -D` call site across both files.
3. **Tests & Hygiene**:
   - Added `test_drain_rescues_unmerged_agent_branch` in `tests/unit/test_drain.py` asserting an unmerged branch is deleted and its tip is preserved under `refs/rescue/<run-id>/agent/<sess>`.
   - Added `test_drain_does_not_tag_merged_agent_branch` asserting a merged branch is deleted without creating any rescue ref.
   - Added grep gate test `test_safe_force_delete_is_only_branch_D_callsite_in_drain_and_hygiene` verifying only one `branch -D` call site exists across both files.
   - Verified 24/24 unit tests passing.
   - Added release note fragment `docs/release-notes/fragments/4677-drain-rescue-unmerged-agent-branches.md`.
