### PR TITLE
fix(pr): compose the description against the base the pull request merges onto

### DIFF
--- a/src/bernstein/cli/commands/pr_cmd.py
+++ b/src/bernstein/cli/commands/pr_cmd.py
@@ -84,6 +84,26 @@ def _current_branch(cwd: Path) -> str:
     return result.stdout.strip() or "HEAD"
 
 
+def _base_rev(cwd: Path, base: str) -> str:
+    """Return the revision to diff the branch against.
+
+    ``base`` names the branch the pull request will merge onto -- a name on
+    the hosting side. Inside the workspace that name is a local branch that
+    nothing maintains: a single-branch clone does not have it at all, and a
+    clone that has fetched since it was created has a stale one. Both were
+    published: a description composed where ``main`` did not resolve went
+    out under "the diff could not be read", and a stale ``main`` composes
+    the description against commits the pull request does not touch. The
+    remote-tracking ref is the branch the pull request actually merges
+    onto, so it wins whenever it exists; the local name is the fallback for
+    a workspace with no remote at all.
+    """
+    result = _run_git(["rev-parse", "--verify", "-q", f"refs/remotes/origin/{base}"], cwd=cwd)
+    if result.returncode == 0:
+        return f"origin/{base}"
+    return base
+
+
 def _git_error(
     result: subprocess.CompletedProcess[str] | subprocess.CompletedProcess[bytes],
 ) -> str:
@@ -163,17 +183,18 @@ def _enrich_summary_with_git(summary: SessionSummary, cwd: Path) -> SessionSumma
         when they were missing from the original.
     """
     branch = summary.branch if summary.branch not in ("", "HEAD") else _current_branch(cwd)
+    base_rev = _base_rev(cwd, summary.base_branch)
     errors: list[str] = []
 
     diff_stat = summary.diff_stat
     if not diff_stat:
-        diff_stat, error = _diff_stat(cwd, summary.base_branch, branch)
+        diff_stat, error = _diff_stat(cwd, base_rev, branch)
         if error:
             errors.append(f"diff --stat: {error}")
 
     commits = summary.commits
     if not commits:
-        raw, error = _commit_log(cwd, summary.base_branch, branch)
+        raw, error = _commit_log(cwd, base_rev, branch)
         commits = parse_commit_log(raw)
         if error:
             errors.append(f"log: {error}")
@@ -184,7 +205,7 @@ def _enrich_summary_with_git(summary: SessionSummary, cwd: Path) -> SessionSumma
     # it is a receipt that cannot be honoured. Bind only a diff that exists.
     provenance = summary.provenance
     if provenance is None:
-        diff, error = _diff_bytes(cwd, summary.base_branch, branch)
+        diff, error = _diff_bytes(cwd, base_rev, branch)
         if error:
             errors.append(f"diff: {error}")
         if diff:
@@ -196,7 +217,7 @@ def _enrich_summary_with_git(summary: SessionSummary, cwd: Path) -> SessionSumma
         # description written from an unanswered git reads as a run that
         # changed nothing, and nothing in the log says otherwise.
         click.echo(
-            f"warning: git could not describe {summary.base_branch}..{branch} ({git_error}); "
+            f"warning: git could not describe {base_rev}..{branch} ({git_error}); "
             "the description says so instead of claiming the branch is empty",
             err=True,
         )
@@ -521,7 +542,7 @@ def _attest_description(
     if not pr_url or summary.provenance is None:
         return
     try:
-        diff, diff_error = _diff_bytes(cwd, summary.base_branch, summary.branch)
+        diff, diff_error = _diff_bytes(cwd, _base_rev(cwd, summary.base_branch), summary.branch)
         if diff_error:
             click.echo(f"note: could not re-read the diff to anchor it: {diff_error}", err=True)
             return

--- a/src/bernstein/cli/commands/wrap_up_cmd.py
+++ b/src/bernstein/cli/commands/wrap_up_cmd.py
@@ -43,7 +43,11 @@ def _get_git_diff_stat(start_sha: str) -> str:
             check=False,
         )
         if result.returncode == 0:
-            return result.stdout.strip() or "(no uncommitted changes)"
+            # An empty stat means "nothing to describe", and that is what
+            # gets recorded. The old placeholder string here ended up
+            # published as pull-request diff-stats by every consumer that
+            # treated any non-empty string as an answer.
+            return result.stdout.strip()
     return ""
 
 

--- a/src/bernstein/core/integrations/pr_gen.py
+++ b/src/bernstein/core/integrations/pr_gen.py
@@ -1631,6 +1631,14 @@ def load_session_summary(
     changes_summary = str(wrapup.get("changes_summary") or "")
     branch = str(wrapup.get("branch") or live_session.get("branch") or run_metadata.get("git_branch") or "HEAD")
     diff_stat = str(wrapup.get("git_diff_stat") or wrapup.get("diff_stat") or "")
+    if diff_stat == "(no uncommitted changes)":
+        # Wrap-up's old fallback answered a different question -- "any
+        # uncommitted changes right now?" -- and recorded that answer where
+        # the branch diff-stat belongs. Ten pull requests shipped it as
+        # their whole diff-stat block. Treat it as no answer so the git
+        # enrichment recomputes the real one; wrap-up files that predate
+        # the fix are still on disk and get replayed by bundle rescues.
+        diff_stat = ""
     primary_role_raw = wrapup.get("primary_role") or live_session.get("primary_role")
     primary_role = str(primary_role_raw) if primary_role_raw else None
 

--- a/tests/unit/cli/test_pr_cmd_base_rev.py
+++ b/tests/unit/cli/test_pr_cmd_base_rev.py
@@ -1,0 +1,133 @@
+"""The base revision a pull-request description is composed against.
+
+``_enrich_summary_with_git`` diffs the run branch against the *name* of the
+pull request's base -- ``main`` -- as a local ref. Nothing in a working
+clone maintains that ref: a single-branch clone does not have it at all,
+and a clone that has fetched since it was created has a stale one. Both
+shipped: a description composed where ``main`` did not resolve was
+published under "the diff could not be read" with no commit list and no
+provenance, and a stale ``main`` composes the description against commits
+the pull request does not touch.
+
+These tests build the two clone shapes with real git, because the defect
+was in which revision the real git commands were pointed at.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bernstein.cli.commands.pr_cmd import _base_rev, _diff_bytes, _enrich_summary_with_git
+from bernstein.core.integrations.pr_gen import SessionSummary, load_session_summary
+
+
+def _git(cwd: Path, *args: str) -> str:
+    done = subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+    return done.stdout.strip()
+
+
+def _commit_file(cwd: Path, name: str, body: str, message: str) -> None:
+    (cwd / name).write_text(body, encoding="utf-8")
+    _git(cwd, "add", name)
+    _git(cwd, "commit", "-qm", message)
+
+
+@pytest.fixture
+def clones(tmp_path: Path) -> tuple[Path, Path]:
+    """An upstream repository and a working clone of it, like a lane's."""
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    _git(upstream, "init", "-q", "-b", "main")
+    _git(upstream, "config", "user.email", "t@example.invalid")
+    _git(upstream, "config", "user.name", "t")
+    _commit_file(upstream, "base.py", "BASE = 1\n", "base")
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", "-q", str(upstream), str(clone))
+    _git(clone, "config", "user.email", "t@example.invalid")
+    _git(clone, "config", "user.name", "t")
+    return upstream, clone
+
+
+def _work_branch(clone: Path) -> None:
+    _git(clone, "checkout", "-qb", "work", "origin/main")
+    _commit_file(clone, "feature.py", "def f() -> int:\n    return 2\n", "feature")
+
+
+def test_a_clone_without_a_local_base_still_composes_the_description(
+    clones: tuple[Path, Path],
+) -> None:
+    """The #4687 shape: only ``origin/main`` exists, and the description
+    must still get its diff-stat, its commit list, and its provenance."""
+    _upstream, clone = clones
+    _work_branch(clone)
+    _git(clone, "branch", "-D", "main")
+
+    enriched = _enrich_summary_with_git(
+        SessionSummary(session_id="T-1", goal="g", branch="work", base_branch="main"),
+        clone,
+    )
+
+    assert enriched.git_error == "", "every git query failed over a resolvable base"
+    assert "feature.py" in enriched.diff_stat
+    assert [c.subject for c in enriched.commits] == ["feature"]
+    assert enriched.provenance is not None
+
+
+def test_a_stale_local_base_does_not_shape_the_description(
+    clones: tuple[Path, Path],
+) -> None:
+    """A local ``main`` pinned behind ``origin/main`` must not put the
+    upstream commits it is missing into the branch's description."""
+    upstream, clone = clones
+    _commit_file(upstream, "upstream_only.py", "U = 3\n", "upstream moved on")
+    _git(clone, "fetch", "-q", "origin")
+    _work_branch(clone)  # branched from the NEW origin/main; local main is stale
+
+    enriched = _enrich_summary_with_git(
+        SessionSummary(session_id="T-2", goal="g", branch="work", base_branch="main"),
+        clone,
+    )
+
+    assert enriched.git_error == ""
+    assert "feature.py" in enriched.diff_stat
+    assert "upstream_only.py" not in enriched.diff_stat, "the description was composed against the stale local main"
+    diff, error = _diff_bytes(clone, "origin/main", "work")
+    assert not error
+    assert enriched.provenance is not None
+    from bernstein.core.integrations.pr_gen import build_provenance
+
+    assert enriched.provenance.diff_hash == build_provenance(diff=diff, journal_head="").diff_hash
+
+
+def test_the_base_name_is_kept_for_a_workspace_with_no_remote(tmp_path: Path) -> None:
+    """An operator running ``bernstein pr`` in a plain local repository has
+    no ``origin/main``; the local name is then the only answer."""
+    _git(tmp_path, "init", "-q", "-b", "main")
+    assert _base_rev(tmp_path, "main") == "main"
+
+
+def test_the_wrap_up_placeholder_is_not_an_answer(tmp_path: Path) -> None:
+    """Wrap-up files already on disk say ``(no uncommitted changes)`` where
+    the branch diff-stat belongs -- an answer to a different question. Ten
+    pull requests published it as their whole diff-stat block; loading one
+    must leave the field empty so the git enrichment recomputes it."""
+    sessions = tmp_path / ".sdd" / "runtime" / "sessions"
+    sessions.mkdir(parents=True)
+    (sessions / "1-wrapup.json").write_text(
+        json.dumps(
+            {
+                "session_id": "S-1",
+                "branch": "work",
+                "git_diff_stat": "(no uncommitted changes)",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    summary = load_session_summary("S-1", workdir=tmp_path)
+
+    assert summary.diff_stat == ""


### PR DESCRIPTION
## Problem

#4687 was published with "the diff could not be read" as its headline, no commit list, and no provenance anchor. It was composed in a workspace whose clone has no local `main` — the enrichment step diffs the branch against the literal local ref named by `--base`, and all three git queries behind the description died on an unknown revision. The mirror case is quieter and worse: a workspace whose local `main` has gone stale composes the description against commits the pull request does not touch.

Separately, ten merged pull requests shipped `(no uncommitted changes)` as their entire diff-stat block. Wrap-up's fallback answers a different question — "any uncommitted changes right now?" — and records that answer where the branch diff-stat belongs; the description loader treats any non-empty string as an answer and never recomputes.

## Change

- `_base_rev()` resolves the base to `origin/<base>` whenever the remote-tracking ref exists; the local name remains the fallback for repositories with no remote. Used by the description enrichment and by the attestation re-read.
- Wrap-up records an empty diff-stat as empty instead of the placeholder.
- Loading a wrap-up file that predates the fix treats the placeholder as no answer, so the enrichment recomputes the real stat — bundle rescues replay such files.

## Verification

- New tests build both clone shapes with real git: a clone without a local `main` composes a full description (fails on `main` with the exact #4687 error), and a stale local `main` no longer leaks upstream commits into the diff-stat or the provenance hash.
- `tests/unit/cli/` plus the description/wrap-up suites: 624 passed.
- Repro before/after on an unfixed tree: `git_error='diff --stat: fatal: ambiguous argument …'`, `commits=0`, `provenance=False` → `git_error=''`, `commits=1`, `provenance=True`.
