### PR TITLE
fix(docs): document the team-hub manifest that ships, gate deleted sources on the PR

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -278,6 +278,22 @@ jobs:
           uv run pytest tests/unit/test_docs_prose_cli_drift.py -q --no-cov --timeout=120
         shell: bash
 
+      - name: Fail when the change deletes a documented source of truth
+        # The drift report above is advisory on pull requests because a doc
+        # that fell behind can be caught up later. This is the narrower case
+        # and it fails here: the change deletes the very file a doc is
+        # documented against, so it introduces the broken reference, and the
+        # doc plus its playbook row can be corrected in the same change
+        # instead of turning main red after the merge.
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git diff --diff-filter=D --name-only "$BASE_SHA...$HEAD_SHA" > deleted-paths.txt
+          python scripts/check_docs_drift.py --deleted-paths-file deleted-paths.txt
+        shell: bash
+
       - name: Fail the gate on main-branch drift
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |

--- a/docs/concepts/team-hub.md
+++ b/docs/concepts/team-hub.md
@@ -3,7 +3,7 @@
 A team hub is a directory tree that ships shared agents, skills,
 and rules across multiple repositories without symlinks. The
 convention pins one manifest filename (`team-hub.yaml`) and one
-sub-directory (`team/`) so the loader can detect a hub by inspection.
+sub-directory (`team/`) so a hub can be detected by inspection.
 
 ## Why it exists
 
@@ -12,7 +12,7 @@ packs, and prompt rules in three places at once. Symlinking one
 canonical copy into every repo works on Linux but breaks on
 Windows checkouts and on shared CI runners that copy worktrees
 between machines. A convention-driven hub solves both: the
-manifest tells the loader exactly which paths to expose, and
+manifest enumerates exactly which paths the hub publishes, and
 every consumer mirrors the directory layout instead of resolving
 links at runtime.
 
@@ -29,32 +29,44 @@ links at runtime.
 
 The manifest enumerates which entries the hub publishes. Three
 buckets are recognised: `agents`, `skills`, `rules`. Each entry
-points at a path inside `team/`; the loader resolves it on disk
-and rejects entries that escape the hub root.
+is a relative path inside the hub; validation rejects absolute
+paths and any entry containing `..`, so a manifest cannot name a
+path outside the hub root.
 
-## How to use it
+## What ships today
+
+The manifest schema and its parser. `parse_team_hub_yaml` reads
+`team-hub.yaml`, strict-validates it, and returns a frozen
+`TeamHubManifest`:
 
 ```python
 from pathlib import Path
-from bernstein.core.plugins_core.team_hub_loader import load_team_hub
+from bernstein.core.plugins_core.team_hub_manifest import (
+    TeamHubManifestError,
+    parse_team_hub_yaml,
+)
 
-hub = load_team_hub(Path("/path/to/hub-repo"))
-if hub is None:
-    # No hub installed - graceful degradation
-    pass
-else:
-    for entry in hub.entries:
-        print(entry.bucket, entry.relative, "->", entry.absolute)
+try:
+    manifest = parse_team_hub_yaml(Path("/path/to/hub-repo/team-hub.yaml"))
+except TeamHubManifestError as exc:
+    # exc.path is the manifest, exc.detail says what is wrong with it
+    raise
 
-    # Filter by bucket
-    skill_packs = hub.by_bucket("skills")
+print(manifest.name, manifest.version)
+print(manifest.ships.agents, manifest.ships.skills, manifest.ships.rules)
 ```
+
+`validate_team_hub_dict` takes an already-parsed mapping and
+applies the same schema, for callers that read the YAML
+themselves.
 
 Manifest example (`team-hub.yaml`):
 
 ```yaml
 name: acme-platform-hub
 version: "1"
+compatibility:
+  bernstein: ">=3.18"
 ships:
   agents:
     - reviewer
@@ -66,31 +78,34 @@ ships:
     - no-stale-todo.md
 ```
 
+`name`, `version`, and `compatibility` are required. `name` is a
+lowercase slug (`^[a-z][a-z0-9-]*$`). `compatibility.bernstein`
+is a PEP-440 style specifier string; it is held to being a
+non-empty string, and nothing enforces its semantics yet.
+
 ## Failure modes
 
-- **No hub installed.** Missing hub root, missing `team-hub.yaml`,
-  or missing `team/` directory yields `None`. This is the graceful
-  no-op the loader is designed for: a consumer that calls
-  `load_team_hub` on every spawn keeps working when the network is
-  down or the hub has not been cloned yet.
-- **Manifest broken.** A malformed manifest, a bucket entry that
-  escapes the hub root, or an entry that points at a non-existent
-  path raises a hard error so the operator knows the hub is broken
-  before it silently disappears from the resolved graph.
+`TeamHubManifestError` carries the manifest path and a detail
+string. It is raised when the file does not exist, cannot be
+read, exceeds the 64 KiB cap, is not valid YAML, is not a YAML
+mapping, names a `ships` bucket outside `agents`/`skills`/`rules`,
+or fails schema validation.
+
+The size cap exists so a pathological YAML input cannot exhaust
+the parser before validation runs.
 
 ## Limitations
 
-- Read-only by design. Clone, pull, and resolution-path merging
-  live in later slices, so this loader can be unit-tested against
-  a fixture directory without touching git.
-- Manifest size is capped at 64 KiB; a real `team-hub.yaml` is
-  well under that. The cap prevents pathological YAML inputs from
-  exhausting the loader.
-- Bucket vocabulary is fixed at `agents`, `skills`, `rules` for
-  this slice. Custom buckets are a follow-up.
+- **Resolution against disk is not shipped.** The manifest is
+  validated and its entries are checked for escape at validation
+  time, but nothing yet walks `team/` to resolve those entries
+  into concrete files, and no consumer reads a hub during a run.
+  Path resolution, clone/pull, and resolution-path merging are
+  later slices.
+- Bucket vocabulary is fixed at `agents`, `skills`, `rules`.
+  Custom buckets are a follow-up.
 
 ## Related
 
-- Loader: `src/bernstein/core/plugins_core/team_hub_loader.py`
 - Manifest schema: `src/bernstein/core/plugins_core/team_hub_manifest.py`
 - [Skill packs](../architecture/skills.md)

--- a/docs/playbooks/docs-drift.md
+++ b/docs/playbooks/docs-drift.md
@@ -94,7 +94,7 @@ been moved, renamed, deleted, or its public surface changed."
 | `spec-as-test.md` | `src/bernstein/core/planning/spec_assertions.py`, `src/bernstein/core/orchestration/drain.py`, `src/bernstein/cli/run_cmd.py` | Spec-assertion schema change, drain-hook signature change | `manual-prose` |
 | `swarm-migration.md` | `src/bernstein/core/tasks/swarm_migration.py`, `src/bernstein/cli/commands/migrate_cmd.py` | Migration entry point change, CLI flag change | `manual-prose` |
 | `task-budgets.md` | `src/bernstein/core/cost/budget_countdown.py` | Budget-format function renamed | `manual-prose` |
-| `team-hub.md` | `src/bernstein/core/plugins_core/team_hub_loader.py`, `src/bernstein/core/plugins_core/team_hub_manifest.py` | Manifest schema change | `manual-prose` |
+| `team-hub.md` | `src/bernstein/core/plugins_core/team_hub_manifest.py` | Manifest schema change | `manual-prose` |
 | `wiki-build.md` | `src/bernstein/cli/commands/wiki_cmd.py`, `src/bernstein/core/knowledge/ast_symbol_graph.py`, `src/bernstein/core/knowledge/wiki_renderer.py` | Wiki-build CLI flag change, renderer output schema change | `manual-prose` |
 
 ### `docs/gui/`

--- a/docs/release-notes/fragments/4696-team-hub-doc-and-deleted-source-gate.md
+++ b/docs/release-notes/fragments/4696-team-hub-doc-and-deleted-source-gate.md
@@ -1,0 +1,7 @@
+- The team-hub concept page documented a loader module that had been removed
+  as unreachable code, so its copy-pasteable example imported something that
+  no longer existed and its manifest example omitted a required field. The
+  page now documents the manifest parser that ships, and both examples are
+  exercised. A change that deletes a file the drift playbook names as a doc's
+  source of truth now fails on the pull request that deletes it, rather than
+  on the push run afterwards with the broken page already published.

--- a/scripts/check_docs_drift.py
+++ b/scripts/check_docs_drift.py
@@ -21,9 +21,17 @@ called with ``--strict`` (used by the CI gate on pushes to main); for
 pull requests the workflow runs without ``--strict`` so the comment
 posts as advisory.
 
+``--deleted-paths-file`` is a separate, narrower gate that does run on
+pull requests. It takes the list of paths a change deletes and fails when
+one of them is a source of truth the playbook names. Accumulated
+staleness is advisory because the doc merely fell behind; a change that
+deletes the file a doc is documented against introduces the error in that
+same change, and the doc and the playbook row can be fixed alongside it.
+
 Usage:
 
     uv run python scripts/check_docs_drift.py [--strict] [--json]
+    uv run python scripts/check_docs_drift.py --deleted-paths-file deleted.txt
 """
 
 from __future__ import annotations
@@ -35,6 +43,10 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PLAYBOOK = REPO_ROOT / "docs" / "playbooks" / "docs-drift.md"
@@ -144,6 +156,24 @@ def check_sources(rows: list[DocRow]) -> list[tuple[DocRow, str]]:
     return missing
 
 
+def sources_deleted_by(deleted_paths: Iterable[str], rows: list[DocRow]) -> list[tuple[DocRow, str]]:
+    """Return the (row, source) pairs whose source is in ``deleted_paths``.
+
+    ``deleted_paths`` are repo-relative, as ``git diff --diff-filter=D
+    --name-only`` prints them. ``static`` rows are skipped for the same
+    reason :func:`check_sources` skips them.
+    """
+    deleted = {p.strip().rstrip("/") for p in deleted_paths if p.strip()}
+    hits: list[tuple[DocRow, str]] = []
+    for row in rows:
+        if row.remediation == "static":
+            continue
+        for src in row.source_paths:
+            if src in deleted:
+                hits.append((row, src))
+    return hits
+
+
 def check_docs(rows: list[DocRow]) -> list[DocRow]:
     missing: list[DocRow] = []
     for row in rows:
@@ -227,11 +257,33 @@ def main() -> int:
         action="store_true",
         help="Emit a JSON summary instead of the Markdown report.",
     )
+    parser.add_argument(
+        "--deleted-paths-file",
+        type=Path,
+        help=(
+            "File of repo-relative paths a change deletes, one per line. "
+            "Exit 1 when any of them is a source of truth the playbook names."
+        ),
+    )
     args = parser.parse_args()
 
     rows = parse_playbook(PLAYBOOK)
     if not rows:
         print("ERROR: could not parse any doc rows from", PLAYBOOK, file=sys.stderr)
+        return 1
+
+    if args.deleted_paths_file is not None:
+        deleted = args.deleted_paths_file.read_text(encoding="utf-8").splitlines()
+        hits = sources_deleted_by(deleted, rows)
+        if not hits:
+            print("No deleted path is a documented source of truth.")
+            return 0
+        for row, src in hits:
+            print(
+                f"ERROR: `{src}` is deleted here and is the source of truth for `{row.doc}`. "
+                f"Update the doc and its row in {PLAYBOOK.relative_to(REPO_ROOT)} in this change.",
+                file=sys.stderr,
+            )
         return 1
 
     report = DriftReport(

--- a/tests/unit/test_docs_drift_deleted_sources.py
+++ b/tests/unit/test_docs_drift_deleted_sources.py
@@ -1,0 +1,145 @@
+"""The deleted-source-of-truth gate on pull requests.
+
+A change that deletes a module the playbook names as a doc's source of
+truth leaves the doc documenting something the tree no longer contains.
+The drift report next to this gate is advisory on pull requests, so that
+class of change used to land green and turn main red on the push run
+afterwards, with the broken doc already published.
+
+These tests pin the gate to the shape that catches it: the checker
+function itself, the CLI exit codes the workflow depends on, and the
+workflow step that feeds it the change's deleted paths.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import cast
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check_docs_drift.py"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs-drift.yml"
+STEP_NAME = "Fail when the change deletes a documented source of truth"
+
+#: The deletion that produced this gate: `team_hub_loader.py` was removed as
+#: unreachable code while `docs/concepts/team-hub.md` still named it as its
+#: source of truth, and the push run on main failed after the merge.
+REAL_DELETED_SOURCE = "src/bernstein/core/plugins_core/team_hub_loader.py"
+
+
+def _script() -> ModuleType:
+    cached = sys.modules.get("check_docs_drift")
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location("check_docs_drift", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register before executing: the script's dataclasses resolve their own
+    # module out of sys.modules when their fields are built.
+    sys.modules["check_docs_drift"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _row(sources_raw: str, remediation: str = "manual-prose"):
+    return _script().DocRow(
+        doc="team-hub.md",
+        sources_raw=sources_raw,
+        drift_signal="Manifest schema change",
+        remediation=remediation,
+    )
+
+
+def test_deleting_a_documented_source_is_reported() -> None:
+    """The exact deletion that turned main red must be flagged."""
+    mod = _script()
+    rows = [_row(f"`{REAL_DELETED_SOURCE}`, `src/bernstein/core/plugins_core/team_hub_manifest.py`")]
+
+    hits = mod.sources_deleted_by([REAL_DELETED_SOURCE], rows)
+
+    assert [src for _, src in hits] == [REAL_DELETED_SOURCE]
+
+
+def test_deleting_an_undocumented_path_is_not_reported() -> None:
+    """Deletions unrelated to any doc must not block the change."""
+    mod = _script()
+    rows = [_row("`src/bernstein/core/plugins_core/team_hub_manifest.py`")]
+
+    assert mod.sources_deleted_by(["src/bernstein/core/plugins_core/dep_resolver.py"], rows) == []
+
+
+def test_static_rows_are_exempt() -> None:
+    """`static` rows are excluded here exactly as they are in check_sources."""
+    mod = _script()
+    rows = [_row(f"`{REAL_DELETED_SOURCE}`", remediation="static")]
+
+    assert mod.sources_deleted_by([REAL_DELETED_SOURCE], rows) == []
+
+
+def test_playbook_no_longer_names_the_deleted_loader() -> None:
+    """The row that broke must stay fixed, or this gate has nothing to catch."""
+    mod = _script()
+    rows = mod.parse_playbook(mod.PLAYBOOK)
+
+    assert rows, "playbook parsed to zero rows"
+    assert mod.sources_deleted_by([REAL_DELETED_SOURCE], rows) == []
+
+
+def test_cli_exits_nonzero_when_a_documented_source_is_deleted(tmp_path: Path) -> None:
+    """The workflow step reads the process exit code, so pin it."""
+    deleted = tmp_path / "deleted.txt"
+    deleted.write_text(f"{REAL_DELETED_SOURCE}\nsrc/bernstein/core/routing/cloudflare_ai.py\n", encoding="utf-8")
+
+    # The current playbook is fixed, so a path it still names is needed to
+    # drive the failing branch; team_hub_manifest.py is that path.
+    documented = tmp_path / "documented.txt"
+    documented.write_text("src/bernstein/core/plugins_core/team_hub_manifest.py\n", encoding="utf-8")
+
+    clean = subprocess.run(
+        [sys.executable, str(SCRIPT), "--deleted-paths-file", str(deleted)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert clean.returncode == 0, clean.stderr
+
+    flagged = subprocess.run(
+        [sys.executable, str(SCRIPT), "--deleted-paths-file", str(documented)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert flagged.returncode == 1
+    assert "team_hub_manifest.py" in flagged.stderr
+    assert "docs/playbooks/docs-drift.md" in flagged.stderr
+
+
+def _step() -> dict[str, object]:
+    data = cast("dict[str, object]", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+    jobs = cast("dict[str, object]", data["jobs"])
+    job = cast("dict[str, object]", jobs["drift-check"])
+    steps = cast("list[object]", job["steps"])
+    for step in steps:
+        if isinstance(step, dict) and step.get("name") == STEP_NAME:
+            return cast("dict[str, object]", step)
+    pytest.fail(f"docs-drift.yml has no {STEP_NAME!r} step")
+
+
+def test_workflow_runs_the_gate_on_pull_requests() -> None:
+    """A gate that only ran on push would repeat the failure it exists to stop."""
+    step = _step()
+
+    assert "pull_request" in str(step.get("if", ""))
+
+    run = str(step.get("run", ""))
+    assert "--diff-filter=D" in run, "the step must feed the gate deletions only"
+    assert "--deleted-paths-file" in run


### PR DESCRIPTION
`main` is red on the docs-drift gate: `docs/concepts/team-hub.md` names
`src/bernstein/core/plugins_core/team_hub_loader.py` as its source of truth, and
that module was removed as unreachable code.

The page was worse than a stale path. Its "How to use it" block imported
`load_team_hub` from the deleted module, so anyone copying it got an
`ImportError`, and its manifest example omitted `compatibility`, which is
required — pasting it into `team-hub.yaml` fails validation.

## What changed

- `docs/concepts/team-hub.md` documents `team_hub_manifest.py`, the surface that
  ships: `parse_team_hub_yaml`, `validate_team_hub_dict`, the error type and its
  failure modes. The limitations section now says outright that nothing resolves
  manifest entries against disk yet, instead of describing a read-only loader.
  Both examples in the page were executed against this branch before committing.
- `docs/playbooks/docs-drift.md` drops the deleted path from the `team-hub.md`
  row and keeps `team_hub_manifest.py`.
- `scripts/check_docs_drift.py` gains `sources_deleted_by()` and a
  `--deleted-paths-file` mode that exits 1 when a deleted path is a documented
  source of truth.
- `.github/workflows/docs-drift.yml` runs that mode on pull requests over the
  deletions in the diff.

## Why the new gate is blocking on PRs

The drift report stays advisory there on purpose: a doc that fell behind can be
caught up in a follow-up. A change that deletes the file a doc is documented
against is not staleness — it introduces the broken reference in that change,
and both the doc and the playbook row can be corrected alongside it. That is the
same reasoning the removed-verb gate already uses one step above. The gate looks
only at deletions in the diff, so pre-existing drift never blocks an unrelated
change.

## Test evidence

New `tests/unit/test_docs_drift_deleted_sources.py`, driven by the deletion that
caused this:

- `test_deleting_a_documented_source_is_reported`
- `test_deleting_an_undocumented_path_is_not_reported`
- `test_static_rows_are_exempt`
- `test_playbook_no_longer_names_the_deleted_loader`
- `test_cli_exits_nonzero_when_a_documented_source_is_deleted`
- `test_workflow_runs_the_gate_on_pull_requests`

Verified against the real artefact, not a fixture: with the playbook row as it
stood when the deletion merged, the gate exits 1 naming `team_hub_loader.py` and
`team-hub.md`; with the row corrected it exits 0.

```
pytest tests/unit/test_docs_drift_deleted_sources.py tests/unit/test_docs_drift_workflow_yaml.py tests/unit/test_docs_prose_cli_drift.py -q --no-cov
25 passed

python scripts/check_docs_drift.py --strict   # exit 0
ruff check / ruff format --check / mypy       # clean
```
