### PR TITLE
fix(test): patch the correct _is_process_alive binding in test_ownership_released_on_reap

### DIFF
--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2043,8 +2043,17 @@ class TestFileOwnership:
         r2 = orch.tick()
         assert len(r2.spawned) == 1  # no conflict, spawns fine
 
+    # The reap path calls agent_lifecycle's own local _is_process_alive, not this
+    # one; patch both bindings so the outcome no longer depends on whether the
+    # real PID 99 is alive on the host (same fix as #1476's sibling test).
+    @patch("bernstein.core.agents.agent_lifecycle._is_process_alive", return_value=False)
     @patch("bernstein.core.agent_recycling._is_process_alive", return_value=False)
-    def test_ownership_released_on_reap(self, _mock_alive: MagicMock, tmp_path: Path) -> None:
+    def test_ownership_released_on_reap(
+        self,
+        _mock_alive: MagicMock,
+        _mock_alive_lifecycle: MagicMock,
+        tmp_path: Path,
+    ) -> None:
         """File ownership released when a stale agent is reaped."""
         transport = _mock_transport(
             {


### PR DESCRIPTION
## What

`test_ownership_released_on_reap` patches the wrong `_is_process_alive` binding, so its outcome depends on whether the real PID 99 happens to be alive on the host running the suite.

## Why

The reap path (`agent_lifecycle.reap_dead_agents` -> `_refresh_heartbeat_from_signals`) calls a local `_is_process_alive` defined in `agent_lifecycle.py`. The test patches the separate copy in `agent_recycling.py`. The two became independent functions when `d0a0532e5` split the module and, in the same commit, repointed this test's patch target at the now-wrong one. The real, unmocked call falls through to `os.kill(99, 0)`; whether that raises depends on whatever process the host's PID table assigns to 99 at the time.

`#1476` fixed the identical defect for the sibling test `test_reaps_stale_heartbeat`, adding a second patch for the `agent_lifecycle` binding. It never got applied here, or to two other single-patch tests that carry the same defect and are outside this issue's scope: `test_stale_heartbeat_reaps_agent` (line 3217) and `test_heartbeat_reap_records_agent_lifetime` (line 5657).

Related: `#4672` also names this test's flakiness, attributing it to a separate race between the two file-ownership authorities. I did not verify that race; this PR only fixes the mock-target defect reproduced below, the same class `#1476` already fixed for the sibling test.

## How

Patch both bindings, matching `#1476`.

Fixes #4633

## Verification

- Deterministic repro: with only the current (wrong-target) mock applied, forcing the real `bernstein.core.config.platform_compat.process_alive` to return `True` makes the test's assertion fail (`assert 'src/owned.py' not in orch._file_ownership`), and forcing it `False` makes it pass; identical to what a real live vs. dead PID 99 would do on any host. With both bindings patched, the assertion passes regardless of that forced value.
- `uv run python scripts/run_tests.py tests/unit/test_orchestrator.py::TestFileOwnership::test_ownership_released_on_reap` and the full `tests/unit/test_orchestrator.py` file (227 tests) pass.
- `ruff check`, `ruff format --check`, and `typos` pass on the changed file. `pyright` is advisory repo-wide and this file is outside `pyrightconfig.strict.json`'s scope.
- Not verified: whether `#4672`'s separate ownership-authority race is real; this test's execution model has no concurrent writer, so it could not reproduce that mechanism either way.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes (advisory repo-wide, this file is outside the strict zone, unrelated to this change)
- [x] `uv run python scripts/run_tests.py -x` passes (ran the full `test_orchestrator.py` file, not the whole suite; see Verification)
- [x] New code has type hints
