### PR TITLE
fix(pr): anchor the description without aborting the command

### DIFF
--- a/docs/release-notes/fragments/4686-pr-attest-abort.md
+++ b/docs/release-notes/fragments/4686-pr-attest-abort.md
@@ -1,0 +1,1 @@
+`bernstein pr` no longer exits non-zero after opening the pull request: the description-anchoring step passed a `(bytes, error)` tuple to the diff hasher and raised past a handler that named only three exception types (#4686).

--- a/mypy.gate.ini
+++ b/mypy.gate.ini
@@ -31,7 +31,17 @@ files =
     src/bernstein/core/evidence,
     src/bernstein/core/identity,
     src/bernstein/core/lineage,
-    src/bernstein/core/persistence
+    src/bernstein/core/persistence,
+    # `bernstein pr` composes the PR description and anchors it to the diff
+    # it describes. A wrong argument type here does not produce a wrong
+    # receipt, it aborts the command: passing `_diff_bytes`' whole
+    # `(bytes, error)` tuple to a sha256 helper raised TypeError and failed
+    # a publish whose branch had already passed its verification gate. Both
+    # type checkers reported that call for as long as it existed, and both
+    # repo-wide runs are advisory, so the report went into a log and the
+    # command kept dying. The module is strict-clean; gating it makes the
+    # next one of these fail the pull request instead of the publish.
+    src/bernstein/cli/commands/pr_cmd.py
 
 # Not yet strict-clean. Remove entries as they are cleaned up.
 exclude = (?x)(

--- a/src/bernstein/cli/commands/pr_cmd.py
+++ b/src/bernstein/cli/commands/pr_cmd.py
@@ -84,13 +84,19 @@ def _current_branch(cwd: Path) -> str:
     return result.stdout.strip() or "HEAD"
 
 
-def _git_error(result: subprocess.CompletedProcess) -> str:
+def _git_error(
+    result: subprocess.CompletedProcess[str] | subprocess.CompletedProcess[bytes],
+) -> str:
     """Summarise a failed git invocation in one line.
 
     A description is written from what git answers.  When git does not
     answer, the description must say so rather than describe the silence:
     an unanswered query is not a negative answer.  This returns the line
     the caller reports; ``""`` means the invocation succeeded.
+
+    Both stream types are accepted on purpose: the diff is captured as bytes
+    so its hash does not depend on this process's decoding, everything else
+    is captured as text, and both go through this one reporter.
     """
     if result.returncode == 0:
         return ""
@@ -515,7 +521,10 @@ def _attest_description(
     if not pr_url or summary.provenance is None:
         return
     try:
-        diff = _diff_bytes(cwd, summary.base_branch, summary.branch)
+        diff, diff_error = _diff_bytes(cwd, summary.base_branch, summary.branch)
+        if diff_error:
+            click.echo(f"note: could not re-read the diff to anchor it: {diff_error}", err=True)
+            return
         recomputed = build_provenance(diff=diff, journal_head=summary.journal_head)
         if recomputed.diff_hash != summary.provenance.diff_hash:
             click.echo(
@@ -534,5 +543,12 @@ def _attest_description(
             journal_head=summary.journal_head,
             task_id=summary.session_id,
         )
-    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+    except Exception as exc:
+        # Deliberately every exception, not a named few. This step's whole
+        # contract is that it is optional, and a handler that names the errors
+        # it expects only honours that contract for failures someone thought
+        # of. The one that happened -- a TypeError from a mis-called helper --
+        # was not in the list, so it walked past the handler and failed a
+        # command whose pull request was already open and whose run had
+        # already passed its verification gate.
         click.echo(f"note: could not anchor the pull-request description: {exc}", err=True)

--- a/tests/unit/cli/test_pr_cmd_attest.py
+++ b/tests/unit/cli/test_pr_cmd_attest.py
@@ -1,0 +1,120 @@
+"""The description-attestation step of ``bernstein pr``.
+
+``attest_pr_description`` is covered in
+``tests/unit/test_pr_description_from_change.py``, but it is covered by
+handing it a diff the test made itself. The CLI wrapper that reads the diff
+off the branch was not covered anywhere, so a wrong call into it survived
+every existing test: the wrapper passed ``_diff_bytes``' whole
+``(bytes, error)`` tuple to a hasher that wants bytes, and ``bernstein pr``
+died with ``TypeError: object supporting the buffer API required``.
+
+The command dies *after* the pull request is open and after the run has
+already passed its verification gate, so the caller reads a failure for work
+that succeeded, and the run's claim on its issue is withdrawn.
+
+These tests drive the wrapper against a real git repository, because the
+defect lived in what it did with the real ``_diff_bytes`` result.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bernstein.cli.commands.pr_cmd import _attest_description, _diff_bytes
+from bernstein.core.integrations.pr_gen import SessionSummary, build_provenance
+
+PR_URL = "https://github.com/sipyourdrink-ltd/bernstein/pull/4485"
+ISSUE_BODY = "The description must be anchored to the diff it describes."
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repository with a ``main`` and a branch that changed one file."""
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "t@example.invalid")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "keys.py").write_text("def derive() -> None: ...\n", encoding="utf-8")
+    _git(tmp_path, "add", "keys.py")
+    _git(tmp_path, "commit", "-qm", "base")
+    _git(tmp_path, "checkout", "-qb", "work")
+    (tmp_path / "keys.py").write_text("def derive() -> int:\n    return 1\n", encoding="utf-8")
+    _git(tmp_path, "commit", "-aqm", "change")
+    return tmp_path
+
+
+def _summary(repo: Path) -> SessionSummary:
+    diff, error = _diff_bytes(repo, "main", "work")
+    assert not error and diff, "the fixture must produce a real diff to hash"
+    return SessionSummary(
+        session_id="T-1",
+        goal="anchor the description",
+        branch="work",
+        base_branch="main",
+        journal_head="sha256:deadbeef",
+        provenance=build_provenance(diff=diff, journal_head="sha256:deadbeef"),
+    )
+
+
+def test_attesting_a_real_branch_does_not_raise(repo: Path) -> None:
+    """The regression itself: the wrapper hashed a tuple, not the diff."""
+    _attest_description(
+        summary=_summary(repo),
+        pr_url=PR_URL,
+        description="body",
+        issue_body=ISSUE_BODY,
+        cwd=repo,
+    )
+
+
+def test_attesting_writes_a_receipt(repo: Path) -> None:
+    """Not raising is not enough -- the step must reach its own output.
+
+    A wrapper that swallowed everything would pass the test above while
+    anchoring nothing, so this one asserts the receipt exists.
+    """
+    _attest_description(
+        summary=_summary(repo),
+        pr_url=PR_URL,
+        description="body",
+        issue_body=ISSUE_BODY,
+        cwd=repo,
+    )
+
+    receipts = list((repo / ".sdd" / "lineage").rglob("*")) if (repo / ".sdd").exists() else []
+    assert any(p.is_file() for p in receipts), "attestation produced no receipt"
+
+
+def test_an_unexpected_error_inside_attestation_does_not_fail_the_command(
+    repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The step promises it never fails the command. It must mean any error.
+
+    The handler used to name three exception types, so the one that actually
+    happened -- a ``TypeError`` -- walked straight past it and killed a
+    publish. A guard whose whole purpose is "this step is optional" cannot
+    be selective about which failures it treats as optional.
+    """
+
+    def boom(**_: object) -> None:
+        raise TypeError("object supporting the buffer API required")
+
+    monkeypatch.setattr("bernstein.cli.commands.pr_cmd.build_provenance", boom)
+
+    _attest_description(
+        summary=_summary(repo),
+        pr_url=PR_URL,
+        description="body",
+        issue_body=ISSUE_BODY,
+        cwd=repo,
+    )
+
+    assert "could not anchor" in capsys.readouterr().err


### PR DESCRIPTION
`bernstein pr` reads the diff back after opening the pull request, to anchor the posted description to the diff it describes. It passed `_diff_bytes`' whole `(bytes, error)` tuple to the sha256 helper that hashes it:

```
TypeError: object supporting the buffer API required
  compute_diff_hash(diff) -> _sha256_bytes(data) -> hashlib.sha256(data)
```

The step runs *after* the pull request exists and *after* the branch has passed its verification gate. Its own docstring states that failure to attest never fails the command, because "an unanchored description is a smaller problem than a command that reports failure for work that succeeded." It failed the command anyway: the handler named `OSError`, `ValueError` and `subprocess.SubprocessError`, and the error that actually happened was not one of those, so it walked past the handler and the command exited non-zero. A caller that reads that exit as "no pull request was produced" discards a branch that is complete and already open.

## Changes

- Unpack `_diff_bytes`, and report the git error the way the other caller of the same helper already does. The other four tuple-returning helpers in this module are unpacked at every call site; this was the only one that was not.
- Catch every exception in the step that promises it never fails the command. A handler that names the errors it expects only honours that promise for failures someone thought of.
- Annotate `_git_error` for the two stream types it already branches on — the diff is captured as bytes so its hash does not depend on this process's decoding, everything else is captured as text.

## Why it was not caught

Both `mypy` and `pyright` reported this exact call for as long as it existed:

```
pr_cmd.py:519: error: Argument "diff" to "build_provenance" has incompatible
  type "tuple[bytes, str]"; expected "bytes"  [arg-type]
```

Both repo-wide runs are advisory, so the report went into a log and the command kept failing. The module is already strict-clean, so it joins the gated zone in `mypy.gate.ini` at the cost of one annotation, and the next argument-type error here fails the pull request instead of the publish.

## Tests

`tests/unit/cli/test_pr_cmd_attest.py` drives the wrapper against a real git repository, because the defect was in what it did with a real `_diff_bytes` result — the existing coverage exercises `attest_pr_description` with a diff the test builds itself, one layer below where this broke. Three cases: attesting a real branch does not raise; it reaches its own output rather than silently doing nothing; an unexpected error inside attestation does not fail the command.

All three fail on `main` and pass here. 1444 related unit tests pass.